### PR TITLE
refactor: thin entry files (fix #12)

### DIFF
--- a/extension/src/background/chrome-runtime-bus.ts
+++ b/extension/src/background/chrome-runtime-bus.ts
@@ -1,0 +1,54 @@
+import type {
+  ContentToBackgroundMessage,
+  PopupToBackgroundMessage,
+} from "../shared/messages";
+
+type RuntimeMessage = PopupToBackgroundMessage | ContentToBackgroundMessage;
+
+export function registerBackgroundListeners(args: {
+  getBootstrapStatus: () => "pending" | "ready" | "failed";
+  bootstrapPendingMessage: string;
+  bootstrapFailedMessage: string;
+  popupStateController: {
+    popupState: () => unknown;
+    attachPort: (port: chrome.runtime.Port) => void;
+  };
+  messageController: {
+    handleRuntimeMessage: (
+      message: RuntimeMessage,
+      sender: chrome.runtime.MessageSender,
+      sendResponse: (response?: unknown) => void,
+    ) => Promise<void>;
+  };
+}): void {
+  chrome.runtime.onMessage.addListener(
+    (message: RuntimeMessage, sender, sendResponse) => {
+      const bootstrapStatus = args.getBootstrapStatus();
+      if (bootstrapStatus !== "ready") {
+        const error =
+          bootstrapStatus === "failed"
+            ? args.bootstrapFailedMessage
+            : args.bootstrapPendingMessage;
+        if (message.type === "popup:get-state") {
+          sendResponse(args.popupStateController.popupState());
+        } else {
+          sendResponse({ ok: false, error });
+        }
+        return true;
+      }
+      void args.messageController.handleRuntimeMessage(
+        message,
+        sender,
+        sendResponse,
+      );
+      return true;
+    },
+  );
+
+  chrome.runtime.onConnect.addListener((port) => {
+    if (port.name !== "popup-state") {
+      return;
+    }
+    args.popupStateController.attachPort(port);
+  });
+}

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -2,27 +2,21 @@ import {
   type ClientMessage,
   type ServerMessage,
 } from "@bili-syncplay/protocol";
-import type {
-  BackgroundToContentMessage,
-  ContentToBackgroundMessage,
-  PopupToBackgroundMessage,
-} from "../shared/messages";
+import type { BackgroundToContentMessage } from "../shared/messages";
 import { normalizeSharedVideoUrl } from "../shared/url";
-import {
-  preparePendingLocalShareCleanupForRoomLifecycle,
-  type RoomLifecycleAction,
-} from "./room-state";
+import { resetRoomLifecycleTransientState } from "./room-state";
 import {
   toConnectionCheckUrl as buildConnectionCheckUrl,
   toHealthcheckUrl as buildHealthcheckUrl,
 } from "./clock-sync";
+import { registerBackgroundListeners } from "./chrome-runtime-bus";
 import { notifyContentTabs } from "./content-bus";
 import { bootstrapBackground } from "./bootstrap";
 import { createClockController } from "./clock-controller";
 import { createDiagnosticsController } from "./diagnostics-controller";
 import { createMessageController } from "./message-controller";
 import { createOutgoingMessageController } from "./outgoing-message-controller";
-import { flushPendingShare as getPendingShareFlushPlan } from "./room-manager";
+import { executeFlushPendingShare } from "./room-manager";
 import { createPopupStateController } from "./popup-state-controller";
 import { createRoomSessionController } from "./room-session-controller";
 import {
@@ -41,6 +35,7 @@ import {
   persistBackgroundProfile,
   persistBackgroundState,
 } from "./storage-manager";
+import { disconnectSocket as executeDisconnectSocket } from "./socket-lifecycle";
 import { createTabController } from "./tab-controller";
 import { t } from "../shared/i18n";
 
@@ -124,7 +119,7 @@ const roomSessionController = createRoomSessionController({
   connect: () => socketController.connect(),
   disconnectSocket,
   resetReconnectState: () => socketController.resetReconnectState(),
-  resetRoomLifecycleTransientState,
+  resetRoomLifecycleTransientState: doResetRoomLifecycleTransientState,
   flushPendingShare,
   ensureSharedVideoOpen: () => tabController.ensureSharedVideoOpen(),
   notifyContentScripts,
@@ -390,73 +385,33 @@ function updateClockOffset(
 }
 
 function flushPendingShare(): void {
-  const plan = getPendingShareFlushPlan({
-    pendingSharedVideo: roomSessionState.pendingSharedVideo,
-    pendingSharedPlayback: roomSessionState.pendingSharedPlayback,
-    connected: connectionState.connected,
-    roomCode: roomSessionState.roomCode,
-    memberToken: roomSessionState.memberToken,
+  executeFlushPendingShare({
+    roomSessionState,
+    connectionState,
+    sendToServer,
   });
-  if (!plan.shouldFlush || !plan.video) {
-    return;
-  }
-  sendToServer({
-    type: "video:share",
-    payload: {
-      memberToken: roomSessionState.memberToken,
-      video: plan.video,
-      ...(plan.playback ? { playback: plan.playback } : {}),
-    },
-  });
-  roomSessionState.pendingSharedVideo = null;
-  roomSessionState.pendingSharedPlayback = null;
 }
 
 function disconnectSocket(): void {
-  socketController.resetReconnectState();
-  clockController.stopClockSyncTimer();
-  shareController.clearPendingLocalShare("socket disconnected");
-  roomSessionState.memberToken = null;
-  if (!connectionState.socket) {
-    connectionState.connected = false;
-    return;
-  }
-
-  const currentSocket = connectionState.socket;
-  connectionState.socket = null;
-  connectionState.connected = false;
-  currentSocket.close();
+  executeDisconnectSocket({
+    connectionState,
+    memberTokenState: roomSessionState,
+    resetReconnectState: () => socketController.resetReconnectState(),
+    stopClockSyncTimer: () => clockController.stopClockSyncTimer(),
+    clearPendingLocalShare: (reason) =>
+      shareController.clearPendingLocalShare(reason),
+  });
 }
 
-function resetRoomLifecycleTransientState(
-  action: RoomLifecycleAction,
+function doResetRoomLifecycleTransientState(
+  action: Parameters<typeof resetRoomLifecycleTransientState>[0],
   reason: string,
 ): void {
-  const cleanup = preparePendingLocalShareCleanupForRoomLifecycle(action, {
-    pendingLocalShareUrl: shareState.pendingLocalShareUrl,
-    pendingLocalShareExpiresAt: shareState.pendingLocalShareExpiresAt,
-    pendingLocalShareTimer: shareState.pendingLocalShareTimer,
+  resetRoomLifecycleTransientState(action, reason, {
+    shareState,
+    roomSessionState,
+    log: (message) => diagnosticsController.log("background", message),
   });
-  if (cleanup.hadPendingLocalShare) {
-    if (cleanup.shouldCancelTimer) {
-      if (shareState.pendingLocalShareTimer !== null) {
-        clearTimeout(shareState.pendingLocalShareTimer);
-        shareState.pendingLocalShareTimer = null;
-      }
-    }
-    diagnosticsController.log(
-      "background",
-      `Cleared pending local share (${reason})`,
-    );
-    ({
-      pendingLocalShareUrl: shareState.pendingLocalShareUrl,
-      pendingLocalShareExpiresAt: shareState.pendingLocalShareExpiresAt,
-      pendingLocalShareTimer: shareState.pendingLocalShareTimer,
-    } = cleanup.nextState);
-  }
-  shareState.pendingShareToast = null;
-  roomSessionState.pendingSharedVideo = null;
-  roomSessionState.pendingSharedPlayback = null;
 }
 
 async function notifyContentScripts(
@@ -481,33 +436,10 @@ async function updateServerUrl(nextServerUrl: string): Promise<void> {
   await serverUrlController.updateServerUrl(nextServerUrl);
 }
 
-chrome.runtime.onMessage.addListener(
-  (
-    message: PopupToBackgroundMessage | ContentToBackgroundMessage,
-    sender,
-    sendResponse,
-  ) => {
-    if (bootstrapStatus !== "ready") {
-      const error =
-        bootstrapStatus === "failed"
-          ? BOOTSTRAP_FAILED_MESSAGE
-          : BOOTSTRAP_PENDING_MESSAGE;
-      if (message.type === "popup:get-state") {
-        sendResponse(popupStateController.popupState());
-      } else {
-        sendResponse({ ok: false, error });
-      }
-      return true;
-    }
-    void messageController.handleRuntimeMessage(message, sender, sendResponse);
-
-    return true;
-  },
-);
-
-chrome.runtime.onConnect.addListener((port) => {
-  if (port.name !== "popup-state") {
-    return;
-  }
-  popupStateController.attachPort(port);
+registerBackgroundListeners({
+  getBootstrapStatus: () => bootstrapStatus,
+  bootstrapPendingMessage: BOOTSTRAP_PENDING_MESSAGE,
+  bootstrapFailedMessage: BOOTSTRAP_FAILED_MESSAGE,
+  popupStateController,
+  messageController,
 });

--- a/extension/src/background/room-manager.ts
+++ b/extension/src/background/room-manager.ts
@@ -1,4 +1,5 @@
 import type {
+  ClientMessage,
   PlaybackState,
   RoomState,
   SharedVideo,
@@ -103,4 +104,37 @@ export function flushPendingShare(args: {
     video: args.pendingSharedVideo,
     playback: args.pendingSharedPlayback,
   };
+}
+
+export function executeFlushPendingShare(args: {
+  roomSessionState: {
+    pendingSharedVideo: SharedVideo | null;
+    pendingSharedPlayback: PlaybackState | null;
+    memberToken: string | null;
+    roomCode: string | null;
+  };
+  connectionState: { connected: boolean };
+  sendToServer: (message: ClientMessage) => void;
+}): void {
+  const plan = flushPendingShare({
+    pendingSharedVideo: args.roomSessionState.pendingSharedVideo,
+    pendingSharedPlayback: args.roomSessionState.pendingSharedPlayback,
+    connected: args.connectionState.connected,
+    roomCode: args.roomSessionState.roomCode,
+    memberToken: args.roomSessionState.memberToken,
+  });
+  if (!plan.shouldFlush || !plan.video) {
+    return;
+  }
+  // memberToken is guaranteed non-null when plan.shouldFlush is true
+  args.sendToServer({
+    type: "video:share",
+    payload: {
+      memberToken: args.roomSessionState.memberToken!,
+      video: plan.video,
+      ...(plan.playback ? { playback: plan.playback } : {}),
+    },
+  });
+  args.roomSessionState.pendingSharedVideo = null;
+  args.roomSessionState.pendingSharedPlayback = null;
 }

--- a/extension/src/background/room-state.ts
+++ b/extension/src/background/room-state.ts
@@ -114,3 +114,49 @@ export function isSharedVideoChange(
 ): boolean {
   return previousSharedUrl !== (nextState.sharedVideo?.url ?? null);
 }
+
+export interface TransientShareLifecycleState {
+  pendingLocalShareUrl: string | null;
+  pendingLocalShareExpiresAt: number | null;
+  pendingLocalShareTimer: number | null;
+  pendingShareToast: unknown;
+}
+
+export interface TransientRoomSessionLifecycleState {
+  pendingSharedVideo: unknown;
+  pendingSharedPlayback: unknown;
+}
+
+export function resetRoomLifecycleTransientState(
+  action: RoomLifecycleAction,
+  reason: string,
+  args: {
+    shareState: TransientShareLifecycleState;
+    roomSessionState: TransientRoomSessionLifecycleState;
+    log: (message: string) => void;
+  },
+): void {
+  const cleanup = preparePendingLocalShareCleanupForRoomLifecycle(action, {
+    pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
+    pendingLocalShareExpiresAt: args.shareState.pendingLocalShareExpiresAt,
+    pendingLocalShareTimer: args.shareState.pendingLocalShareTimer,
+  });
+  if (cleanup.hadPendingLocalShare) {
+    if (cleanup.shouldCancelTimer) {
+      if (args.shareState.pendingLocalShareTimer !== null) {
+        clearTimeout(args.shareState.pendingLocalShareTimer);
+        args.shareState.pendingLocalShareTimer = null;
+      }
+    }
+    args.log(`Cleared pending local share (${reason})`);
+    args.shareState.pendingLocalShareUrl =
+      cleanup.nextState.pendingLocalShareUrl;
+    args.shareState.pendingLocalShareExpiresAt =
+      cleanup.nextState.pendingLocalShareExpiresAt;
+    args.shareState.pendingLocalShareTimer =
+      cleanup.nextState.pendingLocalShareTimer;
+  }
+  args.shareState.pendingShareToast = null;
+  args.roomSessionState.pendingSharedVideo = null;
+  args.roomSessionState.pendingSharedPlayback = null;
+}

--- a/extension/src/background/socket-lifecycle.ts
+++ b/extension/src/background/socket-lifecycle.ts
@@ -1,0 +1,25 @@
+export function disconnectSocket(args: {
+  connectionState: {
+    socket: WebSocket | null;
+    connected: boolean;
+  };
+  memberTokenState: { memberToken: string | null };
+  resetReconnectState: () => void;
+  stopClockSyncTimer: () => void;
+  clearPendingLocalShare: (reason: string) => void;
+}): void {
+  args.resetReconnectState();
+  args.stopClockSyncTimer();
+  args.clearPendingLocalShare("socket disconnected");
+  args.memberTokenState.memberToken = null;
+
+  if (!args.connectionState.socket) {
+    args.connectionState.connected = false;
+    return;
+  }
+
+  const currentSocket = args.connectionState.socket;
+  args.connectionState.socket = null;
+  args.connectionState.connected = false;
+  currentSocket.close();
+}

--- a/extension/src/content/content-messaging.ts
+++ b/extension/src/content/content-messaging.ts
@@ -1,0 +1,15 @@
+export async function runtimeSendMessage<T>(
+  message: unknown,
+): Promise<T | null> {
+  try {
+    return await chrome.runtime.sendMessage(message);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("Extension context invalidated")
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/extension/src/content/gesture-tracker.ts
+++ b/extension/src/content/gesture-tracker.ts
@@ -1,0 +1,14 @@
+export function startUserGestureTracking(onGesture: () => void): void {
+  const gestureEvents: Array<keyof DocumentEventMap> = [
+    "pointerdown",
+    "mousedown",
+    "click",
+    "touchstart",
+    "keydown",
+  ];
+
+  for (const eventName of gestureEvents) {
+    document.addEventListener(eventName, onGesture, true);
+    window.addEventListener(eventName, onGesture, true);
+  }
+}

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -1,6 +1,8 @@
 import type { BackgroundToContentMessage } from "../shared/messages";
 import { normalizeSharedVideoUrl } from "../shared/url";
+import { runtimeSendMessage } from "./content-messaging";
 import { createFestivalBridgeController } from "./festival-bridge";
+import { startUserGestureTracking } from "./gesture-tracker";
 import { getVideoElement, pauseVideo } from "./player-binding";
 import { createContentStateStore } from "./content-store";
 import { createNavigationController } from "./navigation-controller";
@@ -9,6 +11,7 @@ import { createRoomStateController } from "./room-state-controller";
 import { createShareController } from "./share-controller";
 import { createSyncController } from "./sync-controller";
 import { createToastCoordinatorState, createToastPresenter } from "./toast";
+import { reportCurrentUser } from "./user-reporter";
 
 const normalizeUrl = normalizeSharedVideoUrl;
 let seq = 0;
@@ -154,28 +157,20 @@ function shouldLogHeartbeat(
   return true;
 }
 
-async function runtimeSendMessage<T>(message: unknown): Promise<T | null> {
-  try {
-    return await chrome.runtime.sendMessage(message);
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message.includes("Extension context invalidated")
-    ) {
-      return null;
-    }
-    throw error;
-  }
+function activatePauseHold(durationMs = PAUSE_HOLD_MS): void {
+  runtimeState.pauseHoldUntil = Date.now() + durationMs;
 }
 
 async function init(): Promise<void> {
-  startUserGestureTracking();
+  startUserGestureTracking(() => {
+    runtimeState.lastUserGestureAt = Date.now();
+  });
   playbackBindingController.start();
   navigationController.start();
   document.addEventListener("fullscreenchange", () => {
     toastPresenter.resetMountTarget();
   });
-  void reportCurrentUser();
+  void reportCurrentUser((msg) => runtimeSendMessage(msg));
 
   chrome.runtime.onMessage.addListener(
     (message: BackgroundToContentMessage, _sender, sendResponse) => {
@@ -207,66 +202,4 @@ async function init(): Promise<void> {
   );
 
   await syncController.hydrateRoomState();
-}
-
-function startUserGestureTracking(): void {
-  const markUserGesture = () => {
-    runtimeState.lastUserGestureAt = Date.now();
-  };
-
-  const gestureEvents: Array<keyof DocumentEventMap> = [
-    "pointerdown",
-    "mousedown",
-    "click",
-    "touchstart",
-    "keydown",
-  ];
-
-  for (const eventName of gestureEvents) {
-    document.addEventListener(eventName, markUserGesture, true);
-    window.addEventListener(eventName, markUserGesture, true);
-  }
-}
-
-function activatePauseHold(durationMs = PAUSE_HOLD_MS): void {
-  runtimeState.pauseHoldUntil = Date.now() + durationMs;
-}
-
-async function reportCurrentUser(): Promise<void> {
-  try {
-    const response = await fetch(
-      "https://api.bilibili.com/x/web-interface/nav",
-      {
-        credentials: "include",
-      },
-    );
-    const data = (await response.json()) as {
-      code: number;
-      data?: {
-        isLogin?: boolean;
-        uname?: string;
-        mid?: number;
-      };
-    };
-
-    if (data.code !== 0 || !data.data?.isLogin) {
-      return;
-    }
-
-    const nextDisplayName =
-      data.data.uname?.trim() || (data.data.mid ? `UID-${data.data.mid}` : "");
-    if (!nextDisplayName) {
-      return;
-    }
-
-    const reportResponse = await runtimeSendMessage({
-      type: "content:report-user",
-      payload: { displayName: nextDisplayName },
-    });
-    if (reportResponse === null) {
-      return;
-    }
-  } catch {
-    // Ignore lookup failures and keep guest naming.
-  }
 }

--- a/extension/src/content/user-reporter.ts
+++ b/extension/src/content/user-reporter.ts
@@ -1,0 +1,34 @@
+export async function reportCurrentUser(
+  sendMessage: (message: unknown) => Promise<unknown>,
+): Promise<void> {
+  try {
+    const response = await fetch(
+      "https://api.bilibili.com/x/web-interface/nav",
+      { credentials: "include" },
+    );
+    const data = (await response.json()) as {
+      code: number;
+      data?: { isLogin?: boolean; uname?: string; mid?: number };
+    };
+
+    if (data.code !== 0 || !data.data?.isLogin) {
+      return;
+    }
+
+    const nextDisplayName =
+      data.data.uname?.trim() || (data.data.mid ? `UID-${data.data.mid}` : "");
+    if (!nextDisplayName) {
+      return;
+    }
+
+    const reportResponse = await sendMessage({
+      type: "content:report-user",
+      payload: { displayName: nextDisplayName },
+    });
+    if (reportResponse === null) {
+      return;
+    }
+  } catch {
+    // Ignore lookup failures and keep guest naming.
+  }
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,14 +1,9 @@
 import { createServer, type Server as HttpServer } from "node:http";
-import { randomBytes, randomUUID } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { WebSocketServer, type RawData, type WebSocket } from "ws";
-import {
-  isClientMessage,
-  type ErrorCode,
-  type ServerMessage,
-} from "@bili-syncplay/protocol";
+import { WebSocketServer } from "ws";
 import { createEventStore } from "./admin/event-store.js";
 import { createRedisEventStore } from "./admin/redis-event-store.js";
 import { createAdminServices } from "./bootstrap/admin-services.js";
@@ -22,7 +17,6 @@ import { createAdminCommandConsumer } from "./admin-command-consumer.js";
 import { createMessageHandler } from "./message-handler.js";
 import { createMirroredRuntimeStore } from "./mirrored-runtime-store.js";
 import { createNodeHeartbeat } from "./node-heartbeat.js";
-import { createSessionRateLimitState } from "./rate-limit.js";
 import { createRedisAdminCommandBus } from "./redis-admin-command-bus.js";
 import { createRedisRoomEventBus } from "./redis-room-event-bus.js";
 import { createRoomEventConsumer } from "./room-event-consumer.js";
@@ -50,20 +44,19 @@ import {
 } from "./runtime-store.js";
 import { createSecurityPolicy } from "./security.js";
 import { hasAttachedSocket } from "./types.js";
+import {
+  createWsConnectionHandler,
+  createWsUpgradeHandler,
+  send,
+  sendError,
+} from "./ws-session-handler.js";
 import type {
   AdminConfig,
   AdminUiConfig,
   LogEvent,
   PersistenceConfig,
   SecurityConfig,
-  Session,
 } from "./types.js";
-import {
-  INTERNAL_SERVER_ERROR_MESSAGE,
-  INVALID_CLIENT_MESSAGE_MESSAGE,
-  INVALID_JSON_MESSAGE,
-} from "./messages.js";
-
 export type {
   AdminConfig,
   AdminUiConfig,
@@ -75,8 +68,9 @@ export {
   INVALID_CLIENT_MESSAGE_MESSAGE,
   INVALID_JSON_MESSAGE,
 } from "./messages.js";
+// Re-exported for backward compatibility with existing tests
+export { cleanupSessionAfterClose } from "./ws-session-handler.js";
 
-const CLOSE_CODE_POLICY_VIOLATION = 1008;
 const DEFAULT_CLOSE_STEP_TIMEOUT_MS = 5_000;
 const PACKAGE_JSON_PATH = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -148,78 +142,8 @@ export async function runShutdownSteps(
   }
 }
 
-function hasClose(value: object | null | undefined): value is Closeable {
+export function hasClose(value: object | null | undefined): value is Closeable {
   return typeof value === "object" && value !== null && "close" in value;
-}
-
-export async function cleanupSessionAfterClose(options: {
-  session: Session;
-  code: number;
-  reason: Buffer;
-  messageHandler: { leaveRoom: (session: Session) => Promise<void> };
-  runtimeStore: Pick<RuntimeStore, "unregisterSession">;
-  securityPolicy: {
-    decrementConnectionCount: (remoteAddress: string | null) => void;
-  };
-  logEvent: LogEvent;
-  decodeCloseReason: (reason: Buffer) => string;
-}): Promise<void> {
-  const decodedReason = options.decodeCloseReason(options.reason);
-  const roomCodeAtClose = options.session.roomCode;
-
-  try {
-    await options.messageHandler.leaveRoom(options.session);
-  } catch (error) {
-    options.logEvent("ws_connection_cleanup_failed", {
-      sessionId: options.session.id,
-      roomCode: roomCodeAtClose,
-      remoteAddress: options.session.remoteAddress,
-      origin: options.session.origin,
-      result: "error",
-      step: "leave_room",
-      error: error instanceof Error ? error.message : "unknown_error",
-    });
-  } finally {
-    try {
-      options.runtimeStore.unregisterSession(options.session.id);
-    } catch (error) {
-      options.logEvent("ws_connection_cleanup_failed", {
-        sessionId: options.session.id,
-        roomCode: roomCodeAtClose,
-        remoteAddress: options.session.remoteAddress,
-        origin: options.session.origin,
-        result: "error",
-        step: "unregister_session",
-        error: error instanceof Error ? error.message : "unknown_error",
-      });
-    }
-
-    try {
-      options.securityPolicy.decrementConnectionCount(
-        options.session.remoteAddress,
-      );
-    } catch (error) {
-      options.logEvent("ws_connection_cleanup_failed", {
-        sessionId: options.session.id,
-        roomCode: roomCodeAtClose,
-        remoteAddress: options.session.remoteAddress,
-        origin: options.session.origin,
-        result: "error",
-        step: "decrement_connection_count",
-        error: error instanceof Error ? error.message : "unknown_error",
-      });
-    }
-  }
-
-  options.logEvent("ws_connection_closed", {
-    sessionId: options.session.id,
-    remoteAddress: options.session.remoteAddress,
-    origin: options.session.origin,
-    roomCode: options.session.roomCode ?? roomCodeAtClose,
-    result: "closed",
-    code: options.code,
-    reason: decodedReason,
-  });
 }
 
 export async function resolveServiceVersion(): Promise<string> {
@@ -561,197 +485,23 @@ export async function createSyncServer(
   });
   const pendingSessionCleanup = new Set<Promise<void>>();
 
-  function send(socket: WebSocket, message: ServerMessage): void {
-    if (socket.readyState === socket.OPEN) {
-      socket.send(JSON.stringify(message));
-    }
-  }
+  httpServer.on(
+    "upgrade",
+    createWsUpgradeHandler({ securityPolicy, wss, logEvent }),
+  );
 
-  function sendError(
-    socket: WebSocket,
-    code: ErrorCode,
-    message: string,
-  ): void {
-    send(socket, {
-      type: "error",
-      payload: { code, message },
-    });
-  }
-
-  function parseIncomingMessage(raw: RawData): unknown {
-    return JSON.parse(raw.toString());
-  }
-
-  function decodeCloseReason(reason: Buffer): string {
-    const decoded = reason.toString("utf8");
-    return decoded.length > 0 ? decoded : "";
-  }
-
-  function countInvalidMessage(session: Session, reason: string): void {
-    session.invalidMessageCount += 1;
-    logEvent("invalid_message", {
-      sessionId: session.id,
-      roomCode: session.roomCode,
-      remoteAddress: session.remoteAddress,
-      origin: session.origin,
-      result: "rejected",
-      reason,
-      invalidMessageCount: session.invalidMessageCount,
-    });
-
-    if (
-      session.invalidMessageCount >=
-        securityConfig.invalidMessageCloseThreshold &&
-      hasAttachedSocket(session)
-    ) {
-      session.socket.close(
-        CLOSE_CODE_POLICY_VIOLATION,
-        "Too many invalid messages",
-      );
-    }
-  }
-
-  function rejectUpgrade(
-    socket: import("node:stream").Duplex,
-    statusCode: number,
-    statusText: string,
-    details: Record<string, unknown>,
-  ): void {
-    socket.write(
-      `HTTP/1.1 ${statusCode} ${statusText}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
-    );
-    socket.destroy();
-    logEvent("ws_connection_rejected", details);
-  }
-
-  httpServer.on("upgrade", (request, socket, head) => {
-    const decision = securityPolicy.evaluateUpgrade(request);
-    if (!decision.ok) {
-      rejectUpgrade(socket, decision.statusCode, decision.statusText, {
-        remoteAddress: decision.context.remoteAddress,
-        origin: decision.context.origin,
-        result: "rejected",
-        reason: decision.reason,
-      });
-      return;
-    }
-
-    request.biliSyncPlayContext = decision.context;
-    wss.handleUpgrade(request, socket, head, (ws) => {
-      wss.emit("connection", ws, request);
-    });
-  });
-
-  wss.on("connection", (socket, request) => {
-    const context = request.biliSyncPlayContext ?? {
-      remoteAddress: securityPolicy.getRemoteAddress(request),
-      origin:
-        typeof request.headers.origin === "string"
-          ? request.headers.origin
-          : null,
-    };
-    const session: Session = {
-      id: randomUUID(),
-      connectionState: "attached",
-      socket,
+  wss.on(
+    "connection",
+    createWsConnectionHandler({
+      securityPolicy,
+      securityConfig,
       instanceId: persistenceConfig.instanceId,
-      remoteAddress: context.remoteAddress,
-      origin: context.origin,
-      roomCode: null,
-      memberId: null,
-      displayName: `Guest-${Math.floor(Math.random() * 900 + 100)}`,
-      memberToken: null,
-      joinedAt: null,
-      invalidMessageCount: 0,
-      rateLimitState: createSessionRateLimitState(securityConfig),
-    };
-
-    securityPolicy.incrementConnectionCount(session.remoteAddress);
-    runtimeStore.registerSession(session);
-    logEvent("ws_connection_accepted", {
-      sessionId: session.id,
-      remoteAddress: session.remoteAddress,
-      origin: session.origin,
-      result: "ok",
-    });
-    let messageQueue = Promise.resolve();
-
-    socket.on("message", (raw) => {
-      messageQueue = messageQueue
-        .catch((error: unknown) => {
-          logEvent("ws_message_queue_failed", {
-            sessionId: session.id,
-            roomCode: session.roomCode,
-            remoteAddress: session.remoteAddress,
-            origin: session.origin,
-            result: "error",
-            error: error instanceof Error ? error.message : "unknown_error",
-          });
-        })
-        .then(async () => {
-          let parsed: unknown;
-          try {
-            parsed = parseIncomingMessage(raw);
-          } catch {
-            sendError(socket, "invalid_message", INVALID_JSON_MESSAGE);
-            countInvalidMessage(session, "invalid_json");
-            return;
-          }
-
-          if (!isClientMessage(parsed)) {
-            sendError(
-              socket,
-              "invalid_message",
-              INVALID_CLIENT_MESSAGE_MESSAGE,
-            );
-            countInvalidMessage(session, "invalid_client_message");
-            return;
-          }
-
-          try {
-            await messageHandler.handleClientMessage(session, parsed);
-          } catch (error) {
-            logEvent("ws_client_message_failed", {
-              sessionId: session.id,
-              roomCode: session.roomCode,
-              remoteAddress: session.remoteAddress,
-              origin: session.origin,
-              result: "error",
-              error: error instanceof Error ? error.message : "unknown_error",
-            });
-            sendError(socket, "internal_error", INTERNAL_SERVER_ERROR_MESSAGE);
-          }
-        });
-    });
-
-    socket.on("error", (error) => {
-      logEvent("ws_connection_error", {
-        sessionId: session.id,
-        remoteAddress: session.remoteAddress,
-        origin: session.origin,
-        roomCode: session.roomCode,
-        result: "error",
-        error: error.message,
-      });
-    });
-
-    socket.on("close", (code, reason) => {
-      const cleanup = cleanupSessionAfterClose({
-        session,
-        code,
-        reason,
-        messageHandler,
-        runtimeStore,
-        securityPolicy,
-        logEvent,
-        decodeCloseReason,
-      });
-      pendingSessionCleanup.add(cleanup);
-      void cleanup.finally(() => {
-        pendingSessionCleanup.delete(cleanup);
-      });
-    });
-  });
+      runtimeStore,
+      messageHandler,
+      logEvent,
+      pendingSessionCleanup,
+    }),
+  );
 
   return {
     httpServer,

--- a/server/src/global-admin-app.ts
+++ b/server/src/global-admin-app.ts
@@ -10,26 +10,24 @@ import { createStructuredLogger } from "./logger.js";
 import {
   createInMemoryAdminCommandBus,
   createNoopAdminCommandBus,
-  type AdminCommandBus,
 } from "./admin-command-bus.js";
 import {
   getDefaultPersistenceConfig,
   getDefaultSecurityConfig,
+  hasClose,
   resolveServiceVersion,
+  runShutdownSteps,
 } from "./app.js";
 import { createRedisAdminCommandBus } from "./redis-admin-command-bus.js";
 import { createRedisRoomEventBus } from "./redis-room-event-bus.js";
 import { createInMemoryRoomStore, type RoomStore } from "./room-store.js";
 import { createRoomService } from "./room-service.js";
-import type { RoomEventBus, RoomEventBusMessage } from "./room-event-bus.js";
+import type { RoomEventBusMessage } from "./room-event-bus.js";
 import {
   createInMemoryRoomEventBus,
   createNoopRoomEventBus,
 } from "./room-event-bus.js";
-import {
-  createInMemoryRuntimeStore,
-  type RuntimeStore,
-} from "./runtime-store.js";
+import { createInMemoryRuntimeStore } from "./runtime-store.js";
 import { createRuntimeIndexReaper } from "./runtime-index-reaper.js";
 import { createSecurityPolicy } from "./security.js";
 import { createRedisRoomStore } from "./redis-room-store.js";
@@ -41,7 +39,6 @@ import {
   getRedisRoomEventChannel,
   getRedisRuntimeKeyPrefix,
 } from "./redis-namespace.js";
-import type { GlobalEventStore } from "./admin/global-event-store.js";
 import type {
   AdminConfig,
   AdminUiConfig,
@@ -181,50 +178,55 @@ export async function createGlobalAdminServer(
 
   return {
     httpServer,
-    async close() {
-      await new Promise<void>((resolve, reject) => {
-        httpServer.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
-      await runtimeIndexReaper.stop();
-
-      const maybeClosableRoomStore = roomStore as RoomStore & {
-        close?: () => Promise<void>;
-      };
-      if (typeof maybeClosableRoomStore.close === "function") {
-        await maybeClosableRoomStore.close();
-      }
-      const maybeClosableRuntimeStore = runtimeStore as RuntimeStore & {
-        close?: () => Promise<void>;
-      };
-      if (typeof maybeClosableRuntimeStore.close === "function") {
-        await maybeClosableRuntimeStore.close();
-      }
-      const maybeClosableEventStore = eventStore as GlobalEventStore & {
-        close?: () => Promise<void>;
-      };
-      if (typeof maybeClosableEventStore.close === "function") {
-        await maybeClosableEventStore.close();
-      }
-      const maybeClosableAdminCommandBus =
-        adminCommandBus as AdminCommandBus & {
-          close?: () => Promise<void>;
-        };
-      if (typeof maybeClosableAdminCommandBus.close === "function") {
-        await maybeClosableAdminCommandBus.close();
-      }
-      const maybeClosableRoomEventBus = roomEventBus as RoomEventBus & {
-        close?: () => Promise<void>;
-      };
-      if (typeof maybeClosableRoomEventBus.close === "function") {
-        await maybeClosableRoomEventBus.close();
-      }
-      await closeAdminServices();
-    },
+    close: () =>
+      runShutdownSteps(
+        [
+          {
+            name: "close_http_server",
+            run: () =>
+              new Promise<void>((resolve, reject) => {
+                httpServer.close((error) => {
+                  if (error) {
+                    reject(error);
+                    return;
+                  }
+                  resolve();
+                });
+              }),
+          },
+          {
+            name: "stop_runtime_index_reaper",
+            run: () => runtimeIndexReaper.stop(),
+          },
+          {
+            name: "close_room_store",
+            run: () => (hasClose(roomStore) ? roomStore.close() : undefined),
+          },
+          {
+            name: "close_runtime_store",
+            run: () =>
+              hasClose(runtimeStore) ? runtimeStore.close() : undefined,
+          },
+          {
+            name: "close_event_store",
+            run: () => (hasClose(eventStore) ? eventStore.close() : undefined),
+          },
+          {
+            name: "close_admin_command_bus",
+            run: () =>
+              hasClose(adminCommandBus) ? adminCommandBus.close() : undefined,
+          },
+          {
+            name: "close_room_event_bus",
+            run: () =>
+              hasClose(roomEventBus) ? roomEventBus.close() : undefined,
+          },
+          {
+            name: "close_admin_services",
+            run: () => closeAdminServices(),
+          },
+        ],
+        logEvent,
+      ),
   };
 }

--- a/server/src/ws-session-handler.ts
+++ b/server/src/ws-session-handler.ts
@@ -1,0 +1,335 @@
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { type RawData, type WebSocket, WebSocketServer } from "ws";
+import {
+  isClientMessage,
+  type ClientMessage,
+  type ErrorCode,
+  type ServerMessage,
+} from "@bili-syncplay/protocol";
+import { createSessionRateLimitState } from "./rate-limit.js";
+import { hasAttachedSocket } from "./types.js";
+import type { LogEvent, SecurityConfig, Session } from "./types.js";
+import {
+  INTERNAL_SERVER_ERROR_MESSAGE,
+  INVALID_CLIENT_MESSAGE_MESSAGE,
+  INVALID_JSON_MESSAGE,
+} from "./messages.js";
+import type { RuntimeStore } from "./runtime-store.js";
+
+const CLOSE_CODE_POLICY_VIOLATION = 1008;
+
+export function send(socket: WebSocket, message: ServerMessage): void {
+  if (socket.readyState === socket.OPEN) {
+    socket.send(JSON.stringify(message));
+  }
+}
+
+export function sendError(
+  socket: WebSocket,
+  code: ErrorCode,
+  message: string,
+): void {
+  send(socket, { type: "error", payload: { code, message } });
+}
+
+export function rejectUpgrade(
+  socket: Duplex,
+  statusCode: number,
+  statusText: string,
+  details: Record<string, unknown>,
+  logEvent: LogEvent,
+): void {
+  socket.write(
+    `HTTP/1.1 ${statusCode} ${statusText}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
+  );
+  socket.destroy();
+  logEvent("ws_connection_rejected", details);
+}
+
+export async function cleanupSessionAfterClose(options: {
+  session: Session;
+  code: number;
+  reason: Buffer;
+  messageHandler: { leaveRoom: (session: Session) => Promise<void> };
+  runtimeStore: Pick<RuntimeStore, "unregisterSession">;
+  securityPolicy: {
+    decrementConnectionCount: (remoteAddress: string | null) => void;
+  };
+  logEvent: LogEvent;
+  decodeCloseReason: (reason: Buffer) => string;
+}): Promise<void> {
+  const decodedReason = options.decodeCloseReason(options.reason);
+  const roomCodeAtClose = options.session.roomCode;
+
+  try {
+    await options.messageHandler.leaveRoom(options.session);
+  } catch (error) {
+    options.logEvent("ws_connection_cleanup_failed", {
+      sessionId: options.session.id,
+      roomCode: roomCodeAtClose,
+      remoteAddress: options.session.remoteAddress,
+      origin: options.session.origin,
+      result: "error",
+      step: "leave_room",
+      error: error instanceof Error ? error.message : "unknown_error",
+    });
+  } finally {
+    try {
+      options.runtimeStore.unregisterSession(options.session.id);
+    } catch (error) {
+      options.logEvent("ws_connection_cleanup_failed", {
+        sessionId: options.session.id,
+        roomCode: roomCodeAtClose,
+        remoteAddress: options.session.remoteAddress,
+        origin: options.session.origin,
+        result: "error",
+        step: "unregister_session",
+        error: error instanceof Error ? error.message : "unknown_error",
+      });
+    }
+
+    try {
+      options.securityPolicy.decrementConnectionCount(
+        options.session.remoteAddress,
+      );
+    } catch (error) {
+      options.logEvent("ws_connection_cleanup_failed", {
+        sessionId: options.session.id,
+        roomCode: roomCodeAtClose,
+        remoteAddress: options.session.remoteAddress,
+        origin: options.session.origin,
+        result: "error",
+        step: "decrement_connection_count",
+        error: error instanceof Error ? error.message : "unknown_error",
+      });
+    }
+  }
+
+  options.logEvent("ws_connection_closed", {
+    sessionId: options.session.id,
+    remoteAddress: options.session.remoteAddress,
+    origin: options.session.origin,
+    roomCode: options.session.roomCode ?? roomCodeAtClose,
+    result: "closed",
+    code: options.code,
+    reason: decodedReason,
+  });
+}
+
+export function createWsUpgradeHandler(args: {
+  securityPolicy: {
+    evaluateUpgrade: (request: IncomingMessage) => {
+      ok: boolean;
+      statusCode?: number;
+      statusText?: string;
+      context: { remoteAddress: string | null; origin: string | null };
+      reason?: string;
+    };
+  };
+  wss: WebSocketServer;
+  logEvent: LogEvent;
+}): (request: IncomingMessage, socket: Duplex, head: Buffer) => void {
+  return (request, socket, head) => {
+    const decision = args.securityPolicy.evaluateUpgrade(request);
+    if (!decision.ok) {
+      rejectUpgrade(
+        socket,
+        decision.statusCode!,
+        decision.statusText!,
+        {
+          remoteAddress: decision.context.remoteAddress,
+          origin: decision.context.origin,
+          result: "rejected",
+          reason: decision.reason,
+        },
+        args.logEvent,
+      );
+      return;
+    }
+
+    request.biliSyncPlayContext = decision.context as {
+      remoteAddress: string | null;
+      origin: string | null;
+    };
+    args.wss.handleUpgrade(request, socket, head, (ws) => {
+      args.wss.emit("connection", ws, request);
+    });
+  };
+}
+
+export function createWsConnectionHandler(args: {
+  securityPolicy: {
+    getRemoteAddress: (request: IncomingMessage) => string | null;
+    incrementConnectionCount: (remoteAddress: string | null) => void;
+    decrementConnectionCount: (remoteAddress: string | null) => void;
+  };
+  securityConfig: SecurityConfig;
+  instanceId: string;
+  runtimeStore: RuntimeStore;
+  messageHandler: {
+    handleClientMessage: (
+      session: Session,
+      message: ClientMessage,
+    ) => Promise<void>;
+    leaveRoom: (session: Session) => Promise<void>;
+  };
+  logEvent: LogEvent;
+  pendingSessionCleanup: Set<Promise<void>>;
+}): (socket: WebSocket, request: IncomingMessage) => void {
+  return (socket, request) => {
+    const context = request.biliSyncPlayContext ?? {
+      remoteAddress: args.securityPolicy.getRemoteAddress(request),
+      origin:
+        typeof request.headers.origin === "string"
+          ? request.headers.origin
+          : null,
+    };
+    const session: Session = {
+      id: randomUUID(),
+      connectionState: "attached",
+      socket,
+      instanceId: args.instanceId,
+      remoteAddress: context.remoteAddress,
+      origin: context.origin,
+      roomCode: null,
+      memberId: null,
+      displayName: `Guest-${Math.floor(Math.random() * 900 + 100)}`,
+      memberToken: null,
+      joinedAt: null,
+      invalidMessageCount: 0,
+      rateLimitState: createSessionRateLimitState(args.securityConfig),
+    };
+
+    args.securityPolicy.incrementConnectionCount(session.remoteAddress);
+    args.runtimeStore.registerSession(session);
+    args.logEvent("ws_connection_accepted", {
+      sessionId: session.id,
+      remoteAddress: session.remoteAddress,
+      origin: session.origin,
+      result: "ok",
+    });
+
+    let messageQueue = Promise.resolve();
+
+    socket.on("message", (raw: RawData) => {
+      messageQueue = messageQueue
+        .catch((error: unknown) => {
+          args.logEvent("ws_message_queue_failed", {
+            sessionId: session.id,
+            roomCode: session.roomCode,
+            remoteAddress: session.remoteAddress,
+            origin: session.origin,
+            result: "error",
+            error: error instanceof Error ? error.message : "unknown_error",
+          });
+        })
+        .then(async () => {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(raw.toString());
+          } catch {
+            sendError(socket, "invalid_message", INVALID_JSON_MESSAGE);
+            countInvalidMessage(
+              session,
+              "invalid_json",
+              args.securityConfig,
+              args.logEvent,
+            );
+            return;
+          }
+
+          if (!isClientMessage(parsed)) {
+            sendError(
+              socket,
+              "invalid_message",
+              INVALID_CLIENT_MESSAGE_MESSAGE,
+            );
+            countInvalidMessage(
+              session,
+              "invalid_client_message",
+              args.securityConfig,
+              args.logEvent,
+            );
+            return;
+          }
+
+          try {
+            await args.messageHandler.handleClientMessage(session, parsed);
+          } catch (error) {
+            args.logEvent("ws_client_message_failed", {
+              sessionId: session.id,
+              roomCode: session.roomCode,
+              remoteAddress: session.remoteAddress,
+              origin: session.origin,
+              result: "error",
+              error: error instanceof Error ? error.message : "unknown_error",
+            });
+            sendError(socket, "internal_error", INTERNAL_SERVER_ERROR_MESSAGE);
+          }
+        });
+    });
+
+    socket.on("error", (error) => {
+      args.logEvent("ws_connection_error", {
+        sessionId: session.id,
+        remoteAddress: session.remoteAddress,
+        origin: session.origin,
+        roomCode: session.roomCode,
+        result: "error",
+        error: error.message,
+      });
+    });
+
+    socket.on("close", (code, reason) => {
+      const decodeCloseReason = (r: Buffer): string => {
+        const decoded = r.toString("utf8");
+        return decoded.length > 0 ? decoded : "";
+      };
+      const cleanup = cleanupSessionAfterClose({
+        session,
+        code,
+        reason,
+        messageHandler: args.messageHandler,
+        runtimeStore: args.runtimeStore,
+        securityPolicy: args.securityPolicy,
+        logEvent: args.logEvent,
+        decodeCloseReason,
+      });
+      args.pendingSessionCleanup.add(cleanup);
+      void cleanup.finally(() => {
+        args.pendingSessionCleanup.delete(cleanup);
+      });
+    });
+  };
+}
+
+function countInvalidMessage(
+  session: Session,
+  reason: string,
+  securityConfig: SecurityConfig,
+  logEvent: LogEvent,
+): void {
+  session.invalidMessageCount += 1;
+  logEvent("invalid_message", {
+    sessionId: session.id,
+    roomCode: session.roomCode,
+    remoteAddress: session.remoteAddress,
+    origin: session.origin,
+    result: "rejected",
+    reason,
+    invalidMessageCount: session.invalidMessageCount,
+  });
+
+  if (
+    session.invalidMessageCount >=
+      securityConfig.invalidMessageCloseThreshold &&
+    hasAttachedSocket(session)
+  ) {
+    session.socket.close(
+      CLOSE_CODE_POLICY_VIOLATION,
+      "Too many invalid messages",
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- **`extension/src/content/index.ts`**：提取 `runtimeSendMessage` → `content-messaging.ts`，`startUserGestureTracking` → `gesture-tracker.ts`，`reportCurrentUser` → `user-reporter.ts`
- **`extension/src/background/index.ts`**：Chrome 监听器注册 → `chrome-runtime-bus.ts`；`disconnectSocket` → `socket-lifecycle.ts`；`executeFlushPendingShare` → `room-manager.ts`；`resetRoomLifecycleTransientState` → `room-state.ts`
- **`server/src/app.ts`**：WS upgrade/connection 处理器 + `cleanupSessionAfterClose` + `send`/`sendError` → `ws-session-handler.ts`；导出 `hasClose` 供复用
- **`server/src/global-admin-app.ts`**：`close()` 改用 `runShutdownSteps` + `hasClose`，消除重复的手动关闭模式

Closes #12

## Test plan

- [x] `npm run typecheck` — 通过
- [x] `npm run lint` — 通过
- [x] `npm run format:check` — 通过
- [x] `npm test` — 170/170 通过
- [x] `npm run build` — 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)