### PR TITLE
[codex] Centralize runtime config schema to prevent config drift

### DIFF
--- a/server/src/config/admin-config.ts
+++ b/server/src/config/admin-config.ts
@@ -1,11 +1,11 @@
 import type { AdminRole } from "../admin/types.js";
 import { type AdminConfig, type AdminUiConfig } from "../app.js";
 import type { EnvSource } from "./env.js";
+import { parsePositiveIntegerEnv, readTrimmedEnv } from "./env.js";
 import {
-  parseBooleanEnv,
-  parsePositiveIntegerEnv,
-  readTrimmedEnv,
-} from "./env.js";
+  ADMIN_UI_CONFIG_FIELDS,
+  loadSectionConfigFromEnv,
+} from "./runtime-config-schema.js";
 
 function parseAdminSessionStoreProvider(
   name: string,
@@ -61,10 +61,13 @@ export function loadAdminConfig(env: EnvSource = process.env): AdminConfig {
 }
 
 export function loadAdminUiConfig(env: EnvSource = process.env): AdminUiConfig {
-  const apiBaseUrl = readTrimmedEnv(env, "GLOBAL_ADMIN_API_BASE_URL");
-  return {
-    demoEnabled: parseBooleanEnv(env, "ADMIN_UI_DEMO_ENABLED", false),
-    apiBaseUrl: apiBaseUrl && apiBaseUrl.length > 0 ? apiBaseUrl : undefined,
-    enabled: parseBooleanEnv(env, "GLOBAL_ADMIN_ENABLED", true),
-  };
+  return loadSectionConfigFromEnv(
+    env,
+    {
+      demoEnabled: false,
+      apiBaseUrl: undefined,
+      enabled: true,
+    },
+    ADMIN_UI_CONFIG_FIELDS,
+  );
 }

--- a/server/src/config/persistence-config.ts
+++ b/server/src/config/persistence-config.ts
@@ -1,116 +1,46 @@
 import { getDefaultPersistenceConfig, type PersistenceConfig } from "../app.js";
 import type { EnvSource } from "./env.js";
 import {
-  parseBooleanEnv,
-  parsePositiveIntegerEnv,
-  readTrimmedEnv,
-} from "./env.js";
-
-function parseProviderEnv(
-  env: EnvSource,
-  name: string,
-  fallback: PersistenceConfig["provider"],
-): PersistenceConfig["provider"] {
-  const rawValue = env[name];
-  if (rawValue === undefined || rawValue === "") {
-    return fallback;
-  }
-  if (rawValue === "memory" || rawValue === "redis") {
-    return rawValue;
-  }
-  throw new Error(`Environment variable ${name} must be "memory" or "redis".`);
-}
-
-function parseRoomEventBusProviderEnv(
-  env: EnvSource,
-  fallback: PersistenceConfig["roomEventBusProvider"],
-): PersistenceConfig["roomEventBusProvider"] {
-  const rawValue = env.ROOM_EVENT_BUS_PROVIDER;
-  if (rawValue === undefined || rawValue === "") {
-    return fallback;
-  }
-  if (rawValue === "none" || rawValue === "memory" || rawValue === "redis") {
-    return rawValue;
-  }
-  throw new Error(
-    'Environment variable ROOM_EVENT_BUS_PROVIDER must be "none", "memory", or "redis".',
-  );
-}
-
-function parseAdminCommandBusProviderEnv(
-  env: EnvSource,
-  fallback: PersistenceConfig["adminCommandBusProvider"],
-): PersistenceConfig["adminCommandBusProvider"] {
-  const rawValue = env.ADMIN_COMMAND_BUS_PROVIDER;
-  if (rawValue === undefined || rawValue === "") {
-    return fallback;
-  }
-  if (rawValue === "none" || rawValue === "memory" || rawValue === "redis") {
-    return rawValue;
-  }
-  throw new Error(
-    'Environment variable ADMIN_COMMAND_BUS_PROVIDER must be "none", "memory", or "redis".',
-  );
-}
+  loadSectionConfigFromEnv,
+  parseConfigEnvFieldValue,
+  PERSISTENCE_ADMIN_COMMAND_BUS_PROVIDER_FIELD,
+  PERSISTENCE_CONFIG_FIELDS,
+  PERSISTENCE_PROVIDER_FIELD,
+  PERSISTENCE_ROOM_EVENT_BUS_PROVIDER_FIELD,
+  PERSISTENCE_RUNTIME_STORE_PROVIDER_FIELD,
+} from "./runtime-config-schema.js";
 
 export function loadPersistenceConfig(
   env: EnvSource = process.env,
 ): PersistenceConfig {
   const defaults = getDefaultPersistenceConfig();
-  const provider = parseProviderEnv(
+  const provider = parseConfigEnvFieldValue(
+    PERSISTENCE_PROVIDER_FIELD,
     env,
-    "ROOM_STORE_PROVIDER",
     defaults.provider,
   );
-  const runtimeStoreProvider = parseProviderEnv(
+  const runtimeStoreProvider = parseConfigEnvFieldValue(
+    PERSISTENCE_RUNTIME_STORE_PROVIDER_FIELD,
     env,
-    "RUNTIME_STORE_PROVIDER",
     provider === "redis" ? "redis" : defaults.runtimeStoreProvider,
   );
-  const roomEventBusProvider = parseRoomEventBusProviderEnv(
+  const roomEventBusProvider = parseConfigEnvFieldValue(
+    PERSISTENCE_ROOM_EVENT_BUS_PROVIDER_FIELD,
     env,
     runtimeStoreProvider === "redis" ? "redis" : defaults.roomEventBusProvider,
   );
-  const adminCommandBusProvider = parseAdminCommandBusProviderEnv(
+  const adminCommandBusProvider = parseConfigEnvFieldValue(
+    PERSISTENCE_ADMIN_COMMAND_BUS_PROVIDER_FIELD,
     env,
     runtimeStoreProvider === "redis"
       ? "redis"
       : defaults.adminCommandBusProvider,
   );
 
-  return {
-    provider,
-    runtimeStoreProvider,
-    roomEventBusProvider,
-    adminCommandBusProvider,
-    nodeHeartbeatEnabled: parseBooleanEnv(
-      env,
-      "NODE_HEARTBEAT_ENABLED",
-      defaults.nodeHeartbeatEnabled,
-    ),
-    nodeHeartbeatIntervalMs: parsePositiveIntegerEnv(
-      env,
-      "NODE_HEARTBEAT_INTERVAL_MS",
-      defaults.nodeHeartbeatIntervalMs,
-    ),
-    nodeHeartbeatTtlMs: parsePositiveIntegerEnv(
-      env,
-      "NODE_HEARTBEAT_TTL_MS",
-      defaults.nodeHeartbeatTtlMs,
-    ),
-    emptyRoomTtlMs: parsePositiveIntegerEnv(
-      env,
-      "EMPTY_ROOM_TTL_MS",
-      defaults.emptyRoomTtlMs,
-    ),
-    roomCleanupIntervalMs: parsePositiveIntegerEnv(
-      env,
-      "ROOM_CLEANUP_INTERVAL_MS",
-      defaults.roomCleanupIntervalMs,
-    ),
-    redisUrl: readTrimmedEnv(env, "REDIS_URL") ?? defaults.redisUrl,
-    redisNamespace:
-      readTrimmedEnv(env, "REDIS_NAMESPACE") ?? defaults.redisNamespace,
-    instanceId: readTrimmedEnv(env, "INSTANCE_ID") ?? defaults.instanceId,
-  };
+  return loadSectionConfigFromEnv(env, defaults, PERSISTENCE_CONFIG_FIELDS, {
+    "persistence.provider": provider,
+    "persistence.runtimeStoreProvider": runtimeStoreProvider,
+    "persistence.roomEventBusProvider": roomEventBusProvider,
+    "persistence.adminCommandBusProvider": adminCommandBusProvider,
+  });
 }

--- a/server/src/config/runtime-config-schema.ts
+++ b/server/src/config/runtime-config-schema.ts
@@ -1,0 +1,417 @@
+import type {
+  AdminUiConfig,
+  PersistenceConfig,
+  SecurityConfig,
+} from "../types.js";
+import type { EnvSource } from "./env.js";
+import {
+  parseBooleanEnv,
+  parseCsvEnv,
+  parseIntegerEnv,
+  parsePositiveIntegerEnv,
+  readTrimmedEnv,
+} from "./env.js";
+
+type ConfigValueKind =
+  | "integer"
+  | "positiveInteger"
+  | "boolean"
+  | "string"
+  | "stringArray"
+  | "enum";
+
+export type ConfigField = {
+  path: readonly [string, ...string[]];
+  envName: string;
+  kind: ConfigValueKind;
+  enumValues?: readonly string[];
+};
+
+type SchemaNode = {
+  field?: ConfigField;
+  children: Map<string, SchemaNode>;
+};
+
+type ConfigObject = Record<string, unknown>;
+
+function createField(
+  path: ConfigField["path"],
+  envName: string,
+  kind: ConfigField["kind"],
+  enumValues?: readonly string[],
+): ConfigField {
+  return { path, envName, kind, enumValues };
+}
+
+export const SERVER_CONFIG_FIELDS = [
+  createField(["port"], "PORT", "integer"),
+  createField(["globalAdminPort"], "GLOBAL_ADMIN_PORT", "integer"),
+  createField(["security", "allowedOrigins"], "ALLOWED_ORIGINS", "stringArray"),
+  createField(
+    ["security", "allowMissingOriginInDev"],
+    "ALLOW_MISSING_ORIGIN_IN_DEV",
+    "boolean",
+  ),
+  createField(
+    ["security", "trustedProxyAddresses"],
+    "TRUSTED_PROXY_ADDRESSES",
+    "stringArray",
+  ),
+  createField(
+    ["security", "maxConnectionsPerIp"],
+    "MAX_CONNECTIONS_PER_IP",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "connectionAttemptsPerMinute"],
+    "CONNECTION_ATTEMPTS_PER_MINUTE",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "maxMembersPerRoom"],
+    "MAX_MEMBERS_PER_ROOM",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "maxMessageBytes"],
+    "MAX_MESSAGE_BYTES",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "invalidMessageCloseThreshold"],
+    "INVALID_MESSAGE_CLOSE_THRESHOLD",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "rateLimits", "roomCreatePerMinute"],
+    "RATE_LIMIT_ROOM_CREATE_PER_MINUTE",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "rateLimits", "roomJoinPerMinute"],
+    "RATE_LIMIT_ROOM_JOIN_PER_MINUTE",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "rateLimits", "videoSharePer10Seconds"],
+    "RATE_LIMIT_VIDEO_SHARE_PER_10_SECONDS",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "rateLimits", "playbackUpdatePerSecond"],
+    "RATE_LIMIT_PLAYBACK_UPDATE_PER_SECOND",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "rateLimits", "playbackUpdateBurst"],
+    "RATE_LIMIT_PLAYBACK_UPDATE_BURST",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "rateLimits", "syncRequestPer10Seconds"],
+    "RATE_LIMIT_SYNC_REQUEST_PER_10_SECONDS",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "rateLimits", "syncPingPerSecond"],
+    "RATE_LIMIT_SYNC_PING_PER_SECOND",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "rateLimits", "syncPingBurst"],
+    "RATE_LIMIT_SYNC_PING_BURST",
+    "positiveInteger",
+  ),
+  createField(["persistence", "provider"], "ROOM_STORE_PROVIDER", "enum", [
+    "memory",
+    "redis",
+  ]),
+  createField(
+    ["persistence", "runtimeStoreProvider"],
+    "RUNTIME_STORE_PROVIDER",
+    "enum",
+    ["memory", "redis"],
+  ),
+  createField(
+    ["persistence", "roomEventBusProvider"],
+    "ROOM_EVENT_BUS_PROVIDER",
+    "enum",
+    ["none", "memory", "redis"],
+  ),
+  createField(
+    ["persistence", "adminCommandBusProvider"],
+    "ADMIN_COMMAND_BUS_PROVIDER",
+    "enum",
+    ["none", "memory", "redis"],
+  ),
+  createField(
+    ["persistence", "nodeHeartbeatEnabled"],
+    "NODE_HEARTBEAT_ENABLED",
+    "boolean",
+  ),
+  createField(
+    ["persistence", "nodeHeartbeatIntervalMs"],
+    "NODE_HEARTBEAT_INTERVAL_MS",
+    "positiveInteger",
+  ),
+  createField(
+    ["persistence", "nodeHeartbeatTtlMs"],
+    "NODE_HEARTBEAT_TTL_MS",
+    "positiveInteger",
+  ),
+  createField(
+    ["persistence", "emptyRoomTtlMs"],
+    "EMPTY_ROOM_TTL_MS",
+    "positiveInteger",
+  ),
+  createField(
+    ["persistence", "roomCleanupIntervalMs"],
+    "ROOM_CLEANUP_INTERVAL_MS",
+    "positiveInteger",
+  ),
+  createField(["persistence", "redisUrl"], "REDIS_URL", "string"),
+  createField(["persistence", "redisNamespace"], "REDIS_NAMESPACE", "string"),
+  createField(["persistence", "instanceId"], "INSTANCE_ID", "string"),
+  createField(["adminUi", "demoEnabled"], "ADMIN_UI_DEMO_ENABLED", "boolean"),
+  createField(["adminUi", "apiBaseUrl"], "GLOBAL_ADMIN_API_BASE_URL", "string"),
+  createField(["adminUi", "enabled"], "GLOBAL_ADMIN_ENABLED", "boolean"),
+] as const satisfies readonly ConfigField[];
+
+export const SECURITY_CONFIG_FIELDS = SERVER_CONFIG_FIELDS.filter(
+  (field) => field.path[0] === "security",
+);
+export const PERSISTENCE_CONFIG_FIELDS = SERVER_CONFIG_FIELDS.filter(
+  (field) => field.path[0] === "persistence",
+);
+export const ADMIN_UI_CONFIG_FIELDS = SERVER_CONFIG_FIELDS.filter(
+  (field) => field.path[0] === "adminUi",
+);
+
+export const PERSISTENCE_PROVIDER_FIELD = PERSISTENCE_CONFIG_FIELDS.find(
+  (field) => field.path[1] === "provider",
+)!;
+export const PERSISTENCE_RUNTIME_STORE_PROVIDER_FIELD =
+  PERSISTENCE_CONFIG_FIELDS.find(
+    (field) => field.path[1] === "runtimeStoreProvider",
+  )!;
+export const PERSISTENCE_ROOM_EVENT_BUS_PROVIDER_FIELD =
+  PERSISTENCE_CONFIG_FIELDS.find(
+    (field) => field.path[1] === "roomEventBusProvider",
+  )!;
+export const PERSISTENCE_ADMIN_COMMAND_BUS_PROVIDER_FIELD =
+  PERSISTENCE_CONFIG_FIELDS.find(
+    (field) => field.path[1] === "adminCommandBusProvider",
+  )!;
+
+function createSchemaTree(fields: readonly ConfigField[]): SchemaNode {
+  const root: SchemaNode = { children: new Map() };
+
+  for (const field of fields) {
+    let node = root;
+    for (const segment of field.path) {
+      const child = node.children.get(segment) ?? { children: new Map() };
+      node.children.set(segment, child);
+      node = child;
+    }
+    node.field = field;
+  }
+
+  return root;
+}
+
+export const SERVER_CONFIG_SCHEMA_TREE = createSchemaTree(SERVER_CONFIG_FIELDS);
+
+export function getConfigValue(
+  source: ConfigObject | undefined,
+  path: readonly string[],
+): unknown {
+  let current: unknown = source;
+  for (const segment of path) {
+    if (typeof current !== "object" || current === null) {
+      return undefined;
+    }
+    current = (current as ConfigObject)[segment];
+  }
+  return current;
+}
+
+export function setConfigValue(
+  target: ConfigObject,
+  path: readonly string[],
+  value: unknown,
+): void {
+  let current = target;
+  for (const segment of path.slice(0, -1)) {
+    const next = current[segment];
+    if (typeof next !== "object" || next === null || Array.isArray(next)) {
+      current[segment] = {};
+    }
+    current = current[segment] as ConfigObject;
+  }
+  current[path[path.length - 1]!] = value;
+}
+
+function assertFiniteNumber(scope: string, value: unknown): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Config field "${scope}" must be a finite number.`);
+  }
+  return value;
+}
+
+function assertBoolean(scope: string, value: unknown): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "boolean") {
+    throw new Error(`Config field "${scope}" must be a boolean.`);
+  }
+  return value;
+}
+
+function assertString(scope: string, value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`Config field "${scope}" must be a string.`);
+  }
+  return value;
+}
+
+function assertStringArray(
+  scope: string,
+  value: unknown,
+): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => typeof entry !== "string")
+  ) {
+    throw new Error(`Config field "${scope}" must be an array of strings.`);
+  }
+  return value;
+}
+
+export function parseConfigFileFieldValue(
+  field: ConfigField,
+  scope: string,
+  value: unknown,
+): unknown {
+  switch (field.kind) {
+    case "integer":
+    case "positiveInteger":
+      return assertFiniteNumber(scope, value);
+    case "boolean":
+      return assertBoolean(scope, value);
+    case "string":
+    case "enum":
+      return assertString(scope, value);
+    case "stringArray":
+      return assertStringArray(scope, value);
+  }
+}
+
+export function parseConfigEnvFieldValue<T>(
+  field: ConfigField,
+  env: EnvSource,
+  fallback: T,
+): T {
+  switch (field.kind) {
+    case "integer":
+      return parseIntegerEnv(env, field.envName, fallback as number) as T;
+    case "positiveInteger":
+      return parsePositiveIntegerEnv(
+        env,
+        field.envName,
+        fallback as number,
+      ) as T;
+    case "boolean":
+      return parseBooleanEnv(env, field.envName, fallback as boolean) as T;
+    case "stringArray":
+      return parseCsvEnv(env, field.envName, fallback as string[]) as T;
+    case "string":
+      return (readTrimmedEnv(env, field.envName) ?? fallback) as T;
+    case "enum": {
+      const rawValue = env[field.envName];
+      if (rawValue === undefined || rawValue === "") {
+        return fallback;
+      }
+      if (field.enumValues?.includes(rawValue)) {
+        return rawValue as T;
+      }
+      throw new Error(
+        `Environment variable ${field.envName} must be one of ${field.enumValues
+          ?.map((value) => `"${value}"`)
+          .join(", ")}.`,
+      );
+    }
+  }
+}
+
+export function loadSectionConfigFromEnv<T extends ConfigObject>(
+  env: EnvSource,
+  defaults: T,
+  fields: readonly ConfigField[],
+  fallbackOverrides: Partial<Record<string, unknown>> = {},
+): T {
+  const config: ConfigObject = {};
+
+  for (const field of fields) {
+    const localPath = field.path.slice(1);
+    const fieldKey = field.path.join(".");
+    const fallback =
+      fieldKey in fallbackOverrides
+        ? fallbackOverrides[fieldKey]
+        : getConfigValue(defaults, localPath);
+
+    setConfigValue(
+      config,
+      localPath,
+      parseConfigEnvFieldValue(field, env, fallback),
+    );
+  }
+
+  return config as T;
+}
+
+export function getSectionFields(
+  sectionName: "security" | "persistence" | "adminUi",
+): readonly ConfigField[] {
+  switch (sectionName) {
+    case "security":
+      return SECURITY_CONFIG_FIELDS;
+    case "persistence":
+      return PERSISTENCE_CONFIG_FIELDS;
+    case "adminUi":
+      return ADMIN_UI_CONFIG_FIELDS;
+  }
+}
+
+export function getDefaultConfigSampleValue(field: ConfigField): unknown {
+  switch (field.kind) {
+    case "integer":
+      return field.path[0] === "port" ? 9001 : 9002;
+    case "positiveInteger":
+      return 7;
+    case "boolean":
+      return true;
+    case "string":
+      return `${field.envName.toLowerCase()}-sample`;
+    case "stringArray":
+      return [
+        `https://${field.envName.toLowerCase()}-a.example`,
+        `https://${field.envName.toLowerCase()}-b.example`,
+      ];
+    case "enum":
+      return field.enumValues?.[field.enumValues.length - 1];
+  }
+}
+
+export type SecurityConfigShape = SecurityConfig;
+export type PersistenceConfigShape = PersistenceConfig;
+export type AdminUiConfigShape = AdminUiConfig;

--- a/server/src/config/runtime-config.ts
+++ b/server/src/config/runtime-config.ts
@@ -10,6 +10,12 @@ import { loadAdminConfig, loadAdminUiConfig } from "./admin-config.js";
 import type { EnvSource } from "./env.js";
 import { parseIntegerEnv } from "./env.js";
 import { loadPersistenceConfig } from "./persistence-config.js";
+import {
+  getConfigValue,
+  parseConfigFileFieldValue,
+  SERVER_CONFIG_FIELDS,
+  SERVER_CONFIG_SCHEMA_TREE,
+} from "./runtime-config-schema.js";
 import { loadSecurityConfig } from "./security-config.js";
 
 type JsonObject = Record<string, unknown>;
@@ -92,61 +98,6 @@ function assertAllowedKeys(
   }
 }
 
-function assertOptionalNumber(
-  scope: string,
-  value: unknown,
-): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    throw new Error(`Config field "${scope}" must be a finite number.`);
-  }
-  return value;
-}
-
-function assertOptionalBoolean(
-  scope: string,
-  value: unknown,
-): boolean | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== "boolean") {
-    throw new Error(`Config field "${scope}" must be a boolean.`);
-  }
-  return value;
-}
-
-function assertOptionalString(
-  scope: string,
-  value: unknown,
-): string | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== "string") {
-    throw new Error(`Config field "${scope}" must be a string.`);
-  }
-  return value;
-}
-
-function assertOptionalStringArray(
-  scope: string,
-  value: unknown,
-): string[] | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (
-    !Array.isArray(value) ||
-    value.some((entry) => typeof entry !== "string")
-  ) {
-    throw new Error(`Config field "${scope}" must be an array of strings.`);
-  }
-  return value;
-}
-
 function parseOptionalObject<T extends JsonObject>(
   scope: string,
   value: unknown,
@@ -162,212 +113,55 @@ function parseOptionalObject<T extends JsonObject>(
   return value as T;
 }
 
-function parseConfigFileShape(raw: unknown): ServerConfigFile {
-  if (!isPlainObject(raw)) {
-    throw new Error("Config file root must be a JSON object.");
+function parseConfigNode(
+  node: typeof SERVER_CONFIG_SCHEMA_TREE,
+  scope: string,
+  value: unknown,
+): unknown {
+  if (node.field) {
+    return parseConfigFileFieldValue(node.field, scope, value);
   }
 
-  assertAllowedKeys("", raw, [
-    "port",
-    "globalAdminPort",
-    "security",
-    "persistence",
-    "adminUi",
-  ]);
+  if (scope.length === 0) {
+    if (!isPlainObject(value)) {
+      throw new Error("Config file root must be a JSON object.");
+    }
+  } else if (value === undefined) {
+    return undefined;
+  }
 
-  const security = parseOptionalObject<JsonObject>("security", raw.security, [
-    "allowedOrigins",
-    "allowMissingOriginInDev",
-    "trustedProxyAddresses",
-    "maxConnectionsPerIp",
-    "connectionAttemptsPerMinute",
-    "maxMembersPerRoom",
-    "maxMessageBytes",
-    "invalidMessageCloseThreshold",
-    "rateLimits",
-  ]);
-  const securityRateLimits = parseOptionalObject<JsonObject>(
-    "security.rateLimits",
-    security?.rateLimits,
-    [
-      "roomCreatePerMinute",
-      "roomJoinPerMinute",
-      "videoSharePer10Seconds",
-      "playbackUpdatePerSecond",
-      "playbackUpdateBurst",
-      "syncRequestPer10Seconds",
-      "syncPingPerSecond",
-      "syncPingBurst",
-    ],
-  );
-  const persistence = parseOptionalObject<JsonObject>(
-    "persistence",
-    raw.persistence,
-    [
-      "provider",
-      "runtimeStoreProvider",
-      "roomEventBusProvider",
-      "adminCommandBusProvider",
-      "nodeHeartbeatEnabled",
-      "nodeHeartbeatIntervalMs",
-      "nodeHeartbeatTtlMs",
-      "emptyRoomTtlMs",
-      "roomCleanupIntervalMs",
-      "redisUrl",
-      "redisNamespace",
-      "instanceId",
-    ],
-  );
-  const adminUi = parseOptionalObject<JsonObject>("adminUi", raw.adminUi, [
-    "demoEnabled",
-    "apiBaseUrl",
-    "enabled",
-  ]);
+  const objectValue =
+    scope.length === 0
+      ? (value as JsonObject)
+      : parseOptionalObject<JsonObject>(scope, value, [
+          ...node.children.keys(),
+        ]);
+  if (objectValue === undefined) {
+    return undefined;
+  }
 
-  return {
-    port: assertOptionalNumber("port", raw.port),
-    globalAdminPort: assertOptionalNumber(
-      "globalAdminPort",
-      raw.globalAdminPort,
-    ),
-    security: security
-      ? {
-          allowedOrigins: assertOptionalStringArray(
-            "security.allowedOrigins",
-            security.allowedOrigins,
-          ),
-          allowMissingOriginInDev: assertOptionalBoolean(
-            "security.allowMissingOriginInDev",
-            security.allowMissingOriginInDev,
-          ),
-          trustedProxyAddresses: assertOptionalStringArray(
-            "security.trustedProxyAddresses",
-            security.trustedProxyAddresses,
-          ),
-          maxConnectionsPerIp: assertOptionalNumber(
-            "security.maxConnectionsPerIp",
-            security.maxConnectionsPerIp,
-          ),
-          connectionAttemptsPerMinute: assertOptionalNumber(
-            "security.connectionAttemptsPerMinute",
-            security.connectionAttemptsPerMinute,
-          ),
-          maxMembersPerRoom: assertOptionalNumber(
-            "security.maxMembersPerRoom",
-            security.maxMembersPerRoom,
-          ),
-          maxMessageBytes: assertOptionalNumber(
-            "security.maxMessageBytes",
-            security.maxMessageBytes,
-          ),
-          invalidMessageCloseThreshold: assertOptionalNumber(
-            "security.invalidMessageCloseThreshold",
-            security.invalidMessageCloseThreshold,
-          ),
-          rateLimits: securityRateLimits
-            ? {
-                roomCreatePerMinute: assertOptionalNumber(
-                  "security.rateLimits.roomCreatePerMinute",
-                  securityRateLimits.roomCreatePerMinute,
-                ),
-                roomJoinPerMinute: assertOptionalNumber(
-                  "security.rateLimits.roomJoinPerMinute",
-                  securityRateLimits.roomJoinPerMinute,
-                ),
-                videoSharePer10Seconds: assertOptionalNumber(
-                  "security.rateLimits.videoSharePer10Seconds",
-                  securityRateLimits.videoSharePer10Seconds,
-                ),
-                playbackUpdatePerSecond: assertOptionalNumber(
-                  "security.rateLimits.playbackUpdatePerSecond",
-                  securityRateLimits.playbackUpdatePerSecond,
-                ),
-                playbackUpdateBurst: assertOptionalNumber(
-                  "security.rateLimits.playbackUpdateBurst",
-                  securityRateLimits.playbackUpdateBurst,
-                ),
-                syncRequestPer10Seconds: assertOptionalNumber(
-                  "security.rateLimits.syncRequestPer10Seconds",
-                  securityRateLimits.syncRequestPer10Seconds,
-                ),
-                syncPingPerSecond: assertOptionalNumber(
-                  "security.rateLimits.syncPingPerSecond",
-                  securityRateLimits.syncPingPerSecond,
-                ),
-                syncPingBurst: assertOptionalNumber(
-                  "security.rateLimits.syncPingBurst",
-                  securityRateLimits.syncPingBurst,
-                ),
-              }
-            : undefined,
-        }
-      : undefined,
-    persistence: persistence
-      ? {
-          provider: assertOptionalString(
-            "persistence.provider",
-            persistence.provider,
-          ) as PersistenceConfigFile["provider"],
-          runtimeStoreProvider: assertOptionalString(
-            "persistence.runtimeStoreProvider",
-            persistence.runtimeStoreProvider,
-          ) as PersistenceConfigFile["runtimeStoreProvider"],
-          roomEventBusProvider: assertOptionalString(
-            "persistence.roomEventBusProvider",
-            persistence.roomEventBusProvider,
-          ) as PersistenceConfigFile["roomEventBusProvider"],
-          adminCommandBusProvider: assertOptionalString(
-            "persistence.adminCommandBusProvider",
-            persistence.adminCommandBusProvider,
-          ) as PersistenceConfigFile["adminCommandBusProvider"],
-          nodeHeartbeatEnabled: assertOptionalBoolean(
-            "persistence.nodeHeartbeatEnabled",
-            persistence.nodeHeartbeatEnabled,
-          ),
-          nodeHeartbeatIntervalMs: assertOptionalNumber(
-            "persistence.nodeHeartbeatIntervalMs",
-            persistence.nodeHeartbeatIntervalMs,
-          ),
-          nodeHeartbeatTtlMs: assertOptionalNumber(
-            "persistence.nodeHeartbeatTtlMs",
-            persistence.nodeHeartbeatTtlMs,
-          ),
-          emptyRoomTtlMs: assertOptionalNumber(
-            "persistence.emptyRoomTtlMs",
-            persistence.emptyRoomTtlMs,
-          ),
-          roomCleanupIntervalMs: assertOptionalNumber(
-            "persistence.roomCleanupIntervalMs",
-            persistence.roomCleanupIntervalMs,
-          ),
-          redisUrl: assertOptionalString(
-            "persistence.redisUrl",
-            persistence.redisUrl,
-          ),
-          redisNamespace: assertOptionalString(
-            "persistence.redisNamespace",
-            persistence.redisNamespace,
-          ),
-          instanceId: assertOptionalString(
-            "persistence.instanceId",
-            persistence.instanceId,
-          ),
-        }
-      : undefined,
-    adminUi: adminUi
-      ? {
-          demoEnabled: assertOptionalBoolean(
-            "adminUi.demoEnabled",
-            adminUi.demoEnabled,
-          ),
-          apiBaseUrl: assertOptionalString(
-            "adminUi.apiBaseUrl",
-            adminUi.apiBaseUrl,
-          ),
-          enabled: assertOptionalBoolean("adminUi.enabled", adminUi.enabled),
-        }
-      : undefined,
-  };
+  if (scope.length === 0) {
+    assertAllowedKeys("", objectValue, [...node.children.keys()]);
+  }
+
+  const parsed: JsonObject = {};
+  for (const [key, childNode] of node.children) {
+    const childScope = scope ? `${scope}.${key}` : key;
+    const childValue = parseConfigNode(childNode, childScope, objectValue[key]);
+    if (childValue !== undefined) {
+      parsed[key] = childValue;
+    }
+  }
+
+  return parsed;
+}
+
+function parseConfigFileShape(raw: unknown): ServerConfigFile {
+  return parseConfigNode(
+    SERVER_CONFIG_SCHEMA_TREE,
+    "",
+    raw,
+  ) as ServerConfigFile;
 }
 
 async function readServerConfigFile(
@@ -416,124 +210,18 @@ function setEnvValue(
 
 export function configFileToEnv(fileConfig: ServerConfigFile): EnvSource {
   const env: EnvSource = {};
-
-  setEnvValue(env, "PORT", fileConfig.port);
-  setEnvValue(env, "GLOBAL_ADMIN_PORT", fileConfig.globalAdminPort);
-  setEnvValue(env, "ALLOWED_ORIGINS", fileConfig.security?.allowedOrigins);
-  setEnvValue(
-    env,
-    "ALLOW_MISSING_ORIGIN_IN_DEV",
-    fileConfig.security?.allowMissingOriginInDev,
-  );
-  setEnvValue(
-    env,
-    "TRUSTED_PROXY_ADDRESSES",
-    fileConfig.security?.trustedProxyAddresses,
-  );
-  setEnvValue(
-    env,
-    "MAX_CONNECTIONS_PER_IP",
-    fileConfig.security?.maxConnectionsPerIp,
-  );
-  setEnvValue(
-    env,
-    "CONNECTION_ATTEMPTS_PER_MINUTE",
-    fileConfig.security?.connectionAttemptsPerMinute,
-  );
-  setEnvValue(
-    env,
-    "MAX_MEMBERS_PER_ROOM",
-    fileConfig.security?.maxMembersPerRoom,
-  );
-  setEnvValue(env, "MAX_MESSAGE_BYTES", fileConfig.security?.maxMessageBytes);
-  setEnvValue(
-    env,
-    "INVALID_MESSAGE_CLOSE_THRESHOLD",
-    fileConfig.security?.invalidMessageCloseThreshold,
-  );
-  setEnvValue(
-    env,
-    "RATE_LIMIT_ROOM_CREATE_PER_MINUTE",
-    fileConfig.security?.rateLimits?.roomCreatePerMinute,
-  );
-  setEnvValue(
-    env,
-    "RATE_LIMIT_ROOM_JOIN_PER_MINUTE",
-    fileConfig.security?.rateLimits?.roomJoinPerMinute,
-  );
-  setEnvValue(
-    env,
-    "RATE_LIMIT_VIDEO_SHARE_PER_10_SECONDS",
-    fileConfig.security?.rateLimits?.videoSharePer10Seconds,
-  );
-  setEnvValue(
-    env,
-    "RATE_LIMIT_PLAYBACK_UPDATE_PER_SECOND",
-    fileConfig.security?.rateLimits?.playbackUpdatePerSecond,
-  );
-  setEnvValue(
-    env,
-    "RATE_LIMIT_PLAYBACK_UPDATE_BURST",
-    fileConfig.security?.rateLimits?.playbackUpdateBurst,
-  );
-  setEnvValue(
-    env,
-    "RATE_LIMIT_SYNC_REQUEST_PER_10_SECONDS",
-    fileConfig.security?.rateLimits?.syncRequestPer10Seconds,
-  );
-  setEnvValue(
-    env,
-    "RATE_LIMIT_SYNC_PING_PER_SECOND",
-    fileConfig.security?.rateLimits?.syncPingPerSecond,
-  );
-  setEnvValue(
-    env,
-    "RATE_LIMIT_SYNC_PING_BURST",
-    fileConfig.security?.rateLimits?.syncPingBurst,
-  );
-  setEnvValue(env, "ROOM_STORE_PROVIDER", fileConfig.persistence?.provider);
-  setEnvValue(
-    env,
-    "RUNTIME_STORE_PROVIDER",
-    fileConfig.persistence?.runtimeStoreProvider,
-  );
-  setEnvValue(
-    env,
-    "ROOM_EVENT_BUS_PROVIDER",
-    fileConfig.persistence?.roomEventBusProvider,
-  );
-  setEnvValue(
-    env,
-    "ADMIN_COMMAND_BUS_PROVIDER",
-    fileConfig.persistence?.adminCommandBusProvider,
-  );
-  setEnvValue(
-    env,
-    "NODE_HEARTBEAT_ENABLED",
-    fileConfig.persistence?.nodeHeartbeatEnabled,
-  );
-  setEnvValue(
-    env,
-    "NODE_HEARTBEAT_INTERVAL_MS",
-    fileConfig.persistence?.nodeHeartbeatIntervalMs,
-  );
-  setEnvValue(
-    env,
-    "NODE_HEARTBEAT_TTL_MS",
-    fileConfig.persistence?.nodeHeartbeatTtlMs,
-  );
-  setEnvValue(env, "EMPTY_ROOM_TTL_MS", fileConfig.persistence?.emptyRoomTtlMs);
-  setEnvValue(
-    env,
-    "ROOM_CLEANUP_INTERVAL_MS",
-    fileConfig.persistence?.roomCleanupIntervalMs,
-  );
-  setEnvValue(env, "REDIS_URL", fileConfig.persistence?.redisUrl);
-  setEnvValue(env, "REDIS_NAMESPACE", fileConfig.persistence?.redisNamespace);
-  setEnvValue(env, "INSTANCE_ID", fileConfig.persistence?.instanceId);
-  setEnvValue(env, "ADMIN_UI_DEMO_ENABLED", fileConfig.adminUi?.demoEnabled);
-  setEnvValue(env, "GLOBAL_ADMIN_API_BASE_URL", fileConfig.adminUi?.apiBaseUrl);
-  setEnvValue(env, "GLOBAL_ADMIN_ENABLED", fileConfig.adminUi?.enabled);
+  for (const field of SERVER_CONFIG_FIELDS) {
+    setEnvValue(
+      env,
+      field.envName,
+      getConfigValue(fileConfig as JsonObject, field.path) as
+        | string
+        | number
+        | boolean
+        | string[]
+        | undefined,
+    );
+  }
 
   return env;
 }

--- a/server/src/config/security-config.ts
+++ b/server/src/config/security-config.ts
@@ -1,99 +1,16 @@
 import { getDefaultSecurityConfig, type SecurityConfig } from "../app.js";
 import type { EnvSource } from "./env.js";
 import {
-  parseBooleanEnv,
-  parseCsvEnv,
-  parsePositiveIntegerEnv,
-} from "./env.js";
+  loadSectionConfigFromEnv,
+  SECURITY_CONFIG_FIELDS,
+} from "./runtime-config-schema.js";
 
 export function loadSecurityConfig(
   env: EnvSource = process.env,
 ): SecurityConfig {
-  const defaults = getDefaultSecurityConfig();
-
-  return {
-    ...defaults,
-    allowedOrigins: parseCsvEnv(
-      env,
-      "ALLOWED_ORIGINS",
-      defaults.allowedOrigins,
-    ),
-    allowMissingOriginInDev: parseBooleanEnv(
-      env,
-      "ALLOW_MISSING_ORIGIN_IN_DEV",
-      defaults.allowMissingOriginInDev,
-    ),
-    trustedProxyAddresses: parseCsvEnv(
-      env,
-      "TRUSTED_PROXY_ADDRESSES",
-      defaults.trustedProxyAddresses,
-    ),
-    maxConnectionsPerIp: parsePositiveIntegerEnv(
-      env,
-      "MAX_CONNECTIONS_PER_IP",
-      defaults.maxConnectionsPerIp,
-    ),
-    connectionAttemptsPerMinute: parsePositiveIntegerEnv(
-      env,
-      "CONNECTION_ATTEMPTS_PER_MINUTE",
-      defaults.connectionAttemptsPerMinute,
-    ),
-    maxMembersPerRoom: parsePositiveIntegerEnv(
-      env,
-      "MAX_MEMBERS_PER_ROOM",
-      defaults.maxMembersPerRoom,
-    ),
-    maxMessageBytes: parsePositiveIntegerEnv(
-      env,
-      "MAX_MESSAGE_BYTES",
-      defaults.maxMessageBytes,
-    ),
-    invalidMessageCloseThreshold: parsePositiveIntegerEnv(
-      env,
-      "INVALID_MESSAGE_CLOSE_THRESHOLD",
-      defaults.invalidMessageCloseThreshold,
-    ),
-    rateLimits: {
-      roomCreatePerMinute: parsePositiveIntegerEnv(
-        env,
-        "RATE_LIMIT_ROOM_CREATE_PER_MINUTE",
-        defaults.rateLimits.roomCreatePerMinute,
-      ),
-      roomJoinPerMinute: parsePositiveIntegerEnv(
-        env,
-        "RATE_LIMIT_ROOM_JOIN_PER_MINUTE",
-        defaults.rateLimits.roomJoinPerMinute,
-      ),
-      videoSharePer10Seconds: parsePositiveIntegerEnv(
-        env,
-        "RATE_LIMIT_VIDEO_SHARE_PER_10_SECONDS",
-        defaults.rateLimits.videoSharePer10Seconds,
-      ),
-      playbackUpdatePerSecond: parsePositiveIntegerEnv(
-        env,
-        "RATE_LIMIT_PLAYBACK_UPDATE_PER_SECOND",
-        defaults.rateLimits.playbackUpdatePerSecond,
-      ),
-      playbackUpdateBurst: parsePositiveIntegerEnv(
-        env,
-        "RATE_LIMIT_PLAYBACK_UPDATE_BURST",
-        defaults.rateLimits.playbackUpdateBurst,
-      ),
-      syncRequestPer10Seconds: parsePositiveIntegerEnv(
-        env,
-        "RATE_LIMIT_SYNC_REQUEST_PER_10_SECONDS",
-        defaults.rateLimits.syncRequestPer10Seconds,
-      ),
-      syncPingPerSecond: parsePositiveIntegerEnv(
-        env,
-        "RATE_LIMIT_SYNC_PING_PER_SECOND",
-        defaults.rateLimits.syncPingPerSecond,
-      ),
-      syncPingBurst: parsePositiveIntegerEnv(
-        env,
-        "RATE_LIMIT_SYNC_PING_BURST",
-        defaults.rateLimits.syncPingBurst,
-      ),
-    },
-  };
+  return loadSectionConfigFromEnv(
+    env,
+    getDefaultSecurityConfig(),
+    SECURITY_CONFIG_FIELDS,
+  );
 }

--- a/server/test/runtime-config.test.ts
+++ b/server/test/runtime-config.test.ts
@@ -3,7 +3,18 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { loadRuntimeConfig } from "../src/config/runtime-config.js";
+import {
+  getConfigValue,
+  getDefaultConfigSampleValue,
+  SERVER_CONFIG_FIELDS,
+  setConfigValue,
+} from "../src/config/runtime-config-schema.js";
+import {
+  configFileToEnv,
+  type RuntimeConfig,
+  loadRuntimeConfig,
+  type ServerConfigFile,
+} from "../src/config/runtime-config.js";
 
 async function withTempDir(
   run: (tempDir: string) => Promise<void>,
@@ -13,6 +24,40 @@ async function withTempDir(
     await run(tempDir);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+function buildConfigSample(): ServerConfigFile {
+  const config: Record<string, unknown> = {};
+  for (const field of SERVER_CONFIG_FIELDS) {
+    setConfigValue(config, field.path, getDefaultConfigSampleValue(field));
+  }
+  return config as ServerConfigFile;
+}
+
+function readRuntimeValue(
+  config: RuntimeConfig,
+  path: readonly [string, ...string[]],
+): unknown {
+  switch (path[0]) {
+    case "port":
+    case "globalAdminPort":
+      return getConfigValue(config as Record<string, unknown>, path);
+    case "security":
+      return getConfigValue(
+        config.securityConfig as Record<string, unknown>,
+        path.slice(1),
+      );
+    case "persistence":
+      return getConfigValue(
+        config.persistenceConfig as Record<string, unknown>,
+        path.slice(1),
+      );
+    case "adminUi":
+      return getConfigValue(
+        config.adminUiConfig as Record<string, unknown>,
+        path.slice(1),
+      );
   }
 }
 
@@ -267,5 +312,34 @@ test("runtime config resolves explicit config file path from env", async () => {
 
     assert.equal(config.port, 8787);
     assert.equal(config.globalAdminPort, 9123);
+  });
+});
+
+test("runtime config schema keeps file mapping and loaders in sync", async () => {
+  await withTempDir(async (tempDir) => {
+    const sampleConfig = buildConfigSample();
+    const configEnv = configFileToEnv(sampleConfig);
+
+    for (const field of SERVER_CONFIG_FIELDS) {
+      assert.ok(
+        configEnv[field.envName] !== undefined,
+        `missing env mapping for ${field.path.join(".")}`,
+      );
+    }
+
+    await writeFile(
+      join(tempDir, "server.config.json"),
+      JSON.stringify(sampleConfig),
+      "utf8",
+    );
+
+    const runtimeConfig = await loadRuntimeConfig({}, { cwd: tempDir });
+    for (const field of SERVER_CONFIG_FIELDS) {
+      assert.deepEqual(
+        readRuntimeValue(runtimeConfig, field.path),
+        getConfigValue(sampleConfig as Record<string, unknown>, field.path),
+        `runtime config drifted at ${field.path.join(".")}`,
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

This PR centralizes the server runtime config mapping into a single schema so config fields no longer need to be manually wired through multiple places.

## What Changed

- added a shared runtime config schema for server config fields, env names, and parsing kinds
- updated JSON config parsing and `configFileToEnv()` to derive from the shared schema
- updated `security`, `persistence`, and `adminUi` env loaders to read from the same schema-driven metadata
- added a regression test that verifies every schema field remains reachable from config file -> env mapping -> runtime config

## Why

Issue #10 points out that adding a config field currently requires editing multiple hand-written mappings. That duplication creates drift risk, and `redisNamespace` was already a concrete example of the problem.

By moving these mappings into one schema, new config fields now have a single source of truth and tests can catch missing links earlier.

## Impact

- lowers maintenance cost for future config additions
- reduces the chance of config fields being supported in one layer but forgotten in another
- keeps runtime behavior consistent while making the config pipeline easier to evolve

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run typecheck -w @bili-syncplay/server`

## Notes

- an unrelated untracked local file (`PROJECT_IMPROVEMENTS.zh-CN.md`) was intentionally left out of this PR.

Closes #10
