### PR TITLE
[codex] Ignore codex and temp directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ docs/
 !/.claude/skills/
 !/.claude/agents/
 !/.claude/commands/
+.codex/
+.tmp/


### PR DESCRIPTION
## What changed
- ignore `.codex/`
- ignore `.tmp/`

## Why
These local tool and temporary directories should not be tracked by Git. Ignoring them helps keep the working tree clean and avoids accidental commits of machine-local files.

## Impact
- reduces noise in `git status`
- prevents accidental inclusion of local Codex and temp artifacts in future commits
- no runtime or production behavior changes

## Validation
- no code validation run
- this change only updates `.gitignore`
