### PR TITLE
fix: 链式 soft-apply 刷新保留原始 restorePlaybackRate (#54)

### DIFF
--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -175,15 +175,19 @@ export function createSoftApplyController(args: {
       return;
     }
     const timeoutMs = computeSoftApplyTimeoutMs(remainingDriftSeconds);
+    const restorePlaybackRate =
+      activeSoftApply && activeSoftApply.normalizedUrl === normalizedUrl
+        ? activeSoftApply.restorePlaybackRate
+        : playback.playbackRate;
     activeSoftApply = {
       normalizedUrl,
       targetTime: playback.currentTime,
-      restorePlaybackRate: playback.playbackRate,
+      restorePlaybackRate,
       deadlineAt: nowOf() + timeoutMs,
     };
     scheduleActiveSoftApplyTimeout();
     args.debugLog(
-      `Started soft apply url=${normalizedUrl} target=${playback.currentTime.toFixed(2)} rate=${playback.playbackRate.toFixed(2)} timeout=${timeoutMs}`,
+      `Started soft apply url=${normalizedUrl} target=${playback.currentTime.toFixed(2)} rate=${restorePlaybackRate.toFixed(2)} timeout=${timeoutMs}`,
     );
   }
 

--- a/extension/test/soft-apply-controller.test.ts
+++ b/extension/test/soft-apply-controller.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { PlaybackState } from "@bili-syncplay/protocol";
+import { createContentRuntimeState } from "../src/content/runtime-state";
+import { createSoftApplyController } from "../src/content/soft-apply-controller";
+
+function installWindowStub() {
+  const originalWindow = globalThis.window;
+  const timers = new Map<number, () => void>();
+  let nextTimer = 1;
+  const windowStub = {
+    setTimeout(callback: () => void) {
+      const id = nextTimer++;
+      timers.set(id, callback);
+      return id;
+    },
+    clearTimeout(id: number) {
+      timers.delete(id);
+    },
+  };
+  Object.assign(globalThis, { window: windowStub });
+  return {
+    restore() {
+      Object.assign(globalThis, { window: originalWindow });
+    },
+  };
+}
+
+function createPlayback(overrides: Partial<PlaybackState> = {}): PlaybackState {
+  return {
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    currentTime: 24,
+    playState: "playing",
+    playbackRate: 1,
+    updatedAt: 1,
+    serverTime: 1,
+    actorId: "remote",
+    seq: 1,
+    ...overrides,
+  };
+}
+
+function createVideo(
+  overrides: Partial<HTMLVideoElement> = {},
+): HTMLVideoElement {
+  return {
+    paused: false,
+    readyState: 4,
+    duration: 120,
+    currentTime: 24,
+    playbackRate: 1,
+    pause() {},
+    play: async () => undefined,
+    ...overrides,
+  } as HTMLVideoElement;
+}
+
+test("chained upsertActiveSoftApply preserves the first session's restore rate", () => {
+  const windowStub = installWindowStub();
+  try {
+    const runtimeState = createContentRuntimeState();
+    const video = createVideo({ currentTime: 24, playbackRate: 1.3 });
+    let now = 10_000;
+    const controller = createSoftApplyController({
+      runtimeState,
+      normalizeUrl: (url) => url?.trim() ?? null,
+      getVideoElement: () => video,
+      debugLog: () => {},
+      userGestureGraceMs: 300,
+      programmaticApplyWindowMs: 700,
+      getNow: () => now,
+      armProgrammaticApplyWindow: () => {},
+    });
+
+    controller.upsertActiveSoftApply(
+      createPlayback({ currentTime: 24.5, playbackRate: 1 }),
+      0.5,
+    );
+
+    now = 10_200;
+    controller.upsertActiveSoftApply(
+      createPlayback({ currentTime: 24.6, playbackRate: 1.3 }),
+      0.4,
+    );
+
+    video.currentTime = 24.55;
+    controller.maintainActiveSoftApply(video);
+
+    assert.ok(
+      Math.abs(video.playbackRate - 1) < 0.001,
+      `expected restore to original rate 1, got ${video.playbackRate}`,
+    );
+  } finally {
+    windowStub.restore();
+  }
+});
+
+test("upsertActiveSoftApply for a different url starts a fresh restore rate", () => {
+  const windowStub = installWindowStub();
+  try {
+    const runtimeState = createContentRuntimeState();
+    const video = createVideo({ currentTime: 24, playbackRate: 1.2 });
+    const controller = createSoftApplyController({
+      runtimeState,
+      normalizeUrl: (url) => url?.trim() ?? null,
+      getVideoElement: () => video,
+      debugLog: () => {},
+      userGestureGraceMs: 300,
+      programmaticApplyWindowMs: 700,
+      getNow: () => 10_000,
+      armProgrammaticApplyWindow: () => {},
+    });
+
+    controller.upsertActiveSoftApply(
+      createPlayback({
+        url: "https://www.bilibili.com/video/BV1AAAAAAAAA?p=1",
+        currentTime: 24,
+        playbackRate: 1,
+      }),
+      0.2,
+    );
+
+    controller.upsertActiveSoftApply(
+      createPlayback({
+        url: "https://www.bilibili.com/video/BV1BBBBBBBBB?p=1",
+        currentTime: 24,
+        playbackRate: 2,
+      }),
+      0.2,
+    );
+
+    controller.maintainActiveSoftApply(video);
+
+    assert.ok(
+      Math.abs(video.playbackRate - 2) < 0.001,
+      `expected restore to new session's rate 2, got ${video.playbackRate}`,
+    );
+  } finally {
+    windowStub.restore();
+  }
+});


### PR DESCRIPTION
## Summary
- `SoftApplyController.upsertActiveSoftApply` 在链式刷新同一个 URL 的活跃 session 时，保留第一次记录的 `restorePlaybackRate`，只刷新 `targetTime` 和 `deadlineAt`。避免把第一次 soft-apply 临时写入 `video.playbackRate` 的追赶速率误当作"原始恢复目标"，导致 `cancelActiveSoftApply` 恢复到的是追赶速率而不是用户真实设定。
- 换 URL 或没有活跃 session 时仍按新 `playback.playbackRate` 作为恢复目标，保持和先前一致的边界行为。
- 新增 `extension/test/soft-apply-controller.test.ts`，对控制器进行直接单元测试：覆盖链式刷新保留首个 restore rate 以及换 URL 时重置为新 rate 两条路径。

Fixes #54

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`