### PR TITLE
feat: add LRU micro-cache to normalizeSharedVideoUrl

### DIFF
--- a/extension/src/shared/url.ts
+++ b/extension/src/shared/url.ts
@@ -1,9 +1,27 @@
 import { normalizeBilibiliUrl } from "@bili-syncplay/protocol";
 
+const NORMALIZE_CACHE_CAPACITY = 16;
+const normalizeCache = new Map<string, string | null>();
+
 export function normalizeSharedVideoUrl(
   url: string | null | undefined,
 ): string | null {
-  return normalizeBilibiliUrl(url);
+  if (!url) {
+    return null;
+  }
+  if (normalizeCache.has(url)) {
+    const cached = normalizeCache.get(url)!;
+    // Refresh to most-recently-used position
+    normalizeCache.delete(url);
+    normalizeCache.set(url, cached);
+    return cached;
+  }
+  const result = normalizeBilibiliUrl(url);
+  if (normalizeCache.size >= NORMALIZE_CACHE_CAPACITY) {
+    normalizeCache.delete(normalizeCache.keys().next().value!);
+  }
+  normalizeCache.set(url, result);
+  return result;
 }
 
 export function areSharedVideoUrlsEqual(


### PR DESCRIPTION
Closes #21

## Summary

- 在 `extension/src/shared/url.ts` 的 `normalizeSharedVideoUrl` 内添加容量 16 的 Map-based LRU 缓存
- `sync-controller` 单次 playback 事件中对同一 URL 调用十余次 `normalizeUrl`，缓存命中后跳过 `new URL()` + 正则解析
- LRU 策略：命中时 delete + re-insert 刷新 MRU 位置；未命中且满容时 evict 最旧 key（Map 首个键）
- `null`/`undefined` 直接短路返回，不进缓存
- 协议包（`normalizeBilibiliUrl`）保持不变，缓存仅在扩展侧

## Test plan

- [x] `npm run format:check` 通过
- [x] `npm run lint` 通过
- [x] `npm run typecheck` 通过
- [x] `npm run build` 通过
- [x] `npm test` 通过（170 tests, 0 fail）

🤖 Generated with [Claude Code](https://claude.com/claude-code)