### PR TITLE
[codex] Refactor shared server bootstrap helpers for issue #39

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,8 +1,10 @@
-import { createServer, type Server as HttpServer } from "node:http";
-import { randomBytes } from "node:crypto";
+import type { Server as HttpServer } from "node:http";
 import { WebSocketServer } from "ws";
-import { createAdminServices } from "./bootstrap/admin-services.js";
-import { createHttpRequestHandler } from "./bootstrap/http-handler.js";
+import {
+  createCloseHttpServerStep,
+  createSharedAdminHttpBootstrap,
+  resolveServerRuntimeDependencies,
+} from "./bootstrap/admin-http-bootstrap.js";
 import {
   createServerBootstrapContext,
   createSharedServerShutdownSteps,
@@ -17,10 +19,8 @@ import { createRoomEventConsumer } from "./room-event-consumer.js";
 import { type RoomStore } from "./room-store.js";
 import { createRoomReaper } from "./room-reaper.js";
 import { createRoomService } from "./room-service.js";
-import { createRuntimeIndexReaper } from "./runtime-index-reaper.js";
 import type { RoomEventBusMessage } from "./room-event-bus.js";
 import { type RuntimeStore } from "./runtime-store.js";
-import { createSecurityPolicy } from "./security.js";
 import { hasAttachedSocket } from "./types.js";
 import {
   createWsConnectionHandler,
@@ -76,9 +76,7 @@ export async function createSyncServer(
   persistenceConfig: PersistenceConfig = getDefaultPersistenceConfig(),
   dependencies: SyncServerDependencies = {},
 ): Promise<SyncServer> {
-  const now = dependencies.now ?? Date.now;
-  const generateToken =
-    dependencies.generateToken ?? (() => randomBytes(24).toString("base64url"));
+  const { now, generateToken } = resolveServerRuntimeDependencies(dependencies);
   const {
     serviceVersion,
     roomStore,
@@ -133,7 +131,6 @@ export async function createSyncServer(
       },
     },
   });
-  const securityPolicy = createSecurityPolicy(securityConfig);
 
   const roomService = createRoomService({
     config: securityConfig,
@@ -255,40 +252,24 @@ export async function createSyncServer(
     logEvent,
   });
   nodeHeartbeat.start();
-  const runtimeIndexReaper = createRuntimeIndexReaper({
-    enabled:
-      persistenceConfig.nodeHeartbeatEnabled &&
-      persistenceConfig.runtimeStoreProvider === "redis",
-    runtimeStore,
-    intervalMs: persistenceConfig.nodeHeartbeatIntervalMs,
-    now,
-    logEvent,
-  });
-  runtimeIndexReaper.start();
-  const { adminRouter, close: closeAdminServices } = await createAdminServices({
-    securityConfig,
-    persistenceConfig,
-    roomStore,
-    runtimeStore,
-    eventStore,
-    roomService,
-    send,
-    publishRoomEvent,
-    requestAdminCommand: (command, timeoutMs) =>
-      adminCommandBus.request(command, timeoutMs),
-    logEvent,
-    now,
-    adminConfig: dependencies.adminConfig,
-    serviceVersion,
-  });
-
-  const httpServer = createServer(
-    createHttpRequestHandler({
-      adminRouter,
-      securityPolicy,
+  const { securityPolicy, httpServer, runtimeIndexReaper, closeAdminServices } =
+    await createSharedAdminHttpBootstrap({
+      securityConfig,
+      persistenceConfig,
+      roomStore,
+      runtimeStore,
+      eventStore,
+      roomService,
+      send,
+      publishRoomEvent,
+      requestAdminCommand: (command, timeoutMs) =>
+        adminCommandBus.request(command, timeoutMs),
+      logEvent,
+      now,
+      adminConfig: dependencies.adminConfig,
       adminUiConfig: dependencies.adminUiConfig,
-    }),
-  );
+      serviceVersion,
+    });
 
   const wss = new WebSocketServer({
     noServer: true,
@@ -353,13 +334,9 @@ export async function createSyncServer(
                     reject(wsError);
                     return;
                   }
-                  httpServer.close((httpError) => {
-                    if (httpError) {
-                      reject(httpError);
-                      return;
-                    }
-                    resolve();
-                  });
+                  Promise.resolve(
+                    createCloseHttpServerStep(httpServer).run(),
+                  ).then(() => resolve(), reject);
                 });
               }),
           },

--- a/server/src/bootstrap/admin-http-bootstrap.ts
+++ b/server/src/bootstrap/admin-http-bootstrap.ts
@@ -1,0 +1,128 @@
+import { randomBytes } from "node:crypto";
+import { createServer, type Server as HttpServer } from "node:http";
+import type { ServerMessage } from "@bili-syncplay/protocol";
+import type { WebSocket } from "ws";
+import type { GlobalEventStore } from "../admin/global-event-store.js";
+import { createAdminOverviewService } from "../admin/overview-service.js";
+import { createAdminRoomQueryService } from "../admin/room-query-service.js";
+import type { AdminCommandBus } from "../admin-command-bus.js";
+import type { RoomEventBusMessage } from "../room-event-bus.js";
+import type { RoomStore } from "../room-store.js";
+import { createRoomService } from "../room-service.js";
+import { createRuntimeIndexReaper } from "../runtime-index-reaper.js";
+import { createSecurityPolicy } from "../security.js";
+import type {
+  AdminConfig,
+  AdminUiConfig,
+  LogEvent,
+  PersistenceConfig,
+  SecurityConfig,
+} from "../types.js";
+import type { RuntimeStore } from "../runtime-store.js";
+import { createAdminServices } from "./admin-services.js";
+import { createHttpRequestHandler } from "./http-handler.js";
+import type { ShutdownStep } from "./server-bootstrap.js";
+
+export function resolveServerRuntimeDependencies(dependencies: {
+  now?: () => number;
+  generateToken?: () => string;
+}): {
+  now: () => number;
+  generateToken: () => string;
+} {
+  return {
+    now: dependencies.now ?? Date.now,
+    generateToken:
+      dependencies.generateToken ??
+      (() => randomBytes(24).toString("base64url")),
+  };
+}
+
+export async function createSharedAdminHttpBootstrap(args: {
+  securityConfig: SecurityConfig;
+  persistenceConfig: PersistenceConfig;
+  roomStore: RoomStore;
+  runtimeStore: RuntimeStore;
+  eventStore: GlobalEventStore;
+  roomService: ReturnType<typeof createRoomService>;
+  send: (socket: WebSocket, message: ServerMessage) => void;
+  publishRoomEvent: (message: RoomEventBusMessage) => Promise<void>;
+  requestAdminCommand: AdminCommandBus["request"];
+  logEvent: LogEvent;
+  now: () => number;
+  adminConfig?: AdminConfig;
+  adminUiConfig?: AdminUiConfig;
+  serviceVersion: string;
+  serviceName?: string;
+  createOverviewService?: typeof createAdminOverviewService;
+  createRoomQueryService?: typeof createAdminRoomQueryService;
+}): Promise<{
+  securityPolicy: ReturnType<typeof createSecurityPolicy>;
+  httpServer: HttpServer;
+  runtimeIndexReaper: ReturnType<typeof createRuntimeIndexReaper>;
+  closeAdminServices: () => Promise<void>;
+}> {
+  const securityPolicy = createSecurityPolicy(args.securityConfig);
+  const runtimeIndexReaper = createRuntimeIndexReaper({
+    enabled:
+      args.persistenceConfig.nodeHeartbeatEnabled &&
+      args.persistenceConfig.runtimeStoreProvider === "redis",
+    runtimeStore: args.runtimeStore,
+    intervalMs: args.persistenceConfig.nodeHeartbeatIntervalMs,
+    now: args.now,
+    logEvent: args.logEvent,
+  });
+  runtimeIndexReaper.start();
+
+  const { adminRouter, close: closeAdminServices } = await createAdminServices({
+    securityConfig: args.securityConfig,
+    persistenceConfig: args.persistenceConfig,
+    roomStore: args.roomStore,
+    runtimeStore: args.runtimeStore,
+    eventStore: args.eventStore,
+    roomService: args.roomService,
+    send: args.send,
+    publishRoomEvent: args.publishRoomEvent,
+    requestAdminCommand: args.requestAdminCommand,
+    logEvent: args.logEvent,
+    now: args.now,
+    adminConfig: args.adminConfig,
+    serviceVersion: args.serviceVersion,
+    serviceName: args.serviceName,
+    createOverviewService: args.createOverviewService,
+    createRoomQueryService: args.createRoomQueryService,
+  });
+
+  const httpServer = createServer(
+    createHttpRequestHandler({
+      adminRouter,
+      securityPolicy,
+      adminUiConfig: args.adminUiConfig,
+    }),
+  );
+
+  return {
+    securityPolicy,
+    httpServer,
+    runtimeIndexReaper,
+    closeAdminServices,
+  };
+}
+
+export function createCloseHttpServerStep(
+  httpServer: HttpServer,
+): ShutdownStep {
+  return {
+    name: "close_http_server",
+    run: () =>
+      new Promise<void>((resolve, reject) => {
+        httpServer.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+  };
+}

--- a/server/src/bootstrap/admin-http-bootstrap.ts
+++ b/server/src/bootstrap/admin-http-bootstrap.ts
@@ -72,7 +72,6 @@ export async function createSharedAdminHttpBootstrap(args: {
     now: args.now,
     logEvent: args.logEvent,
   });
-  runtimeIndexReaper.start();
 
   const { adminRouter, close: closeAdminServices } = await createAdminServices({
     securityConfig: args.securityConfig,
@@ -100,6 +99,7 @@ export async function createSharedAdminHttpBootstrap(args: {
       adminUiConfig: args.adminUiConfig,
     }),
   );
+  runtimeIndexReaper.start();
 
   return {
     securityPolicy,

--- a/server/src/global-admin-app.ts
+++ b/server/src/global-admin-app.ts
@@ -1,8 +1,11 @@
-import { createServer, type Server as HttpServer } from "node:http";
-import { randomBytes } from "node:crypto";
+import type { Server as HttpServer } from "node:http";
 import { createGlobalAdminOverviewService } from "./admin/global-overview-service.js";
 import { createGlobalAdminRoomQueryService } from "./admin/global-room-query-service.js";
-import { createAdminServices } from "./bootstrap/admin-services.js";
+import {
+  createCloseHttpServerStep,
+  createSharedAdminHttpBootstrap,
+  resolveServerRuntimeDependencies,
+} from "./bootstrap/admin-http-bootstrap.js";
 import {
   createServerBootstrapContext,
   createSharedServerShutdownSteps,
@@ -10,12 +13,9 @@ import {
   getDefaultSecurityConfig,
   runShutdownSteps,
 } from "./bootstrap/server-bootstrap.js";
-import { createHttpRequestHandler } from "./bootstrap/http-handler.js";
 import { type RoomStore } from "./room-store.js";
 import { createRoomService } from "./room-service.js";
 import type { RoomEventBusMessage } from "./room-event-bus.js";
-import { createRuntimeIndexReaper } from "./runtime-index-reaper.js";
-import { createSecurityPolicy } from "./security.js";
 import type {
   AdminConfig,
   AdminUiConfig,
@@ -44,9 +44,7 @@ export async function createGlobalAdminServer(
   persistenceConfig: PersistenceConfig = getDefaultPersistenceConfig(),
   dependencies: GlobalAdminServerDependencies = {},
 ): Promise<GlobalAdminServer> {
-  const now = dependencies.now ?? Date.now;
-  const generateToken =
-    dependencies.generateToken ?? (() => randomBytes(24).toString("base64url"));
+  const { now, generateToken } = resolveServerRuntimeDependencies(dependencies);
   const {
     serviceVersion,
     roomStore,
@@ -67,64 +65,35 @@ export async function createGlobalAdminServer(
     logEvent,
     now,
   });
-  const securityPolicy = createSecurityPolicy(securityConfig);
-  const { adminRouter, close: closeAdminServices } = await createAdminServices({
-    securityConfig,
-    persistenceConfig,
-    roomStore,
-    runtimeStore,
-    eventStore,
-    roomService,
-    send() {},
-    publishRoomEvent: (message: RoomEventBusMessage) =>
-      roomEventBus.publish(message),
-    requestAdminCommand: (command, timeoutMs) =>
-      adminCommandBus.request(command, timeoutMs),
-    logEvent,
-    now,
-    adminConfig: dependencies.adminConfig,
-    serviceName: "bili-syncplay-global-admin",
-    createOverviewService: createGlobalAdminOverviewService,
-    createRoomQueryService: createGlobalAdminRoomQueryService,
-    serviceVersion,
-  });
-  const runtimeIndexReaper = createRuntimeIndexReaper({
-    enabled:
-      persistenceConfig.nodeHeartbeatEnabled &&
-      persistenceConfig.runtimeStoreProvider === "redis",
-    runtimeStore,
-    intervalMs: persistenceConfig.nodeHeartbeatIntervalMs,
-    now,
-    logEvent,
-  });
-  runtimeIndexReaper.start();
-
-  const httpServer = createServer(
-    createHttpRequestHandler({
-      adminRouter,
-      securityPolicy,
+  const { httpServer, runtimeIndexReaper, closeAdminServices } =
+    await createSharedAdminHttpBootstrap({
+      securityConfig,
+      persistenceConfig,
+      roomStore,
+      runtimeStore,
+      eventStore,
+      roomService,
+      send() {},
+      publishRoomEvent: (message: RoomEventBusMessage) =>
+        roomEventBus.publish(message),
+      requestAdminCommand: (command, timeoutMs) =>
+        adminCommandBus.request(command, timeoutMs),
+      logEvent,
+      now,
+      adminConfig: dependencies.adminConfig,
       adminUiConfig: dependencies.adminUiConfig,
-    }),
-  );
+      serviceName: "bili-syncplay-global-admin",
+      createOverviewService: createGlobalAdminOverviewService,
+      createRoomQueryService: createGlobalAdminRoomQueryService,
+      serviceVersion,
+    });
 
   return {
     httpServer,
     close: () =>
       runShutdownSteps(
         [
-          {
-            name: "close_http_server",
-            run: () =>
-              new Promise<void>((resolve, reject) => {
-                httpServer.close((error) => {
-                  if (error) {
-                    reject(error);
-                    return;
-                  }
-                  resolve();
-                });
-              }),
-          },
+          createCloseHttpServerStep(httpServer),
           {
             name: "stop_runtime_index_reaper",
             run: () => runtimeIndexReaper.stop(),


### PR DESCRIPTION
## What changed

- extracted shared server/admin HTTP bootstrap helpers into `server/src/bootstrap/admin-http-bootstrap.ts`
- reused the shared bootstrap flow from both `server/src/app.ts` and `server/src/global-admin-app.ts`
- centralized common runtime dependency defaults, admin service wiring, runtime index reaper startup, HTTP server creation, and HTTP close-step creation

## Why

Issue #39 pointed out that room node and global admin startup paths still had parallel bootstrap code for store/service wiring and shutdown orchestration. That duplication made it easier for one path to drift when adding new capabilities.

This refactor reduces that duplication while keeping the room node specific WebSocket, consumer, heartbeat, and session-cleanup behavior in `app.ts`.

## Impact

- lowers maintenance risk between room node and global admin node bootstrap paths
- keeps existing runtime behavior unchanged by preserving node-specific responsibilities at the entry points
- makes future shared bootstrap changes easier to implement in one place

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm test`
