### PR TITLE
fix: harden socket message parsing and X-Forwarded-For IP resolution

### DIFF
--- a/extension/src/background/socket-controller.ts
+++ b/extension/src/background/socket-controller.ts
@@ -1,4 +1,5 @@
 import type { ClientMessage, ServerMessage } from "@bili-syncplay/protocol";
+import { isServerMessage } from "@bili-syncplay/protocol";
 import type { DebugLogEntry } from "../shared/messages";
 import type { ConnectionState, RoomSessionState } from "./runtime-state";
 import { getConnectionErrorMessage } from "./connection-error";
@@ -204,8 +205,18 @@ export function createSocketController(args: {
     });
 
     args.connectionState.socket.addEventListener("message", (event) => {
-      const message = JSON.parse(event.data) as ServerMessage;
-      void args.handleServerMessage(message);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(event.data);
+      } catch {
+        args.log("background", "Received invalid JSON from server");
+        return;
+      }
+      if (!isServerMessage(parsed)) {
+        args.log("background", "Received unrecognized server message");
+        return;
+      }
+      void args.handleServerMessage(parsed);
     });
 
     args.connectionState.socket.addEventListener("close", (event) => {

--- a/server/src/security.ts
+++ b/server/src/security.ts
@@ -28,7 +28,8 @@ export function createSecurityPolicy(config: SecurityConfig): {
       typeof forwarded === "string" &&
       forwarded.trim()
     ) {
-      return forwarded.split(",")[0]?.trim() ?? null;
+      const parts = forwarded.split(",");
+      return parts[parts.length - 1]?.trim() ?? null;
     }
     return request.socket.remoteAddress ?? null;
   }

--- a/server/test/security.test.ts
+++ b/server/test/security.test.ts
@@ -57,6 +57,20 @@ test("security policy respects trusted proxy headers when enabled", () => {
   assert.equal(trustedSecurity.getRemoteAddress(directRequest), "203.0.113.10");
 });
 
+test("security policy uses the last IP from x-forwarded-for to prevent spoofing", () => {
+  const config = getDefaultSecurityConfig();
+  config.allowedOrigins = ["chrome-extension://allowed-extension"];
+  config.trustProxyHeaders = true;
+  const security = createSecurityPolicy(config);
+  const spoofedRequest = createRequest({
+    origin: "chrome-extension://allowed-extension",
+    remoteAddress: "127.0.0.1",
+    forwardedFor: "fake-ip, real-client-ip",
+  });
+
+  assert.equal(security.getRemoteAddress(spoofedRequest), "real-client-ip");
+});
+
 test("security policy rejects upgrades when connection count exceeds the configured maximum", () => {
   const config = getDefaultSecurityConfig();
   config.allowedOrigins = ["chrome-extension://allowed-extension"];


### PR DESCRIPTION
Wrap extension WebSocket message handler with try/catch and isServerMessage validation to prevent service worker crashes from malformed server messages. Change X-Forwarded-For to use the last IP (proxy-appended) instead of the first (attacker-controllable) to prevent rate-limit bypass via header spoofing.