### PR TITLE
fix: wire redisNamespace through full config loading chain

### DIFF
--- a/server/src/config/persistence-config.ts
+++ b/server/src/config/persistence-config.ts
@@ -109,6 +109,8 @@ export function loadPersistenceConfig(
       defaults.roomCleanupIntervalMs,
     ),
     redisUrl: readTrimmedEnv(env, "REDIS_URL") ?? defaults.redisUrl,
+    redisNamespace:
+      readTrimmedEnv(env, "REDIS_NAMESPACE") ?? defaults.redisNamespace,
     instanceId: readTrimmedEnv(env, "INSTANCE_ID") ?? defaults.instanceId,
   };
 }

--- a/server/src/config/runtime-config.ts
+++ b/server/src/config/runtime-config.ts
@@ -46,6 +46,7 @@ type PersistenceConfigFile = {
   emptyRoomTtlMs?: number;
   roomCleanupIntervalMs?: number;
   redisUrl?: string;
+  redisNamespace?: string;
   instanceId?: string;
 };
 
@@ -213,6 +214,7 @@ function parseConfigFileShape(raw: unknown): ServerConfigFile {
       "emptyRoomTtlMs",
       "roomCleanupIntervalMs",
       "redisUrl",
+      "redisNamespace",
       "instanceId",
     ],
   );
@@ -341,6 +343,10 @@ function parseConfigFileShape(raw: unknown): ServerConfigFile {
           redisUrl: assertOptionalString(
             "persistence.redisUrl",
             persistence.redisUrl,
+          ),
+          redisNamespace: assertOptionalString(
+            "persistence.redisNamespace",
+            persistence.redisNamespace,
           ),
           instanceId: assertOptionalString(
             "persistence.instanceId",
@@ -523,6 +529,7 @@ export function configFileToEnv(fileConfig: ServerConfigFile): EnvSource {
     fileConfig.persistence?.roomCleanupIntervalMs,
   );
   setEnvValue(env, "REDIS_URL", fileConfig.persistence?.redisUrl);
+  setEnvValue(env, "REDIS_NAMESPACE", fileConfig.persistence?.redisNamespace);
   setEnvValue(env, "INSTANCE_ID", fileConfig.persistence?.instanceId);
   setEnvValue(env, "ADMIN_UI_DEMO_ENABLED", fileConfig.adminUi?.demoEnabled);
   setEnvValue(env, "GLOBAL_ADMIN_API_BASE_URL", fileConfig.adminUi?.apiBaseUrl);

--- a/server/test/runtime-config.test.ts
+++ b/server/test/runtime-config.test.ts
@@ -57,6 +57,7 @@ test("runtime config maps JSON file values through existing loaders", async () =
           nodeHeartbeatIntervalMs: 5000,
           nodeHeartbeatTtlMs: 15000,
           redisUrl: "redis://cache.internal:6379",
+          redisNamespace: "myapp",
           instanceId: "room-node-a",
         },
         adminUi: {
@@ -92,6 +93,7 @@ test("runtime config maps JSON file values through existing loaders", async () =
       config.persistenceConfig.redisUrl,
       "redis://cache.internal:6379",
     );
+    assert.equal(config.persistenceConfig.redisNamespace, "myapp");
     assert.equal(config.persistenceConfig.instanceId, "room-node-a");
     assert.deepEqual(config.adminUiConfig, {
       demoEnabled: true,
@@ -113,6 +115,7 @@ test("environment variables override config file values", async () => {
         persistence: {
           provider: "memory",
           instanceId: "room-node-a",
+          redisNamespace: "file-ns",
         },
       }),
       "utf8",
@@ -123,6 +126,7 @@ test("environment variables override config file values", async () => {
         PORT: "9002",
         TRUSTED_PROXY_ADDRESSES: "127.0.0.1, 127.0.0.2",
         ROOM_STORE_PROVIDER: "redis",
+        REDIS_NAMESPACE: "env-ns",
         INSTANCE_ID: "room-node-b",
       },
       { cwd: tempDir },
@@ -134,6 +138,7 @@ test("environment variables override config file values", async () => {
       "127.0.0.2",
     ]);
     assert.equal(config.persistenceConfig.provider, "redis");
+    assert.equal(config.persistenceConfig.redisNamespace, "env-ns");
     assert.equal(config.persistenceConfig.instanceId, "room-node-b");
   });
 });
@@ -216,6 +221,29 @@ test("runtime config reports invalid config field types", async () => {
       () => loadRuntimeConfig({}, { cwd: tempDir }),
       /security\.allowedOrigins/,
     );
+  });
+});
+
+test("redisNamespace is loaded from config file and passable through env override", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeFile(
+      join(tempDir, "server.config.json"),
+      JSON.stringify({
+        persistence: {
+          redisNamespace: "from-file",
+        },
+      }),
+      "utf8",
+    );
+
+    const configFromFile = await loadRuntimeConfig({}, { cwd: tempDir });
+    assert.equal(configFromFile.persistenceConfig.redisNamespace, "from-file");
+
+    const configFromEnv = await loadRuntimeConfig(
+      { REDIS_NAMESPACE: "from-env" },
+      { cwd: tempDir },
+    );
+    assert.equal(configFromEnv.persistenceConfig.redisNamespace, "from-env");
   });
 });
 


### PR DESCRIPTION
## Summary

- `PersistenceConfig.redisNamespace` 在所有 Redis 组件中已正确使用，但因配置加载链路有四处断点，始终无法通过配置文件或环境变量设置该值
- 修复 `PersistenceConfigFile` 类型、`allowedKeys` 白名单、`configFileToEnv()` 映射、`loadPersistenceConfig()` 读取四处断点
- 引入环境变量 `REDIS_NAMESPACE`，与现有 `REDIS_URL`、`INSTANCE_ID` 保持一致的加载模式

## Test plan

- [x] 现有测试全部通过（无回归）
- [x] 新增：从配置文件加载 `redisNamespace` 全链路测试
- [x] 新增：环境变量 `REDIS_NAMESPACE` 覆盖配置文件值测试
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` 全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)