### PR TITLE
refactor: extract createStore<T> factory for flat-state stores

### DIFF
--- a/extension/src/content/content-store.ts
+++ b/extension/src/content/content-store.ts
@@ -1,35 +1,11 @@
+import { createStore, type StateStore } from "../shared/create-store";
 import {
   createContentRuntimeState,
   type ContentRuntimeState,
 } from "./runtime-state";
 
-export type ContentRuntimeStatePatch = Partial<ContentRuntimeState>;
-
-export interface ContentStateStore {
-  getState(): ContentRuntimeState;
-  patch(patch: ContentRuntimeStatePatch): ContentRuntimeState;
-  replace(nextState: ContentRuntimeState): ContentRuntimeState;
-  reset(): ContentRuntimeState;
-}
+export type ContentStateStore = StateStore<ContentRuntimeState>;
 
 export function createContentStateStore(): ContentStateStore {
-  const state = createContentRuntimeState();
-
-  return {
-    getState() {
-      return state;
-    },
-    patch(patch) {
-      Object.assign(state, patch);
-      return state;
-    },
-    replace(nextState) {
-      Object.assign(state, nextState);
-      return state;
-    },
-    reset() {
-      Object.assign(state, createContentRuntimeState());
-      return state;
-    },
-  };
+  return createStore<ContentRuntimeState>(createContentRuntimeState);
 }

--- a/extension/src/popup/popup-store.ts
+++ b/extension/src/popup/popup-store.ts
@@ -1,3 +1,5 @@
+import { createStore, type StateStore } from "../shared/create-store";
+
 export interface PopupUiState {
   roomActionPending: boolean;
   lastKnownPendingCreateRoom: boolean;
@@ -11,11 +13,7 @@ export interface PopupUiState {
   popupPort: chrome.runtime.Port | null;
 }
 
-export interface PopupUiStateStore {
-  getState(): PopupUiState;
-  patch(nextState: Partial<PopupUiState>): PopupUiState;
-  reset(): PopupUiState;
-}
+export type PopupUiStateStore = StateStore<PopupUiState>;
 
 export function createPopupUiState(): PopupUiState {
   return {
@@ -33,19 +31,5 @@ export function createPopupUiState(): PopupUiState {
 }
 
 export function createPopupUiStateStore(): PopupUiStateStore {
-  const state = createPopupUiState();
-
-  return {
-    getState() {
-      return state;
-    },
-    patch(nextState) {
-      Object.assign(state, nextState);
-      return state;
-    },
-    reset() {
-      Object.assign(state, createPopupUiState());
-      return state;
-    },
-  };
+  return createStore<PopupUiState>(createPopupUiState);
 }

--- a/extension/src/shared/create-store.ts
+++ b/extension/src/shared/create-store.ts
@@ -1,0 +1,34 @@
+export interface StateStore<T> {
+  getState(): T;
+  patch(patch: Partial<T>): T;
+  replace(nextState: T): T;
+  reset(): T;
+}
+
+/**
+ * Creates a lightweight store for flat (non-nested) state objects.
+ * All mutations are in-place via Object.assign so existing references remain valid.
+ */
+export function createStore<T extends object>(
+  createInitialState: () => T,
+): StateStore<T> {
+  const state = createInitialState();
+
+  return {
+    getState() {
+      return state;
+    },
+    patch(patch) {
+      Object.assign(state, patch);
+      return state;
+    },
+    replace(nextState) {
+      Object.assign(state, nextState);
+      return state;
+    },
+    reset() {
+      Object.assign(state, createInitialState());
+      return state;
+    },
+  };
+}


### PR DESCRIPTION
Closes #19

## Summary

- 新建 `extension/src/shared/create-store.ts`，提取泛型 `createStore<T>` 工厂，统一 `getState / patch / replace / reset` 接口
- `content/content-store.ts` 和 `popup/popup-store.ts` 委托给 `createStore<T>`，各自由 ~35 行缩减为 ~10 行
- `popup/popup-store.ts` 的 `PopupUiStateStore` 接口顺带补齐 `replace` 方法，与 `ContentStateStore` 对齐
- `background/state-store.ts` 保持不动——其嵌套 patch 逻辑（逐 key `Object.assign` 子对象）是真实的结构差异，不属于重复

## Test plan

- [x] `npm run format:check` 通过
- [x] `npm run lint` 通过
- [x] `npm run typecheck` 通过（extension / server / protocol）
- [x] `npm run build` 通过
- [x] `npm test` 通过（170 tests, 0 fail）

🤖 Generated with [Claude Code](https://claude.com/claude-code)