### PR TITLE
fix: add runtime guard for popup action responses (#11)

### DIFF
--- a/extension/src/popup/popup-actions.ts
+++ b/extension/src/popup/popup-actions.ts
@@ -1,11 +1,9 @@
-import type {
-  BackgroundPopupState,
-  BackgroundPopupStateMessage,
-} from "../shared/messages";
+import type { BackgroundPopupState } from "../shared/messages";
 import { getUiLanguage, t } from "../shared/i18n";
 import { areSharedVideoUrlsEqual } from "../shared/url";
 import { parseInviteValue } from "./helpers";
 import { formatInviteDraft } from "./popup-render";
+import { sendPopupAction } from "./popup-port";
 import type { PopupUiStateStore } from "./popup-store";
 import {
   syncServerUrlDraft,
@@ -52,10 +50,8 @@ export function bindPopupActions(args: {
     void args.sendPopupLog("Create room button clicked");
     patchUiState({ localStatusMessage: null, roomActionPending: true });
     try {
-      const response = (await chrome.runtime.sendMessage({
-        type: "popup:create-room",
-      })) as BackgroundPopupStateMessage;
-      args.applyActionState(response.payload);
+      const state = await sendPopupAction({ type: "popup:create-room" });
+      args.applyActionState(state);
       void args.sendPopupLog("Create room message resolved");
       patchUiState({ roomActionPending: false });
     } finally {
@@ -99,10 +95,8 @@ export function bindPopupActions(args: {
       roomActionPending: true,
     });
     try {
-      const response = (await chrome.runtime.sendMessage({
-        type: "popup:leave-room",
-      })) as BackgroundPopupStateMessage;
-      args.applyActionState(response.payload);
+      const state = await sendPopupAction({ type: "popup:leave-room" });
+      args.applyActionState(state);
       void args.sendPopupLog("Leave room message resolved");
       patchUiState({ roomActionPending: false });
     } finally {
@@ -183,13 +177,13 @@ export function bindPopupActions(args: {
   const saveServerUrl = async () => {
     patchUiState({ localStatusMessage: null });
     const requestedServerUrl = args.serverUrlDraft.value.trim();
-    const response = (await chrome.runtime.sendMessage({
+    const state = await sendPopupAction({
       type: "popup:set-server-url",
       serverUrl: requestedServerUrl,
-    })) as BackgroundPopupStateMessage;
-    args.applyActionState(response.payload);
-    syncServerUrlDraft(args.serverUrlDraft, response.payload.serverUrl);
-    refs.serverUrlInput.value = response.payload.serverUrl;
+    });
+    args.applyActionState(state);
+    syncServerUrlDraft(args.serverUrlDraft, state.serverUrl);
+    refs.serverUrlInput.value = state.serverUrl;
     args.render();
   };
 
@@ -297,12 +291,12 @@ export function bindPopupActions(args: {
     void args.sendPopupLog(`${args2.reasonLabel} room=${invite.roomCode}`);
     patchUiState({ roomActionPending: true });
     try {
-      const response = (await chrome.runtime.sendMessage({
+      const state = await sendPopupAction({
         type: "popup:join-room",
         roomCode: invite.roomCode,
         joinToken: invite.joinToken,
-      })) as BackgroundPopupStateMessage;
-      args.applyActionState(response.payload);
+      });
+      args.applyActionState(state);
       void args.sendPopupLog(`${args2.resolvedLabel} room=${invite.roomCode}`);
       patchUiState({ roomActionPending: false });
     } finally {

--- a/extension/src/popup/popup-port.ts
+++ b/extension/src/popup/popup-port.ts
@@ -1,17 +1,32 @@
 import type {
   BackgroundPopupState,
-  BackgroundPopupStateMessage,
   BackgroundToPopupMessage,
+  PopupToBackgroundMessage,
 } from "../shared/messages";
+import { isBackgroundPopupStateMessage } from "../shared/messages";
 
 export async function queryPopupState(): Promise<BackgroundPopupState> {
-  const response = (await chrome.runtime.sendMessage({
+  const response: unknown = await chrome.runtime.sendMessage({
     type: "popup:get-state",
-  })) as BackgroundToPopupMessage;
-  if (response.type !== "background:state") {
-    throw new Error("Unexpected popup state response");
+  });
+  if (!isBackgroundPopupStateMessage(response)) {
+    throw new Error(
+      `Unexpected popup state response: ${JSON.stringify(response)}`,
+    );
   }
-  return (response as BackgroundPopupStateMessage).payload;
+  return response.payload;
+}
+
+export async function sendPopupAction(
+  message: PopupToBackgroundMessage,
+): Promise<BackgroundPopupState> {
+  const response: unknown = await chrome.runtime.sendMessage(message);
+  if (!isBackgroundPopupStateMessage(response)) {
+    throw new Error(
+      `Unexpected response to ${message.type}: ${JSON.stringify(response)}`,
+    );
+  }
+  return response.payload;
 }
 
 export function connectPopupStatePort(args: {

--- a/extension/src/shared/messages.ts
+++ b/extension/src/shared/messages.ts
@@ -74,6 +74,25 @@ export type BackgroundPopupConnected = Extract<
   { type: "background:popup-connected" }
 >["payload"];
 
+export function isBackgroundPopupStateMessage(
+  value: unknown,
+): value is BackgroundPopupStateMessage {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    (value as { type?: unknown }).type !== "background:state"
+  ) {
+    return false;
+  }
+  const payload = (value as { payload?: unknown }).payload;
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    typeof (payload as { connected?: unknown }).connected === "boolean" &&
+    typeof (payload as { serverUrl?: unknown }).serverUrl === "string"
+  );
+}
+
 export type BackgroundToContentMessage =
   | {
       type: "background:apply-room-state";

--- a/extension/test/popup-port.test.ts
+++ b/extension/test/popup-port.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isBackgroundPopupStateMessage } from "../src/shared/messages";
+
+const validStateMessage = {
+  type: "background:state",
+  payload: {
+    connected: true,
+    roomCode: "ROOM01",
+    joinToken: "join-token-123456",
+    memberId: "member-1",
+    displayName: "Alice",
+    roomState: null,
+    serverUrl: "ws://localhost:9999",
+    error: null,
+    pendingCreateRoom: false,
+    pendingJoinRoomCode: null,
+    retryInMs: null,
+    retryAttempt: 0,
+    retryAttemptMax: 5,
+    clockOffsetMs: null,
+    rttMs: null,
+    logs: [],
+  },
+};
+
+test("isBackgroundPopupStateMessage returns true for valid background:state message", () => {
+  assert.ok(isBackgroundPopupStateMessage(validStateMessage));
+});
+
+test("isBackgroundPopupStateMessage returns false for null", () => {
+  assert.equal(isBackgroundPopupStateMessage(null), false);
+});
+
+test("isBackgroundPopupStateMessage returns false for undefined", () => {
+  assert.equal(isBackgroundPopupStateMessage(undefined), false);
+});
+
+test("isBackgroundPopupStateMessage returns false for wrong type field", () => {
+  assert.equal(
+    isBackgroundPopupStateMessage({ type: "background:popup-connected" }),
+    false,
+  );
+});
+
+test("isBackgroundPopupStateMessage returns false for non-object", () => {
+  assert.equal(isBackgroundPopupStateMessage("background:state"), false);
+  assert.equal(isBackgroundPopupStateMessage(42), false);
+});
+
+test("isBackgroundPopupStateMessage returns false for object without type", () => {
+  assert.equal(isBackgroundPopupStateMessage({ payload: {} }), false);
+});
+
+test("isBackgroundPopupStateMessage returns false when payload is absent", () => {
+  assert.equal(
+    isBackgroundPopupStateMessage({ type: "background:state" }),
+    false,
+  );
+});
+
+test("isBackgroundPopupStateMessage returns false when payload is null", () => {
+  assert.equal(
+    isBackgroundPopupStateMessage({ type: "background:state", payload: null }),
+    false,
+  );
+});
+
+test("isBackgroundPopupStateMessage returns false when payload lacks required fields", () => {
+  assert.equal(
+    isBackgroundPopupStateMessage({ type: "background:state", payload: {} }),
+    false,
+  );
+  assert.equal(
+    isBackgroundPopupStateMessage({
+      type: "background:state",
+      payload: { connected: true },
+    }),
+    false,
+  );
+  assert.equal(
+    isBackgroundPopupStateMessage({
+      type: "background:state",
+      payload: { serverUrl: "ws://localhost" },
+    }),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary

- 新增 `isBackgroundPopupStateMessage` 类型守卫，同时校验 `type === "background:state"`、`payload` 为非空对象，以及 `connected: boolean` 和 `serverUrl: string` 两个关键字段
- 新增 `sendPopupAction` 统一封装函数，替换 `popup-actions.ts` 中 4 处不安全的 `as BackgroundPopupStateMessage` 直接断言（create-room、leave-room、join-room、set-server-url）
- 同步修复 `queryPopupState`（首屏初始查询路径），从旧的 cast + type 检查改为经过同一守卫验证，关闭 `payload` 缺失/null 情形的穿透漏洞
- 新增 9 个测试用例（`extension/test/popup-port.test.ts`），覆盖有效消息及各类畸形响应场景

Closes #11

## Test plan

- [ ] `npm run typecheck` 无报错
- [ ] `npm run lint` 无报错
- [ ] `npm test` 全部 166 个测试通过（含新增的 9 个守卫测试）
- [ ] 手动在弹窗中执行创建/加入/离开房间，行为与修复前一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)