### PR TITLE
fix: suppress expected TypeError log noise in URL parsing

### DIFF
--- a/packages/protocol/src/video-ref.ts
+++ b/packages/protocol/src/video-ref.ts
@@ -95,11 +95,11 @@ export function parseBilibiliVideoRef(
     return { videoId, normalizedUrl };
   } catch (err) {
     if (
-      typeof process === "undefined" ||
-      process.env.NODE_ENV !== "production"
+      !(err instanceof TypeError) &&
+      (typeof process === "undefined" || process.env.NODE_ENV !== "production")
     ) {
       console.debug(
-        "[bili-syncplay] parseBilibiliVideoRef: failed to parse URL",
+        "[bili-syncplay] parseBilibiliVideoRef: unexpected error parsing URL",
         url,
         err,
       );


### PR DESCRIPTION
## Summary

- `new URL()` 对无效 URL 抛出的 `TypeError` 属于预期失败，不应产生堆栈日志
- 修改 catch 块，仅在 `err` 不是 `TypeError` 时才输出调试信息
- 常规无效输入（如 `not-a-url`）不再污染测试或开发环境输出
- 意外的非 TypeError 异常仍会被记录，诊断能力保留

Closes #41

## Test plan

- [ ] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` 全部通过（170 个测试）
- [ ] `parseBilibiliVideoRef("not-a-url")` 返回 `null`，不再打印堆栈日志
- [ ] 合法 URL 解析行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)