### PR TITLE
fix: /metrics 在关闭 admin UI 时仍保留端点 (#55)

### DIFF
--- a/server/src/bootstrap/http-handler.ts
+++ b/server/src/bootstrap/http-handler.ts
@@ -65,7 +65,10 @@ export function createHttpRequestHandler(args: {
 
     try {
       const handled =
-        adminUiEnabled || pathname === "/healthz" || pathname === "/readyz"
+        adminUiEnabled ||
+        pathname === "/healthz" ||
+        pathname === "/readyz" ||
+        pathname === "/metrics"
           ? await args.adminRouter.handle(request, response)
           : false;
       if (handled) {

--- a/server/test/admin-backend.test.ts
+++ b/server/test/admin-backend.test.ts
@@ -1370,6 +1370,10 @@ test("room node can disable admin routes while keeping health probes", async () 
     const ready = await requestJson(server.httpBaseUrl, "/readyz");
     assert.equal(ready.status, 200);
     assert.equal((ready.body.data as { status: string }).status, "ready");
+
+    const metrics = await requestText(server.httpBaseUrl, "/metrics");
+    assert.equal(metrics.status, 200);
+    assert.equal(metrics.body.includes("bili_syncplay_connections"), true);
   } finally {
     await server.close();
   }


### PR DESCRIPTION
## Summary
- `server/src/bootstrap/http-handler.ts`：把 `/metrics` 加入 `adminUiEnabled=false` 时的白名单，与 `/healthz`、`/readyz` 同级，避免 Prometheus scrape 落到默认 JSON fallback。
- `server/test/admin-backend.test.ts`：在 "room node can disable admin routes..." 用例里补充 `/metrics` 回归断言，确认禁用 admin UI 后 `/metrics` 仍返回 Prometheus 文本。

Fixes #55

## Test plan
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`
- [x] 新增 `/metrics` 断言：`room node can disable admin routes while keeping health probes` 通过