### PR TITLE
docs: 使用 Prettier 格式化 README 表格

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,12 +530,12 @@ If the admin UI should talk to a separate API origin, set `GLOBAL_ADMIN_API_BASE
 
 #### Node role configuration matrix
 
-| Role | Typical process | External responsibility | Must be unique | Must stay aligned | Recommended value / note |
-| --- | --- | --- | --- | --- | --- |
-| `room-node` | `server/dist/index.js` | WebSocket, `/`, `/healthz`, `/readyz` | `INSTANCE_ID`, bind address / port | `REDIS_URL`, shared `*_PROVIDER` values, security and rate-limit settings | `GLOBAL_ADMIN_ENABLED=false` |
-| `global-admin` | `server/dist/global-admin-index.js` | `/admin`, `/api/admin/*` | `INSTANCE_ID`, `GLOBAL_ADMIN_PORT` | `REDIS_URL`, admin auth settings, shared provider settings | `GLOBAL_ADMIN_ENABLED=true` |
-| `edge` | `nginx` / `haproxy` / cloud LB | TLS termination, single public entrypoint, reverse proxy, connection distribution | public hostname, certificate, upstream definitions | backend node list | end users connect only to the edge URL |
-| `redis` | `redis-server` | shared persistence, runtime indexes, buses | instance address, password, ACL | every node must point to the same Redis | production should keep it private |
+| Role           | Typical process                     | External responsibility                                                           | Must be unique                                     | Must stay aligned                                                         | Recommended value / note               |
+| -------------- | ----------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------- |
+| `room-node`    | `server/dist/index.js`              | WebSocket, `/`, `/healthz`, `/readyz`                                             | `INSTANCE_ID`, bind address / port                 | `REDIS_URL`, shared `*_PROVIDER` values, security and rate-limit settings | `GLOBAL_ADMIN_ENABLED=false`           |
+| `global-admin` | `server/dist/global-admin-index.js` | `/admin`, `/api/admin/*`                                                          | `INSTANCE_ID`, `GLOBAL_ADMIN_PORT`                 | `REDIS_URL`, admin auth settings, shared provider settings                | `GLOBAL_ADMIN_ENABLED=true`            |
+| `edge`         | `nginx` / `haproxy` / cloud LB      | TLS termination, single public entrypoint, reverse proxy, connection distribution | public hostname, certificate, upstream definitions | backend node list                                                         | end users connect only to the edge URL |
+| `redis`        | `redis-server`                      | shared persistence, runtime indexes, buses                                        | instance address, password, ACL                    | every node must point to the same Redis                                   | production should keep it private      |
 
 #### Which settings must match and which must differ
 
@@ -576,13 +576,13 @@ If you currently have only two machines, a practical rollout looks like this:
 
 Suggested port layout:
 
-| Machine | Role | Suggested bind | Publicly exposed | Notes |
-| --- | --- | --- | --- | --- |
-| server 1 | `nginx` | `80/443` | yes | single public entrypoint |
-| server 1 | `room-node-a` | `127.0.0.1:8787` or private IP | no | proxied by the edge |
-| server 1 | `global-admin` | `127.0.0.1:8788` or private IP | no | proxied by the edge |
-| server 1 | `redis` | `127.0.0.1:6379` or private IP | no | allow only node access |
-| server 2 | `room-node-b` | private IP such as `10.0.0.12:8787` | no | proxied by server 1 edge |
+| Machine  | Role           | Suggested bind                      | Publicly exposed | Notes                    |
+| -------- | -------------- | ----------------------------------- | ---------------- | ------------------------ |
+| server 1 | `nginx`        | `80/443`                            | yes              | single public entrypoint |
+| server 1 | `room-node-a`  | `127.0.0.1:8787` or private IP      | no               | proxied by the edge      |
+| server 1 | `global-admin` | `127.0.0.1:8788` or private IP      | no               | proxied by the edge      |
+| server 1 | `redis`        | `127.0.0.1:6379` or private IP      | no               | allow only node access   |
+| server 2 | `room-node-b`  | private IP such as `10.0.0.12:8787` | no               | proxied by server 1 edge |
 
 ##### Environment examples
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -530,12 +530,12 @@ node server/dist/global-admin-index.js
 
 #### 节点角色配置矩阵
 
-| 角色 | 典型进程 | 对外职责 | 必须唯一 | 必须保持一致 | 推荐值 / 说明 |
-| --- | --- | --- | --- | --- | --- |
-| `room-node` | `server/dist/index.js` | WebSocket、`/`、`/healthz`、`/readyz` | `INSTANCE_ID`、监听地址/端口 | `REDIS_URL`、各类 `*_PROVIDER`、安全与限流参数 | `GLOBAL_ADMIN_ENABLED=false` |
-| `global-admin` | `server/dist/global-admin-index.js` | `/admin`、`/api/admin/*` | `INSTANCE_ID`、`GLOBAL_ADMIN_PORT` | `REDIS_URL`、管理员认证参数、共享 provider 配置 | `GLOBAL_ADMIN_ENABLED=true` |
-| `edge` | `nginx` / `haproxy` / 云 LB | TLS 终止、统一入口、反向代理、连接分发 | 对外域名、证书、upstream 定义 | 指向的后端节点列表 | 用户只连接统一入口地址 |
-| `redis` | `redis-server` | 共享持久化、运行时索引、总线 | 实例地址、密码、ACL | 所有节点都要指向同一个 Redis | 生产建议仅内网开放 |
+| 角色           | 典型进程                            | 对外职责                               | 必须唯一                           | 必须保持一致                                    | 推荐值 / 说明                |
+| -------------- | ----------------------------------- | -------------------------------------- | ---------------------------------- | ----------------------------------------------- | ---------------------------- |
+| `room-node`    | `server/dist/index.js`              | WebSocket、`/`、`/healthz`、`/readyz`  | `INSTANCE_ID`、监听地址/端口       | `REDIS_URL`、各类 `*_PROVIDER`、安全与限流参数  | `GLOBAL_ADMIN_ENABLED=false` |
+| `global-admin` | `server/dist/global-admin-index.js` | `/admin`、`/api/admin/*`               | `INSTANCE_ID`、`GLOBAL_ADMIN_PORT` | `REDIS_URL`、管理员认证参数、共享 provider 配置 | `GLOBAL_ADMIN_ENABLED=true`  |
+| `edge`         | `nginx` / `haproxy` / 云 LB         | TLS 终止、统一入口、反向代理、连接分发 | 对外域名、证书、upstream 定义      | 指向的后端节点列表                              | 用户只连接统一入口地址       |
+| `redis`        | `redis-server`                      | 共享持久化、运行时索引、总线           | 实例地址、密码、ACL                | 所有节点都要指向同一个 Redis                    | 生产建议仅内网开放           |
 
 #### 哪些配置必须一致，哪些必须不同
 
@@ -576,13 +576,13 @@ node server/dist/global-admin-index.js
 
 建议端口规划：
 
-| 机器 | 角色 | 建议监听 | 是否公网开放 | 说明 |
-| --- | --- | --- | --- | --- |
-| 服务器 1 | `nginx` | `80/443` | 是 | 用户统一入口 |
-| 服务器 1 | `room-node-a` | `127.0.0.1:8787` 或内网地址 | 否 | 由入口层反代 |
-| 服务器 1 | `global-admin` | `127.0.0.1:8788` 或内网地址 | 否 | 由入口层反代 |
-| 服务器 1 | `redis` | `127.0.0.1:6379` 或内网地址 | 否 | 只允许节点访问 |
-| 服务器 2 | `room-node-b` | `10.0.0.12:8787` 等内网地址 | 否 | 由服务器 1 的入口层反代 |
+| 机器     | 角色           | 建议监听                    | 是否公网开放 | 说明                    |
+| -------- | -------------- | --------------------------- | ------------ | ----------------------- |
+| 服务器 1 | `nginx`        | `80/443`                    | 是           | 用户统一入口            |
+| 服务器 1 | `room-node-a`  | `127.0.0.1:8787` 或内网地址 | 否           | 由入口层反代            |
+| 服务器 1 | `global-admin` | `127.0.0.1:8788` 或内网地址 | 否           | 由入口层反代            |
+| 服务器 1 | `redis`        | `127.0.0.1:6379` 或内网地址 | 否           | 只允许节点访问          |
+| 服务器 2 | `room-node-b`  | `10.0.0.12:8787` 等内网地址 | 否           | 由服务器 1 的入口层反代 |
 
 ##### 环境变量示意
 


### PR DESCRIPTION
### Motivation

- 修复 `npm run format:check` 报错，保持文档 Markdown 表格的 Prettier 风格一致以通过格式检查。

### Description

- 对 `README.md` 与 `README.zh-CN.md` 中的两处 Markdown 表格（节点角色矩阵与端口规划）应用 Prettier 格式化，调整列对齐与表格分隔符，变更仅限文档格式化，无代码或行为改动。  
- 变更文件：`README.md`，`README.zh-CN.md`。

### Testing

- 已运行 `npm run format`，结果成功且修复了格式问题。  
- 已运行 `npm run lint`，`npm run format:check`，`npm run typecheck` 与 `npm run build`，均成功。  
- 已运行 `npm test`，失败：`@bili-syncplay/protocol` 包的测试脚本 `tsx --test test/**/*.test.ts` 在当前环境下未匹配到文件导致测试命令以非零退出（与本次文档格式化无关）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c809d3b8cc833082d1837dd3b558c5)