### PR TITLE
fix: expand prometheus metrics coverage

### DIFF
--- a/server/src/admin/metrics.ts
+++ b/server/src/admin/metrics.ts
@@ -44,6 +44,7 @@ type CounterMetric = {
 };
 
 export type MetricsCollector = {
+  bindRuntimeStore: (runtimeStore: RuntimeStore) => void;
   recordEvent: (event: string) => void;
   observeMessageHandlerDuration: (
     messageType: MonitoredMessageType,
@@ -135,6 +136,7 @@ export function createMetricsCollector(options: {
   runtimeStore: RuntimeStore;
   roomStore: RoomStore;
 }): MetricsCollector {
+  let runtimeStore = options.runtimeStore;
   const eventCounter: CounterMetric = {
     help: "Total structured log events grouped by event name",
     samples: new Map(),
@@ -222,13 +224,13 @@ export function createMetricsCollector(options: {
       "# TYPE bili_syncplay_connections gauge",
       formatMetricLine(
         "bili_syncplay_connections",
-        options.runtimeStore.getConnectionCount(),
+        runtimeStore.getConnectionCount(),
       ),
       "# HELP bili_syncplay_active_rooms Current active room count",
       "# TYPE bili_syncplay_active_rooms gauge",
       formatMetricLine(
         "bili_syncplay_active_rooms",
-        options.runtimeStore.getActiveRoomCount(),
+        runtimeStore.getActiveRoomCount(),
       ),
       "# HELP bili_syncplay_rooms_non_expired Current non-expired room count",
       "# TYPE bili_syncplay_rooms_non_expired gauge",
@@ -315,6 +317,9 @@ export function createMetricsCollector(options: {
   }
 
   return {
+    bindRuntimeStore(nextRuntimeStore) {
+      runtimeStore = nextRuntimeStore;
+    },
     recordEvent(event) {
       incrementCounter(eventCounter, { event });
     },

--- a/server/src/admin/metrics.ts
+++ b/server/src/admin/metrics.ts
@@ -1,43 +1,363 @@
 import type { RuntimeStore } from "../runtime-store.js";
 import type { RoomStore } from "../room-store.js";
 
+const DEFAULT_HISTOGRAM_BUCKETS_SECONDS = [
+  0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
+] as const;
+
+const CORE_EVENT_NAMES = [
+  "room_created",
+  "room_joined",
+  "ws_connection_rejected",
+  "rate_limited",
+] as const;
+
+export type MonitoredMessageType =
+  | "video:share"
+  | "playback:update"
+  | "room:join"
+  | "room:leave";
+
+type LabelValues = Record<string, string>;
+
+type HistogramSample = {
+  bucketCounts: number[];
+  count: number;
+  sum: number;
+  labels: LabelValues;
+};
+
+type HistogramMetric = {
+  help: string;
+  buckets: readonly number[];
+  samples: Map<string, HistogramSample>;
+};
+
+type CounterSample = {
+  labels: LabelValues;
+  value: number;
+};
+
+type CounterMetric = {
+  help: string;
+  samples: Map<string, CounterSample>;
+};
+
+export type MetricsCollector = {
+  recordEvent: (event: string) => void;
+  observeMessageHandlerDuration: (
+    messageType: MonitoredMessageType,
+    durationMs: number,
+  ) => void;
+  observeRedisRuntimeStoreDuration: (
+    operation: string,
+    durationMs: number,
+  ) => void;
+  observeRedisRuntimeStoreFailure: (operation: string) => void;
+  observeRedisRoomEventBusPublishDuration: (durationMs: number) => void;
+  observeRedisRoomEventBusPublishFailure: () => void;
+  render: () => Promise<string>;
+};
+
+function createLabelKey(labels: LabelValues): string {
+  return JSON.stringify(
+    Object.entries(labels).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function escapeLabelValue(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\n", "\\n")
+    .replaceAll('"', '\\"');
+}
+
+function formatLabels(labels: LabelValues): string {
+  const entries = Object.entries(labels).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  if (entries.length === 0) {
+    return "";
+  }
+
+  return `{${entries
+    .map(([key, value]) => `${key}="${escapeLabelValue(value)}"`)
+    .join(",")}}`;
+}
+
+function formatMetricLine(
+  name: string,
+  value: number,
+  labels: LabelValues = {},
+): string {
+  return `${name}${formatLabels(labels)} ${value}`;
+}
+
+function ensureCounterSample(
+  metric: CounterMetric,
+  labels: LabelValues,
+): CounterSample {
+  const key = createLabelKey(labels);
+  const existing = metric.samples.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const sample: CounterSample = {
+    labels,
+    value: 0,
+  };
+  metric.samples.set(key, sample);
+  return sample;
+}
+
+function ensureHistogramSample(
+  metric: HistogramMetric,
+  labels: LabelValues,
+): HistogramSample {
+  const key = createLabelKey(labels);
+  const existing = metric.samples.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const sample: HistogramSample = {
+    bucketCounts: Array.from({ length: metric.buckets.length }, () => 0),
+    count: 0,
+    sum: 0,
+    labels,
+  };
+  metric.samples.set(key, sample);
+  return sample;
+}
+
+export function createMetricsCollector(options: {
+  runtimeStore: RuntimeStore;
+  roomStore: RoomStore;
+}): MetricsCollector {
+  const eventCounter: CounterMetric = {
+    help: "Total structured log events grouped by event name",
+    samples: new Map(),
+  };
+  const redisFailureCounter: CounterMetric = {
+    help: "Total Redis metric-instrumented operation failures",
+    samples: new Map(),
+  };
+  const messageDurationHistogram: HistogramMetric = {
+    help: "Duration of monitored message handler paths in seconds",
+    buckets: DEFAULT_HISTOGRAM_BUCKETS_SECONDS,
+    samples: new Map(),
+  };
+  const redisRuntimeStoreDurationHistogram: HistogramMetric = {
+    help: "Duration of Redis runtime store operations in seconds",
+    buckets: DEFAULT_HISTOGRAM_BUCKETS_SECONDS,
+    samples: new Map(),
+  };
+  const redisRoomEventBusPublishDurationHistogram: HistogramMetric = {
+    help: "Duration of Redis room event bus publish operations in seconds",
+    buckets: DEFAULT_HISTOGRAM_BUCKETS_SECONDS,
+    samples: new Map(),
+  };
+
+  for (const eventName of CORE_EVENT_NAMES) {
+    ensureCounterSample(eventCounter, { event: eventName });
+  }
+
+  function incrementCounter(
+    metric: CounterMetric,
+    labels: LabelValues,
+    value = 1,
+  ): void {
+    ensureCounterSample(metric, labels).value += value;
+  }
+
+  function observeHistogram(
+    metric: HistogramMetric,
+    labels: LabelValues,
+    durationMs: number,
+  ): void {
+    const sample = ensureHistogramSample(metric, labels);
+    const durationSeconds = Math.max(durationMs, 0) / 1_000;
+    sample.count += 1;
+    sample.sum += durationSeconds;
+    for (const [index, bucket] of metric.buckets.entries()) {
+      if (durationSeconds <= bucket) {
+        sample.bucketCounts[index] += 1;
+      }
+    }
+  }
+
+  async function render(): Promise<string> {
+    const totalNonExpired = await options.roomStore.countRooms({
+      keyword: undefined,
+      includeExpired: false,
+    });
+    const eventSamples = Array.from(eventCounter.samples.values()).sort(
+      (a, b) => (a.labels.event ?? "").localeCompare(b.labels.event ?? ""),
+    );
+    const redisFailureSamples = Array.from(
+      redisFailureCounter.samples.values(),
+    ).sort((a, b) => {
+      const left = `${a.labels.component}:${a.labels.operation}`;
+      const right = `${b.labels.component}:${b.labels.operation}`;
+      return left.localeCompare(right);
+    });
+    const histogramMetrics = [
+      {
+        name: "bili_syncplay_message_handler_duration_seconds",
+        metric: messageDurationHistogram,
+      },
+      {
+        name: "bili_syncplay_redis_runtime_store_duration_seconds",
+        metric: redisRuntimeStoreDurationHistogram,
+      },
+      {
+        name: "bili_syncplay_redis_room_event_bus_publish_duration_seconds",
+        metric: redisRoomEventBusPublishDurationHistogram,
+      },
+    ] as const;
+
+    const lines = [
+      "# HELP bili_syncplay_connections Current websocket connection count",
+      "# TYPE bili_syncplay_connections gauge",
+      formatMetricLine(
+        "bili_syncplay_connections",
+        options.runtimeStore.getConnectionCount(),
+      ),
+      "# HELP bili_syncplay_active_rooms Current active room count",
+      "# TYPE bili_syncplay_active_rooms gauge",
+      formatMetricLine(
+        "bili_syncplay_active_rooms",
+        options.runtimeStore.getActiveRoomCount(),
+      ),
+      "# HELP bili_syncplay_rooms_non_expired Current non-expired room count",
+      "# TYPE bili_syncplay_rooms_non_expired gauge",
+      formatMetricLine("bili_syncplay_rooms_non_expired", totalNonExpired),
+      "# HELP bili_syncplay_events_total Total structured log events grouped by event name",
+      "# TYPE bili_syncplay_events_total counter",
+      ...eventSamples.map((sample) =>
+        formatMetricLine(
+          "bili_syncplay_events_total",
+          sample.value,
+          sample.labels,
+        ),
+      ),
+      "# HELP bili_syncplay_room_created_total Total room_created events",
+      "# TYPE bili_syncplay_room_created_total counter",
+      formatMetricLine(
+        "bili_syncplay_room_created_total",
+        ensureCounterSample(eventCounter, { event: "room_created" }).value,
+      ),
+      "# HELP bili_syncplay_room_joined_total Total room_joined events",
+      "# TYPE bili_syncplay_room_joined_total counter",
+      formatMetricLine(
+        "bili_syncplay_room_joined_total",
+        ensureCounterSample(eventCounter, { event: "room_joined" }).value,
+      ),
+      "# HELP bili_syncplay_ws_connection_rejected_total Total rejected websocket upgrades",
+      "# TYPE bili_syncplay_ws_connection_rejected_total counter",
+      formatMetricLine(
+        "bili_syncplay_ws_connection_rejected_total",
+        ensureCounterSample(eventCounter, {
+          event: "ws_connection_rejected",
+        }).value,
+      ),
+      "# HELP bili_syncplay_rate_limited_total Total rate_limited events",
+      "# TYPE bili_syncplay_rate_limited_total counter",
+      formatMetricLine(
+        "bili_syncplay_rate_limited_total",
+        ensureCounterSample(eventCounter, { event: "rate_limited" }).value,
+      ),
+      "# HELP bili_syncplay_redis_operation_failures_total Total Redis metric-instrumented operation failures",
+      "# TYPE bili_syncplay_redis_operation_failures_total counter",
+      ...redisFailureSamples.map((sample) =>
+        formatMetricLine(
+          "bili_syncplay_redis_operation_failures_total",
+          sample.value,
+          sample.labels,
+        ),
+      ),
+    ];
+
+    for (const { name, metric } of histogramMetrics) {
+      lines.push(`# HELP ${name} ${metric.help}`);
+      lines.push(`# TYPE ${name} histogram`);
+      const samples = Array.from(metric.samples.values()).sort((left, right) =>
+        createLabelKey(left.labels).localeCompare(createLabelKey(right.labels)),
+      );
+      for (const sample of samples) {
+        for (const [index, bucket] of metric.buckets.entries()) {
+          lines.push(
+            formatMetricLine(
+              `${name}_bucket`,
+              sample.bucketCounts[index] ?? 0,
+              {
+                ...sample.labels,
+                le: String(bucket),
+              },
+            ),
+          );
+        }
+        lines.push(
+          formatMetricLine(`${name}_bucket`, sample.count, {
+            ...sample.labels,
+            le: "+Inf",
+          }),
+        );
+        lines.push(formatMetricLine(`${name}_sum`, sample.sum, sample.labels));
+        lines.push(
+          formatMetricLine(`${name}_count`, sample.count, sample.labels),
+        );
+      }
+    }
+
+    return `${lines.join("\n")}\n`;
+  }
+
+  return {
+    recordEvent(event) {
+      incrementCounter(eventCounter, { event });
+    },
+    observeMessageHandlerDuration(messageType, durationMs) {
+      observeHistogram(
+        messageDurationHistogram,
+        { message_type: messageType },
+        durationMs,
+      );
+    },
+    observeRedisRuntimeStoreDuration(operation, durationMs) {
+      observeHistogram(
+        redisRuntimeStoreDurationHistogram,
+        { operation },
+        durationMs,
+      );
+    },
+    observeRedisRuntimeStoreFailure(operation) {
+      incrementCounter(redisFailureCounter, {
+        component: "runtime_store",
+        operation,
+      });
+    },
+    observeRedisRoomEventBusPublishDuration(durationMs) {
+      observeHistogram(
+        redisRoomEventBusPublishDurationHistogram,
+        { operation: "publish" },
+        durationMs,
+      );
+    },
+    observeRedisRoomEventBusPublishFailure() {
+      incrementCounter(redisFailureCounter, {
+        component: "room_event_bus",
+        operation: "publish",
+      });
+    },
+    render,
+  };
+}
+
 export function createMetricsService(options: {
   runtimeStore: RuntimeStore;
   roomStore: RoomStore;
 }) {
-  return {
-    async render(): Promise<string> {
-      const totals = options.runtimeStore.getLifetimeEventCounts();
-      const totalNonExpired = await options.roomStore.countRooms({
-        keyword: undefined,
-        includeExpired: false,
-      });
-
-      const lines = [
-        "# HELP bili_syncplay_connections Current websocket connection count",
-        "# TYPE bili_syncplay_connections gauge",
-        `bili_syncplay_connections ${options.runtimeStore.getConnectionCount()}`,
-        "# HELP bili_syncplay_active_rooms Current active room count",
-        "# TYPE bili_syncplay_active_rooms gauge",
-        `bili_syncplay_active_rooms ${options.runtimeStore.getActiveRoomCount()}`,
-        "# HELP bili_syncplay_rooms_non_expired Current non-expired room count",
-        "# TYPE bili_syncplay_rooms_non_expired gauge",
-        `bili_syncplay_rooms_non_expired ${totalNonExpired}`,
-        "# HELP bili_syncplay_room_created_total Total room_created events",
-        "# TYPE bili_syncplay_room_created_total counter",
-        `bili_syncplay_room_created_total ${totals.room_created ?? 0}`,
-        "# HELP bili_syncplay_room_joined_total Total room_joined events",
-        "# TYPE bili_syncplay_room_joined_total counter",
-        `bili_syncplay_room_joined_total ${totals.room_joined ?? 0}`,
-        "# HELP bili_syncplay_ws_connection_rejected_total Total rejected websocket upgrades",
-        "# TYPE bili_syncplay_ws_connection_rejected_total counter",
-        `bili_syncplay_ws_connection_rejected_total ${totals.ws_connection_rejected ?? 0}`,
-        "# HELP bili_syncplay_rate_limited_total Total rate_limited events",
-        "# TYPE bili_syncplay_rate_limited_total counter",
-        `bili_syncplay_rate_limited_total ${totals.rate_limited ?? 0}`,
-      ];
-
-      return `${lines.join("\n")}\n`;
-    },
-  };
+  return createMetricsCollector(options);
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -87,6 +87,7 @@ export async function createSyncServer(
     roomEventBus,
     eventStore,
     logEvent,
+    metricsCollector,
   } = await createServerBootstrapContext(persistenceConfig, dependencies, {
     useMirroredRuntimeStore: true,
     loggingHooks: {
@@ -218,6 +219,7 @@ export async function createSyncServer(
     sendError,
     publishRoomEvent,
     instanceId: persistenceConfig.instanceId,
+    metricsCollector,
     onRoomJoined: (session, roomCode) => {
       runtimeStore.registerSession(session);
       runtimeStore.markSessionJoinedRoom(session.id, roomCode);
@@ -265,6 +267,7 @@ export async function createSyncServer(
       requestAdminCommand: (command, timeoutMs) =>
         adminCommandBus.request(command, timeoutMs),
       logEvent,
+      metricsCollector,
       now,
       adminConfig: dependencies.adminConfig,
       adminUiConfig: dependencies.adminUiConfig,

--- a/server/src/bootstrap/admin-http-bootstrap.ts
+++ b/server/src/bootstrap/admin-http-bootstrap.ts
@@ -5,6 +5,7 @@ import type { WebSocket } from "ws";
 import type { GlobalEventStore } from "../admin/global-event-store.js";
 import { createAdminOverviewService } from "../admin/overview-service.js";
 import { createAdminRoomQueryService } from "../admin/room-query-service.js";
+import type { MetricsCollector } from "../admin/metrics.js";
 import type { AdminCommandBus } from "../admin-command-bus.js";
 import type { RoomEventBusMessage } from "../room-event-bus.js";
 import type { RoomStore } from "../room-store.js";
@@ -49,6 +50,7 @@ export async function createSharedAdminHttpBootstrap(args: {
   publishRoomEvent: (message: RoomEventBusMessage) => Promise<void>;
   requestAdminCommand: AdminCommandBus["request"];
   logEvent: LogEvent;
+  metricsCollector: MetricsCollector;
   now: () => number;
   adminConfig?: AdminConfig;
   adminUiConfig?: AdminUiConfig;
@@ -84,6 +86,7 @@ export async function createSharedAdminHttpBootstrap(args: {
     publishRoomEvent: args.publishRoomEvent,
     requestAdminCommand: args.requestAdminCommand,
     logEvent: args.logEvent,
+    metricsCollector: args.metricsCollector,
     now: args.now,
     adminConfig: args.adminConfig,
     serviceVersion: args.serviceVersion,

--- a/server/src/bootstrap/admin-services.ts
+++ b/server/src/bootstrap/admin-services.ts
@@ -8,7 +8,7 @@ import { createAdminAuthService } from "../admin/auth-service.js";
 import { createAdminConfigService } from "../admin/config-service.js";
 import type { GlobalAuditStore } from "../admin/global-audit-store.js";
 import type { GlobalEventStore } from "../admin/global-event-store.js";
-import { createMetricsService } from "../admin/metrics.js";
+import type { MetricsCollector } from "../admin/metrics.js";
 import { createAdminOverviewService } from "../admin/overview-service.js";
 import { createAdminRoomQueryService } from "../admin/room-query-service.js";
 import { createRedisAuditStore } from "../admin/redis-audit-store.js";
@@ -42,6 +42,7 @@ export function createAdminServices(args: {
   publishRoomEvent: (message: RoomEventBusMessage) => Promise<void>;
   requestAdminCommand: AdminCommandBus["request"];
   logEvent: LogEvent;
+  metricsCollector: MetricsCollector;
   now: () => number;
   adminConfig?: AdminConfig;
   serviceVersion: string;
@@ -112,10 +113,7 @@ export function createAdminServices(args: {
       runtimeStore: args.runtimeStore,
       eventStore: args.eventStore,
     });
-    const metricsService = createMetricsService({
-      runtimeStore: args.runtimeStore,
-      roomStore: args.roomStore,
-    });
+    const metricsService = args.metricsCollector;
     const configService = createAdminConfigService({
       adminConfig: args.adminConfig ?? null,
       persistenceConfig: args.persistenceConfig,

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -264,6 +264,7 @@ export async function createServerBootstrapContext(
     options.useMirroredRuntimeStore && sharedRuntimeStore !== localRuntimeStore
       ? createMirroredRuntimeStore(localRuntimeStore, sharedRuntimeStore)
       : sharedRuntimeStore;
+  metricsCollector.bindRuntimeStore(runtimeStore);
   const adminCommandBus =
     persistenceConfig.adminCommandBusProvider === "redis"
       ? await createRedisAdminCommandBus(persistenceConfig.redisUrl, {

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -4,6 +4,10 @@ import { fileURLToPath } from "node:url";
 import { createEventStore } from "../admin/event-store.js";
 import { createRedisEventStore } from "../admin/redis-event-store.js";
 import {
+  createMetricsCollector,
+  type MetricsCollector,
+} from "../admin/metrics.js";
+import {
   createInMemoryAdminCommandBus,
   createNoopAdminCommandBus,
   type AdminCommandBus,
@@ -101,6 +105,7 @@ export type ServerBootstrapContext = {
   roomEventBus: RoomEventBus;
   eventStore: GlobalEventStore;
   logEvent: LogEvent;
+  metricsCollector: MetricsCollector;
 };
 
 export async function runShutdownSteps(
@@ -231,6 +236,10 @@ export async function createServerBootstrapContext(
         })
       : createInMemoryRoomStore({ now }));
   const localRuntimeStore = createInMemoryRuntimeStore(now);
+  const metricsCollector = createMetricsCollector({
+    runtimeStore: localRuntimeStore,
+    roomStore,
+  });
   const runtimeStorePendingOperationLogger =
     options.loggingHooks?.onRuntimeStorePendingOperationError;
 
@@ -241,6 +250,7 @@ export async function createServerBootstrapContext(
       ? await createRedisRuntimeStore(persistenceConfig.redisUrl, {
           now,
           keyPrefix: getRedisRuntimeKeyPrefix(persistenceConfig.redisNamespace),
+          metricsCollector,
           ...(runtimeStorePendingOperationLogger
             ? {
                 onPendingOperationError: (context, error) => {
@@ -271,6 +281,7 @@ export async function createServerBootstrapContext(
     persistenceConfig.roomEventBusProvider === "redis"
       ? await createRedisRoomEventBus(persistenceConfig.redisUrl, {
           channel: getRedisRoomEventChannel(persistenceConfig.redisNamespace),
+          metricsCollector,
           onConnectionError: (role, error) => {
             options.loggingHooks?.onRoomEventBusConnectionError?.(
               logEvent,
@@ -302,9 +313,18 @@ export async function createServerBootstrapContext(
         })
       : createEventStore();
 
-  logEvent =
-    dependencies.logEvent ??
-    createStructuredLogger(undefined, eventStore, runtimeStore);
+  logEvent = dependencies.logEvent
+    ? (event, data) => {
+        dependencies.logEvent?.(event, data);
+        runtimeStore.recordEvent(event, now());
+        metricsCollector.recordEvent(event);
+      }
+    : createStructuredLogger(
+        undefined,
+        eventStore,
+        runtimeStore,
+        metricsCollector,
+      );
 
   const purgedStartupSessions =
     (await runtimeStore.purgeSessionsByInstance?.(
@@ -328,6 +348,7 @@ export async function createServerBootstrapContext(
     roomEventBus,
     eventStore,
     logEvent,
+    metricsCollector,
   };
 }
 

--- a/server/src/global-admin-app.ts
+++ b/server/src/global-admin-app.ts
@@ -53,6 +53,7 @@ export async function createGlobalAdminServer(
     roomEventBus,
     eventStore,
     logEvent,
+    metricsCollector,
   } = await createServerBootstrapContext(persistenceConfig, dependencies, {
     useMirroredRuntimeStore: false,
   });
@@ -79,6 +80,7 @@ export async function createGlobalAdminServer(
       requestAdminCommand: (command, timeoutMs) =>
         adminCommandBus.request(command, timeoutMs),
       logEvent,
+      metricsCollector,
       now,
       adminConfig: dependencies.adminConfig,
       adminUiConfig: dependencies.adminUiConfig,

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -1,5 +1,6 @@
 import type { LogEvent } from "./types.js";
 import type { GlobalEventStore } from "./admin/global-event-store.js";
+import type { MetricsCollector } from "./admin/metrics.js";
 import type { RuntimeStore } from "./runtime-store.js";
 
 const EVENT_STORE_EXCLUDED_EVENTS = new Set(["node_heartbeat_sent"]);
@@ -8,6 +9,7 @@ export function createStructuredLogger(
   writeLine?: (line: string) => void,
   eventStore?: GlobalEventStore,
   runtimeStore?: RuntimeStore,
+  metricsCollector?: Pick<MetricsCollector, "recordEvent">,
 ): LogEvent {
   const emitLine = (line: string) => {
     (writeLine ?? console.log)(line);
@@ -32,5 +34,6 @@ export function createStructuredLogger(
       );
     }
     runtimeStore?.recordEvent(event, Date.parse(timestamp));
+    metricsCollector?.recordEvent(event);
   };
 }

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -1,4 +1,9 @@
 import type { ClientMessage } from "@bili-syncplay/protocol";
+import { performance } from "node:perf_hooks";
+import type {
+  MetricsCollector,
+  MonitoredMessageType,
+} from "./admin/metrics.js";
 import {
   consumeFixedWindow,
   consumeTokenBucket,
@@ -83,6 +88,7 @@ export function createMessageHandler(options: {
   sendError: SendError;
   publishRoomEvent: (message: RoomEventBusMessage) => Promise<void>;
   instanceId: string;
+  metricsCollector?: Pick<MetricsCollector, "observeMessageHandlerDuration">;
   onRoomJoined?: (
     session: Session,
     roomCode: string,
@@ -99,6 +105,7 @@ export function createMessageHandler(options: {
 } {
   const { config, roomService, logEvent, send, sendError } = options;
   const now = options.now ?? Date.now;
+  const metricsCollector = options.metricsCollector;
 
   async function publishRoomEvent(
     type: RoomEventBusMessage["type"],
@@ -148,6 +155,21 @@ export function createMessageHandler(options: {
       messageType,
       result: "rejected",
     });
+  }
+
+  async function measureMessageHandling(
+    messageType: MonitoredMessageType,
+    handler: () => Promise<void>,
+  ): Promise<void> {
+    const startedAt = performance.now();
+    try {
+      await handler();
+    } finally {
+      metricsCollector?.observeMessageHandlerDuration(
+        messageType,
+        performance.now() - startedAt,
+      );
+    }
   }
 
   async function handleClientMessage(
@@ -221,32 +243,34 @@ export function createMessageHandler(options: {
             return;
           }
 
-          const { room, memberToken } = await roomService.joinRoomForSession(
-            session,
-            message.payload.roomCode,
-            message.payload.joinToken,
-            message.payload.displayName,
-            message.payload.memberToken,
-          );
-          if (previousRoomCode && previousRoomCode !== room.code) {
-            options.onRoomLeft?.(session, previousRoomCode);
-          }
-          options.onRoomJoined?.(session, room.code, previousRoomCode);
-          send(socket, {
-            type: "room:joined",
-            payload: {
+          await measureMessageHandling("room:join", async () => {
+            const { room, memberToken } = await roomService.joinRoomForSession(
+              session,
+              message.payload.roomCode,
+              message.payload.joinToken,
+              message.payload.displayName,
+              message.payload.memberToken,
+            );
+            if (previousRoomCode && previousRoomCode !== room.code) {
+              options.onRoomLeft?.(session, previousRoomCode);
+            }
+            options.onRoomJoined?.(session, room.code, previousRoomCode);
+            send(socket, {
+              type: "room:joined",
+              payload: {
+                roomCode: room.code,
+                memberId: session.memberId ?? session.id,
+                memberToken,
+              },
+            });
+            await publishRoomEvent("room_member_changed", room.code);
+            logEvent("room_joined", {
+              sessionId: session.id,
               roomCode: room.code,
-              memberId: session.memberId ?? session.id,
-              memberToken,
-            },
-          });
-          await publishRoomEvent("room_member_changed", room.code);
-          logEvent("room_joined", {
-            sessionId: session.id,
-            roomCode: room.code,
-            remoteAddress: session.remoteAddress,
-            origin: session.origin,
-            result: "ok",
+              remoteAddress: session.remoteAddress,
+              origin: session.origin,
+              result: "ok",
+            });
           });
           return;
         }
@@ -263,7 +287,7 @@ export function createMessageHandler(options: {
             );
             return;
           }
-          await leaveRoom(session);
+          await measureMessageHandling("room:leave", () => leaveRoom(session));
           return;
         }
         case "profile:update": {
@@ -289,13 +313,15 @@ export function createMessageHandler(options: {
             return;
           }
 
-          const { room } = await roomService.shareVideoForSession(
-            session,
-            message.payload.memberToken,
-            message.payload.video,
-            message.payload.playback,
-          );
-          await publishRoomEvent("room_state_updated", room.code);
+          await measureMessageHandling("video:share", async () => {
+            const { room } = await roomService.shareVideoForSession(
+              session,
+              message.payload.memberToken,
+              message.payload.video,
+              message.payload.playback,
+            );
+            await publishRoomEvent("room_state_updated", room.code);
+          });
           return;
         }
         case "playback:update": {
@@ -311,14 +337,16 @@ export function createMessageHandler(options: {
             return;
           }
 
-          const result = await roomService.updatePlaybackForSession(
-            session,
-            message.payload.memberToken,
-            message.payload.playback,
-          );
-          if (!result.ignored && result.room) {
-            await publishRoomEvent("room_state_updated", result.room.code);
-          }
+          await measureMessageHandling("playback:update", async () => {
+            const result = await roomService.updatePlaybackForSession(
+              session,
+              message.payload.memberToken,
+              message.payload.playback,
+            );
+            if (!result.ignored && result.room) {
+              await publishRoomEvent("room_state_updated", result.room.code);
+            }
+          });
           return;
         }
         case "sync:request": {

--- a/server/src/redis-room-event-bus.ts
+++ b/server/src/redis-room-event-bus.ts
@@ -1,4 +1,6 @@
 import { Redis } from "ioredis";
+import { performance } from "node:perf_hooks";
+import type { MetricsCollector } from "./admin/metrics.js";
 import type { RoomEventBus, RoomEventBusMessage } from "./room-event-bus.js";
 
 const DEFAULT_ROOM_EVENT_CHANNEL = "bsp:room-events";
@@ -46,6 +48,11 @@ export async function createRedisRoomEventBus(
     ) => void;
     onInvalidMessage?: (payload: string) => void;
     onHandlerError?: (message: RoomEventBusMessage, error: unknown) => void;
+    metricsCollector?: Pick<
+      MetricsCollector,
+      | "observeRedisRoomEventBusPublishDuration"
+      | "observeRedisRoomEventBusPublishFailure"
+    >;
   } = {},
 ): Promise<RoomEventBus & { close: () => Promise<void> }> {
   const publishClient = new Redis(redisUrl, {
@@ -93,7 +100,17 @@ export async function createRedisRoomEventBus(
         return;
       }
 
-      await publishClient.publish(channel, JSON.stringify(message));
+      const startedAt = performance.now();
+      try {
+        await publishClient.publish(channel, JSON.stringify(message));
+      } catch (error) {
+        options.metricsCollector?.observeRedisRoomEventBusPublishFailure();
+        throw error;
+      } finally {
+        options.metricsCollector?.observeRedisRoomEventBusPublishDuration(
+          performance.now() - startedAt,
+        );
+      }
     },
     async subscribe(handler) {
       if (closing) {

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -317,12 +317,20 @@ export async function createRedisRuntimeStore(
     operation: Promise<T>,
   ): Promise<T | undefined> {
     const startedAt = performance.now();
+    let failureRecorded = false;
+    const recordFailureOnce = () => {
+      if (failureRecorded) {
+        return;
+      }
+      failureRecorded = true;
+      metricsCollector?.observeRedisRuntimeStoreFailure(operationName);
+    };
     const trackedOperation = new Promise<T>((resolve, reject) => {
       const timeout = setTimeout(() => {
         const error = new Error(
           `Redis runtime store operation timed out: ${operationName}.`,
         );
-        metricsCollector?.observeRedisRuntimeStoreFailure(operationName);
+        recordFailureOnce();
         logPendingOperationError(
           {
             operationName,
@@ -341,7 +349,7 @@ export async function createRedisRuntimeStore(
         },
         (error: unknown) => {
           clearTimeout(timeout);
-          metricsCollector?.observeRedisRuntimeStoreFailure(operationName);
+          recordFailureOnce();
           logPendingOperationError(
             {
               operationName,

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
+import { performance } from "node:perf_hooks";
 import { Redis } from "ioredis";
+import type { MetricsCollector } from "./admin/metrics.js";
 import type { ActiveRoom, ClusterNodeStatus, Session } from "./types.js";
 import {
   createInMemoryRuntimeStore,
@@ -75,6 +77,10 @@ type RuntimeStoreOptions = {
     context: PendingOperationLogContext,
     error: unknown,
   ) => void;
+  metricsCollector?: Pick<
+    MetricsCollector,
+    "observeRedisRuntimeStoreDuration" | "observeRedisRuntimeStoreFailure"
+  >;
 };
 
 const RUNTIME_STORE_METHOD_NAMES = [
@@ -260,6 +266,7 @@ export async function createRedisRuntimeStore(
     options.maxPendingOperations ?? DEFAULT_MAX_PENDING_OPERATIONS;
   const pendingOperationTimeoutMs =
     options.pendingOperationTimeoutMs ?? DEFAULT_PENDING_OPERATION_TIMEOUT_MS;
+  const metricsCollector = options.metricsCollector;
   const localRuntimeStore = createInMemoryRuntimeStore(now);
   const pendingOperations = new Set<Promise<unknown>>();
   const sessionOperationChains = new Map<string, Promise<void>>();
@@ -309,11 +316,13 @@ export async function createRedisRuntimeStore(
     operationName: string,
     operation: Promise<T>,
   ): Promise<T | undefined> {
+    const startedAt = performance.now();
     const trackedOperation = new Promise<T>((resolve, reject) => {
       const timeout = setTimeout(() => {
         const error = new Error(
           `Redis runtime store operation timed out: ${operationName}.`,
         );
+        metricsCollector?.observeRedisRuntimeStoreFailure(operationName);
         logPendingOperationError(
           {
             operationName,
@@ -332,6 +341,7 @@ export async function createRedisRuntimeStore(
         },
         (error: unknown) => {
           clearTimeout(timeout);
+          metricsCollector?.observeRedisRuntimeStoreFailure(operationName);
           logPendingOperationError(
             {
               operationName,
@@ -348,6 +358,10 @@ export async function createRedisRuntimeStore(
     pendingOperations.add(handledOperation);
     void handledOperation.finally(() => {
       pendingOperations.delete(handledOperation);
+      metricsCollector?.observeRedisRuntimeStoreDuration(
+        operationName,
+        performance.now() - startedAt,
+      );
     });
     return handledOperation;
   }

--- a/server/test/admin-backend.test.ts
+++ b/server/test/admin-backend.test.ts
@@ -1176,6 +1176,23 @@ test("admin exposes metrics and config summary", async () => {
       metrics.body.includes("bili_syncplay_room_created_total"),
       true,
     );
+    assert.equal(metrics.body.includes("bili_syncplay_events_total"), true);
+    assert.equal(
+      metrics.body.includes("bili_syncplay_message_handler_duration_seconds"),
+      true,
+    );
+    assert.equal(
+      metrics.body.includes(
+        "bili_syncplay_redis_runtime_store_duration_seconds",
+      ),
+      true,
+    );
+    assert.equal(
+      metrics.body.includes(
+        "bili_syncplay_redis_room_event_bus_publish_duration_seconds",
+      ),
+      true,
+    );
 
     const config = await requestJson(server.httpBaseUrl, "/api/admin/config", {
       token,

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -304,3 +304,117 @@ test("message handler keeps leave completed when member change publish fails", a
   assert.deepEqual(left, ["ROOM01"]);
   assert.ok(events.includes("room_event_publish_failed"));
 });
+
+test("message handler records monitored duration metrics for critical room paths", async () => {
+  const observedTypes: string[] = [];
+  const session = createSession("member-1", {
+    roomCode: "ROOM01",
+    memberId: "member-1",
+    memberToken: "member-token-1",
+  });
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession(currentSession) {
+        currentSession.roomCode = "ROOM01";
+        currentSession.memberId = "member-1";
+        currentSession.memberToken = "member-token-1";
+        return {
+          room: { code: "ROOM01" },
+          memberToken: "member-token-1",
+        };
+      },
+      async leaveRoomForSession(currentSession) {
+        currentSession.roomCode = null;
+        return {
+          room: { code: "ROOM01" },
+          notifyRoom: true,
+        };
+      },
+      async shareVideoForSession() {
+        return { room: { code: "ROOM01" } };
+      },
+      async updatePlaybackForSession() {
+        return { room: { code: "ROOM01" }, ignored: false };
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent() {},
+    send() {},
+    sendError() {
+      throw new Error("sendError should not be called");
+    },
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+    metricsCollector: {
+      observeMessageHandlerDuration(messageType) {
+        observedTypes.push(messageType);
+      },
+    },
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      displayName: "Alice",
+    },
+  });
+  await handler.handleClientMessage(session, {
+    type: "video:share",
+    payload: {
+      memberToken: "member-token-1",
+      video: {
+        videoId: "BV1xx411c7mD",
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        title: "Test Episode",
+      },
+      playback: {
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 0,
+        playState: "paused",
+        playbackRate: 1,
+        updatedAt: 1,
+        serverTime: 0,
+        actorId: "member-1",
+        seq: 1,
+      },
+    },
+  });
+  await handler.handleClientMessage(session, {
+    type: "playback:update",
+    payload: {
+      memberToken: "member-token-1",
+      playback: {
+        currentTime: 5,
+        playState: "playing",
+        playbackRate: 1,
+        updatedAt: 2,
+        serverTime: 0,
+        actorId: "member-1",
+        seq: 2,
+      },
+    },
+  });
+  await handler.handleClientMessage(session, {
+    type: "room:leave",
+    payload: { memberToken: "member-token-1" },
+  });
+
+  assert.deepEqual(observedTypes, [
+    "room:join",
+    "video:share",
+    "playback:update",
+    "room:leave",
+  ]);
+});

--- a/server/test/metrics.test.ts
+++ b/server/test/metrics.test.ts
@@ -85,3 +85,47 @@ test("metrics collector renders event counters, histograms, and redis failure co
     true,
   );
 });
+
+test("metrics collector can rebind to the effective runtime store", async () => {
+  const localRuntimeStore = createInMemoryRuntimeStore(() => 0);
+  const sharedRuntimeStore = createInMemoryRuntimeStore(() => 0);
+  const metrics = createMetricsCollector({
+    runtimeStore: localRuntimeStore,
+    roomStore: {
+      async countRooms() {
+        return 0;
+      },
+    } as never,
+  });
+
+  sharedRuntimeStore.registerSession({
+    id: "shared-session",
+    connectionState: "detached",
+    socket: null,
+    instanceId: "instance-shared",
+    remoteAddress: "127.0.0.1",
+    origin: "chrome-extension://allowed-extension",
+    roomCode: null,
+    memberId: null,
+    displayName: "Bob",
+    memberToken: null,
+    joinedAt: null,
+    invalidMessageCount: 0,
+    rateLimitState: {
+      roomCreate: { windowStart: 0, count: 0 },
+      roomJoin: { windowStart: 0, count: 0 },
+      videoShare: { windowStart: 0, count: 0 },
+      playbackUpdate: { tokens: 0, lastRefillAt: 0 },
+      syncRequest: { windowStart: 0, count: 0 },
+      syncPing: { tokens: 0, lastRefillAt: 0 },
+    },
+  });
+  sharedRuntimeStore.markSessionJoinedRoom("shared-session", "ROOM99");
+
+  metrics.bindRuntimeStore(sharedRuntimeStore);
+
+  const rendered = await metrics.render();
+
+  assert.equal(rendered.includes("bili_syncplay_connections 1"), true);
+  assert.equal(rendered.includes("bili_syncplay_active_rooms 1"), true);
+});

--- a/server/test/metrics.test.ts
+++ b/server/test/metrics.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMetricsCollector } from "../src/admin/metrics.js";
+import { createInMemoryRuntimeStore } from "../src/runtime-store.js";
+
+test("metrics collector renders event counters, histograms, and redis failure counters", async () => {
+  const runtimeStore = createInMemoryRuntimeStore(() => 0);
+  const metrics = createMetricsCollector({
+    runtimeStore,
+    roomStore: {
+      async countRooms() {
+        return 2;
+      },
+    } as never,
+  });
+
+  runtimeStore.registerSession({
+    id: "session-1",
+    connectionState: "detached",
+    socket: null,
+    instanceId: "instance-1",
+    remoteAddress: "127.0.0.1",
+    origin: "chrome-extension://allowed-extension",
+    roomCode: null,
+    memberId: null,
+    displayName: "Alice",
+    memberToken: null,
+    joinedAt: null,
+    invalidMessageCount: 0,
+    rateLimitState: {
+      roomCreate: { windowStart: 0, count: 0 },
+      roomJoin: { windowStart: 0, count: 0 },
+      videoShare: { windowStart: 0, count: 0 },
+      playbackUpdate: { tokens: 0, lastRefillAt: 0 },
+      syncRequest: { windowStart: 0, count: 0 },
+      syncPing: { tokens: 0, lastRefillAt: 0 },
+    },
+  });
+  runtimeStore.markSessionJoinedRoom("session-1", "ROOM01");
+
+  metrics.recordEvent("room_created");
+  metrics.observeMessageHandlerDuration("room:join", 12);
+  metrics.observeRedisRuntimeStoreDuration("register_session", 8);
+  metrics.observeRedisRuntimeStoreFailure("register_session");
+  metrics.observeRedisRoomEventBusPublishDuration(5);
+  metrics.observeRedisRoomEventBusPublishFailure();
+
+  const rendered = await metrics.render();
+
+  assert.equal(rendered.includes("bili_syncplay_connections 1"), true);
+  assert.equal(rendered.includes("bili_syncplay_active_rooms 1"), true);
+  assert.equal(rendered.includes("bili_syncplay_rooms_non_expired 2"), true);
+  assert.equal(
+    rendered.includes('bili_syncplay_events_total{event="room_created"} 1'),
+    true,
+  );
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_message_handler_duration_seconds_count{message_type="room:join"} 1',
+    ),
+    true,
+  );
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_redis_runtime_store_duration_seconds_count{operation="register_session"} 1',
+    ),
+    true,
+  );
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_redis_room_event_bus_publish_duration_seconds_count{operation="publish"} 1',
+    ),
+    true,
+  );
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_redis_operation_failures_total{component="room_event_bus",operation="publish"} 1',
+    ),
+    true,
+  );
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_redis_operation_failures_total{component="runtime_store",operation="register_session"} 1',
+    ),
+    true,
+  );
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -512,3 +512,31 @@ test("redis runtime store removes timed out pending operations and recovers", as
     await store.close();
   }
 });
+
+test("redis runtime store counts a timed-out operation failure only once", async () => {
+  const pending = createDeferred<unknown>();
+  const failureOperations: string[] = [];
+  const store = await createRedisRuntimeStore("redis://example.test:6379", {
+    redisClient: createFakeRedisClient([pending.promise]),
+    pendingOperationTimeoutMs: 5,
+    metricsCollector: {
+      observeRedisRuntimeStoreDuration() {},
+      observeRedisRuntimeStoreFailure(operation) {
+        failureOperations.push(operation);
+      },
+    },
+  });
+
+  try {
+    const session = createSession("session-timeout");
+    store.registerSession(session);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    pending.reject(new Error("late redis failure"));
+    await store.flush?.();
+
+    assert.deepEqual(failureOperations, ["register_session"]);
+  } finally {
+    await store.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add in-process Prometheus collectors for event counters, message handler latency histograms, and Redis latency/failure metrics
- instrument message handler, Redis runtime store, and Redis room event bus paths, then wire the collector through both room-node and global-admin bootstrap flows
- cover metric rendering and critical-path sampling with dedicated server tests

Fixes #64

## Test plan
- [x] npm run format:check
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run build
- [x] npm test
