### PR TITLE
fix: log malformed URL in parseBilibiliVideoRef catch block

### DIFF
--- a/packages/protocol/src/video-ref.ts
+++ b/packages/protocol/src/video-ref.ts
@@ -94,11 +94,16 @@ export function parseBilibiliVideoRef(
         : basePath;
     return { videoId, normalizedUrl };
   } catch (err) {
-    console.debug(
-      "[bili-syncplay] parseBilibiliVideoRef: failed to parse URL",
-      url,
-      err,
-    );
+    if (
+      typeof process === "undefined" ||
+      process.env.NODE_ENV !== "production"
+    ) {
+      console.debug(
+        "[bili-syncplay] parseBilibiliVideoRef: failed to parse URL",
+        url,
+        err,
+      );
+    }
     return null;
   }
 }

--- a/packages/protocol/src/video-ref.ts
+++ b/packages/protocol/src/video-ref.ts
@@ -93,7 +93,12 @@ export function parseBilibiliVideoRef(
         ? `${basePath}?p=${p}`
         : basePath;
     return { videoId, normalizedUrl };
-  } catch {
+  } catch (err) {
+    console.debug(
+      "[bili-syncplay] parseBilibiliVideoRef: failed to parse URL",
+      url,
+      err,
+    );
     return null;
   }
 }


### PR DESCRIPTION
Closes #22

## Summary

- `parseBilibiliVideoRef` 的 `catch` 块现在通过 `console.debug` 输出失败的 URL 和原始错误，方便快速定位异常输入
- 仅覆盖真正的异常路径（`new URL()` 抛出，即格式错误的 URL）；不支持的域名/路径属于预期控制流，保持静默
- `console.debug` 属于 DevTools Verbose 级别，默认不显示，生产环境用户无感知

## Test plan

- [x] `npm run format:check` 通过
- [x] `npm run lint` 通过
- [x] `npm run typecheck` 通过
- [x] `npm run build` 通过
- [x] `npm test` 通过（170 tests, 0 fail）

🤖 Generated with [Claude Code](https://claude.com/claude-code)