### PR TITLE
[codex] fix: recover leave room failure paths

### DIFF
--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -120,7 +120,20 @@ export function createMessageHandler(options: {
     }
     options.onRoomLeft?.(session, roomCode);
 
-    await publishRoomEvent("room_member_changed", roomCode);
+    try {
+      await publishRoomEvent("room_member_changed", roomCode);
+    } catch (error) {
+      logEvent("room_event_publish_failed", {
+        sessionId: session.id,
+        roomCode,
+        remoteAddress: session.remoteAddress,
+        origin: session.origin,
+        result: "error",
+        reason: "leave_room_broadcast_failed",
+        eventType: "room_member_changed",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   function handleRateLimitedMessage(

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -679,10 +679,14 @@ export function createRoomService(options: {
           : "leave_room_persist_failed";
 
       if (removal.removed) {
-        const roomStillExists = await roomStore
-          .getRoom(roomCode)
-          .then((room) => room !== null)
-          .catch(() => false);
+        let roomStillExists: boolean;
+        try {
+          roomStillExists = (await roomStore.getRoom(roomCode)) !== null;
+        } catch {
+          // Cannot determine room status — err on the side of restoring to
+          // avoid leaving runtime and persistence out of sync.
+          roomStillExists = true;
+        }
 
         if (roomStillExists) {
           await restoreLeaveState({

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -679,13 +679,28 @@ export function createRoomService(options: {
           : "leave_room_persist_failed";
 
       if (removal.removed) {
-        await restoreLeaveState({
-          session,
-          snapshot: sessionSnapshot,
-          roomCode,
-          reason,
-          error,
-        });
+        const roomStillExists = await roomStore
+          .getRoom(roomCode)
+          .then((room) => room !== null)
+          .catch(() => false);
+
+        if (roomStillExists) {
+          await restoreLeaveState({
+            session,
+            snapshot: sessionSnapshot,
+            roomCode,
+            reason,
+            error,
+          });
+        } else {
+          logEvent("room_leave_recovery_skipped", {
+            sessionId: session.id,
+            roomCode,
+            remoteAddress: session.remoteAddress,
+            origin: session.origin,
+            reason: "room_deleted",
+          });
+        }
       }
 
       logEvent("room_persist_failed", {

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -609,7 +609,11 @@ export function createRoomService(options: {
     const sessionSnapshot = snapshotJoinedSession(session);
     const removal = session.memberId
       ? runtimeStore.removeMember(roomCode, session.memberId, session)
-      : { room: runtimeStore.getRoom(roomCode), roomEmpty: false };
+      : {
+          room: runtimeStore.getRoom(roomCode),
+          roomEmpty: false,
+          removed: false,
+        };
     await runtimeStore.flush?.();
     clearSessionRoom(session);
 
@@ -674,13 +678,15 @@ export function createRoomService(options: {
           ? error.details.reason
           : "leave_room_persist_failed";
 
-      await restoreLeaveState({
-        session,
-        snapshot: sessionSnapshot,
-        roomCode,
-        reason,
-        error,
-      });
+      if (removal.removed) {
+        await restoreLeaveState({
+          session,
+          snapshot: sessionSnapshot,
+          roomCode,
+          reason,
+          error,
+        });
+      }
 
       logEvent("room_persist_failed", {
         sessionId: session.id,

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -75,6 +75,13 @@ type JoinIdentity = {
   memberToken: string;
 };
 
+type JoinedSessionSnapshot = {
+  roomCode: string;
+  memberId: string;
+  memberToken: string;
+  joinedAt: number | null;
+};
+
 export function createRoomService(options: {
   config: SecurityConfig;
   persistence: PersistenceConfig;
@@ -177,6 +184,63 @@ export function createRoomService(options: {
     session.memberId = null;
     session.memberToken = null;
     session.joinedAt = null;
+  }
+
+  function snapshotJoinedSession(
+    session: Session,
+  ): JoinedSessionSnapshot | null {
+    if (!session.roomCode || !session.memberId || !session.memberToken) {
+      return null;
+    }
+
+    return {
+      roomCode: session.roomCode,
+      memberId: session.memberId,
+      memberToken: session.memberToken,
+      joinedAt: session.joinedAt,
+    };
+  }
+
+  function restoreJoinedSession(
+    session: Session,
+    snapshot: JoinedSessionSnapshot,
+  ): void {
+    session.roomCode = snapshot.roomCode;
+    session.memberId = snapshot.memberId;
+    session.memberToken = snapshot.memberToken;
+    session.joinedAt = snapshot.joinedAt;
+  }
+
+  async function restoreLeaveState(args: {
+    session: Session;
+    snapshot: JoinedSessionSnapshot | null;
+    roomCode: string;
+    reason: string;
+    error?: unknown;
+  }): Promise<void> {
+    if (!args.snapshot) {
+      return;
+    }
+
+    runtimeStore.addMember(
+      args.snapshot.roomCode,
+      args.snapshot.memberId,
+      args.session,
+      args.snapshot.memberToken,
+    );
+    restoreJoinedSession(args.session, args.snapshot);
+    await runtimeStore.flush?.();
+
+    logEvent("room_leave_recovered", {
+      sessionId: args.session.id,
+      roomCode: args.roomCode,
+      remoteAddress: args.session.remoteAddress,
+      origin: args.session.origin,
+      result: "ok",
+      reason: args.reason,
+      error:
+        args.error instanceof Error ? args.error.message : String(args.error),
+    });
   }
 
   async function resolveRoom(code: string): Promise<PersistedRoom | null> {
@@ -542,17 +606,58 @@ export function createRoomService(options: {
     }
 
     const roomCode = session.roomCode;
+    const sessionSnapshot = snapshotJoinedSession(session);
     const removal = session.memberId
       ? runtimeStore.removeMember(roomCode, session.memberId, session)
       : { room: runtimeStore.getRoom(roomCode), roomEmpty: false };
+    await runtimeStore.flush?.();
     clearSessionRoom(session);
 
-    const persistedRoom = await resolveRoom(roomCode);
-    if (!persistedRoom) {
-      return { room: null };
-    }
+    try {
+      const persistedRoom = await resolveRoom(roomCode);
+      if (!persistedRoom) {
+        return { room: null };
+      }
 
-    if (!removal.roomEmpty) {
+      if (!removal.roomEmpty) {
+        logEvent("room_left", {
+          sessionId: session.id,
+          roomCode,
+          remoteAddress: session.remoteAddress,
+          origin: session.origin,
+          result: "ok",
+        });
+        return { room: persistedRoom };
+      }
+
+      const expiresAt = now() + persistence.emptyRoomTtlMs;
+      const updatedRoom = await withVersionRetry(roomCode, async (room) => {
+        const result = await roomStore.updateRoom(roomCode, room.version, {
+          expiresAt,
+          lastActiveAt: now(),
+        });
+        if (!result.ok) {
+          return null;
+        }
+        return result.room;
+      });
+
+      if (!updatedRoom) {
+        throw new RoomServiceError(
+          "internal_error",
+          INTERNAL_SERVER_ERROR_MESSAGE,
+          "internal_error",
+          { roomCode, reason: "leave_room_expiry_schedule_failed" },
+        );
+      }
+
+      logEvent("room_expiry_scheduled", {
+        roomCode,
+        version: updatedRoom.version,
+        expiresAt,
+        result: "ok",
+      });
+
       logEvent("room_left", {
         sessionId: session.id,
         roomCode,
@@ -560,39 +665,45 @@ export function createRoomService(options: {
         origin: session.origin,
         result: "ok",
       });
-      return { room: persistedRoom };
-    }
 
-    const expiresAt = now() + persistence.emptyRoomTtlMs;
-    const updatedRoom = await withVersionRetry(roomCode, async (room) => {
-      const result = await roomStore.updateRoom(roomCode, room.version, {
-        expiresAt,
-        lastActiveAt: now(),
-      });
-      if (!result.ok) {
-        return null;
-      }
-      return result.room;
-    });
+      return { room: updatedRoom };
+    } catch (error) {
+      const reason =
+        error instanceof RoomServiceError &&
+        typeof error.details.reason === "string"
+          ? error.details.reason
+          : "leave_room_persist_failed";
 
-    if (updatedRoom) {
-      logEvent("room_expiry_scheduled", {
+      await restoreLeaveState({
+        session,
+        snapshot: sessionSnapshot,
         roomCode,
-        version: updatedRoom.version,
-        expiresAt,
-        result: "ok",
+        reason,
+        error,
       });
+
+      logEvent("room_persist_failed", {
+        sessionId: session.id,
+        roomCode,
+        remoteAddress: session.remoteAddress,
+        origin: session.origin,
+        provider: persistence.provider,
+        result: "error",
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      if (error instanceof RoomServiceError) {
+        throw error;
+      }
+
+      throw new RoomServiceError(
+        "internal_error",
+        INTERNAL_SERVER_ERROR_MESSAGE,
+        "internal_error",
+        { roomCode, reason },
+      );
     }
-
-    logEvent("room_left", {
-      sessionId: session.id,
-      roomCode,
-      remoteAddress: session.remoteAddress,
-      origin: session.origin,
-      result: "ok",
-    });
-
-    return { room: updatedRoom };
   }
 
   return {

--- a/server/src/runtime-store-state.ts
+++ b/server/src/runtime-store-state.ts
@@ -125,11 +125,11 @@ export function removeMemberFromRoom(
     }
   }
 
-  room.members.delete(memberId);
+  const existed = room.members.delete(memberId);
   room.memberTokens.delete(memberId);
   const roomEmpty = room.members.size === 0;
   if (roomEmpty) {
     rooms.delete(code);
   }
-  return { room: roomEmpty ? null : room, roomEmpty, removed: true };
+  return { room: roomEmpty ? null : room, roomEmpty, removed: existed };
 }

--- a/server/src/runtime-store-state.ts
+++ b/server/src/runtime-store-state.ts
@@ -112,16 +112,16 @@ export function removeMemberFromRoom(
   code: string,
   memberId: string,
   session?: Session,
-): { room: ActiveRoom | null; roomEmpty: boolean } {
+): { room: ActiveRoom | null; roomEmpty: boolean; removed: boolean } {
   const room = rooms.get(code) ?? null;
   if (!room) {
-    return { room: null, roomEmpty: true };
+    return { room: null, roomEmpty: true, removed: false };
   }
 
   if (session) {
     const currentSession = room.members.get(memberId);
     if (currentSession && currentSession !== session) {
-      return { room, roomEmpty: false };
+      return { room, roomEmpty: false, removed: false };
     }
   }
 
@@ -131,5 +131,5 @@ export function removeMemberFromRoom(
   if (roomEmpty) {
     rooms.delete(code);
   }
-  return { room: roomEmpty ? null : room, roomEmpty };
+  return { room: roomEmpty ? null : room, roomEmpty, removed: true };
 }

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -57,7 +57,7 @@ export type RuntimeStore = {
     code: string,
     memberId: string,
     session?: Session,
-  ) => { room: ActiveRoom | null; roomEmpty: boolean };
+  ) => { room: ActiveRoom | null; roomEmpty: boolean; removed: boolean };
   deleteRoom: (code: string) => void;
   heartbeatNode: (status: ClusterNodeStatus) => Promise<void>;
   listNodeStatuses: (currentTime?: number) => Promise<ClusterNodeStatus[]>;

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -228,3 +228,79 @@ test("message handler skips room state publish when playback update is ignored",
 
   assert.deepEqual(published, []);
 });
+
+test("message handler keeps leave completed when member change publish fails", async () => {
+  const events: string[] = [];
+  const left: string[] = [];
+  const session = createSession("member-1", {
+    roomCode: "ROOM01",
+    memberId: "member-1",
+    memberToken: "member-token-1",
+  });
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession(currentSession) {
+        currentSession.roomCode = null;
+        currentSession.memberId = null;
+        currentSession.memberToken = null;
+        return {
+          room: {
+            code: "ROOM01",
+            joinToken: "join-token-1",
+            createdAt: 1,
+            ownerMemberId: "member-1",
+            ownerDisplayName: "Alice",
+            sharedVideo: null,
+            playback: null,
+            version: 1,
+            lastActiveAt: 1,
+            expiresAt: null,
+          },
+        };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent(event) {
+      events.push(event);
+    },
+    send() {},
+    sendError() {
+      throw new Error("sendError should not be called");
+    },
+    async publishRoomEvent() {
+      throw new Error("publish failed");
+    },
+    instanceId: "node-a",
+    onRoomLeft(_session, roomCode) {
+      left.push(roomCode);
+    },
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:leave",
+    payload: { memberToken: "member-token-1" },
+  });
+
+  assert.equal(session.roomCode, null);
+  assert.deepEqual(left, ["ROOM01"]);
+  assert.ok(events.includes("room_event_publish_failed"));
+});

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -261,6 +261,86 @@ test("room service does not recover stale session leave state when member remova
   );
 });
 
+test("room service skips leave recovery when room is concurrently deleted", async () => {
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const activeRooms = createActiveRoomRegistry();
+  const events: Array<{ event: string; data: Record<string, unknown> }> = [];
+  const baseService = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: {
+      ...getDefaultPersistenceConfig(),
+      emptyRoomTtlMs: 5_000,
+    },
+    roomStore,
+    activeRooms,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent(event, data) {
+      events.push({ event, data });
+    },
+    now: () => 1_000,
+    createRoomCode: () => "ROOM01",
+  });
+
+  const owner = createSession("owner");
+  await baseService.createRoomForSession(owner, "Alice");
+
+  // Make updateRoom fail on expiry writes and delete the room from persistence
+  // after the failed attempt to simulate concurrent deletion before the
+  // catch block's existence check.
+  const concurrentDeleteRoomStore = {
+    ...roomStore,
+    async updateRoom(code, expectedVersion, patch) {
+      if (patch.expiresAt !== undefined) {
+        // Delete the room so the catch block's getRoom check sees the room is gone.
+        await roomStore.deleteRoom(code);
+        throw new Error("expiry write failed");
+      }
+      return roomStore.updateRoom(code, expectedVersion, patch);
+    },
+  };
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: {
+      ...getDefaultPersistenceConfig(),
+      emptyRoomTtlMs: 5_000,
+    },
+    roomStore: concurrentDeleteRoomStore,
+    activeRooms,
+    generateToken: (() => {
+      let id = 2;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent(event, data) {
+      events.push({ event, data });
+    },
+    now: () => 1_000,
+  });
+
+  await assert.rejects(
+    service.leaveRoomForSession(owner),
+    (error: unknown) =>
+      error instanceof Error && error.message === "Internal server error.",
+  );
+
+  // Session should NOT be restored since the room is gone
+  assert.equal(owner.roomCode, null);
+  assert.equal(owner.memberId, null);
+  assert.ok(!events.some((entry) => entry.event === "room_leave_recovered"));
+  assert.ok(
+    events.some((entry) => entry.event === "room_leave_recovery_skipped"),
+  );
+  assert.ok(
+    events.some(
+      (entry) =>
+        entry.event === "room_persist_failed" &&
+        entry.data.reason === "leave_room_persist_failed",
+    ),
+  );
+});
+
 test("room service clears sync intent when sharing a new video with playback", async () => {
   const currentTime = 1_000;
   const roomStore = createInMemoryRoomStore({ now: () => currentTime });

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -183,6 +183,84 @@ test("room service restores member state when empty-room expiry scheduling fails
   );
 });
 
+test("room service does not recover stale session leave state when member removal is skipped", async () => {
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const activeRooms = createActiveRoomRegistry();
+  const events: Array<{ event: string; data: Record<string, unknown> }> = [];
+  const baseService = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: {
+      ...getDefaultPersistenceConfig(),
+      emptyRoomTtlMs: 5_000,
+    },
+    roomStore,
+    activeRooms,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent(event, data) {
+      events.push({ event, data });
+    },
+    now: () => 1_000,
+    createRoomCode: () => "ROOM01",
+  });
+  const failingRoomStore = {
+    ...roomStore,
+    async getRoom() {
+      throw new Error("transient read failure");
+    },
+  };
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: {
+      ...getDefaultPersistenceConfig(),
+      emptyRoomTtlMs: 5_000,
+    },
+    roomStore: failingRoomStore,
+    activeRooms,
+    generateToken: (() => {
+      let id = 2;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent(event, data) {
+      events.push({ event, data });
+    },
+    now: () => 1_000,
+  });
+
+  const staleSession = createSession("owner");
+  const created = await baseService.createRoomForSession(staleSession, "Alice");
+  const replacementSession = createSession("owner-replaced");
+  activeRooms.addMember(
+    created.room.code,
+    "owner",
+    replacementSession,
+    created.memberToken,
+  );
+
+  await assert.rejects(
+    service.leaveRoomForSession(staleSession),
+    (error: unknown) =>
+      error instanceof Error && error.message === "Internal server error.",
+  );
+
+  assert.equal(staleSession.roomCode, null);
+  assert.equal(staleSession.memberId, null);
+  assert.equal(
+    activeRooms.getRoom(created.room.code)?.members.get("owner"),
+    replacementSession,
+  );
+  assert.ok(!events.some((entry) => entry.event === "room_leave_recovered"));
+  assert.ok(
+    events.some(
+      (entry) =>
+        entry.event === "room_persist_failed" &&
+        entry.data.reason === "leave_room_persist_failed",
+    ),
+  );
+});
+
 test("room service clears sync intent when sharing a new video with playback", async () => {
   const currentTime = 1_000;
   const roomStore = createInMemoryRoomStore({ now: () => currentTime });

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -102,6 +102,87 @@ test("room service keeps empty rooms for TTL and allows rejoin before expiry", a
   assert.ok(joiner.memberToken);
 });
 
+test("room service restores member state when empty-room expiry scheduling fails", async () => {
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const activeRooms = createActiveRoomRegistry();
+  const events: Array<{ event: string; data: Record<string, unknown> }> = [];
+  const baseService = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: {
+      ...getDefaultPersistenceConfig(),
+      emptyRoomTtlMs: 5_000,
+    },
+    roomStore,
+    activeRooms,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent(event, data) {
+      events.push({ event, data });
+    },
+    now: () => 1_000,
+    createRoomCode: () => "ROOM01",
+  });
+  const failingRoomStore = {
+    ...roomStore,
+    async updateRoom(code, expectedVersion, patch) {
+      if (patch.expiresAt !== undefined) {
+        throw new Error("expiry write failed");
+      }
+      return roomStore.updateRoom(code, expectedVersion, patch);
+    },
+  };
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: {
+      ...getDefaultPersistenceConfig(),
+      emptyRoomTtlMs: 5_000,
+    },
+    roomStore: failingRoomStore,
+    activeRooms,
+    generateToken: (() => {
+      let id = 2;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent(event, data) {
+      events.push({ event, data });
+    },
+    now: () => 1_000,
+  });
+
+  const owner = createSession("owner");
+  const created = await baseService.createRoomForSession(owner, "Alice");
+
+  await assert.rejects(
+    service.leaveRoomForSession(owner),
+    (error: unknown) =>
+      error instanceof Error && error.message === "Internal server error.",
+  );
+
+  assert.equal(owner.roomCode, created.room.code);
+  assert.equal(owner.memberId, "owner");
+  assert.equal(owner.memberToken, created.memberToken);
+  assert.equal(activeRooms.getRoom(created.room.code)?.members.size, 1);
+
+  const persisted = await roomStore.getRoom(created.room.code);
+  assert.equal(persisted?.expiresAt, null);
+  assert.ok(
+    events.some(
+      (entry) =>
+        entry.event === "room_leave_recovered" &&
+        entry.data.reason === "leave_room_persist_failed",
+    ),
+  );
+  assert.ok(
+    events.some(
+      (entry) =>
+        entry.event === "room_persist_failed" &&
+        entry.data.reason === "leave_room_persist_failed",
+    ),
+  );
+});
+
 test("room service clears sync intent when sharing a new video with playback", async () => {
   const currentTime = 1_000;
   const roomStore = createInMemoryRoomStore({ now: () => currentTime });


### PR DESCRIPTION
## Summary
- recover room membership and session state when empty-room leave finalization fails
- degrade leave-room member-change broadcast failures to structured logs so the leave still completes
- add regression coverage for both recovery and broadcast-failure paths

## Why
Issue #13 points out that `leaveRoom` had no recovery strategy when persistence or finalization failed. That could leave the runtime state half-finished or keep empty-room expiry unscheduled, and a broadcast failure could surface as a failed leave even after local cleanup had already happened.

## Impact
Leaving a room is now more resilient:
- empty-room expiry scheduling failures restore the member/session state instead of silently drifting
- failed leave broadcasts no longer undo a successful local leave
- operators get explicit logs for recovery and publish failures

## Root Cause
The previous flow removed the member from runtime state and cleared the session before empty-room expiry scheduling finished, and it treated leave-room event publishing as a hard failure.

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm test`

Closes #13