### PR TITLE
fix: tryClaimMessageSlot TTL 非正时用最小 TTL 兜底并发日志 (#51)

### DIFF
--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -170,6 +170,10 @@ function nodeStatusKey(prefix: string, instanceId: string): string {
 
 const DEFAULT_MAX_PENDING_OPERATIONS = 256;
 const DEFAULT_PENDING_OPERATION_TIMEOUT_MS = 5_000;
+// Floor TTL applied only when the caller's expiresAt is already non-positive
+// (GC pause, event-loop jitter, clock drift). Positive but small TTLs are
+// respected as-is so callers retain control over the dedup window semantics.
+const DEDUP_SLOT_MIN_TTL_MS = 1_000;
 
 function serializeSession(session: Session): RedisRuntimeSession {
   return {
@@ -650,8 +654,25 @@ export async function createRedisRuntimeStore(
       key: string,
       expiresAt: number,
     ) {
-      const ttlMs = Math.max(0, expiresAt - now());
-      if (ttlMs === 0) return true;
+      const currentTime = now();
+      const requestedTtlMs = expiresAt - currentTime;
+      let ttlMs: number;
+      if (requestedTtlMs <= 0) {
+        ttlMs = DEDUP_SLOT_MIN_TTL_MS;
+        console.log(
+          JSON.stringify({
+            event: "dedup_slot_ttl_clamped",
+            timestamp: new Date(currentTime).toISOString(),
+            roomCode,
+            key,
+            requestedTtlMs,
+            appliedTtlMs: ttlMs,
+          }),
+        );
+      } else {
+        ttlMs = requestedTtlMs;
+      }
+      const effectiveExpiresAt = Math.max(expiresAt, currentTime + ttlMs);
       const slotKey = dedupSlotKey(keyPrefix, roomCode, key);
       const result = await redis.set(slotKey, "1", "NX", "PX", ttlMs);
       if (result !== null) {
@@ -660,7 +681,7 @@ export async function createRedisRuntimeStore(
           // Await so deleteRoom's ZRANGE always sees this entry.
           // If tracking fails, the slot still expires via its TTL.
           await Promise.all([
-            redis.zadd(trackingKey, String(expiresAt), slotKey),
+            redis.zadd(trackingKey, String(effectiveExpiresAt), slotKey),
             redis.zremrangebyscore(trackingKey, 0, now() - 1),
           ]);
         } catch {

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { Redis } from "ioredis";
 import type { ActiveRoom, ClusterNodeStatus, Session } from "./types.js";
 import {
@@ -659,12 +660,22 @@ export async function createRedisRuntimeStore(
       let ttlMs: number;
       if (requestedTtlMs <= 0) {
         ttlMs = DEDUP_SLOT_MIN_TTL_MS;
+        // Redact the slot key before logging: its body contains caller-provided
+        // URLs and actor/session identifiers. Keep only the non-sensitive kind
+        // prefix (before the first ':') and a short hash for correlation.
+        const colonIndex = key.indexOf(":");
+        const keyKind = colonIndex === -1 ? key : key.slice(0, colonIndex);
+        const keyHash = createHash("sha256")
+          .update(key)
+          .digest("hex")
+          .slice(0, 16);
         console.log(
           JSON.stringify({
             event: "dedup_slot_ttl_clamped",
             timestamp: new Date(currentTime).toISOString(),
             roomCode,
-            key,
+            keyKind,
+            keyHash,
             requestedTtlMs,
             appliedTtlMs: ttlMs,
           }),

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -379,9 +379,13 @@ test("redis runtime store clamps dedup slot TTL to a floor when expiresAt is alr
       .find((entry) => entry?.event === "dedup_slot_ttl_clamped");
     assert.ok(clampLog, "expected dedup_slot_ttl_clamped event to be logged");
     assert.equal(clampLog.roomCode, "ROOMXX");
-    assert.equal(clampLog.key, "share:actor:url:1");
     assert.equal(clampLog.requestedTtlMs, -10);
     assert.equal(clampLog.appliedTtlMs, 1_000);
+    // Raw key must not be logged (contains caller URL + actor id).
+    assert.equal(clampLog.key, undefined);
+    assert.equal(clampLog.keyKind, "share");
+    assert.equal(typeof clampLog.keyHash, "string");
+    assert.match(clampLog.keyHash as string, /^[0-9a-f]{16}$/);
   } finally {
     console.log = originalLog;
     await store.close();

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -311,6 +311,142 @@ test("redis runtime store can purge stale sessions for a restarted instance", as
   }
 });
 
+test("redis runtime store clamps dedup slot TTL to a floor when expiresAt is already in the past", async () => {
+  const setCalls: Array<{
+    key: string;
+    value: string;
+    nx: string;
+    px: string;
+    ms: number;
+  }> = [];
+  const zaddCalls: Array<{ key: string; score: string; member: string }> = [];
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async set(
+      key: string,
+      value: string,
+      nx: "NX",
+      px: "PX",
+      milliseconds: number,
+    ) {
+      setCalls.push({ key, value, nx, px, ms: milliseconds });
+      return "OK";
+    },
+    async zadd(key: string, score: string, member: string) {
+      zaddCalls.push({ key, score, member });
+      return null;
+    },
+  };
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (message: unknown) => {
+    logs.push(String(message));
+  };
+
+  const currentTime = 5_000;
+  const store = await createRedisRuntimeStore("redis://unused", {
+    redisClient: fakeRedis,
+    keyPrefix: "bsp:test:dedup:",
+    now: () => currentTime,
+  });
+
+  try {
+    const claimed = await store.tryClaimMessageSlot(
+      "ROOMXX",
+      "share:actor:url:1",
+      currentTime - 10,
+    );
+    assert.equal(claimed, true, "slot should still be claimed via minimum TTL");
+    assert.equal(setCalls.length, 1);
+    assert.ok(
+      setCalls[0].ms >= 1_000,
+      `expected minimum TTL >= 1000ms, got ${setCalls[0].ms}`,
+    );
+    assert.equal(setCalls[0].nx, "NX");
+    assert.equal(setCalls[0].px, "PX");
+    assert.equal(zaddCalls.length, 1);
+    assert.equal(Number(zaddCalls[0].score), currentTime + setCalls[0].ms);
+
+    const clampLog = logs
+      .map((line) => {
+        try {
+          return JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          return null;
+        }
+      })
+      .find((entry) => entry?.event === "dedup_slot_ttl_clamped");
+    assert.ok(clampLog, "expected dedup_slot_ttl_clamped event to be logged");
+    assert.equal(clampLog.roomCode, "ROOMXX");
+    assert.equal(clampLog.key, "share:actor:url:1");
+    assert.equal(clampLog.requestedTtlMs, -10);
+    assert.equal(clampLog.appliedTtlMs, 1_000);
+  } finally {
+    console.log = originalLog;
+    await store.close();
+  }
+});
+
+test("redis runtime store preserves caller-provided TTL without clamping when expiresAt is in the future", async () => {
+  const setCalls: Array<{ ms: number }> = [];
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async set(
+      _key: string,
+      _value: string,
+      _nx: "NX",
+      _px: "PX",
+      milliseconds: number,
+    ) {
+      setCalls.push({ ms: milliseconds });
+      return "OK";
+    },
+  };
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (message: unknown) => {
+    logs.push(String(message));
+  };
+
+  const currentTime = 5_000;
+  const store = await createRedisRuntimeStore("redis://unused", {
+    redisClient: fakeRedis,
+    keyPrefix: "bsp:test:dedup:",
+    now: () => currentTime,
+  });
+
+  try {
+    // Large positive TTL: used as-is.
+    const claimedLarge = await store.tryClaimMessageSlot(
+      "ROOMYY",
+      "share:actor:url:1",
+      currentTime + 5_000,
+    );
+    assert.equal(claimedLarge, true);
+    assert.equal(setCalls.at(-1)?.ms, 5_000);
+
+    // Small but positive TTL: must not be extended to the floor — the caller
+    // controls the dedup window and clamping would change its semantics.
+    const claimedSmall = await store.tryClaimMessageSlot(
+      "ROOMYY",
+      "share:actor:url:2",
+      currentTime + 50,
+    );
+    assert.equal(claimedSmall, true);
+    assert.equal(setCalls.at(-1)?.ms, 50);
+
+    const clampLogged = logs.some((line) =>
+      line.includes("dedup_slot_ttl_clamped"),
+    );
+    assert.equal(clampLogged, false);
+  } finally {
+    console.log = originalLog;
+    await store.close();
+  }
+});
+
 test("redis runtime store rejects new pending operations after reaching the configured cap", async () => {
   const firstOperation = createDeferred<unknown>();
   const fakeRedis = createFakeRedisClient([firstOperation.promise]);


### PR DESCRIPTION
## Summary
- `tryClaimMessageSlot` 不再在 `expiresAt <= now()` 时静默返回 `true` 跳过 Redis 写入；改为用最小 TTL 1000ms 兜底，保证跨节点幂等保护始终生效
- 触发兜底时通过 `dedup_slot_ttl_clamped` 结构化事件打日志，让该罕见路径（GC 暂停、事件循环抖动、时钟漂移）可观测
- 正的 TTL（哪怕小于 1 秒）原样使用，保留调用方的去重窗口语义
- 追踪 ZSET 的 score 随夹紧后的 TTL 同步调整，避免 `deleteRoom` 在真正过期前就清理条目

Closes #51

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`（170 通过；含新增 `clamps dedup slot TTL to a floor ...` 与 `preserves caller-provided TTL without clamping ...` 两个用例）

🤖 Generated with [Claude Code](https://claude.com/claude-code)