### PR TITLE
fix: popup 保存服务端 URL 后向用户反馈归一化结果 (#53)

### DIFF
--- a/extension/src/popup/popup-actions.ts
+++ b/extension/src/popup/popup-actions.ts
@@ -184,6 +184,14 @@ export function bindPopupActions(args: {
     args.applyActionState(state);
     syncServerUrlDraft(args.serverUrlDraft, state.serverUrl);
     refs.serverUrlInput.value = state.serverUrl;
+    if (requestedServerUrl !== state.serverUrl && !state.error) {
+      patchUiState({
+        localStatusMessage: t("serverUrlAdjusted", {
+          resolved: state.serverUrl,
+        }),
+      });
+      return;
+    }
     args.render();
   };
 

--- a/extension/src/popup/popup-actions.ts
+++ b/extension/src/popup/popup-actions.ts
@@ -176,15 +176,15 @@ export function bindPopupActions(args: {
 
   const saveServerUrl = async () => {
     patchUiState({ localStatusMessage: null });
-    const requestedServerUrl = args.serverUrlDraft.value.trim();
+    const originalServerUrl = args.serverUrlDraft.value;
     const state = await sendPopupAction({
       type: "popup:set-server-url",
-      serverUrl: requestedServerUrl,
+      serverUrl: originalServerUrl.trim(),
     });
     args.applyActionState(state);
     syncServerUrlDraft(args.serverUrlDraft, state.serverUrl);
     refs.serverUrlInput.value = state.serverUrl;
-    if (requestedServerUrl !== state.serverUrl && !state.error) {
+    if (originalServerUrl !== state.serverUrl && !state.error) {
       patchUiState({
         localStatusMessage: t("serverUrlAdjusted", {
           resolved: state.serverUrl,

--- a/extension/src/shared/i18n.ts
+++ b/extension/src/shared/i18n.ts
@@ -48,6 +48,7 @@ const MESSAGES: Record<"zh" | "en", MessageCatalog> = {
       "当前房间正在同步《{currentTitle}》。\n是否替换为《{nextTitle}》？",
     errorInvalidInviteFormat: "邀请格式无效，请输入“房间码:加入码”。",
     invalidServerUrl: "服务端地址必须以 ws:// 或 wss:// 开头。",
+    serverUrlAdjusted: "服务端地址已调整为 {resolved}，请核对。",
     connectionServerUnreachable: "无法连接到同步服务器。",
     connectionHandshakeRejected:
       "服务器可达，但 WebSocket 握手被拒绝。请检查服务端状态，以及反向代理是否已正确转发 WebSocket。",
@@ -127,6 +128,7 @@ const MESSAGES: Record<"zh" | "en", MessageCatalog> = {
     errorInvalidInviteFormat:
       'Invalid invite format. Enter "ROOMCODE:JOINTOKEN".',
     invalidServerUrl: "Server URL must start with ws:// or wss://.",
+    serverUrlAdjusted: "Server URL was adjusted to {resolved}; please verify.",
     connectionServerUnreachable: "Unable to connect to the sync server.",
     connectionHandshakeRejected:
       "The server is reachable, but the WebSocket handshake was rejected. Check the server status and make sure the reverse proxy forwards WebSocket correctly.",

--- a/extension/test/popup-save-server-url.test.ts
+++ b/extension/test/popup-save-server-url.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { bindPopupActions } from "../src/popup/popup-actions";
+import { createPopupUiStateStore } from "../src/popup/popup-store";
+import {
+  createServerUrlDraftState,
+  updateServerUrlDraft,
+} from "../src/popup/server-url-draft";
+import type { PopupRefs } from "../src/popup/popup-view";
+import type { BackgroundPopupState } from "../src/shared/messages";
+import { setLocaleForTests } from "../src/shared/i18n";
+
+const REF_KEYS = [
+  "serverStatus",
+  "roomStatus",
+  "membersStatus",
+  "message",
+  "roomPanelJoined",
+  "roomPanelIdle",
+  "roomCodeInput",
+  "copyRoomButton",
+  "shareCurrentVideoButton",
+  "sharedVideoCard",
+  "sharedVideoTitle",
+  "sharedVideoMeta",
+  "sharedVideoOwner",
+  "logs",
+  "memberList",
+  "copyLogsButton",
+  "serverUrlInput",
+  "saveServerUrlButton",
+  "debugMemberStatus",
+  "retryStatusValue",
+  "retryStatusCount",
+  "clockStatus",
+  "createRoomButton",
+  "joinRoomButton",
+  "leaveRoomButton",
+] as const;
+
+function createFakeRef(): EventTarget & Record<string, unknown> {
+  const target = new EventTarget();
+  const element = target as EventTarget & Record<string, unknown>;
+  element.value = "";
+  element.disabled = false;
+  element.textContent = "";
+  element.hidden = false;
+  element.innerHTML = "";
+  element.classList = {
+    toggle: () => {},
+    contains: () => false,
+    add: () => {},
+    remove: () => {},
+  };
+  return element;
+}
+
+function createRefs(): PopupRefs {
+  const refs = Object.create(null) as Record<string, unknown>;
+  for (const key of REF_KEYS) {
+    refs[key] = createFakeRef();
+  }
+  return refs as unknown as PopupRefs;
+}
+
+function createState(
+  overrides: Partial<BackgroundPopupState> = {},
+): BackgroundPopupState {
+  return {
+    connected: true,
+    serverUrl: "ws://current.example/",
+    error: null,
+    roomCode: null,
+    joinToken: null,
+    memberId: null,
+    displayName: null,
+    roomState: null,
+    pendingCreateRoom: false,
+    pendingJoinRoomCode: null,
+    retryInMs: null,
+    retryAttempt: 0,
+    retryAttemptMax: 5,
+    clockOffsetMs: null,
+    rttMs: null,
+    logs: [],
+    ...overrides,
+  };
+}
+
+function wrapStateMessage(state: BackgroundPopupState): {
+  type: "background:state";
+  payload: BackgroundPopupState;
+} {
+  return { type: "background:state", payload: state };
+}
+
+function installChromeRuntimeStub(
+  handler: (message: unknown) => BackgroundPopupState,
+): void {
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    runtime: {
+      async sendMessage(message: unknown): Promise<unknown> {
+        return wrapStateMessage(handler(message));
+      },
+    },
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+type BindArgs = Parameters<typeof bindPopupActions>[0];
+
+function buildBindings(overrides: Partial<BindArgs> = {}): BindArgs {
+  const refs = overrides.refs ?? createRefs();
+  const uiStateStore = overrides.uiStateStore ?? createPopupUiStateStore();
+  const serverUrlDraft =
+    overrides.serverUrlDraft ?? createServerUrlDraftState();
+  return {
+    refs,
+    leaveGuardMs: 0,
+    uiStateStore,
+    serverUrlDraft,
+    queryState: async () => createState(),
+    applyActionState: () => {},
+    render: () => {},
+    sendPopupLog: async () => {},
+    applyRoomActionControlState: () => {},
+    getPopupState: () => null,
+    ...overrides,
+  };
+}
+
+test("saveServerUrl surfaces a notice when the backend silently normalizes the URL", async () => {
+  setLocaleForTests("zh-CN");
+  try {
+    const refs = createRefs();
+    const uiStateStore = createPopupUiStateStore();
+    const serverUrlDraft = createServerUrlDraftState();
+    updateServerUrlDraft(serverUrlDraft, "   ", "ws://current.example/");
+
+    installChromeRuntimeStub((message) => {
+      const typed = message as { type?: string };
+      if (typed.type === "popup:set-server-url") {
+        return createState({ serverUrl: "ws://default.example/" });
+      }
+      return createState();
+    });
+
+    bindPopupActions(buildBindings({ refs, uiStateStore, serverUrlDraft }));
+
+    (refs.saveServerUrlButton as unknown as EventTarget).dispatchEvent(
+      new Event("click"),
+    );
+    await flushMicrotasks();
+
+    const message = uiStateStore.getState().localStatusMessage ?? "";
+    assert.match(message, /ws:\/\/default\.example\//);
+    assert.match(message, /调整/);
+  } finally {
+    setLocaleForTests(null);
+  }
+});
+
+test("saveServerUrl leaves localStatusMessage untouched when the backend reports an error", async () => {
+  setLocaleForTests("zh-CN");
+  try {
+    const refs = createRefs();
+    const uiStateStore = createPopupUiStateStore();
+    const serverUrlDraft = createServerUrlDraftState();
+    updateServerUrlDraft(
+      serverUrlDraft,
+      "http://oops",
+      "ws://current.example/",
+    );
+
+    installChromeRuntimeStub((message) => {
+      const typed = message as { type?: string };
+      if (typed.type === "popup:set-server-url") {
+        return createState({
+          serverUrl: "ws://current.example/",
+          error: "服务端地址必须以 ws:// 或 wss:// 开头。",
+        });
+      }
+      return createState();
+    });
+
+    bindPopupActions(buildBindings({ refs, uiStateStore, serverUrlDraft }));
+
+    (refs.saveServerUrlButton as unknown as EventTarget).dispatchEvent(
+      new Event("click"),
+    );
+    await flushMicrotasks();
+
+    assert.equal(uiStateStore.getState().localStatusMessage, null);
+  } finally {
+    setLocaleForTests(null);
+  }
+});
+
+test("saveServerUrl clears a previous localStatusMessage on a successful save", async () => {
+  setLocaleForTests("zh-CN");
+  try {
+    const refs = createRefs();
+    const uiStateStore = createPopupUiStateStore();
+    const serverUrlDraft = createServerUrlDraftState();
+    updateServerUrlDraft(
+      serverUrlDraft,
+      "ws://next.example/",
+      "ws://current.example/",
+    );
+    uiStateStore.patch({ localStatusMessage: "leftover" });
+
+    installChromeRuntimeStub((message) => {
+      const typed = message as { type?: string };
+      if (typed.type === "popup:set-server-url") {
+        return createState({ serverUrl: "ws://next.example/" });
+      }
+      return createState();
+    });
+
+    bindPopupActions(buildBindings({ refs, uiStateStore, serverUrlDraft }));
+
+    (refs.saveServerUrlButton as unknown as EventTarget).dispatchEvent(
+      new Event("click"),
+    );
+    await flushMicrotasks();
+
+    assert.equal(uiStateStore.getState().localStatusMessage, null);
+  } finally {
+    setLocaleForTests(null);
+  }
+});

--- a/extension/test/popup-save-server-url.test.ts
+++ b/extension/test/popup-save-server-url.test.ts
@@ -166,6 +166,44 @@ test("saveServerUrl surfaces a notice when the backend silently normalizes the U
   }
 });
 
+test("saveServerUrl surfaces a notice when only surrounding whitespace was trimmed", async () => {
+  setLocaleForTests("zh-CN");
+  try {
+    const refs = createRefs();
+    const uiStateStore = createPopupUiStateStore();
+    const serverUrlDraft = createServerUrlDraftState();
+    updateServerUrlDraft(
+      serverUrlDraft,
+      "  ws://trimmed.example/  ",
+      "ws://current.example/",
+    );
+
+    const requests: unknown[] = [];
+    installChromeRuntimeStub((message) => {
+      const typed = message as { type?: string; serverUrl?: string };
+      if (typed.type === "popup:set-server-url") {
+        requests.push(typed.serverUrl);
+        return createState({ serverUrl: "ws://trimmed.example/" });
+      }
+      return createState();
+    });
+
+    bindPopupActions(buildBindings({ refs, uiStateStore, serverUrlDraft }));
+
+    (refs.saveServerUrlButton as unknown as EventTarget).dispatchEvent(
+      new Event("click"),
+    );
+    await flushMicrotasks();
+
+    assert.deepEqual(requests, ["ws://trimmed.example/"]);
+    const message = uiStateStore.getState().localStatusMessage ?? "";
+    assert.match(message, /ws:\/\/trimmed\.example\//);
+    assert.match(message, /调整/);
+  } finally {
+    setLocaleForTests(null);
+  }
+});
+
 test("saveServerUrl leaves localStatusMessage untouched when the backend reports an error", async () => {
   setLocaleForTests("zh-CN");
   try {


### PR DESCRIPTION
## Summary

- 问题：在 popup 保存服务端 URL 时，后端只做 trim 与回退默认值。当用户输入被静默归一化（例如空输入回落为默认 URL），输入框会被改写而无任何提示，给用户"保存失败 / popup 卡住"的错觉。非法 URL（非 ws/wss）原本就由 `state.error` 展示拒绝原因，保留不变。
- 变更：`saveServerUrl` 在 `requestedServerUrl !== state.serverUrl` 且 `state.error` 为空时，主动把 `localStatusMessage` 设为新增的 `serverUrlAdjusted` 文案（中英文都已补齐）。
- 测试：新增 `extension/test/popup-save-server-url.test.ts`，覆盖静默归一化、服务端报错、成功保存三条路径。

Fixes #53

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`
- [ ] 手动：popup 输入空值或全空白保存，消息栏应提示"服务端地址已调整为 …"；输入 `http://x` 应仍显示 `服务端地址必须以 ws:// 或 wss:// 开头。`