### PR TITLE
[codex] Fix admin console cluster status

### DIFF
--- a/server/admin-ui/app.js
+++ b/server/admin-ui/app.js
@@ -247,6 +247,32 @@ function renderDataPair(primary, secondary) {
   `;
 }
 
+function isGlobalAdminInstance(instanceId) {
+  return typeof instanceId === "string" && instanceId.includes("global-admin");
+}
+
+function resolveConsoleContext(instanceId, serviceName = "") {
+  if (
+    serviceName === "bili-syncplay-global-admin" ||
+    isGlobalAdminInstance(instanceId)
+  ) {
+    return {
+      label: "全局后台",
+      title: "全局控制面",
+      description:
+        "这里代表治理与观测入口本身；具体房间会显示它所属的业务实例。",
+      pill: "集群视图",
+    };
+  }
+
+  return {
+    label: "实例",
+    title: "实例上下文",
+    description: "统一管理当前服务实例的运行状态与治理动作。",
+    pill: `实例 ${instanceId || "—"}`,
+  };
+}
+
 function renderOriginValue(value) {
   if (!value) {
     return renderEmptyValue();
@@ -413,6 +439,10 @@ async function render() {
     state.instanceId ||
     state.lastOverviewData?.instanceId ||
     "—";
+  const consoleContext = resolveConsoleContext(
+    instanceId,
+    page.serviceName || state.lastOverviewData?.name,
+  );
   document.title = `${meta.title} | Bili-SyncPlay Admin`;
 
   appRoot.innerHTML = `
@@ -431,10 +461,10 @@ async function render() {
           ${renderNavLink("/config", "配置摘要")}
         </nav>
         <div class="sidebar-meta-card">
-          <div class="sidebar-meta-kicker">实例上下文</div>
-          <div class="sidebar-meta">实例</div>
+          <div class="sidebar-meta-kicker">${escapeHtml(consoleContext.title)}</div>
+          <div class="sidebar-meta">${escapeHtml(consoleContext.label)}</div>
           <strong>${escapeHtml(instanceId)}</strong>
-          <div class="sidebar-meta">统一管理当前服务实例的运行状态与治理动作。</div>
+          <div class="sidebar-meta">${escapeHtml(consoleContext.description)}</div>
         </div>
       </aside>
       <main class="main">
@@ -453,13 +483,13 @@ async function render() {
               </div>
               <div class="userbar">
                 <span class="pill">${escapeHtml(state.me.role)}</span>
-                <span class="pill">${escapeHtml(instanceId)}</span>
+                <span class="pill">${escapeHtml(consoleContext.pill)}</span>
               </div>
               <button class="button ghost" data-action="logout">退出登录</button>
             </div>
           </div>
           <div class="topbar-subline">
-            <div class="pill subtle">实例 ${escapeHtml(instanceId)}</div>
+            <div class="pill subtle">${escapeHtml(consoleContext.pill)}</div>
             <div class="topbar-note">桌面优先的后台工作台，面向排障、治理和运行观察。</div>
           </div>
         </section>
@@ -604,7 +634,10 @@ async function renderOverviewPage() {
   state.lastOverviewData = overview.service;
   const readyWarning = ready.status !== "ready";
   const overviewHighlights = [
-    ["实例", overview.service.instanceId],
+    [
+      isGlobalAdminInstance(overview.service.instanceId) ? "全局后台" : "实例",
+      overview.service.instanceId,
+    ],
     ["存储", overview.storage.provider],
     ["Redis", overview.storage.redisConnected ? "已连接" : "未连接"],
     [
@@ -616,6 +649,7 @@ async function renderOverviewPage() {
   return {
     autoRefresh: state.overviewAutoRefresh,
     instanceId: overview.service.instanceId,
+    serviceName: overview.service.name,
     html: `
       ${readyWarning ? `<div class="warning-banner">readyz 当前状态为 ${escapeHtml(ready.status)}，请优先检查房间存储与 Redis 连通性。</div>` : ""}
       <div class="section">
@@ -640,13 +674,13 @@ async function renderOverviewPage() {
         </section>
         <div class="grid cards-4">
           ${metricCard("服务", escapeHtml(overview.service.name), `版本 ${escapeHtml(overview.service.version)}`)}
-          ${metricCard("实例", escapeHtml(overview.service.instanceId), `启动于 ${new Date(overview.service.startedAt).toLocaleString()}`)}
+          ${metricCard(isGlobalAdminInstance(overview.service.instanceId) ? "全局后台节点" : "实例", escapeHtml(overview.service.instanceId), `启动于 ${new Date(overview.service.startedAt).toLocaleString()}`)}
           ${metricCard("健康检查", escapeHtml(health.status), `readyz ${escapeHtml(ready.status)}`)}
           ${metricCard("运行时长", escapeHtml(formatDuration(overview.service.uptimeMs)), "持续运行时长")}
         </div>
         <div class="grid cards-4">
           ${metricCard("连接数", overview.runtime.connectionCount, "当前 WebSocket 连接")}
-          ${metricCard("在线房间", overview.runtime.activeRoomCount, "活跃房间")}
+          ${metricCard("在线房间", overview.runtime.activeRoomCount, overview.rooms.orphanRuntimeCount > 0 ? `已忽略 ${overview.rooms.orphanRuntimeCount} 个失配运行时索引` : "活跃房间")}
           ${metricCard("在线成员", overview.runtime.activeMemberCount, "当前在线成员")}
           ${metricCard("非过期房间", overview.rooms.totalNonExpired, `空闲 ${overview.rooms.idle}`)}
         </div>
@@ -1262,6 +1296,10 @@ async function renderEventsPage() {
         ${textField("from", "开始时间戳(ms)", query.from, "number")}
         ${textField("to", "结束时间戳(ms)", query.to, "number")}
         ${textField("pageSize", "每页条数", query.pageSize, "number")}
+        <div class="field inline align-end">
+          <input id="includeSystem" name="includeSystem" type="checkbox" ${query.includeSystem ? "checked" : ""} />
+          <label for="includeSystem">显示系统事件</label>
+        </div>
       `,
       rows: data.items
         .map(
@@ -1415,6 +1453,7 @@ function listQueryFromLocation(defaults = {}) {
     targetId: params.get("targetId") || "",
     from: params.get("from") || "",
     to: params.get("to") || "",
+    includeSystem: params.get("includeSystem") === "true",
     page: Number(params.get("page") || "1"),
     pageSize: params.get("pageSize") || defaults.pageSize || "20",
   };
@@ -1456,15 +1495,22 @@ function bindJsonButtons() {
 
 async function renderConfigPage() {
   const config = await api.getConfig();
+  const consoleContext = resolveConsoleContext(config.instanceId);
+  const isGlobalAdminConfig = isGlobalAdminInstance(config.instanceId);
   return {
     instanceId: config.instanceId,
     html: `
       <div class="section">
+        ${
+          isGlobalAdminConfig
+            ? `<div class="warning-banner">当前页面展示的是全局后台进程自身加载到的配置摘要；如果房间节点独立部署，请以对应业务节点的运行配置为准。</div>`
+            : ""
+        }
         <div class="detail-grid">
           <section class="panel config-panel">
             <div class="section-header"><h3>实例与持久化</h3></div>
             <dl class="kv config-kv">
-              <dt>实例 ID</dt><dd>${escapeHtml(config.instanceId)}</dd>
+              <dt>${escapeHtml(consoleContext.label)} ID</dt><dd>${escapeHtml(config.instanceId)}</dd>
               <dt>存储提供方</dt><dd>${escapeHtml(config.persistence.provider)}</dd>
               <dt>空房间保留时长</dt><dd>${escapeHtml(config.persistence.emptyRoomTtlMs)} ms</dd>
               <dt>房间清理间隔</dt><dd>${escapeHtml(config.persistence.roomCleanupIntervalMs)} ms</dd>

--- a/server/src/admin/event-store.ts
+++ b/server/src/admin/event-store.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { shouldIncludeRuntimeEvent } from "./event-visibility.js";
 import type { RuntimeEvent } from "./types.js";
 import type {
   GlobalEventStore,
@@ -47,6 +48,11 @@ export function createEventStore(capacity = 1_000): EventStore {
     async query(query) {
       const filtered = events.filter((event) => {
         const timestamp = eventTime(event);
+        if (
+          !shouldIncludeRuntimeEvent(event.event, query.includeSystem === true)
+        ) {
+          return false;
+        }
         if (query.event && event.event !== query.event) {
           return false;
         }

--- a/server/src/admin/event-visibility.ts
+++ b/server/src/admin/event-visibility.ts
@@ -1,0 +1,21 @@
+const HIDDEN_SYSTEM_EVENTS = new Set([
+  "admin_audit_log_append_failed",
+  "node_heartbeat_failed",
+  "node_heartbeat_sent",
+  "redis_runtime_store_operation_failed",
+  "room_event_bus_error",
+  "room_event_bus_invalid_message",
+  "room_event_handler_failed",
+  "room_event_publish_failed",
+  "room_event_published",
+  "runtime_index_reaper_failed",
+  "runtime_index_sessions_reaped",
+  "server_shutdown_step_failed",
+]);
+
+export function shouldIncludeRuntimeEvent(
+  eventName: string,
+  includeSystem = false,
+): boolean {
+  return includeSystem || !HIDDEN_SYSTEM_EVENTS.has(eventName);
+}

--- a/server/src/admin/global-event-store.ts
+++ b/server/src/admin/global-event-store.ts
@@ -7,6 +7,7 @@ export type GlobalEventStoreQuery = {
   remoteAddress?: string;
   origin?: string;
   result?: string;
+  includeSystem?: boolean;
   from?: number;
   to?: number;
   page: number;

--- a/server/src/admin/overview-service.ts
+++ b/server/src/admin/overview-service.ts
@@ -22,10 +22,24 @@ export function createAdminOverviewService(options: {
         keyword: undefined,
         includeExpired: false,
       });
+      const clusterActiveRoomCodes =
+        await options.runtimeStore.listClusterActiveRoomCodes();
+      const activePersistedRoomCodes = (
+        await Promise.all(
+          clusterActiveRoomCodes.map(async (roomCode) => {
+            const room = await options.roomStore.getRoom(roomCode);
+            if (!room) {
+              return null;
+            }
+            if (room.expiresAt !== null && room.expiresAt <= currentTime) {
+              return null;
+            }
+            return roomCode;
+          }),
+        )
+      ).filter((roomCode): roomCode is string => typeof roomCode === "string");
       const nodeStatuses =
         await options.runtimeStore.listNodeStatuses(currentTime);
-      const clusterActiveRoomCount =
-        await options.runtimeStore.countClusterActiveRooms();
       const activeNodeStatuses =
         nodeStatuses.length === 0
           ? null
@@ -35,10 +49,7 @@ export function createAdminOverviewService(options: {
           (total, status) => total + status.connectionCount,
           0,
         ) ?? options.runtimeStore.getConnectionCount();
-      const activeRoomCount =
-        activeNodeStatuses !== null
-          ? clusterActiveRoomCount
-          : options.runtimeStore.getActiveRoomCount();
+      const activeRoomCount = activePersistedRoomCodes.length;
       const activeMemberCount =
         activeNodeStatuses?.reduce(
           (total, status) => total + status.activeMemberCount,
@@ -69,6 +80,10 @@ export function createAdminOverviewService(options: {
           totalNonExpired,
           active: activeRoomCount,
           idle: Math.max(0, totalNonExpired - activeRoomCount),
+          orphanRuntimeCount: Math.max(
+            0,
+            clusterActiveRoomCodes.length - activePersistedRoomCodes.length,
+          ),
         },
         nodes: {
           total: nodeStatuses.length,

--- a/server/src/admin/redis-event-store.ts
+++ b/server/src/admin/redis-event-store.ts
@@ -1,5 +1,6 @@
 import { Redis } from "ioredis";
 import { randomUUID } from "node:crypto";
+import { shouldIncludeRuntimeEvent } from "./event-visibility.js";
 import type {
   GlobalEventStore,
   GlobalEventStoreAppendInput,
@@ -52,6 +53,9 @@ function matchesQuery(
   query: GlobalEventStoreQuery,
 ): boolean {
   const timestamp = eventTime(event);
+  if (!shouldIncludeRuntimeEvent(event.event, query.includeSystem === true)) {
+    return false;
+  }
   if (query.event && event.event !== query.event) {
     return false;
   }

--- a/server/src/admin/routes/read-routes.ts
+++ b/server/src/admin/routes/read-routes.ts
@@ -92,6 +92,7 @@ export const handleReadRoutes: AdminRouteHandler = async ({
       remoteAddress: queryParams.get("remoteAddress") ?? undefined,
       origin: queryParams.get("origin") ?? undefined,
       result: queryParams.get("result") ?? undefined,
+      includeSystem: queryParams.get("includeSystem") === "true",
       from: queryParams.get("from")
         ? Number(queryParams.get("from"))
         : undefined,

--- a/server/src/admin/types.ts
+++ b/server/src/admin/types.ts
@@ -81,6 +81,7 @@ export type EventListQuery = {
   remoteAddress?: string;
   origin?: string;
   result?: string;
+  includeSystem?: boolean;
   from?: number;
   to?: number;
   page: number;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -222,7 +222,7 @@ export async function cleanupSessionAfterClose(options: {
   });
 }
 
-async function resolveServiceVersion(): Promise<string> {
+export async function resolveServiceVersion(): Promise<string> {
   if (process.env.npm_package_version) {
     return process.env.npm_package_version;
   }

--- a/server/src/global-admin-app.ts
+++ b/server/src/global-admin-app.ts
@@ -15,6 +15,7 @@ import {
 import {
   getDefaultPersistenceConfig,
   getDefaultSecurityConfig,
+  resolveServiceVersion,
 } from "./app.js";
 import { createRedisAdminCommandBus } from "./redis-admin-command-bus.js";
 import { createRedisRoomEventBus } from "./redis-room-event-bus.js";
@@ -29,6 +30,7 @@ import {
   createInMemoryRuntimeStore,
   type RuntimeStore,
 } from "./runtime-store.js";
+import { createRuntimeIndexReaper } from "./runtime-index-reaper.js";
 import { createSecurityPolicy } from "./security.js";
 import { createRedisRoomStore } from "./redis-room-store.js";
 import { createRedisRuntimeStore } from "./redis-runtime-store.js";
@@ -68,6 +70,8 @@ export async function createGlobalAdminServer(
   persistenceConfig: PersistenceConfig = getDefaultPersistenceConfig(),
   dependencies: GlobalAdminServerDependencies = {},
 ): Promise<GlobalAdminServer> {
+  const serviceVersion =
+    dependencies.serviceVersion ?? (await resolveServiceVersion());
   const now = dependencies.now ?? Date.now;
   const generateToken =
     dependencies.generateToken ?? (() => randomBytes(24).toString("base64url"));
@@ -143,8 +147,18 @@ export async function createGlobalAdminServer(
     serviceName: "bili-syncplay-global-admin",
     createOverviewService: createGlobalAdminOverviewService,
     createRoomQueryService: createGlobalAdminRoomQueryService,
-    serviceVersion: dependencies.serviceVersion ?? "0.0.0-global-admin",
+    serviceVersion,
   });
+  const runtimeIndexReaper = createRuntimeIndexReaper({
+    enabled:
+      persistenceConfig.nodeHeartbeatEnabled &&
+      persistenceConfig.runtimeStoreProvider === "redis",
+    runtimeStore,
+    intervalMs: persistenceConfig.nodeHeartbeatIntervalMs,
+    now,
+    logEvent,
+  });
+  runtimeIndexReaper.start();
 
   const httpServer = createServer(
     createHttpRequestHandler({
@@ -166,6 +180,7 @@ export async function createGlobalAdminServer(
           resolve();
         });
       });
+      await runtimeIndexReaper.stop();
 
       const maybeClosableRoomStore = roomStore as RoomStore & {
         close?: () => Promise<void>;

--- a/server/src/mirrored-runtime-store.ts
+++ b/server/src/mirrored-runtime-store.ts
@@ -99,6 +99,9 @@ export function createMirroredRuntimeStore(
     countClusterActiveRooms: readShared(
       sharedRuntimeStore.countClusterActiveRooms,
     ),
+    listClusterActiveRoomCodes: readShared(
+      sharedRuntimeStore.listClusterActiveRoomCodes,
+    ),
     listClusterSessionsByRoom: readShared(
       sharedRuntimeStore.listClusterSessionsByRoom,
     ),

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -94,6 +94,7 @@ const RUNTIME_STORE_METHOD_NAMES = [
   "listNodeStatuses",
   "purgeNodeStatus",
   "countClusterActiveRooms",
+  "listClusterActiveRoomCodes",
   "listClusterSessionsByRoom",
   "listClusterSessions",
   "close",
@@ -677,6 +678,9 @@ export async function createRedisRuntimeStore(
     },
     async countClusterActiveRooms() {
       return redis.scard(`${keyPrefix}rooms`);
+    },
+    async listClusterActiveRoomCodes() {
+      return (await redis.smembers(`${keyPrefix}rooms`)).sort();
     },
     async listClusterSessionsByRoom(roomCode: string) {
       const sessionIds = await redis.smembers(

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -62,6 +62,7 @@ export type RuntimeStore = {
   listNodeStatuses: (currentTime?: number) => Promise<ClusterNodeStatus[]>;
   purgeNodeStatus: (instanceId: string) => Promise<void>;
   countClusterActiveRooms: () => Promise<number>;
+  listClusterActiveRoomCodes: () => Promise<string[]>;
   listClusterSessionsByRoom: (roomCode: string) => Promise<Session[]>;
   listClusterSessions: () => Promise<Session[]>;
 };
@@ -271,6 +272,9 @@ export function createInMemoryRuntimeStore(
     },
     async countClusterActiveRooms() {
       return roomSessionIds.size;
+    },
+    async listClusterActiveRoomCodes() {
+      return Array.from(roomSessionIds.keys()).sort();
     },
     async listClusterSessionsByRoom(roomCode) {
       return Array.from(roomSessionIds.get(roomCode) ?? [])

--- a/server/test/admin-overview-service.test.ts
+++ b/server/test/admin-overview-service.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createAdminOverviewService } from "../src/admin/overview-service.js";
+import { createEventStore } from "../src/admin/event-store.js";
+import { createInMemoryRoomStore } from "../src/room-store.js";
+import { createInMemoryRuntimeStore } from "../src/runtime-store.js";
+import { getDefaultPersistenceConfig } from "../src/app.js";
+
+test("overview counts only persisted non-expired active rooms and reports orphan runtime indexes", async () => {
+  const now = Date.parse("2026-04-05T12:00:00.000Z");
+  const roomStore = createInMemoryRoomStore({ now: () => now });
+  const runtimeStore = createInMemoryRuntimeStore(() => now);
+  const persistenceConfig = {
+    ...getDefaultPersistenceConfig(),
+    instanceId: "instance-a",
+  };
+
+  await roomStore.createRoom({
+    code: "ROOM01",
+    joinToken: "token-1",
+    createdAt: now - 1_000,
+  });
+
+  runtimeStore.registerSession({
+    id: "session-1",
+    connectionState: "detached",
+    socket: null,
+    instanceId: "instance-a",
+    remoteAddress: null,
+    origin: null,
+    roomCode: "ROOM01",
+    memberId: "member-1",
+    displayName: "Alice",
+    memberToken: null,
+    joinedAt: now - 800,
+    invalidMessageCount: 0,
+    rateLimitState: {
+      roomCreate: { windowStart: 0, count: 0 },
+      roomJoin: { windowStart: 0, count: 0 },
+      videoShare: { windowStart: 0, count: 0 },
+      playbackUpdate: { tokens: 0, lastRefillAt: 0 },
+      syncRequest: { windowStart: 0, count: 0 },
+      syncPing: { tokens: 0, lastRefillAt: 0 },
+    },
+  });
+  runtimeStore.markSessionJoinedRoom("session-1", "ROOM01");
+
+  runtimeStore.registerSession({
+    id: "session-2",
+    connectionState: "detached",
+    socket: null,
+    instanceId: "instance-b",
+    remoteAddress: null,
+    origin: null,
+    roomCode: "GHOST1",
+    memberId: "member-2",
+    displayName: "Bob",
+    memberToken: null,
+    joinedAt: now - 500,
+    invalidMessageCount: 0,
+    rateLimitState: {
+      roomCreate: { windowStart: 0, count: 0 },
+      roomJoin: { windowStart: 0, count: 0 },
+      videoShare: { windowStart: 0, count: 0 },
+      playbackUpdate: { tokens: 0, lastRefillAt: 0 },
+      syncRequest: { windowStart: 0, count: 0 },
+      syncPing: { tokens: 0, lastRefillAt: 0 },
+    },
+  });
+  runtimeStore.markSessionJoinedRoom("session-2", "GHOST1");
+
+  const service = createAdminOverviewService({
+    instanceId: persistenceConfig.instanceId,
+    serviceName: "bili-syncplay-server",
+    serviceVersion: "0.9.2-test",
+    persistenceConfig,
+    roomStore,
+    runtimeStore,
+    eventStore: createEventStore(),
+    now: () => now,
+  });
+
+  const overview = await service.getOverview();
+  assert.equal(overview.runtime.activeRoomCount, 1);
+  assert.equal(overview.rooms.active, 1);
+  assert.equal(overview.rooms.orphanRuntimeCount, 1);
+});

--- a/server/test/event-store.test.ts
+++ b/server/test/event-store.test.ts
@@ -62,3 +62,32 @@ test("in-memory event store keeps query semantics through the global interface",
   assert.equal(evicted.total, 0);
   assert.notEqual(created.id, joined.id);
 });
+
+test("in-memory event store hides system events by default and can include them on demand", async () => {
+  const store = createEventStore();
+
+  await store.append({
+    event: "room_created",
+    timestamp: "2026-03-26T12:00:00.000Z",
+    data: { roomCode: "ROOM01", result: "ok" },
+  });
+  await store.append({
+    event: "room_event_bus_error",
+    timestamp: "2026-03-26T12:00:01.000Z",
+    data: { result: "error" },
+  });
+
+  const defaultView = await store.query({
+    page: 1,
+    pageSize: 10,
+  });
+  assert.equal(defaultView.total, 1);
+  assert.equal(defaultView.items[0]?.event, "room_created");
+
+  const fullView = await store.query({
+    includeSystem: true,
+    page: 1,
+    pageSize: 10,
+  });
+  assert.equal(fullView.total, 2);
+});

--- a/server/test/global-admin-app.test.ts
+++ b/server/test/global-admin-app.test.ts
@@ -104,6 +104,62 @@ test("global admin server starts without websocket runtime and serves admin endp
   }
 });
 
+test("global admin server resolves the package service version by default", async () => {
+  const server = await createGlobalAdminServer(
+    getDefaultSecurityConfig(),
+    getDefaultPersistenceConfig(),
+    {
+      adminConfig: {
+        username: "admin",
+        passwordHash: `sha256:${sha256Hex("secret-123")}`,
+        sessionSecret: "session-secret-123",
+        sessionTtlMs: 60_000,
+        role: "admin",
+        sessionStoreProvider: "memory",
+        eventStoreProvider: "memory",
+        auditStoreProvider: "memory",
+      },
+    },
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    server.httpServer.listen(0, "127.0.0.1", () => resolve());
+    server.httpServer.once("error", reject);
+  });
+
+  const address = server.httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to determine test server address.");
+  }
+
+  try {
+    const token = (
+      (
+        await requestJson(
+          `http://127.0.0.1:${address.port}`,
+          "/api/admin/auth/login",
+          {
+            method: "POST",
+            body: { username: "admin", password: "secret-123" },
+          },
+        )
+      ).body.data as { token: string }
+    ).token;
+    const overview = await requestJson(
+      `http://127.0.0.1:${address.port}`,
+      "/api/admin/overview",
+      { token },
+    );
+    assert.equal(overview.status, 200);
+    assert.match(
+      (overview.body.data as { service: { version: string } }).service.version,
+      /^\d+\.\d+\.\d+/,
+    );
+  } finally {
+    await server.close();
+  }
+});
+
 async function connectClient(wsUrl: string): Promise<WebSocket> {
   const socket = new WebSocket(wsUrl, { origin: ALLOWED_ORIGIN });
   await once(socket, "open");

--- a/server/test/redis-event-store.test.ts
+++ b/server/test/redis-event-store.test.ts
@@ -85,3 +85,45 @@ test("redis event store appends, trims, and queries events across store instance
     await storeB.close();
   }
 });
+
+test("redis event store hides system events by default and can include them on demand", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const streamKey = createStreamKey();
+  const store = await createRedisEventStore(REDIS_URL, {
+    streamKey,
+    maxLen: 10,
+  });
+
+  try {
+    await store.append({
+      event: "room_created",
+      timestamp: "2026-03-26T12:30:00.000Z",
+      data: { roomCode: "ROOM01", result: "ok" },
+    });
+    await store.append({
+      event: "runtime_index_reaper_failed",
+      timestamp: "2026-03-26T12:30:01.000Z",
+      data: { result: "error" },
+    });
+
+    const defaultView = await store.query({
+      page: 1,
+      pageSize: 10,
+    });
+    assert.equal(defaultView.total, 1);
+    assert.equal(defaultView.items[0]?.event, "room_created");
+
+    const fullView = await store.query({
+      includeSystem: true,
+      page: 1,
+      pageSize: 10,
+    });
+    assert.equal(fullView.total, 2);
+  } finally {
+    await store.close();
+  }
+});


### PR DESCRIPTION
## What changed

This PR fixes several misleading or noisy behaviors in the admin console and aligns the global admin view with cluster reality.

- clarifies global admin instance labeling so the control plane is no longer presented like a normal room node
- resolves the global admin service version from package metadata instead of showing `0.0.0-global-admin`
- aligns overview active-room counting with persisted non-expired rooms and reports ignored orphan runtime indexes
- hides noisy internal runtime events by default while keeping an opt-in switch for system events
- adds regression coverage for overview counting, event visibility, and global admin version behavior

## Why it changed

The admin console mixed control-plane metadata with room-node metadata, used inconsistent room-counting sources across pages, and surfaced internal maintenance events as if they were operator-facing signals. That made the console confusing during troubleshooting.

## Impact

Operators should now see:

- clearer global admin identity and version information
- overview room counts that better match the room management page
- a quieter default event stream with system-noise opt-in when deeper debugging is needed

## Root cause

The root issues were inconsistent data sources and missing presentation boundaries:

- global admin used a dedicated fallback identity/version that leaked directly into the UI
- overview used runtime indexes while room management used persisted room records
- all structured runtime events were treated as equally user-facing

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm test`

Note: the local worktree still has an unrelated uncommitted `package-lock.json` change, but it is not part of this branch commit.
