### PR TITLE
fix: 收紧 /api/connection-check CORS 并去除原因字段 (#50)

### DIFF
--- a/server/src/bootstrap/http-handler.ts
+++ b/server/src/bootstrap/http-handler.ts
@@ -23,20 +23,23 @@ export function createHttpRequestHandler(args: {
       const originHeader = request.headers.origin;
       const origin = typeof originHeader === "string" ? originHeader : null;
       const originCheck = args.securityPolicy.isOriginAllowed(origin);
-      const corsHeaders = {
+      const responseHeaders: Record<string, string> = {
         "content-type": "application/json; charset=utf-8",
-        "access-control-allow-origin": "*",
-        "access-control-allow-methods": "GET, OPTIONS",
-        "access-control-allow-headers": "content-type",
         "cache-control": "no-store",
+        vary: "origin",
       };
+      if (originCheck.ok && origin) {
+        responseHeaders["access-control-allow-origin"] = origin;
+        responseHeaders["access-control-allow-methods"] = "GET, OPTIONS";
+        responseHeaders["access-control-allow-headers"] = "content-type";
+      }
       if (request.method === "OPTIONS") {
-        response.writeHead(204, corsHeaders);
+        response.writeHead(204, responseHeaders);
         response.end();
         return;
       }
       if (request.method !== "GET") {
-        response.writeHead(405, corsHeaders);
+        response.writeHead(405, responseHeaders);
         response.end(
           JSON.stringify({
             ok: false,
@@ -48,13 +51,12 @@ export function createHttpRequestHandler(args: {
         );
         return;
       }
-      response.writeHead(200, corsHeaders);
+      response.writeHead(200, responseHeaders);
       response.end(
         JSON.stringify({
           ok: true,
           data: {
             websocketAllowed: originCheck.ok,
-            reason: originCheck.ok ? null : originCheck.reason,
           },
         }),
       );

--- a/server/test/admin-backend.test.ts
+++ b/server/test/admin-backend.test.ts
@@ -250,13 +250,13 @@ test("admin endpoints support auth, overview, rooms, and events without breaking
     assert.equal(connectionCheck.status, 200);
     assert.equal(
       connectionCheck.headers.get("access-control-allow-origin"),
-      "*",
+      ALLOWED_ORIGIN,
     );
+    assert.equal(connectionCheck.headers.get("vary"), "origin");
     assert.deepEqual(await connectionCheck.json(), {
       ok: true,
       data: {
         websocketAllowed: true,
-        reason: null,
       },
     });
 

--- a/server/test/http-handler.test.ts
+++ b/server/test/http-handler.test.ts
@@ -79,7 +79,7 @@ function createHandler(adminHandled = false) {
   return { handler, adminCalls };
 }
 
-test("http handler responds to connection-check preflight and origin status", () => {
+test("http handler reflects allowed origin on connection-check preflight", () => {
   const { handler, adminCalls } = createHandler();
 
   const preflightResponse = createResponse();
@@ -92,26 +92,83 @@ test("http handler responds to connection-check preflight and origin status", ()
     preflightResponse,
   );
   assert.equal(preflightResponse.statusCode, 204);
-  assert.equal(preflightResponse.headers["access-control-allow-origin"], "*");
+  assert.equal(
+    preflightResponse.headers["access-control-allow-origin"],
+    "chrome-extension://allowed",
+  );
+  assert.equal(preflightResponse.headers["vary"], "origin");
+  assert.equal(adminCalls.length, 0);
+});
 
-  const getResponse = createResponse();
+test("http handler reports websocketAllowed without leaking reason or CORS to disallowed origins", () => {
+  const { handler, adminCalls } = createHandler();
+
+  const allowedResponse = createResponse();
+  handler(
+    createRequest({
+      url: "/api/connection-check",
+      method: "GET",
+      origin: "chrome-extension://allowed",
+    }),
+    allowedResponse,
+  );
+  assert.equal(allowedResponse.statusCode, 200);
+  assert.equal(
+    allowedResponse.headers["access-control-allow-origin"],
+    "chrome-extension://allowed",
+  );
+  assert.equal(allowedResponse.headers["vary"], "origin");
+  assert.deepEqual(JSON.parse(allowedResponse.body), {
+    ok: true,
+    data: {
+      websocketAllowed: true,
+    },
+  });
+
+  const deniedResponse = createResponse();
   handler(
     createRequest({
       url: "/api/connection-check",
       method: "GET",
       origin: "chrome-extension://denied",
     }),
-    getResponse,
+    deniedResponse,
   );
-  assert.equal(getResponse.statusCode, 200);
-  assert.deepEqual(JSON.parse(getResponse.body), {
+  assert.equal(deniedResponse.statusCode, 200);
+  assert.equal(
+    deniedResponse.headers["access-control-allow-origin"],
+    undefined,
+  );
+  assert.equal(deniedResponse.headers["vary"], "origin");
+  assert.deepEqual(JSON.parse(deniedResponse.body), {
     ok: true,
     data: {
       websocketAllowed: false,
-      reason: "origin_not_allowed",
     },
   });
   assert.equal(adminCalls.length, 0);
+});
+
+test("http handler omits CORS headers when origin is missing", () => {
+  const { handler } = createHandler();
+
+  const response = createResponse();
+  handler(
+    createRequest({
+      url: "/api/connection-check",
+      method: "GET",
+    }),
+    response,
+  );
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers["access-control-allow-origin"], undefined);
+  assert.equal(response.headers["vary"], "origin");
+  assert.deepEqual(JSON.parse(response.body), {
+    ok: true,
+    data: {
+      websocketAllowed: false,
+    },
+  });
 });
 
 test("http handler preserves admin router responses without falling through to root payload", async () => {


### PR DESCRIPTION
## Summary
- 将 `/api/connection-check` 的 `access-control-allow-origin: *` 改为：仅当 Origin 通过 `isOriginAllowed` 时反射该 Origin，并补 `Vary: Origin`
- 从响应体移除 `reason` 字段，避免把 `origin_missing` / `origin_not_allowed` 等策略细节暴露给任意来源
- 更新 `http-handler` 与 `admin-backend` 回归用例，覆盖 allow/deny/missing 三种 Origin 分支

## Closes
- Closes #50

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)