### PR TITLE
feat(server): 支持通过 METRICS_PORT 将 /metrics 暴露到独立端口 (#66)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -59,6 +59,7 @@ export { cleanupSessionAfterClose } from "./ws-session-handler.js";
 
 export type SyncServer = {
   httpServer: HttpServer;
+  metricsHttpServer: HttpServer | undefined;
   close: () => Promise<void>;
 };
 
@@ -72,6 +73,7 @@ export type SyncServerDependencies = {
   serviceVersion?: string;
   logLevel?: LogLevel;
   logSampling?: Record<string, number>;
+  metricsPort?: number;
 };
 
 export async function createSyncServer(
@@ -257,25 +259,31 @@ export async function createSyncServer(
     logEvent,
   });
   nodeHeartbeat.start();
-  const { securityPolicy, httpServer, runtimeIndexReaper, closeAdminServices } =
-    await createSharedAdminHttpBootstrap({
-      securityConfig,
-      persistenceConfig,
-      roomStore,
-      runtimeStore,
-      eventStore,
-      roomService,
-      send,
-      publishRoomEvent,
-      requestAdminCommand: (command, timeoutMs) =>
-        adminCommandBus.request(command, timeoutMs),
-      logEvent,
-      metricsCollector,
-      now,
-      adminConfig: dependencies.adminConfig,
-      adminUiConfig: dependencies.adminUiConfig,
-      serviceVersion,
-    });
+  const {
+    securityPolicy,
+    httpServer,
+    metricsHttpServer,
+    runtimeIndexReaper,
+    closeAdminServices,
+  } = await createSharedAdminHttpBootstrap({
+    securityConfig,
+    persistenceConfig,
+    roomStore,
+    runtimeStore,
+    eventStore,
+    roomService,
+    send,
+    publishRoomEvent,
+    requestAdminCommand: (command, timeoutMs) =>
+      adminCommandBus.request(command, timeoutMs),
+    logEvent,
+    metricsCollector,
+    now,
+    adminConfig: dependencies.adminConfig,
+    adminUiConfig: dependencies.adminUiConfig,
+    serviceVersion,
+    metricsPort: dependencies.metricsPort,
+  });
 
   const wss = new WebSocketServer({
     noServer: true,
@@ -303,6 +311,7 @@ export async function createSyncServer(
 
   return {
     httpServer,
+    metricsHttpServer,
     close: async () => {
       const maybeClosableRuntimeStore =
         sharedRuntimeStore === localRuntimeStore ? null : sharedRuntimeStore;
@@ -346,6 +355,9 @@ export async function createSyncServer(
                 });
               }),
           },
+          ...(metricsHttpServer
+            ? [createCloseHttpServerStep(metricsHttpServer)]
+            : []),
           {
             name: "await_pending_session_cleanup",
             run: () => Promise.allSettled(Array.from(pendingSessionCleanup)),

--- a/server/src/bootstrap/admin-http-bootstrap.ts
+++ b/server/src/bootstrap/admin-http-bootstrap.ts
@@ -22,6 +22,7 @@ import type {
 import type { RuntimeStore } from "../runtime-store.js";
 import { createAdminServices } from "./admin-services.js";
 import { createHttpRequestHandler } from "./http-handler.js";
+import { createMetricsRequestHandler } from "./metrics-handler.js";
 import type { ShutdownStep } from "./server-bootstrap.js";
 
 export function resolveServerRuntimeDependencies(dependencies: {
@@ -58,9 +59,11 @@ export async function createSharedAdminHttpBootstrap(args: {
   serviceName?: string;
   createOverviewService?: typeof createAdminOverviewService;
   createRoomQueryService?: typeof createAdminRoomQueryService;
+  metricsPort?: number;
 }): Promise<{
   securityPolicy: ReturnType<typeof createSecurityPolicy>;
   httpServer: HttpServer;
+  metricsHttpServer: HttpServer | undefined;
   runtimeIndexReaper: ReturnType<typeof createRuntimeIndexReaper>;
   closeAdminServices: () => Promise<void>;
 }> {
@@ -95,18 +98,28 @@ export async function createSharedAdminHttpBootstrap(args: {
     createRoomQueryService: args.createRoomQueryService,
   });
 
+  const metricsOnMain = args.metricsPort === undefined;
   const httpServer = createServer(
     createHttpRequestHandler({
       adminRouter,
       securityPolicy,
       adminUiConfig: args.adminUiConfig,
+      metricsEnabled: metricsOnMain,
     }),
   );
+  const metricsHttpServer = metricsOnMain
+    ? undefined
+    : createServer(
+        createMetricsRequestHandler({
+          getMetrics: () => args.metricsCollector.render(),
+        }),
+      );
   runtimeIndexReaper.start();
 
   return {
     securityPolicy,
     httpServer,
+    metricsHttpServer,
     runtimeIndexReaper,
     closeAdminServices,
   };

--- a/server/src/bootstrap/http-handler.ts
+++ b/server/src/bootstrap/http-handler.ts
@@ -12,6 +12,7 @@ export function createHttpRequestHandler(args: {
   };
   securityPolicy: ReturnType<typeof createSecurityPolicy>;
   adminUiConfig?: AdminUiConfig;
+  metricsEnabled?: boolean;
 }) {
   return async (
     request: IncomingMessage,
@@ -19,6 +20,20 @@ export function createHttpRequestHandler(args: {
   ): Promise<void> => {
     const pathname = new URL(request.url ?? "/", "http://localhost").pathname;
     const adminUiEnabled = args.adminUiConfig?.enabled !== false;
+    const metricsEnabled = args.metricsEnabled ?? true;
+    if (pathname === "/metrics" && !metricsEnabled) {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          ok: false,
+          error: {
+            code: "not_found",
+            message: "Not found.",
+          },
+        }),
+      );
+      return;
+    }
     if (pathname === "/api/connection-check") {
       const originHeader = request.headers.origin;
       const origin = typeof originHeader === "string" ? originHeader : null;

--- a/server/src/bootstrap/metrics-handler.ts
+++ b/server/src/bootstrap/metrics-handler.ts
@@ -1,0 +1,56 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export function createMetricsRequestHandler(args: {
+  getMetrics: () => Promise<string> | string;
+}) {
+  return async (
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> => {
+    const pathname = new URL(request.url ?? "/", "http://localhost").pathname;
+    if (pathname !== "/metrics") {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          ok: false,
+          error: {
+            code: "not_found",
+            message: "Not found.",
+          },
+        }),
+      );
+      return;
+    }
+    if (request.method !== "GET") {
+      response.writeHead(405, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          ok: false,
+          error: {
+            code: "method_not_allowed",
+            message: "Method not allowed.",
+          },
+        }),
+      );
+      return;
+    }
+    try {
+      const body = await args.getMetrics();
+      response.writeHead(200, {
+        "content-type": "text/plain; version=0.0.4; charset=utf-8",
+      });
+      response.end(body);
+    } catch {
+      response.writeHead(500, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          ok: false,
+          error: {
+            code: "internal_error",
+            message: "Internal server error.",
+          },
+        }),
+      );
+    }
+  };
+}

--- a/server/src/config/runtime-config-schema.ts
+++ b/server/src/config/runtime-config-schema.ts
@@ -46,6 +46,7 @@ function createField(
 export const SERVER_CONFIG_FIELDS = [
   createField(["port"], "PORT", "integer"),
   createField(["globalAdminPort"], "GLOBAL_ADMIN_PORT", "integer"),
+  createField(["metricsPort"], "METRICS_PORT", "integer"),
   createField(["logLevel"], "LOG_LEVEL", "enum", [
     "debug",
     "info",

--- a/server/src/config/runtime-config.ts
+++ b/server/src/config/runtime-config.ts
@@ -236,6 +236,22 @@ export function configFileToEnv(fileConfig: ServerConfigFile): EnvSource {
   return env;
 }
 
+export function assertMetricsPortDoesNotCollide(
+  metricsPort: number | undefined,
+  otherPort: number,
+  otherPortName: string,
+): void {
+  if (
+    metricsPort !== undefined &&
+    metricsPort > 0 &&
+    metricsPort === otherPort
+  ) {
+    throw new Error(
+      `METRICS_PORT (${metricsPort}) must not equal ${otherPortName} (${otherPort}).`,
+    );
+  }
+}
+
 export async function loadRuntimeConfig(
   env: EnvSource = process.env,
   options: { cwd?: string } = {},

--- a/server/src/config/runtime-config.ts
+++ b/server/src/config/runtime-config.ts
@@ -9,7 +9,7 @@ import type {
 } from "../types.js";
 import { loadAdminConfig, loadAdminUiConfig } from "./admin-config.js";
 import type { EnvSource } from "./env.js";
-import { parseIntegerEnv } from "./env.js";
+import { parseIntegerEnv, readTrimmedEnv } from "./env.js";
 import { loadPersistenceConfig } from "./persistence-config.js";
 import {
   getConfigValue,
@@ -71,6 +71,7 @@ type AdminUiConfigFile = {
 export type ServerConfigFile = {
   port?: number;
   globalAdminPort?: number;
+  metricsPort?: number;
   logLevel?: LogLevel;
   security?: SecurityConfigFile;
   persistence?: PersistenceConfigFile;
@@ -80,6 +81,7 @@ export type ServerConfigFile = {
 export type RuntimeConfig = {
   port: number;
   globalAdminPort: number;
+  metricsPort: number | undefined;
   logLevel: LogLevel;
   securityConfig: SecurityConfig;
   persistenceConfig: PersistenceConfig;
@@ -252,6 +254,10 @@ export async function loadRuntimeConfig(
       "GLOBAL_ADMIN_PORT",
       parseIntegerEnv(mergedEnv, "PORT", 8788),
     ),
+    metricsPort:
+      readTrimmedEnv(mergedEnv, "METRICS_PORT") !== undefined
+        ? parseIntegerEnv(mergedEnv, "METRICS_PORT", 0)
+        : undefined,
     logLevel: parseConfigEnvFieldValue<LogLevel>(
       LOG_LEVEL_FIELD,
       mergedEnv,

--- a/server/src/global-admin-app.ts
+++ b/server/src/global-admin-app.ts
@@ -27,6 +27,7 @@ import type {
 
 export type GlobalAdminServer = {
   httpServer: HttpServer;
+  metricsHttpServer: HttpServer | undefined;
   close: () => Promise<void>;
 };
 
@@ -40,6 +41,7 @@ export type GlobalAdminServerDependencies = {
   serviceVersion?: string;
   logLevel?: LogLevel;
   logSampling?: Record<string, number>;
+  metricsPort?: number;
 };
 
 export async function createGlobalAdminServer(
@@ -69,36 +71,45 @@ export async function createGlobalAdminServer(
     logEvent,
     now,
   });
-  const { httpServer, runtimeIndexReaper, closeAdminServices } =
-    await createSharedAdminHttpBootstrap({
-      securityConfig,
-      persistenceConfig,
-      roomStore,
-      runtimeStore,
-      eventStore,
-      roomService,
-      send() {},
-      publishRoomEvent: (message: RoomEventBusMessage) =>
-        roomEventBus.publish(message),
-      requestAdminCommand: (command, timeoutMs) =>
-        adminCommandBus.request(command, timeoutMs),
-      logEvent,
-      metricsCollector,
-      now,
-      adminConfig: dependencies.adminConfig,
-      adminUiConfig: dependencies.adminUiConfig,
-      serviceName: "bili-syncplay-global-admin",
-      createOverviewService: createGlobalAdminOverviewService,
-      createRoomQueryService: createGlobalAdminRoomQueryService,
-      serviceVersion,
-    });
+  const {
+    httpServer,
+    metricsHttpServer,
+    runtimeIndexReaper,
+    closeAdminServices,
+  } = await createSharedAdminHttpBootstrap({
+    securityConfig,
+    persistenceConfig,
+    roomStore,
+    runtimeStore,
+    eventStore,
+    roomService,
+    send() {},
+    publishRoomEvent: (message: RoomEventBusMessage) =>
+      roomEventBus.publish(message),
+    requestAdminCommand: (command, timeoutMs) =>
+      adminCommandBus.request(command, timeoutMs),
+    logEvent,
+    metricsCollector,
+    now,
+    adminConfig: dependencies.adminConfig,
+    adminUiConfig: dependencies.adminUiConfig,
+    serviceName: "bili-syncplay-global-admin",
+    createOverviewService: createGlobalAdminOverviewService,
+    createRoomQueryService: createGlobalAdminRoomQueryService,
+    serviceVersion,
+    metricsPort: dependencies.metricsPort,
+  });
 
   return {
     httpServer,
+    metricsHttpServer,
     close: () =>
       runShutdownSteps(
         [
           createCloseHttpServerStep(httpServer),
+          ...(metricsHttpServer
+            ? [createCloseHttpServerStep(metricsHttpServer)]
+            : []),
           {
             name: "stop_runtime_index_reaper",
             run: () => runtimeIndexReaper.stop(),

--- a/server/src/global-admin-index.ts
+++ b/server/src/global-admin-index.ts
@@ -1,4 +1,7 @@
-import { loadRuntimeConfig } from "./config/runtime-config.js";
+import {
+  assertMetricsPortDoesNotCollide,
+  loadRuntimeConfig,
+} from "./config/runtime-config.js";
 import { createGlobalAdminServer } from "./global-admin-app.js";
 
 const {
@@ -10,6 +13,8 @@ const {
   adminConfig,
   adminUiConfig,
 } = await loadRuntimeConfig();
+
+assertMetricsPortDoesNotCollide(metricsPort, port, "GLOBAL_ADMIN_PORT");
 
 const { httpServer, metricsHttpServer } = await createGlobalAdminServer(
   securityConfig,
@@ -30,6 +35,13 @@ httpServer.listen(port, () => {
   );
 });
 if (metricsHttpServer && metricsPort !== undefined) {
+  metricsHttpServer.on("error", (error) => {
+    console.error(
+      `Bili-SyncPlay global admin metrics server failed to listen on ${metricsPort}:`,
+      error,
+    );
+    process.exit(1);
+  });
   metricsHttpServer.listen(metricsPort, () => {
     console.log(
       `Bili-SyncPlay global admin metrics listening on http://localhost:${metricsPort}/metrics`,

--- a/server/src/global-admin-index.ts
+++ b/server/src/global-admin-index.ts
@@ -3,6 +3,7 @@ import { createGlobalAdminServer } from "./global-admin-app.js";
 
 const {
   globalAdminPort: port,
+  metricsPort,
   logLevel,
   securityConfig,
   persistenceConfig,
@@ -10,7 +11,7 @@ const {
   adminUiConfig,
 } = await loadRuntimeConfig();
 
-const { httpServer } = await createGlobalAdminServer(
+const { httpServer, metricsHttpServer } = await createGlobalAdminServer(
   securityConfig,
   persistenceConfig,
   {
@@ -20,6 +21,7 @@ const { httpServer } = await createGlobalAdminServer(
       enabled: true,
     },
     logLevel,
+    metricsPort,
   },
 );
 httpServer.listen(port, () => {
@@ -27,3 +29,10 @@ httpServer.listen(port, () => {
     `Bili-SyncPlay global admin listening on http://localhost:${port}`,
   );
 });
+if (metricsHttpServer && metricsPort !== undefined) {
+  metricsHttpServer.listen(metricsPort, () => {
+    console.log(
+      `Bili-SyncPlay global admin metrics listening on http://localhost:${metricsPort}/metrics`,
+    );
+  });
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,8 @@
 import { createSyncServer } from "./app.js";
-import { loadRuntimeConfig } from "./config/runtime-config.js";
+import {
+  assertMetricsPortDoesNotCollide,
+  loadRuntimeConfig,
+} from "./config/runtime-config.js";
 
 const {
   port,
@@ -10,6 +13,8 @@ const {
   adminConfig,
   adminUiConfig,
 } = await loadRuntimeConfig();
+
+assertMetricsPortDoesNotCollide(metricsPort, port, "PORT");
 
 const { httpServer, metricsHttpServer } = await createSyncServer(
   securityConfig,
@@ -25,6 +30,13 @@ httpServer.listen(port, () => {
   console.log(`Bili-SyncPlay server listening on http://localhost:${port}`);
 });
 if (metricsHttpServer && metricsPort !== undefined) {
+  metricsHttpServer.on("error", (error) => {
+    console.error(
+      `Bili-SyncPlay metrics server failed to listen on ${metricsPort}:`,
+      error,
+    );
+    process.exit(1);
+  });
   metricsHttpServer.listen(metricsPort, () => {
     console.log(
       `Bili-SyncPlay metrics listening on http://localhost:${metricsPort}/metrics`,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,6 +3,7 @@ import { loadRuntimeConfig } from "./config/runtime-config.js";
 
 const {
   port,
+  metricsPort,
   logLevel,
   securityConfig,
   persistenceConfig,
@@ -10,15 +11,23 @@ const {
   adminUiConfig,
 } = await loadRuntimeConfig();
 
-const { httpServer } = await createSyncServer(
+const { httpServer, metricsHttpServer } = await createSyncServer(
   securityConfig,
   persistenceConfig,
   {
     adminConfig,
     adminUiConfig,
     logLevel,
+    metricsPort,
   },
 );
 httpServer.listen(port, () => {
   console.log(`Bili-SyncPlay server listening on http://localhost:${port}`);
 });
+if (metricsHttpServer && metricsPort !== undefined) {
+  metricsHttpServer.listen(metricsPort, () => {
+    console.log(
+      `Bili-SyncPlay metrics listening on http://localhost:${metricsPort}/metrics`,
+    );
+  });
+}

--- a/server/test/admin-backend.test.ts
+++ b/server/test/admin-backend.test.ts
@@ -1395,3 +1395,71 @@ test("room node can disable admin routes while keeping health probes", async () 
     await server.close();
   }
 });
+
+test("metrics can be exposed on a dedicated port distinct from the admin server", async () => {
+  const server = await createSyncServer(
+    {
+      ...getDefaultSecurityConfig(),
+      allowedOrigins: [ALLOWED_ORIGIN],
+    },
+    getDefaultPersistenceConfig(),
+    {
+      serviceVersion: "0.7.0-test",
+      metricsPort: 0,
+    },
+  );
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.httpServer.listen(0, "127.0.0.1", () => resolve());
+      server.httpServer.once("error", reject);
+    });
+    assert.ok(server.metricsHttpServer, "metrics http server must exist");
+    await new Promise<void>((resolve, reject) => {
+      server.metricsHttpServer!.listen(0, "127.0.0.1", () => resolve());
+      server.metricsHttpServer!.once("error", reject);
+    });
+
+    const adminAddress = server.httpServer.address();
+    const metricsAddress = server.metricsHttpServer!.address();
+    if (
+      !adminAddress ||
+      typeof adminAddress === "string" ||
+      !metricsAddress ||
+      typeof metricsAddress === "string"
+    ) {
+      throw new Error("Failed to determine test server addresses.");
+    }
+    assert.notEqual(adminAddress.port, metricsAddress.port);
+
+    const adminMetrics = await requestText(
+      `http://127.0.0.1:${adminAddress.port}`,
+      "/metrics",
+    );
+    assert.equal(adminMetrics.status, 404);
+
+    const adminHealth = await requestText(
+      `http://127.0.0.1:${adminAddress.port}`,
+      "/healthz",
+    );
+    assert.equal(adminHealth.status, 200);
+
+    const dedicatedMetrics = await requestText(
+      `http://127.0.0.1:${metricsAddress.port}`,
+      "/metrics",
+    );
+    assert.equal(dedicatedMetrics.status, 200);
+    assert.equal(
+      dedicatedMetrics.body.includes("bili_syncplay_connections"),
+      true,
+    );
+
+    const dedicatedOtherPath = await requestText(
+      `http://127.0.0.1:${metricsAddress.port}`,
+      "/healthz",
+    );
+    assert.equal(dedicatedOtherPath.status, 404);
+  } finally {
+    await server.close();
+  }
+});

--- a/server/test/http-handler.test.ts
+++ b/server/test/http-handler.test.ts
@@ -171,6 +171,49 @@ test("http handler omits CORS headers when origin is missing", () => {
   });
 });
 
+test("http handler returns 404 for /metrics when metrics are routed to a dedicated port", async () => {
+  const adminCalls: Array<{ url?: string }> = [];
+  const handler = createHttpRequestHandler({
+    adminRouter: {
+      handle: async (request) => {
+        adminCalls.push({ url: request.url });
+        return false;
+      },
+    },
+    securityPolicy: createSecurityPolicy({
+      allowedOrigins: ["chrome-extension://allowed"],
+      allowMissingOriginInDev: false,
+      connectionAttemptsPerMinute: 10,
+      maxConnectionsPerIp: 5,
+      maxMembersPerRoom: 8,
+      trustedProxyAddresses: [],
+      rateLimits: {
+        roomCreatePerMinute: 5,
+        roomJoinPerMinute: 10,
+        videoSharePerMinute: 20,
+        playbackUpdatePerSecond: 30,
+        profileUpdatePerMinute: 20,
+        syncPingPerMinute: 30,
+        syncPingBurst: 5,
+      },
+    }),
+    metricsEnabled: false,
+  });
+
+  const response = createResponse();
+  await handler(createRequest({ url: "/metrics" }), response);
+
+  assert.equal(response.statusCode, 404);
+  assert.deepEqual(JSON.parse(response.body), {
+    ok: false,
+    error: {
+      code: "not_found",
+      message: "Not found.",
+    },
+  });
+  assert.equal(adminCalls.length, 0);
+});
+
 test("http handler preserves admin router responses without falling through to root payload", async () => {
   const { handler, adminCalls } = createHandler(true);
   const response = createResponse();

--- a/server/test/runtime-config.test.ts
+++ b/server/test/runtime-config.test.ts
@@ -10,6 +10,7 @@ import {
   setConfigValue,
 } from "../src/config/runtime-config-schema.js";
 import {
+  assertMetricsPortDoesNotCollide,
   configFileToEnv,
   type RuntimeConfig,
   loadRuntimeConfig,
@@ -115,6 +116,27 @@ test("runtime config keeps metricsPort undefined when METRICS_PORT is blank", as
     );
     assert.equal(config.metricsPort, undefined);
   });
+});
+
+test("assertMetricsPortDoesNotCollide rejects configs where metrics matches the main port", () => {
+  assert.throws(
+    () => assertMetricsPortDoesNotCollide(8787, 8787, "PORT"),
+    /METRICS_PORT \(8787\) must not equal PORT \(8787\)\./,
+  );
+  assert.throws(
+    () => assertMetricsPortDoesNotCollide(9002, 9002, "GLOBAL_ADMIN_PORT"),
+    /METRICS_PORT \(9002\) must not equal GLOBAL_ADMIN_PORT \(9002\)\./,
+  );
+});
+
+test("assertMetricsPortDoesNotCollide allows undefined, mismatched, and ephemeral ports", () => {
+  assert.doesNotThrow(() =>
+    assertMetricsPortDoesNotCollide(undefined, 8787, "PORT"),
+  );
+  assert.doesNotThrow(() =>
+    assertMetricsPortDoesNotCollide(9100, 8787, "PORT"),
+  );
+  assert.doesNotThrow(() => assertMetricsPortDoesNotCollide(0, 0, "PORT"));
 });
 
 test("runtime config maps JSON file values through existing loaders", async () => {

--- a/server/test/runtime-config.test.ts
+++ b/server/test/runtime-config.test.ts
@@ -42,6 +42,7 @@ function readRuntimeValue(
   switch (path[0]) {
     case "port":
     case "globalAdminPort":
+    case "metricsPort":
     case "logLevel":
       return getConfigValue(config as Record<string, unknown>, path);
     case "security":
@@ -74,10 +75,45 @@ test("runtime config falls back to defaults and env when config file is missing"
 
     assert.equal(config.port, 9001);
     assert.equal(config.globalAdminPort, 9001);
+    assert.equal(config.metricsPort, undefined);
     assert.equal(config.logLevel, "info");
     assert.equal(config.persistenceConfig.provider, "memory");
     assert.equal(config.adminUiConfig.enabled, false);
     assert.equal(config.adminConfig, null);
+  });
+});
+
+test("runtime config loads METRICS_PORT from env and config file", async () => {
+  await withTempDir(async (tempDir) => {
+    const envConfig = await loadRuntimeConfig(
+      { METRICS_PORT: "9200" },
+      { cwd: tempDir },
+    );
+    assert.equal(envConfig.metricsPort, 9200);
+
+    await writeFile(
+      join(tempDir, "server.config.json"),
+      JSON.stringify({ metricsPort: 9300 }),
+      "utf8",
+    );
+    const fileConfig = await loadRuntimeConfig({}, { cwd: tempDir });
+    assert.equal(fileConfig.metricsPort, 9300);
+
+    const envOverride = await loadRuntimeConfig(
+      { METRICS_PORT: "9400" },
+      { cwd: tempDir },
+    );
+    assert.equal(envOverride.metricsPort, 9400);
+  });
+});
+
+test("runtime config keeps metricsPort undefined when METRICS_PORT is blank", async () => {
+  await withTempDir(async (tempDir) => {
+    const config = await loadRuntimeConfig(
+      { METRICS_PORT: "   " },
+      { cwd: tempDir },
+    );
+    assert.equal(config.metricsPort, undefined);
   });
 });
 


### PR DESCRIPTION
## Summary
- 新增可选 `METRICS_PORT` 配置项（env 与 `server.config.json` 均可）。未配置时行为与当前一致（`/metrics` 挂在 admin HTTP server 上）。
- 配置后启动独立 HTTP server 仅服务 `GET /metrics`（其他路径 404、非 GET 405），admin 主端口同时对 `/metrics` 返回 404；`/healthz`、`/readyz` 仍保留在主端口。
- `app.ts` 与 `global-admin-app.ts` 双双透传 `metricsPort`，关闭流程里额外加了一步关闭独立 metrics server 的 shutdown step。

## Test plan
- [x] `server/test/runtime-config.test.ts`：新增 `METRICS_PORT` 的 env / file / 空串三组用例；schema round-trip 测试扩展到新字段。
- [x] `server/test/http-handler.test.ts`：`metricsEnabled: false` 时主端口 `/metrics` 应直接 404。
- [x] `server/test/admin-backend.test.ts`：e2e 用例同时监听主端口与 metrics 端口，断言主端口 `/metrics` 返回 404、`/healthz` 仍 200、独立 metrics 端口上 `/metrics` 返回 200 且包含 `bili_syncplay_connections`、独立端口上其他路径 404。
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`（187 通过，0 失败）。

Fixes #66