### PR TITLE
fix: prevent reconnect-storm benchmark OOM

### DIFF
--- a/bench/lib/room-bench.ts
+++ b/bench/lib/room-bench.ts
@@ -13,6 +13,11 @@ import {
 } from "../../server/test/multi-node-test-kit.js";
 import { type RawData } from "ws";
 
+type MessageSocket = Pick<
+  Awaited<ReturnType<typeof connectClient>>,
+  "on" | "off"
+>;
+
 type Collector = {
   next: (type: string, timeoutMs?: number) => Promise<Record<string, unknown>>;
   maybeNext: (
@@ -51,6 +56,11 @@ const SHARED_VIDEO_TITLE = "Benchmark Episode";
 function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+type BenchMessageCollectorOptions = {
+  trackedTypes?: string[];
+  maxQueuePerType?: number;
+};
 
 function createBenchmarkSecurityConfig(input: {
   memberCount: number;
@@ -95,26 +105,99 @@ function createBenchmarkSecurityConfig(input: {
   };
 }
 
-function createBenchMessageCollector(
-  socket: Awaited<ReturnType<typeof connectClient>>,
+export function createBenchMessageCollector(
+  socket: MessageSocket,
+  options: BenchMessageCollectorOptions = {},
 ): Collector {
-  const queuedMessages: Array<Record<string, unknown>> = [];
+  const maxQueuePerType = Math.max(1, options.maxQueuePerType ?? 1);
+  const queuedMessagesByType = new Map<string, Array<Record<string, unknown>>>(
+    (options.trackedTypes ?? []).map((type) => [type, []]),
+  );
+  const pendingByType = new Map<
+    string,
+    Array<(message: Record<string, unknown>) => void>
+  >();
+
   const listener = (raw: RawData) => {
-    queuedMessages.push(JSON.parse(raw.toString()) as Record<string, unknown>);
+    const message = JSON.parse(raw.toString()) as Record<string, unknown>;
+    const type = message.type;
+    if (typeof type !== "string") {
+      return;
+    }
+
+    const pending = pendingByType.get(type);
+    const resolver = pending?.shift();
+    if (resolver) {
+      if (pending && pending.length === 0) {
+        pendingByType.delete(type);
+      }
+      resolver(message);
+      return;
+    }
+
+    const queue = queuedMessagesByType.get(type);
+    if (!queue) {
+      return;
+    }
+
+    queue.push(message);
+    if (queue.length > maxQueuePerType) {
+      queue.splice(0, queue.length - maxQueuePerType);
+    }
   };
   socket.on("message", listener);
 
   return {
     async next(type: string, timeoutMs = 2_000) {
+      const queue = queuedMessagesByType.get(type) ?? [];
+      if (!queuedMessagesByType.has(type)) {
+        queuedMessagesByType.set(type, queue);
+      }
+      const queuedMessage = queue.shift();
+      if (queuedMessage) {
+        return queuedMessage;
+      }
+
       const startedAt = Date.now();
       while (Date.now() - startedAt < timeoutMs) {
-        const index = queuedMessages.findIndex(
-          (message) => message.type === type,
-        );
-        if (index >= 0) {
-          return queuedMessages.splice(index, 1)[0] as Record<string, unknown>;
+        const fromQueue = queue.shift();
+        if (fromQueue) {
+          return fromQueue;
         }
-        await wait(10);
+
+        const delivered = await new Promise<Record<string, unknown> | null>(
+          (resolve) => {
+            const pending = pendingByType.get(type) ?? [];
+            const resolver = (message: Record<string, unknown>) => {
+              clearTimeout(timeout);
+              resolve(message);
+            };
+
+            pending.push(resolver);
+            pendingByType.set(type, pending);
+
+            const timeout = setTimeout(() => {
+              const queueResolvers = pendingByType.get(type);
+              if (!queueResolvers) {
+                resolve(null);
+                return;
+              }
+
+              const resolverIndex = queueResolvers.indexOf(resolver);
+              if (resolverIndex >= 0) {
+                queueResolvers.splice(resolverIndex, 1);
+              }
+              if (queueResolvers.length === 0) {
+                pendingByType.delete(type);
+              }
+              resolve(null);
+            }, 10);
+          },
+        );
+
+        if (delivered) {
+          return delivered;
+        }
       }
       throw new Error(`Timed out waiting for message type ${type}`);
     },
@@ -127,7 +210,8 @@ function createBenchMessageCollector(
     },
     detach() {
       socket.off("message", listener);
-      queuedMessages.length = 0;
+      queuedMessagesByType.clear();
+      pendingByType.clear();
     },
   };
 }
@@ -173,7 +257,9 @@ async function connectParticipants(
         displayName: `Bench Member ${String(index + 1).padStart(3, "0")}`,
         wsUrl,
         socket,
-        inbox: createBenchMessageCollector(socket),
+        inbox: createBenchMessageCollector(socket, {
+          trackedTypes: ["room:created", "room:joined", "room:state"],
+        }),
       };
     }),
   );
@@ -535,7 +621,17 @@ export async function runReconnectStormBenchmark(input: {
 
         try {
           socket = await connectClient(seed.wsUrl);
-          inbox = createBenchMessageCollector(socket);
+          inbox = createBenchMessageCollector(socket, {
+            trackedTypes: ["room:joined", "room:state"],
+          });
+          const joinedPromise = inbox.next(
+            "room:joined",
+            input.reconnectTimeoutMs,
+          );
+          const firstStatePromise = inbox.next(
+            "room:state",
+            input.reconnectTimeoutMs,
+          );
           socket.send(
             JSON.stringify({
               type: "room:join",
@@ -547,8 +643,8 @@ export async function runReconnectStormBenchmark(input: {
               },
             }),
           );
-          await inbox.next("room:joined", input.reconnectTimeoutMs);
-          await inbox.next("room:state", input.reconnectTimeoutMs);
+          await joinedPromise;
+          await firstStatePromise;
           latencySamplesMs.push(Date.now() - reconnectStartedAtMs);
           completed += 1;
         } catch {

--- a/bench/lib/room-bench.ts
+++ b/bench/lib/room-bench.ts
@@ -643,8 +643,7 @@ export async function runReconnectStormBenchmark(input: {
               },
             }),
           );
-          await joinedPromise;
-          await firstStatePromise;
+          await Promise.all([joinedPromise, firstStatePromise]);
           latencySamplesMs.push(Date.now() - reconnectStartedAtMs);
           completed += 1;
         } catch {

--- a/server/test/bench-stats.test.ts
+++ b/server/test/bench-stats.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import test from "node:test";
 import { buildBenchmarkResult } from "../../bench/lib/cli.js";
 import { ensureRedis } from "../../bench/lib/redis-harness.js";
 import {
+  createBenchMessageCollector,
   runPlaybackBroadcastBenchmark,
   runReconnectStormBenchmark,
 } from "../../bench/lib/room-bench.js";
@@ -11,6 +13,13 @@ import {
   summarizeLatencies,
   summarizeThroughput,
 } from "../../bench/lib/stats.js";
+import { type RawData } from "ws";
+
+class FakeMessageSocket extends EventEmitter {
+  emitMessage(message: Record<string, unknown>) {
+    this.emit("message", Buffer.from(JSON.stringify(message)) as RawData);
+  }
+}
 
 test("benchmark stats summarize percentile and throughput fields deterministically", () => {
   assert.deepEqual(summarizeLatencies([12, 10, 20, 18, 14]), {
@@ -161,6 +170,45 @@ test("playback benchmark lifts playback rate limits to match benchmark load", as
   assert.equal(benchmark.attempted, 10);
   assert.equal(benchmark.completed, 10);
   assert.equal(benchmark.errors, 0);
+});
+
+test("bench collector keeps only tracked message types and caps buffered states", async () => {
+  const socket = new FakeMessageSocket();
+  const collector = createBenchMessageCollector(socket, {
+    trackedTypes: ["room:state"],
+    maxQueuePerType: 1,
+  });
+
+  try {
+    socket.emitMessage({ type: "room:joined", payload: { ignored: true } });
+    socket.emitMessage({ type: "room:state", payload: { seq: 1 } });
+    socket.emitMessage({ type: "room:state", payload: { seq: 2 } });
+
+    const state = await collector.next("room:state");
+    assert.deepEqual(state.payload, { seq: 2 });
+    assert.equal(await collector.maybeNext("room:joined", 50), null);
+  } finally {
+    collector.detach();
+  }
+});
+
+test("bench collector delivers awaited room state without buffering a storm", async () => {
+  const socket = new FakeMessageSocket();
+  const collector = createBenchMessageCollector(socket, {
+    trackedTypes: ["room:state"],
+    maxQueuePerType: 1,
+  });
+
+  try {
+    const statePromise = collector.next("room:state", 200);
+    socket.emitMessage({ type: "room:state", payload: { seq: 1 } });
+    socket.emitMessage({ type: "room:state", payload: { seq: 2 } });
+
+    const state = await statePromise;
+    assert.deepEqual(state.payload, { seq: 1 });
+  } finally {
+    collector.detach();
+  }
 });
 
 test("ensureRedis reports a controlled startup error when redis-server is unavailable", async () => {

--- a/server/test/bench-stats.test.ts
+++ b/server/test/bench-stats.test.ts
@@ -255,3 +255,13 @@ test("reconnect benchmark supports member counts above default room and IP limit
   assert.equal(benchmark.attempted, 12);
   assert.equal(benchmark.errors, 0);
 });
+
+test("reconnect benchmark reports timeout failures without aborting the run", async () => {
+  const benchmark = await runReconnectStormBenchmark({
+    memberCount: 4,
+    reconnectTimeoutMs: 1,
+  });
+
+  assert.equal(benchmark.attempted, 4);
+  assert.equal(benchmark.completed + benchmark.errors, 4);
+});


### PR DESCRIPTION
## Summary
- 将 bench collector 改为按消息类型处理：优先直送给等待中的消费者，只为已跟踪类型保留有界缓冲
- 在 reconnect benchmark 中并行等待 `room:joined` 和首个 `room:state`，缩短无人消费窗口并避免 `room:state` 无界堆积
- 新增 collector 缓冲策略回归测试，并验证 reconnect benchmark 仍能完成

Fixes #81

## Test plan
- [x] npx tsx --test server/test/bench-stats.test.ts
- [x] npm run format:check && npm run lint && npm run typecheck && npm run build && npm test
- [x] npm run bench:reconnect-storm