### PR TITLE
feat(server): structured logger 增加级别与采样 (#65)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -32,6 +32,7 @@ import type {
   AdminConfig,
   AdminUiConfig,
   LogEvent,
+  LogLevel,
   PersistenceConfig,
   SecurityConfig,
 } from "./types.js";
@@ -69,6 +70,8 @@ export type SyncServerDependencies = {
   adminConfig?: AdminConfig;
   adminUiConfig?: AdminUiConfig;
   serviceVersion?: string;
+  logLevel?: LogLevel;
+  logSampling?: Record<string, number>;
 };
 
 export async function createSyncServer(

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -12,7 +12,7 @@ import {
   createNoopAdminCommandBus,
   type AdminCommandBus,
 } from "../admin-command-bus.js";
-import { createStructuredLogger } from "../logger.js";
+import { createStructuredLogger, DEFAULT_EVENT_SAMPLING } from "../logger.js";
 import { createMirroredRuntimeStore } from "../mirrored-runtime-store.js";
 import { createRedisAdminCommandBus } from "../redis-admin-command-bus.js";
 import { createRedisRoomEventBus } from "../redis-room-event-bus.js";
@@ -40,6 +40,7 @@ import type { GlobalEventStore } from "../admin/global-event-store.js";
 import type {
   AdminConfig,
   LogEvent,
+  LogLevel,
   PersistenceConfig,
   SecurityConfig,
 } from "../types.js";
@@ -68,6 +69,8 @@ export type ServerBootstrapDependencies = {
   now?: () => number;
   adminConfig?: AdminConfig;
   serviceVersion?: string;
+  logLevel?: LogLevel;
+  logSampling?: Record<string, number>;
 };
 
 type PendingOperationLogContext = {
@@ -315,17 +318,18 @@ export async function createServerBootstrapContext(
       : createEventStore();
 
   logEvent = dependencies.logEvent
-    ? (event, data) => {
-        dependencies.logEvent?.(event, data);
+    ? (event, data, options) => {
+        dependencies.logEvent?.(event, data, options);
         runtimeStore.recordEvent(event, now());
         metricsCollector.recordEvent(event);
       }
-    : createStructuredLogger(
-        undefined,
+    : createStructuredLogger({
         eventStore,
         runtimeStore,
         metricsCollector,
-      );
+        logLevel: dependencies.logLevel,
+        sampling: dependencies.logSampling ?? { ...DEFAULT_EVENT_SAMPLING },
+      });
 
   const purgedStartupSessions =
     (await runtimeStore.purgeSessionsByInstance?.(

--- a/server/src/config/runtime-config-schema.ts
+++ b/server/src/config/runtime-config-schema.ts
@@ -46,6 +46,12 @@ function createField(
 export const SERVER_CONFIG_FIELDS = [
   createField(["port"], "PORT", "integer"),
   createField(["globalAdminPort"], "GLOBAL_ADMIN_PORT", "integer"),
+  createField(["logLevel"], "LOG_LEVEL", "enum", [
+    "debug",
+    "info",
+    "warn",
+    "error",
+  ]),
   createField(["security", "allowedOrigins"], "ALLOWED_ORIGINS", "stringArray"),
   createField(
     ["security", "allowMissingOriginInDev"],

--- a/server/src/config/runtime-config.ts
+++ b/server/src/config/runtime-config.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import type {
   AdminConfig,
   AdminUiConfig,
+  LogLevel,
   PersistenceConfig,
   SecurityConfig,
 } from "../types.js";
@@ -12,11 +13,16 @@ import { parseIntegerEnv } from "./env.js";
 import { loadPersistenceConfig } from "./persistence-config.js";
 import {
   getConfigValue,
+  parseConfigEnvFieldValue,
   parseConfigFileFieldValue,
   SERVER_CONFIG_FIELDS,
   SERVER_CONFIG_SCHEMA_TREE,
 } from "./runtime-config-schema.js";
 import { loadSecurityConfig } from "./security-config.js";
+
+const LOG_LEVEL_FIELD = SERVER_CONFIG_FIELDS.find(
+  (field) => field.path[0] === "logLevel",
+)!;
 
 type JsonObject = Record<string, unknown>;
 
@@ -65,6 +71,7 @@ type AdminUiConfigFile = {
 export type ServerConfigFile = {
   port?: number;
   globalAdminPort?: number;
+  logLevel?: LogLevel;
   security?: SecurityConfigFile;
   persistence?: PersistenceConfigFile;
   adminUi?: AdminUiConfigFile;
@@ -73,6 +80,7 @@ export type ServerConfigFile = {
 export type RuntimeConfig = {
   port: number;
   globalAdminPort: number;
+  logLevel: LogLevel;
   securityConfig: SecurityConfig;
   persistenceConfig: PersistenceConfig;
   adminConfig: AdminConfig;
@@ -243,6 +251,11 @@ export async function loadRuntimeConfig(
       mergedEnv,
       "GLOBAL_ADMIN_PORT",
       parseIntegerEnv(mergedEnv, "PORT", 8788),
+    ),
+    logLevel: parseConfigEnvFieldValue<LogLevel>(
+      LOG_LEVEL_FIELD,
+      mergedEnv,
+      "info",
     ),
     securityConfig: loadSecurityConfig(mergedEnv),
     persistenceConfig: loadPersistenceConfig(mergedEnv),

--- a/server/src/global-admin-app.ts
+++ b/server/src/global-admin-app.ts
@@ -20,6 +20,7 @@ import type {
   AdminConfig,
   AdminUiConfig,
   LogEvent,
+  LogLevel,
   PersistenceConfig,
   SecurityConfig,
 } from "./types.js";
@@ -37,6 +38,8 @@ export type GlobalAdminServerDependencies = {
   adminConfig?: AdminConfig;
   adminUiConfig?: AdminUiConfig;
   serviceVersion?: string;
+  logLevel?: LogLevel;
+  logSampling?: Record<string, number>;
 };
 
 export async function createGlobalAdminServer(

--- a/server/src/global-admin-index.ts
+++ b/server/src/global-admin-index.ts
@@ -3,6 +3,7 @@ import { createGlobalAdminServer } from "./global-admin-app.js";
 
 const {
   globalAdminPort: port,
+  logLevel,
   securityConfig,
   persistenceConfig,
   adminConfig,
@@ -18,6 +19,7 @@ const { httpServer } = await createGlobalAdminServer(
       ...adminUiConfig,
       enabled: true,
     },
+    logLevel,
   },
 );
 httpServer.listen(port, () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,8 +1,14 @@
 import { createSyncServer } from "./app.js";
 import { loadRuntimeConfig } from "./config/runtime-config.js";
 
-const { port, securityConfig, persistenceConfig, adminConfig, adminUiConfig } =
-  await loadRuntimeConfig();
+const {
+  port,
+  logLevel,
+  securityConfig,
+  persistenceConfig,
+  adminConfig,
+  adminUiConfig,
+} = await loadRuntimeConfig();
 
 const { httpServer } = await createSyncServer(
   securityConfig,
@@ -10,6 +16,7 @@ const { httpServer } = await createSyncServer(
   {
     adminConfig,
     adminUiConfig,
+    logLevel,
   },
 );
 httpServer.listen(port, () => {

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -12,6 +12,37 @@ const LEVEL_PRIORITY: Record<LogLevel, number> = {
   error: 40,
 };
 
+const LEVEL_BY_RESULT: Record<string, LogLevel> = {
+  ok: "info",
+  closed: "info",
+  ignored: "info",
+  conflict: "warn",
+  rate_limited: "warn",
+  rejected: "warn",
+  error: "error",
+  timeout: "error",
+};
+
+export function inferLogLevel(
+  event: string,
+  data: Record<string, unknown>,
+): LogLevel {
+  const result = data.result;
+  if (typeof result === "string") {
+    const mapped = LEVEL_BY_RESULT[result];
+    if (mapped) {
+      return mapped;
+    }
+  }
+  if (event.endsWith("_failed") || event.endsWith("_error")) {
+    return "error";
+  }
+  if (event.endsWith("_rejected")) {
+    return "warn";
+  }
+  return "info";
+}
+
 export const DEFAULT_EVENT_SAMPLING: Readonly<Record<string, number>> =
   Object.freeze({
     playback_update_applied: 10,
@@ -46,7 +77,7 @@ export function createStructuredLogger(
   };
 
   return (event, data, eventOptions) => {
-    const level: LogLevel = eventOptions?.level ?? "info";
+    const level: LogLevel = eventOptions?.level ?? inferLogLevel(event, data);
     const timestamp = new Date().toISOString();
     const payload = { event, level, timestamp, ...data };
 

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -1,37 +1,87 @@
-import type { LogEvent } from "./types.js";
+import type { LogEvent, LogLevel } from "./types.js";
 import type { GlobalEventStore } from "./admin/global-event-store.js";
 import type { MetricsCollector } from "./admin/metrics.js";
 import type { RuntimeStore } from "./runtime-store.js";
 
 const EVENT_STORE_EXCLUDED_EVENTS = new Set(["node_heartbeat_sent"]);
 
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+export const DEFAULT_EVENT_SAMPLING: Readonly<Record<string, number>> =
+  Object.freeze({
+    playback_update_applied: 10,
+    sync_ping: 10,
+  });
+
+export type StructuredLoggerOptions = {
+  writeLine?: (line: string) => void;
+  eventStore?: GlobalEventStore;
+  runtimeStore?: RuntimeStore;
+  metricsCollector?: Pick<MetricsCollector, "recordEvent">;
+  logLevel?: LogLevel;
+  sampling?: Record<string, number>;
+};
+
 export function createStructuredLogger(
-  writeLine?: (line: string) => void,
-  eventStore?: GlobalEventStore,
-  runtimeStore?: RuntimeStore,
-  metricsCollector?: Pick<MetricsCollector, "recordEvent">,
+  options: StructuredLoggerOptions = {},
 ): LogEvent {
+  const {
+    writeLine,
+    eventStore,
+    runtimeStore,
+    metricsCollector,
+    logLevel = "info",
+    sampling = {},
+  } = options;
+
+  const threshold = LEVEL_PRIORITY[logLevel];
+  const sampleCounters = new Map<string, number>();
   const emitLine = (line: string) => {
     (writeLine ?? console.log)(line);
   };
 
-  return (event, data) => {
+  return (event, data, eventOptions) => {
+    const level: LogLevel = eventOptions?.level ?? "info";
     const timestamp = new Date().toISOString();
-    emitLine(JSON.stringify({ event, timestamp, ...data }));
+    const payload = { event, level, timestamp, ...data };
+
+    const levelPassesThreshold =
+      level === "error" || LEVEL_PRIORITY[level] >= threshold;
+
+    let shouldWriteStdout = levelPassesThreshold;
+    if (levelPassesThreshold && level !== "error") {
+      const sampleRate = sampling[event];
+      if (typeof sampleRate === "number" && sampleRate > 1) {
+        const nextCounter = (sampleCounters.get(event) ?? 0) + 1;
+        sampleCounters.set(event, nextCounter);
+        shouldWriteStdout = (nextCounter - 1) % sampleRate === 0;
+      }
+    }
+
+    if (shouldWriteStdout) {
+      emitLine(JSON.stringify(payload));
+    }
+
     if (eventStore && !EVENT_STORE_EXCLUDED_EVENTS.has(event)) {
-      void Promise.resolve(eventStore.append({ event, timestamp, data })).catch(
-        (error: unknown) => {
-          emitLine(
-            JSON.stringify({
-              event: "runtime_event_append_failed",
-              timestamp: new Date().toISOString(),
-              result: "error",
-              failedEvent: event,
-              error: error instanceof Error ? error.message : String(error),
-            }),
-          );
-        },
-      );
+      void Promise.resolve(
+        eventStore.append({ event, timestamp, data: { level, ...data } }),
+      ).catch((error: unknown) => {
+        emitLine(
+          JSON.stringify({
+            event: "runtime_event_append_failed",
+            level: "error" satisfies LogLevel,
+            timestamp: new Date().toISOString(),
+            result: "error",
+            failedEvent: event,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+      });
     }
     runtimeStore?.recordEvent(event, Date.parse(timestamp));
     metricsCollector?.recordEvent(event);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -159,7 +159,17 @@ export type SecurityConfig = {
   };
 };
 
-export type LogEvent = (event: string, data: Record<string, unknown>) => void;
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export type LogEventOptions = {
+  level?: LogLevel;
+};
+
+export type LogEvent = (
+  event: string,
+  data: Record<string, unknown>,
+  options?: LogEventOptions,
+) => void;
 
 export type SendMessage = (socket: WebSocket, message: ServerMessage) => void;
 

--- a/server/test/logger.test.ts
+++ b/server/test/logger.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { GlobalEventStoreAppendInput } from "../src/admin/global-event-store.js";
 import type { RuntimeEvent } from "../src/admin/types.js";
-import { createStructuredLogger } from "../src/logger.js";
+import { createStructuredLogger, inferLogLevel } from "../src/logger.js";
 import { createInMemoryRuntimeStore } from "../src/runtime-store.js";
 
 function createCapturingEventStore(): {
@@ -144,6 +144,88 @@ test("error-level events bypass sampling; non-error high-frequency events are sa
   assert.deepEqual(stdoutSeqs, [0, 5, 10, "error-1"]);
 
   assert.equal(appendedEvents.length, 13);
+});
+
+test("log level inference covers result field and event-name suffix fallbacks", () => {
+  assert.equal(inferLogLevel("room_created", { result: "ok" }), "info");
+  assert.equal(
+    inferLogLevel("room_persist_failed", { result: "error" }),
+    "error",
+  );
+  assert.equal(
+    inferLogLevel("server_shutdown_step_failed", { result: "timeout" }),
+    "error",
+  );
+  assert.equal(inferLogLevel("rate_limited", { result: "rejected" }), "warn");
+  assert.equal(inferLogLevel("auth_failed", { result: "rejected" }), "warn");
+  assert.equal(
+    inferLogLevel("room_version_conflict", { result: "conflict" }),
+    "warn",
+  );
+  assert.equal(
+    inferLogLevel("ws_connection_closed", { result: "closed" }),
+    "info",
+  );
+  // No result field: fall back to event-name suffix heuristic.
+  assert.equal(inferLogLevel("ws_send_failed", {}), "error");
+  assert.equal(inferLogLevel("room_event_bus_error", {}), "error");
+  assert.equal(inferLogLevel("admin_room_close_rejected", {}), "warn");
+  assert.equal(inferLogLevel("room_created", {}), "info");
+});
+
+test("LOG_LEVEL=warn keeps production error/warn events visible via inference", async () => {
+  const writtenLines: string[] = [];
+  const { appendedEvents, store } = createCapturingEventStore();
+  const logger = createStructuredLogger({
+    writeLine: (line) => {
+      writtenLines.push(line);
+    },
+    eventStore: store,
+    logLevel: "warn",
+  });
+
+  logger("room_created", { roomCode: "ROOM01", result: "ok" });
+  logger("room_persist_failed", { result: "error", error: "disk full" });
+  logger("rate_limited", { result: "rejected", messageType: "video:share" });
+  logger("ws_send_failed", { error: "broken_pipe" });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const stdoutEvents = writtenLines.map(
+    (line) => (JSON.parse(line) as { event: string }).event,
+  );
+  assert.deepEqual(stdoutEvents, [
+    "room_persist_failed",
+    "rate_limited",
+    "ws_send_failed",
+  ]);
+
+  const storedEvents = appendedEvents.map((entry) => entry.event);
+  assert.deepEqual(storedEvents, [
+    "room_created",
+    "room_persist_failed",
+    "rate_limited",
+    "ws_send_failed",
+  ]);
+});
+
+test("explicit options.level overrides result-based inference", () => {
+  const writtenLines: string[] = [];
+  const logger = createStructuredLogger({
+    writeLine: (line) => {
+      writtenLines.push(line);
+    },
+    logLevel: "warn",
+  });
+
+  // Would infer "info" via result: "ok", but override forces "error" → still emitted at warn threshold.
+  logger(
+    "room_created",
+    { roomCode: "ROOM01", result: "ok" },
+    { level: "error" },
+  );
+  assert.equal(writtenLines.length, 1);
+  const payload = JSON.parse(writtenLines[0]!) as { level: string };
+  assert.equal(payload.level, "error");
 });
 
 test("sampling counter resets per event name and does not leak across names", () => {

--- a/server/test/logger.test.ts
+++ b/server/test/logger.test.ts
@@ -1,25 +1,26 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { GlobalEventStoreAppendInput } from "../src/admin/global-event-store.js";
+import type { RuntimeEvent } from "../src/admin/types.js";
 import { createStructuredLogger } from "../src/logger.js";
 import { createInMemoryRuntimeStore } from "../src/runtime-store.js";
 
-test("structured logger excludes successful node heartbeats from event storage", async () => {
-  const writtenLines: string[] = [];
-  const appendedEvents: Array<{
-    event: string;
-    timestamp?: string;
-    data: Record<string, unknown>;
-  }> = [];
-  const runtimeStore = createInMemoryRuntimeStore(() => 0);
-  const logger = createStructuredLogger(
-    (line) => {
-      writtenLines.push(line);
-    },
-    {
+function createCapturingEventStore(): {
+  appendedEvents: GlobalEventStoreAppendInput[];
+  store: {
+    append: (input: GlobalEventStoreAppendInput) => Promise<RuntimeEvent>;
+    query: () => never;
+    totalCountsByEvent: () => Record<string, number>;
+  };
+} {
+  const appendedEvents: GlobalEventStoreAppendInput[] = [];
+  return {
+    appendedEvents,
+    store: {
       append(input) {
         appendedEvents.push(input);
         return Promise.resolve({
-          id: "evt-1",
+          id: `evt-${appendedEvents.length}`,
           timestamp: input.timestamp ?? new Date().toISOString(),
           event: input.event,
           roomCode: null,
@@ -27,15 +28,30 @@ test("structured logger excludes successful node heartbeats from event storage",
           remoteAddress: null,
           origin: null,
           result: null,
-          details: input.data,
+          details: { ...input.data },
         });
       },
       query() {
         throw new Error("query should not be called in this test");
       },
+      totalCountsByEvent() {
+        return {};
+      },
     },
+  };
+}
+
+test("structured logger excludes successful node heartbeats from event storage", async () => {
+  const writtenLines: string[] = [];
+  const { appendedEvents, store } = createCapturingEventStore();
+  const runtimeStore = createInMemoryRuntimeStore(() => 0);
+  const logger = createStructuredLogger({
+    writeLine: (line) => {
+      writtenLines.push(line);
+    },
+    eventStore: store,
     runtimeStore,
-  );
+  });
 
   logger("node_heartbeat_sent", { instanceId: "node-1", result: "ok" });
   logger("room_created", { roomCode: "ROOM01", result: "ok" });
@@ -48,4 +64,105 @@ test("structured logger excludes successful node heartbeats from event storage",
     "node_heartbeat_sent",
     "room_created",
   ]);
+});
+
+test("structured logger stamps default info level on emitted events", () => {
+  const writtenLines: string[] = [];
+  const logger = createStructuredLogger({
+    writeLine: (line) => {
+      writtenLines.push(line);
+    },
+  });
+
+  logger("room_created", { roomCode: "ROOM01" });
+
+  assert.equal(writtenLines.length, 1);
+  const payload = JSON.parse(writtenLines[0]!) as Record<string, unknown>;
+  assert.equal(payload.level, "info");
+  assert.equal(payload.event, "room_created");
+});
+
+test("log level threshold suppresses lower-level events from stdout but event store still records them", async () => {
+  const writtenLines: string[] = [];
+  const { appendedEvents, store } = createCapturingEventStore();
+  const logger = createStructuredLogger({
+    writeLine: (line) => {
+      writtenLines.push(line);
+    },
+    eventStore: store,
+    logLevel: "warn",
+  });
+
+  logger("debug_event", { detail: 1 }, { level: "debug" });
+  logger("info_event", { detail: 2 }, { level: "info" });
+  logger("warn_event", { detail: 3 }, { level: "warn" });
+  logger("error_event", { detail: 4 }, { level: "error" });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const stdoutEvents = writtenLines.map(
+    (line) => (JSON.parse(line) as { event: string }).event,
+  );
+  assert.deepEqual(stdoutEvents, ["warn_event", "error_event"]);
+
+  const storedEvents = appendedEvents.map((entry) => entry.event);
+  assert.deepEqual(storedEvents, [
+    "debug_event",
+    "info_event",
+    "warn_event",
+    "error_event",
+  ]);
+
+  const storedLevels = appendedEvents.map((entry) => entry.data.level);
+  assert.deepEqual(storedLevels, ["debug", "info", "warn", "error"]);
+});
+
+test("error-level events bypass sampling; non-error high-frequency events are sampled on stdout only", async () => {
+  const writtenLines: string[] = [];
+  const { appendedEvents, store } = createCapturingEventStore();
+  const logger = createStructuredLogger({
+    writeLine: (line) => {
+      writtenLines.push(line);
+    },
+    eventStore: store,
+    sampling: { playback_update_applied: 5 },
+  });
+
+  for (let index = 0; index < 12; index += 1) {
+    logger("playback_update_applied", { seq: index });
+  }
+  logger(
+    "playback_update_applied",
+    { seq: "error-1", result: "error" },
+    { level: "error" },
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const stdoutSeqs = writtenLines.map(
+    (line) => (JSON.parse(line) as { seq: number | string }).seq,
+  );
+  // Sampling rate 5 => emit the 1st, 6th, 11th of the info batch, then the error.
+  assert.deepEqual(stdoutSeqs, [0, 5, 10, "error-1"]);
+
+  assert.equal(appendedEvents.length, 13);
+});
+
+test("sampling counter resets per event name and does not leak across names", () => {
+  const writtenLines: string[] = [];
+  const logger = createStructuredLogger({
+    writeLine: (line) => {
+      writtenLines.push(line);
+    },
+    sampling: { high_freq: 3 },
+  });
+
+  logger("high_freq", { tag: "a" });
+  logger("other_event", { tag: "b" });
+  logger("high_freq", { tag: "c" });
+  logger("high_freq", { tag: "d" });
+  logger("high_freq", { tag: "e" });
+
+  const tags = writtenLines.map(
+    (line) => (JSON.parse(line) as { tag: string }).tag,
+  );
+  assert.deepEqual(tags, ["a", "b", "e"]);
 });

--- a/server/test/runtime-config.test.ts
+++ b/server/test/runtime-config.test.ts
@@ -42,6 +42,7 @@ function readRuntimeValue(
   switch (path[0]) {
     case "port":
     case "globalAdminPort":
+    case "logLevel":
       return getConfigValue(config as Record<string, unknown>, path);
     case "security":
       return getConfigValue(
@@ -73,6 +74,7 @@ test("runtime config falls back to defaults and env when config file is missing"
 
     assert.equal(config.port, 9001);
     assert.equal(config.globalAdminPort, 9001);
+    assert.equal(config.logLevel, "info");
     assert.equal(config.persistenceConfig.provider, "memory");
     assert.equal(config.adminUiConfig.enabled, false);
     assert.equal(config.adminConfig, null);
@@ -289,6 +291,39 @@ test("redisNamespace is loaded from config file and passable through env overrid
       { cwd: tempDir },
     );
     assert.equal(configFromEnv.persistenceConfig.redisNamespace, "from-env");
+  });
+});
+
+test("runtime config loads logLevel from env and config file", async () => {
+  await withTempDir(async (tempDir) => {
+    const envConfig = await loadRuntimeConfig(
+      { LOG_LEVEL: "warn" },
+      { cwd: tempDir },
+    );
+    assert.equal(envConfig.logLevel, "warn");
+
+    await writeFile(
+      join(tempDir, "server.config.json"),
+      JSON.stringify({ logLevel: "debug" }),
+      "utf8",
+    );
+    const fileConfig = await loadRuntimeConfig({}, { cwd: tempDir });
+    assert.equal(fileConfig.logLevel, "debug");
+
+    const envOverride = await loadRuntimeConfig(
+      { LOG_LEVEL: "error" },
+      { cwd: tempDir },
+    );
+    assert.equal(envOverride.logLevel, "error");
+  });
+});
+
+test("runtime config rejects invalid LOG_LEVEL values", async () => {
+  await withTempDir(async (tempDir) => {
+    await assert.rejects(
+      () => loadRuntimeConfig({ LOG_LEVEL: "verbose" }, { cwd: tempDir }),
+      /LOG_LEVEL/,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- 为 `LogEvent` 增加 `level` 字段（`debug`/`info`/`warn`/`error`，默认 `info`），结构化日志 stdout 输出同步带上 `level`。
- 新增顶层 `logLevel` 运行时配置（支持 `LOG_LEVEL` 环境变量与 `server.config.json` 字段），控制 stdout 输出门槛；低于阈值的事件不进 stdout 但仍写入 event store，审计链路保持完整。
- 对高频事件（默认 `playback_update_applied`、`sync_ping`）提供 1/N 采样策略，仅作用于 stdout；错误级别事件始终输出，不参与采样。
- `createStructuredLogger` 重构为 options 对象，接入点（`app.ts` / `global-admin-app.ts` / `bootstrap`）透传 `logLevel`、`logSampling`。

Fixes #65

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`（含新增 logger 级别/采样与 LOG_LEVEL runtime config 覆盖）