### PR TITLE
[codex] test: add protocol boundary acceptance coverage

### DIFF
--- a/packages/protocol/test/client-message.test.ts
+++ b/packages/protocol/test/client-message.test.ts
@@ -3,6 +3,21 @@ import assert from "node:assert/strict";
 import { isClientMessage } from "../src/index.js";
 
 const VALID_TOKEN = "valid-member-token-123";
+const DISPLAY_NAME_MAX_LENGTH = 32;
+const TITLE_MAX_LENGTH = 128;
+const URL_MAX_LENGTH = 512;
+
+function createBilibiliUrlWithExactLength(targetLength: number): string {
+  const baseUrl = "https://www.bilibili.com/video/BV1xx411c7mD?from=test&pad=";
+  const paddingLength = targetLength - baseUrl.length;
+
+  assert.ok(
+    paddingLength >= 0,
+    `target length ${targetLength} must be at least ${baseUrl.length}`,
+  );
+
+  return `${baseUrl}${"a".repeat(paddingLength)}`;
+}
 
 test("accepts a valid room:create message", () => {
   assert.equal(
@@ -37,6 +52,18 @@ test("rejects room:create when displayName is too long", () => {
       },
     }),
     false,
+  );
+});
+
+test("accepts room:create when displayName is exactly 32 characters", () => {
+  assert.equal(
+    isClientMessage({
+      type: "room:create",
+      payload: {
+        displayName: "a".repeat(DISPLAY_NAME_MAX_LENGTH),
+      },
+    }),
+    true,
   );
 });
 
@@ -105,6 +132,20 @@ test("accepts room:join with an optional memberToken for reconnect", () => {
   );
 });
 
+test("accepts room:join when displayName is exactly 32 characters", () => {
+  assert.equal(
+    isClientMessage({
+      type: "room:join",
+      payload: {
+        roomCode: "ABC123",
+        joinToken: VALID_TOKEN,
+        displayName: "a".repeat(DISPLAY_NAME_MAX_LENGTH),
+      },
+    }),
+    true,
+  );
+});
+
 test("accepts a valid profile:update message", () => {
   assert.equal(
     isClientMessage({
@@ -128,6 +169,19 @@ test("rejects profile:update when displayName is too long", () => {
       },
     }),
     false,
+  );
+});
+
+test("accepts profile:update when displayName is exactly 32 characters", () => {
+  assert.equal(
+    isClientMessage({
+      type: "profile:update",
+      payload: {
+        memberToken: VALID_TOKEN,
+        displayName: "a".repeat(DISPLAY_NAME_MAX_LENGTH),
+      },
+    }),
+    true,
   );
 });
 
@@ -177,6 +231,43 @@ test("rejects video:share when title is too long", () => {
       },
     }),
     false,
+  );
+});
+
+test("accepts video:share when title is exactly 128 characters", () => {
+  assert.equal(
+    isClientMessage({
+      type: "video:share",
+      payload: {
+        memberToken: VALID_TOKEN,
+        video: {
+          videoId: "BV1xx411c7mD",
+          url: "https://www.bilibili.com/video/BV1xx411c7mD",
+          title: "x".repeat(TITLE_MAX_LENGTH),
+        },
+      },
+    }),
+    true,
+  );
+});
+
+test("accepts video:share when url is exactly 512 characters", () => {
+  const exactBoundaryUrl = createBilibiliUrlWithExactLength(URL_MAX_LENGTH);
+
+  assert.equal(exactBoundaryUrl.length, URL_MAX_LENGTH);
+  assert.equal(
+    isClientMessage({
+      type: "video:share",
+      payload: {
+        memberToken: VALID_TOKEN,
+        video: {
+          videoId: "BV1xx411c7mD",
+          url: exactBoundaryUrl,
+          title: "Video",
+        },
+      },
+    }),
+    true,
   );
 });
 
@@ -311,6 +402,31 @@ test("accepts a valid playback:update message", () => {
           currentTime: 12,
           playState: "playing",
           syncIntent: "explicit-seek",
+          playbackRate: 1,
+          updatedAt: 1,
+          serverTime: 1,
+          actorId: "member-1",
+          seq: 1,
+        },
+      },
+    }),
+    true,
+  );
+});
+
+test("accepts playback:update when url is exactly 512 characters", () => {
+  const exactBoundaryUrl = createBilibiliUrlWithExactLength(URL_MAX_LENGTH);
+
+  assert.equal(exactBoundaryUrl.length, URL_MAX_LENGTH);
+  assert.equal(
+    isClientMessage({
+      type: "playback:update",
+      payload: {
+        memberToken: VALID_TOKEN,
+        playback: {
+          url: exactBoundaryUrl,
+          currentTime: 12,
+          playState: "playing",
           playbackRate: 1,
           updatedAt: 1,
           serverTime: 1,


### PR DESCRIPTION
## Summary

- add exact-boundary acceptance tests for protocol display name length limits
- add exact-boundary acceptance coverage for shared video title length
- add readable 512-character bilibili URL fixtures for `video:share` and `playback:update`

## Why

Issue #14 called out that the protocol layer already rejected overlong values, but it did not clearly protect the valid boundary cases for `DISPLAY_NAME_MAX_LENGTH = 32`, `TITLE_MAX_LENGTH = 128`, and `URL_MAX_LENGTH = 512`.

Without these acceptance tests, future guard refactors could accidentally reject legal inputs right at the limit.

Closes #14

## Impact

- improves protocol regression coverage around exact accepted limits
- makes the URL boundary case easier to read and reason about
- keeps existing rejection coverage for out-of-range values unchanged

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm test`