### PR TITLE
fix(admin): harden admin session security (CSRF / login throttle / bearer-only)

### DIFF
--- a/server/src/admin/auth-service.ts
+++ b/server/src/admin/auth-service.ts
@@ -25,6 +25,13 @@ export type AdminAuthService = {
   logout: (token: string) => Promise<void>;
 };
 
+export class InvalidCredentialsError extends Error {
+  constructor() {
+    super("invalid_credentials");
+    this.name = "InvalidCredentialsError";
+  }
+}
+
 function sha256(value: string): Buffer {
   return createHash("sha256").update(value).digest();
 }
@@ -70,7 +77,7 @@ export function createAdminAuthService(
         username !== config.username ||
         !verifyPassword(password, config.passwordHash)
       ) {
-        throw new Error("invalid_credentials");
+        throw new InvalidCredentialsError();
       }
 
       const currentTime = now();

--- a/server/src/admin/csrf.ts
+++ b/server/src/admin/csrf.ts
@@ -1,0 +1,68 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { CROSS_ORIGIN_REJECTED_MESSAGE } from "../messages.js";
+import { sendError } from "./response.js";
+
+export type AdminWriteOriginPolicy = {
+  allowedOrigins: readonly string[];
+};
+
+type OriginCheckResult =
+  | { ok: true }
+  | { ok: false; reason: "origin_missing" | "origin_not_allowed" };
+
+function getRequestScheme(request: IncomingMessage): string {
+  const forwardedProto = request.headers["x-forwarded-proto"];
+  if (typeof forwardedProto === "string" && forwardedProto.length > 0) {
+    return forwardedProto.split(",")[0]?.trim() || "http";
+  }
+  const socket = request.socket as { encrypted?: boolean };
+  return socket.encrypted ? "https" : "http";
+}
+
+function sameOriginFromRequest(request: IncomingMessage): string | null {
+  const hostHeader = request.headers.host;
+  if (typeof hostHeader !== "string" || hostHeader.length === 0) {
+    return null;
+  }
+  return `${getRequestScheme(request)}://${hostHeader}`;
+}
+
+export function evaluateAdminWriteOrigin(
+  request: IncomingMessage,
+  policy: AdminWriteOriginPolicy,
+): OriginCheckResult {
+  const originHeader = request.headers.origin;
+  const origin = typeof originHeader === "string" ? originHeader : null;
+  if (!origin) {
+    return { ok: false, reason: "origin_missing" };
+  }
+
+  const sameOrigin = sameOriginFromRequest(request);
+  if (sameOrigin && origin === sameOrigin) {
+    return { ok: true };
+  }
+
+  if (policy.allowedOrigins.includes(origin)) {
+    return { ok: true };
+  }
+
+  return { ok: false, reason: "origin_not_allowed" };
+}
+
+export function requireAdminWriteOrigin(
+  request: IncomingMessage,
+  response: ServerResponse,
+  policy: AdminWriteOriginPolicy,
+): boolean {
+  const result = evaluateAdminWriteOrigin(request, policy);
+  if (result.ok) {
+    return true;
+  }
+  sendError(
+    response,
+    403,
+    `csrf_${result.reason}`,
+    CROSS_ORIGIN_REJECTED_MESSAGE,
+  );
+  return false;
+}

--- a/server/src/admin/login-rate-limit.ts
+++ b/server/src/admin/login-rate-limit.ts
@@ -1,0 +1,167 @@
+import { WINDOW_MINUTE_MS } from "../rate-limit.js";
+
+type CounterEntry = {
+  windowStart: number;
+  count: number;
+  lastSeenAt: number;
+};
+
+const ATTEMPT_WINDOW_TTL_MS = 10 * WINDOW_MINUTE_MS;
+const SWEEP_INTERVAL = 64;
+
+export type AdminLoginRateLimitConfig = {
+  failuresPerIpPerMinute: number;
+  failuresPerUsernamePerMinute: number;
+};
+
+export type AdminLoginRateLimiter = {
+  check(input: { ipKey: string; username: string }): CheckResult;
+  registerFailure(input: { ipKey: string; username: string }): void;
+  registerSuccess(input: { ipKey: string; username: string }): void;
+};
+
+type CheckResult =
+  | { ok: true }
+  | { ok: false; dimension: "ip" | "username"; retryAfterMs: number };
+
+function refreshIfExpired(
+  entry: CounterEntry,
+  windowMs: number,
+  currentTime: number,
+): void {
+  if (currentTime - entry.windowStart >= windowMs) {
+    entry.windowStart = currentTime;
+    entry.count = 0;
+  }
+}
+
+function isExceeded(
+  entry: CounterEntry | undefined,
+  limit: number,
+  windowMs: number,
+  currentTime: number,
+): { exceeded: boolean; retryAfterMs: number } {
+  if (!entry) {
+    return { exceeded: false, retryAfterMs: 0 };
+  }
+  if (currentTime - entry.windowStart >= windowMs) {
+    return { exceeded: false, retryAfterMs: 0 };
+  }
+  if (entry.count < limit) {
+    return { exceeded: false, retryAfterMs: 0 };
+  }
+  const retryAfterMs = Math.max(
+    0,
+    windowMs - (currentTime - entry.windowStart),
+  );
+  return { exceeded: true, retryAfterMs };
+}
+
+export function createAdminLoginRateLimiter(
+  config: AdminLoginRateLimitConfig,
+  now: () => number = Date.now,
+): AdminLoginRateLimiter {
+  const ipEntries = new Map<string, CounterEntry>();
+  const usernameEntries = new Map<string, CounterEntry>();
+  let sweepTick = 0;
+
+  function touch(
+    map: Map<string, CounterEntry>,
+    key: string,
+    currentTime: number,
+  ): CounterEntry {
+    const existing = map.get(key);
+    if (existing) {
+      existing.lastSeenAt = currentTime;
+      return existing;
+    }
+    const entry: CounterEntry = {
+      windowStart: currentTime,
+      count: 0,
+      lastSeenAt: currentTime,
+    };
+    map.set(key, entry);
+    return entry;
+  }
+
+  function maybeSweep(currentTime: number): void {
+    sweepTick += 1;
+    if (sweepTick % SWEEP_INTERVAL !== 0) {
+      return;
+    }
+    for (const map of [ipEntries, usernameEntries]) {
+      for (const [key, entry] of map) {
+        if (currentTime - entry.lastSeenAt >= ATTEMPT_WINDOW_TTL_MS) {
+          map.delete(key);
+        }
+      }
+    }
+  }
+
+  function normalizeUsername(username: string): string {
+    return username.trim().toLowerCase();
+  }
+
+  return {
+    check({ ipKey, username }) {
+      const currentTime = now();
+      maybeSweep(currentTime);
+      const ipCheck = isExceeded(
+        ipEntries.get(ipKey),
+        config.failuresPerIpPerMinute,
+        WINDOW_MINUTE_MS,
+        currentTime,
+      );
+      if (ipCheck.exceeded) {
+        return {
+          ok: false,
+          dimension: "ip",
+          retryAfterMs: ipCheck.retryAfterMs,
+        };
+      }
+
+      const normalizedUsername = normalizeUsername(username);
+      if (normalizedUsername.length > 0) {
+        const usernameCheck = isExceeded(
+          usernameEntries.get(normalizedUsername),
+          config.failuresPerUsernamePerMinute,
+          WINDOW_MINUTE_MS,
+          currentTime,
+        );
+        if (usernameCheck.exceeded) {
+          return {
+            ok: false,
+            dimension: "username",
+            retryAfterMs: usernameCheck.retryAfterMs,
+          };
+        }
+      }
+
+      return { ok: true };
+    },
+    registerFailure({ ipKey, username }) {
+      const currentTime = now();
+      const ipEntry = touch(ipEntries, ipKey, currentTime);
+      refreshIfExpired(ipEntry, WINDOW_MINUTE_MS, currentTime);
+      ipEntry.count += 1;
+
+      const normalizedUsername = normalizeUsername(username);
+      if (normalizedUsername.length > 0) {
+        const usernameEntry = touch(
+          usernameEntries,
+          normalizedUsername,
+          currentTime,
+        );
+        refreshIfExpired(usernameEntry, WINDOW_MINUTE_MS, currentTime);
+        usernameEntry.count += 1;
+      }
+    },
+    registerSuccess({ ipKey, username }) {
+      ipEntries.delete(ipKey);
+      const normalizedUsername = normalizeUsername(username);
+      if (normalizedUsername.length > 0) {
+        usernameEntries.delete(normalizedUsername);
+      }
+    },
+  };
+}

--- a/server/src/admin/router-types.ts
+++ b/server/src/admin/router-types.ts
@@ -1,7 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AdminAuthService } from "./auth-service.js";
+import type { AdminWriteOriginPolicy } from "./csrf.js";
 import type { GlobalAuditQueryResult } from "./global-audit-store.js";
 import type { GlobalEventStore } from "./global-event-store.js";
+import type { AdminLoginRateLimiter } from "./login-rate-limit.js";
 import type {
   AdminRole,
   AdminSession,
@@ -47,6 +49,9 @@ export type AdminRouterOptions = {
   eventStore: GlobalEventStore;
   serviceName: string;
   now?: () => number;
+  writeOriginPolicy: AdminWriteOriginPolicy;
+  loginRateLimiter?: AdminLoginRateLimiter;
+  getRequestIpKey?: (request: IncomingMessage) => string;
 };
 
 export type AdminRouteHelpers = {
@@ -59,6 +64,11 @@ export type AdminRouteHelpers = {
     role: AdminRole,
     response: ServerResponse,
   ) => boolean;
+  requireWriteOrigin: (
+    request: IncomingMessage,
+    response: ServerResponse,
+  ) => boolean;
+  getIpKey: (request: IncomingMessage) => string;
 };
 
 export type AdminRouteInput = {

--- a/server/src/admin/router.ts
+++ b/server/src/admin/router.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { AdminActionError } from "./action-service.js";
+import { requireAdminWriteOrigin } from "./csrf.js";
 import {
   getBearerToken,
   getPathSegments,
@@ -68,6 +69,24 @@ export function createAdminRouter(options: AdminRouterOptions) {
     return true;
   }
 
+  function requireWriteOrigin(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): boolean {
+    return requireAdminWriteOrigin(
+      request,
+      response,
+      options.writeOriginPolicy,
+    );
+  }
+
+  function getIpKey(request: IncomingMessage): string {
+    if (options.getRequestIpKey) {
+      return options.getRequestIpKey(request);
+    }
+    return request.socket.remoteAddress ?? "unknown";
+  }
+
   return {
     async handle(
       request: IncomingMessage,
@@ -88,6 +107,8 @@ export function createAdminRouter(options: AdminRouterOptions) {
               helpers: {
                 requireAdmin,
                 requireRole,
+                requireWriteOrigin,
+                getIpKey,
               },
             })
           ) {

--- a/server/src/admin/routes/action-routes.ts
+++ b/server/src/admin/routes/action-routes.ts
@@ -18,6 +18,9 @@ export const handleActionRoutes: AdminRouteHandler = async ({
     segments[2] === "rooms" &&
     segments[4] === "close"
   ) {
+    if (!helpers.requireWriteOrigin(request, response)) {
+      return true;
+    }
     const roomCode = requireNonEmptyString(
       requireSegment(segments, 3, "roomCode"),
       "roomCode",
@@ -42,6 +45,9 @@ export const handleActionRoutes: AdminRouteHandler = async ({
     segments[2] === "rooms" &&
     segments[4] === "expire"
   ) {
+    if (!helpers.requireWriteOrigin(request, response)) {
+      return true;
+    }
     const roomCode = requireNonEmptyString(
       requireSegment(segments, 3, "roomCode"),
       "roomCode",
@@ -66,6 +72,9 @@ export const handleActionRoutes: AdminRouteHandler = async ({
     segments[2] === "rooms" &&
     segments[4] === "clear-video"
   ) {
+    if (!helpers.requireWriteOrigin(request, response)) {
+      return true;
+    }
     const roomCode = requireNonEmptyString(
       requireSegment(segments, 3, "roomCode"),
       "roomCode",
@@ -94,6 +103,9 @@ export const handleActionRoutes: AdminRouteHandler = async ({
     segments[4] === "members" &&
     segments[6] === "kick"
   ) {
+    if (!helpers.requireWriteOrigin(request, response)) {
+      return true;
+    }
     const roomCode = requireNonEmptyString(
       requireSegment(segments, 3, "roomCode"),
       "roomCode",
@@ -125,6 +137,9 @@ export const handleActionRoutes: AdminRouteHandler = async ({
     segments[2] === "sessions" &&
     segments[4] === "disconnect"
   ) {
+    if (!helpers.requireWriteOrigin(request, response)) {
+      return true;
+    }
     const targetSessionId = requireNonEmptyString(
       requireSegment(segments, 3, "sessionId"),
       "sessionId",

--- a/server/src/admin/routes/auth-routes.ts
+++ b/server/src/admin/routes/auth-routes.ts
@@ -4,6 +4,7 @@ import {
   TOO_MANY_LOGIN_ATTEMPTS_MESSAGE,
   UNAUTHORIZED_MESSAGE,
 } from "../../messages.js";
+import { InvalidCredentialsError } from "../auth-service.js";
 import { getBearerToken, readJsonBody } from "../request.js";
 import { sendError, sendOk } from "../response.js";
 import type { AdminRouteHandler } from "../router-types.js";
@@ -82,14 +83,22 @@ export const handleAuthRoutes: AdminRouteHandler = async ({
           role: result.admin.role,
         },
       });
-    } catch {
-      options.loginRateLimiter?.registerFailure({ ipKey, username });
-      sendError(
-        response,
-        401,
-        "invalid_credentials",
-        INVALID_CREDENTIALS_MESSAGE,
-      );
+    } catch (error) {
+      // Only count credential mismatches toward the rate limiter. Backend
+      // failures (session store outages, etc.) must not inflate the counter,
+      // otherwise a transient outage can lock legitimate admins out after it
+      // recovers.
+      if (error instanceof InvalidCredentialsError) {
+        options.loginRateLimiter?.registerFailure({ ipKey, username });
+        sendError(
+          response,
+          401,
+          "invalid_credentials",
+          INVALID_CREDENTIALS_MESSAGE,
+        );
+        return true;
+      }
+      throw error;
     }
     return true;
   }

--- a/server/src/admin/routes/auth-routes.ts
+++ b/server/src/admin/routes/auth-routes.ts
@@ -1,6 +1,7 @@
 import {
   ADMIN_AUTH_UNAVAILABLE_MESSAGE,
   INVALID_CREDENTIALS_MESSAGE,
+  TOO_MANY_LOGIN_ATTEMPTS_MESSAGE,
   UNAUTHORIZED_MESSAGE,
 } from "../../messages.js";
 import { getBearerToken, readJsonBody } from "../request.js";
@@ -12,6 +13,10 @@ const MAX_ADMIN_USERNAME_LENGTH = 128;
 const MAX_ADMIN_PASSWORD_LENGTH = 512;
 const MAX_ADMIN_TOKEN_LENGTH = 1024;
 
+// Admin sessions are issued as opaque bearer tokens delivered via the
+// `Authorization` header. Cookies are intentionally not used for admin auth,
+// which avoids the need to maintain cookie security attributes and neutralizes
+// classic CSRF against session cookies. The regression tests cover this policy.
 export const handleAuthRoutes: AdminRouteHandler = async ({
   request,
   response,
@@ -20,6 +25,9 @@ export const handleAuthRoutes: AdminRouteHandler = async ({
   options,
 }) => {
   if (request.method === "POST" && pathname === "/api/admin/auth/login") {
+    if (!helpers.requireWriteOrigin(request, response)) {
+      return true;
+    }
     if (!options.authService) {
       sendError(
         response,
@@ -43,8 +51,28 @@ export const handleAuthRoutes: AdminRouteHandler = async ({
       MAX_ADMIN_PASSWORD_LENGTH,
       "password",
     );
+    const ipKey = helpers.getIpKey(request);
+    if (options.loginRateLimiter) {
+      const limitCheck = options.loginRateLimiter.check({ ipKey, username });
+      if (!limitCheck.ok) {
+        const retryAfterSeconds = Math.max(
+          1,
+          Math.ceil(limitCheck.retryAfterMs / 1000),
+        );
+        response.setHeader("retry-after", String(retryAfterSeconds));
+        sendError(
+          response,
+          429,
+          "too_many_login_attempts",
+          TOO_MANY_LOGIN_ATTEMPTS_MESSAGE,
+          { dimension: limitCheck.dimension, retryAfterSeconds },
+        );
+        return true;
+      }
+    }
     try {
       const result = await options.authService.login(username, password);
+      options.loginRateLimiter?.registerSuccess({ ipKey, username });
       sendOk(response, {
         token: result.token,
         expiresAt: result.expiresAt,
@@ -55,6 +83,7 @@ export const handleAuthRoutes: AdminRouteHandler = async ({
         },
       });
     } catch {
+      options.loginRateLimiter?.registerFailure({ ipKey, username });
       sendError(
         response,
         401,
@@ -66,6 +95,9 @@ export const handleAuthRoutes: AdminRouteHandler = async ({
   }
 
   if (request.method === "POST" && pathname === "/api/admin/auth/logout") {
+    if (!helpers.requireWriteOrigin(request, response)) {
+      return true;
+    }
     const token = getBearerToken(request);
     if (token) {
       assertMaxLength(token, MAX_ADMIN_TOKEN_LENGTH, "token");

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -28,6 +28,7 @@ import {
   send,
   sendError,
 } from "./ws-session-handler.js";
+import type { AdminSessionStore } from "./admin-session-store.js";
 import type {
   AdminConfig,
   AdminUiConfig,
@@ -74,6 +75,7 @@ export type SyncServerDependencies = {
   logLevel?: LogLevel;
   logSampling?: Record<string, number>;
   metricsPort?: number;
+  adminSessionStoreOverride?: AdminSessionStore;
 };
 
 export async function createSyncServer(
@@ -283,6 +285,7 @@ export async function createSyncServer(
     adminUiConfig: dependencies.adminUiConfig,
     serviceVersion,
     metricsPort: dependencies.metricsPort,
+    adminSessionStoreOverride: dependencies.adminSessionStoreOverride,
   });
 
   const wss = new WebSocketServer({

--- a/server/src/bootstrap/admin-http-bootstrap.ts
+++ b/server/src/bootstrap/admin-http-bootstrap.ts
@@ -7,6 +7,7 @@ import { createAdminOverviewService } from "../admin/overview-service.js";
 import { createAdminRoomQueryService } from "../admin/room-query-service.js";
 import type { MetricsCollector } from "../admin/metrics.js";
 import type { AdminCommandBus } from "../admin-command-bus.js";
+import type { AdminSessionStore } from "../admin-session-store.js";
 import type { RoomEventBusMessage } from "../room-event-bus.js";
 import type { RoomStore } from "../room-store.js";
 import { createRoomService } from "../room-service.js";
@@ -60,6 +61,7 @@ export async function createSharedAdminHttpBootstrap(args: {
   createOverviewService?: typeof createAdminOverviewService;
   createRoomQueryService?: typeof createAdminRoomQueryService;
   metricsPort?: number;
+  adminSessionStoreOverride?: AdminSessionStore;
 }): Promise<{
   securityPolicy: ReturnType<typeof createSecurityPolicy>;
   httpServer: HttpServer;
@@ -98,6 +100,7 @@ export async function createSharedAdminHttpBootstrap(args: {
     createRoomQueryService: args.createRoomQueryService,
     getRequestIpKey: (request) =>
       securityPolicy.getRemoteAddress(request) ?? "unknown",
+    adminSessionStoreOverride: args.adminSessionStoreOverride,
   });
 
   const metricsOnMain = args.metricsPort === undefined;

--- a/server/src/bootstrap/admin-http-bootstrap.ts
+++ b/server/src/bootstrap/admin-http-bootstrap.ts
@@ -96,6 +96,8 @@ export async function createSharedAdminHttpBootstrap(args: {
     serviceName: args.serviceName,
     createOverviewService: args.createOverviewService,
     createRoomQueryService: args.createRoomQueryService,
+    getRequestIpKey: (request) =>
+      securityPolicy.getRemoteAddress(request) ?? "unknown",
   });
 
   const metricsOnMain = args.metricsPort === undefined;

--- a/server/src/bootstrap/admin-services.ts
+++ b/server/src/bootstrap/admin-services.ts
@@ -52,6 +52,7 @@ export function createAdminServices(args: {
   createOverviewService?: typeof createAdminOverviewService;
   createRoomQueryService?: typeof createAdminRoomQueryService;
   getRequestIpKey?: (request: IncomingMessage) => string;
+  adminSessionStoreOverride?: AdminSessionStore;
 }): Promise<{
   adminRouter: ReturnType<typeof createAdminRouter>;
   close: () => Promise<void>;
@@ -63,7 +64,9 @@ export function createAdminServices(args: {
     let closeAuditLogService: (() => Promise<void>) | undefined;
 
     if (args.adminConfig) {
-      if (args.adminConfig.sessionStoreProvider === "redis") {
+      if (args.adminSessionStoreOverride) {
+        adminSessionStore = args.adminSessionStoreOverride;
+      } else if (args.adminConfig.sessionStoreProvider === "redis") {
         const redisAdminSessionStore = await createRedisAdminSessionStore(
           args.persistenceConfig.redisUrl,
           {

--- a/server/src/bootstrap/admin-services.ts
+++ b/server/src/bootstrap/admin-services.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from "node:http";
 import type { ServerMessage } from "@bili-syncplay/protocol";
 import type { WebSocket } from "ws";
 import { createAdminActionService } from "../admin/action-service.js";
@@ -6,6 +7,7 @@ import { createAuditLogService } from "../admin/audit-log.js";
 import { createInMemoryAdminSessionStore } from "../admin/auth-store.js";
 import { createAdminAuthService } from "../admin/auth-service.js";
 import { createAdminConfigService } from "../admin/config-service.js";
+import { createAdminLoginRateLimiter } from "../admin/login-rate-limit.js";
 import type { GlobalAuditStore } from "../admin/global-audit-store.js";
 import type { GlobalEventStore } from "../admin/global-event-store.js";
 import type { MetricsCollector } from "../admin/metrics.js";
@@ -49,6 +51,7 @@ export function createAdminServices(args: {
   serviceName?: string;
   createOverviewService?: typeof createAdminOverviewService;
   createRoomQueryService?: typeof createAdminRoomQueryService;
+  getRequestIpKey?: (request: IncomingMessage) => string;
 }): Promise<{
   adminRouter: ReturnType<typeof createAdminRouter>;
   close: () => Promise<void>;
@@ -97,6 +100,18 @@ export function createAdminServices(args: {
       args.adminConfig && adminSessionStore
         ? createAdminAuthService(args.adminConfig, adminSessionStore, args.now)
         : undefined;
+    const loginRateLimiter = authService
+      ? createAdminLoginRateLimiter(
+          {
+            failuresPerIpPerMinute:
+              args.securityConfig.rateLimits.adminLoginFailuresPerIpPerMinute,
+            failuresPerUsernamePerMinute:
+              args.securityConfig.rateLimits
+                .adminLoginFailuresPerUsernamePerMinute,
+          },
+          args.now,
+        )
+      : undefined;
     const overviewService = createOverviewService({
       instanceId: args.persistenceConfig.instanceId,
       serviceName: args.serviceName ?? "bili-syncplay-server",
@@ -188,6 +203,11 @@ export function createAdminServices(args: {
       eventStore: args.eventStore,
       serviceName: args.serviceName ?? "bili-syncplay-server",
       now: args.now,
+      writeOriginPolicy: {
+        allowedOrigins: args.securityConfig.allowedOrigins,
+      },
+      loginRateLimiter,
+      getRequestIpKey: args.getRequestIpKey,
     });
 
     return {

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -216,6 +216,8 @@ export function getDefaultSecurityConfig(): SecurityConfig {
       syncRequestPer10Seconds: 6,
       syncPingPerSecond: 1,
       syncPingBurst: 2,
+      adminLoginFailuresPerIpPerMinute: 10,
+      adminLoginFailuresPerUsernamePerMinute: 5,
     },
   };
 }

--- a/server/src/config/runtime-config-schema.ts
+++ b/server/src/config/runtime-config-schema.ts
@@ -129,6 +129,16 @@ export const SERVER_CONFIG_FIELDS = [
     "RATE_LIMIT_SYNC_PING_BURST",
     "positiveInteger",
   ),
+  createField(
+    ["security", "rateLimits", "adminLoginFailuresPerIpPerMinute"],
+    "RATE_LIMIT_ADMIN_LOGIN_FAILURES_PER_IP_PER_MINUTE",
+    "positiveInteger",
+  ),
+  createField(
+    ["security", "rateLimits", "adminLoginFailuresPerUsernamePerMinute"],
+    "RATE_LIMIT_ADMIN_LOGIN_FAILURES_PER_USERNAME_PER_MINUTE",
+    "positiveInteger",
+  ),
   createField(["persistence", "provider"], "ROOM_STORE_PROVIDER", "enum", [
     "memory",
     "redis",

--- a/server/src/messages.ts
+++ b/server/src/messages.ts
@@ -19,6 +19,9 @@ export const FORBIDDEN_MESSAGE = "Forbidden.";
 export const ADMIN_AUTH_UNAVAILABLE_MESSAGE =
   "Admin authentication is not configured.";
 export const INVALID_CREDENTIALS_MESSAGE = "Invalid username or password.";
+export const CROSS_ORIGIN_REJECTED_MESSAGE = "Cross-origin request rejected.";
+export const TOO_MANY_LOGIN_ATTEMPTS_MESSAGE =
+  "Too many login attempts. Try again later.";
 export const ROOM_VERSION_CONFLICT_MESSAGE = "Room state update conflict.";
 export const ROOM_ACTIVE_MESSAGE =
   "Room still has active members. Close the room instead of expiring it early.";

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -156,6 +156,8 @@ export type SecurityConfig = {
     syncRequestPer10Seconds: number;
     syncPingPerSecond: number;
     syncPingBurst: number;
+    adminLoginFailuresPerIpPerMinute: number;
+    adminLoginFailuresPerUsernamePerMinute: number;
   };
 };
 

--- a/server/test/admin-backend.test.ts
+++ b/server/test/admin-backend.test.ts
@@ -10,7 +10,8 @@ import {
   getDefaultSecurityConfig,
   type SyncServerDependencies,
 } from "../src/app.js";
-import type { AdminRole } from "../src/admin/types.js";
+import { createInMemoryAdminSessionStore } from "../src/admin/auth-store.js";
+import type { AdminRole, AdminSession } from "../src/admin/types.js";
 
 const ALLOWED_ORIGIN = "chrome-extension://allowed-extension";
 
@@ -1832,6 +1833,93 @@ test("successful admin login resets the rate-limit counters", async () => {
       body: { username: "admin", password: "wrong" },
     });
     assert.equal(now429.status, 429);
+  } finally {
+    await server.close();
+  }
+});
+
+test("admin login backend outages surface as 500 and do not count toward throttle", async () => {
+  const memory = createInMemoryAdminSessionStore();
+  let outage = true;
+  let saveAttempts = 0;
+  const flakingStore = {
+    async save(tokenId: string, session: AdminSession) {
+      saveAttempts += 1;
+      if (outage) {
+        throw new Error("session-store-down");
+      }
+      await memory.save(tokenId, session);
+    },
+    async get(tokenId: string) {
+      return memory.get(tokenId);
+    },
+    async delete(tokenId: string) {
+      await memory.delete(tokenId);
+    },
+  };
+  const server = await createSyncServer(
+    {
+      ...getDefaultSecurityConfig(),
+      allowedOrigins: [ALLOWED_ORIGIN],
+      rateLimits: {
+        ...getDefaultSecurityConfig().rateLimits,
+        // Limit is 2 failures per IP or username. If the buggy code counted
+        // backend errors as login failures, the third attempt would get 429'd
+        // by the check phase — the 500 assertion below would then fail.
+        adminLoginFailuresPerIpPerMinute: 2,
+        adminLoginFailuresPerUsernamePerMinute: 2,
+      },
+    },
+    getDefaultPersistenceConfig(),
+    {
+      adminConfig: {
+        username: "admin",
+        passwordHash: `sha256:${sha256Hex("secret-123")}`,
+        sessionSecret: "session-secret-123",
+        sessionTtlMs: 60_000,
+        role: "admin",
+        sessionStoreProvider: "memory",
+        eventStoreProvider: "memory",
+        auditStoreProvider: "memory",
+      },
+      serviceVersion: "0.7.0-test",
+      adminSessionStoreOverride: flakingStore,
+    },
+  );
+  await new Promise<void>((resolve, reject) => {
+    server.httpServer.listen(0, "127.0.0.1", () => resolve());
+    server.httpServer.once("error", reject);
+  });
+  const address = server.httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to determine test server address.");
+  }
+  const httpBaseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const outageResponse = await requestJson(
+        httpBaseUrl,
+        "/api/admin/auth/login",
+        {
+          method: "POST",
+          body: { username: "admin", password: "secret-123" },
+        },
+      );
+      assert.equal(outageResponse.status, 500);
+      assert.equal(
+        (outageResponse.body.error as { code: string }).code,
+        "internal_error",
+      );
+    }
+    assert.equal(saveAttempts, 3);
+
+    outage = false;
+    const recovered = await requestJson(httpBaseUrl, "/api/admin/auth/login", {
+      method: "POST",
+      body: { username: "admin", password: "secret-123" },
+    });
+    assert.equal(recovered.status, 200);
   } finally {
     await server.close();
   }

--- a/server/test/admin-backend.test.ts
+++ b/server/test/admin-backend.test.ts
@@ -116,13 +116,18 @@ async function requestJson(
     method?: string;
     token?: string;
     body?: unknown;
+    origin?: string | null;
   } = {},
 ) {
+  const method = options.method ?? "GET";
+  const originHeader =
+    options.origin === null ? undefined : (options.origin ?? baseUrl);
   const response = await fetch(`${baseUrl}${path}`, {
-    method: options.method ?? "GET",
+    method,
     headers: {
       ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
       ...(options.body ? { "content-type": "application/json" } : {}),
+      ...(originHeader ? { Origin: originHeader } : {}),
     },
     body: options.body ? JSON.stringify(options.body) : undefined,
   });
@@ -1459,6 +1464,374 @@ test("metrics can be exposed on a dedicated port distinct from the admin server"
       "/healthz",
     );
     assert.equal(dedicatedOtherPath.status, 404);
+  } finally {
+    await server.close();
+  }
+});
+
+test("admin login rejects requests without an Origin header", async () => {
+  const server = await startAdminServer();
+
+  try {
+    const response = await requestJson(
+      server.httpBaseUrl,
+      "/api/admin/auth/login",
+      {
+        method: "POST",
+        body: { username: "admin", password: "secret-123" },
+        origin: null,
+      },
+    );
+    assert.equal(response.status, 403);
+    assert.equal(
+      (response.body.error as { code: string }).code,
+      "csrf_origin_missing",
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+test("admin login rejects cross-origin requests", async () => {
+  const server = await startAdminServer();
+
+  try {
+    const response = await requestJson(
+      server.httpBaseUrl,
+      "/api/admin/auth/login",
+      {
+        method: "POST",
+        body: { username: "admin", password: "secret-123" },
+        origin: "https://evil.example.com",
+      },
+    );
+    assert.equal(response.status, 403);
+    assert.equal(
+      (response.body.error as { code: string }).code,
+      "csrf_origin_not_allowed",
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+test("admin action routes reject cross-origin POST requests", async () => {
+  const server = await startAdminServer();
+
+  try {
+    const token = await login(server.httpBaseUrl);
+
+    const close = await requestJson(
+      server.httpBaseUrl,
+      "/api/admin/rooms/ROOM1/close",
+      {
+        method: "POST",
+        token,
+        body: { reason: "csrf" },
+        origin: "https://evil.example.com",
+      },
+    );
+    assert.equal(close.status, 403);
+    assert.equal(
+      (close.body.error as { code: string }).code,
+      "csrf_origin_not_allowed",
+    );
+
+    const kick = await requestJson(
+      server.httpBaseUrl,
+      "/api/admin/rooms/ROOM1/members/m1/kick",
+      {
+        method: "POST",
+        token,
+        body: { reason: "csrf" },
+        origin: null,
+      },
+    );
+    assert.equal(kick.status, 403);
+    assert.equal(
+      (kick.body.error as { code: string }).code,
+      "csrf_origin_missing",
+    );
+
+    const disconnect = await requestJson(
+      server.httpBaseUrl,
+      "/api/admin/sessions/sess-1/disconnect",
+      {
+        method: "POST",
+        token,
+        body: { reason: "csrf" },
+        origin: "https://evil.example.com",
+      },
+    );
+    assert.equal(disconnect.status, 403);
+    assert.equal(
+      (disconnect.body.error as { code: string }).code,
+      "csrf_origin_not_allowed",
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+test("admin login response does not set any session cookie", async () => {
+  const server = await startAdminServer();
+
+  try {
+    const response = await fetch(`${server.httpBaseUrl}/api/admin/auth/login`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Origin: server.httpBaseUrl,
+      },
+      body: JSON.stringify({ username: "admin", password: "secret-123" }),
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("set-cookie"), null);
+  } finally {
+    await server.close();
+  }
+});
+
+test("admin auth ignores stray Cookie headers (bearer-only session policy)", async () => {
+  const server = await startAdminServer();
+
+  try {
+    const loginResponse = await requestJson(
+      server.httpBaseUrl,
+      "/api/admin/auth/login",
+      {
+        method: "POST",
+        body: { username: "admin", password: "secret-123" },
+      },
+    );
+    assert.equal(loginResponse.status, 200);
+    const token = (loginResponse.body.data as { token: string }).token;
+
+    const cookieOnly = await fetch(`${server.httpBaseUrl}/api/admin/me`, {
+      method: "GET",
+      headers: {
+        Origin: server.httpBaseUrl,
+        Cookie: `bili-syncplay-admin-token=${token}`,
+      },
+    });
+    assert.equal(cookieOnly.status, 401);
+
+    const bearer = await fetch(`${server.httpBaseUrl}/api/admin/me`, {
+      method: "GET",
+      headers: {
+        Origin: server.httpBaseUrl,
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    assert.equal(bearer.status, 200);
+  } finally {
+    await server.close();
+  }
+});
+
+test("admin login failures are rate-limited per IP independent of WS connection limits", async () => {
+  const server = await createSyncServer(
+    {
+      ...getDefaultSecurityConfig(),
+      allowedOrigins: [ALLOWED_ORIGIN],
+      connectionAttemptsPerMinute: 1000,
+      rateLimits: {
+        ...getDefaultSecurityConfig().rateLimits,
+        adminLoginFailuresPerIpPerMinute: 3,
+        adminLoginFailuresPerUsernamePerMinute: 100,
+      },
+    },
+    getDefaultPersistenceConfig(),
+    {
+      adminConfig: {
+        username: "admin",
+        passwordHash: `sha256:${sha256Hex("secret-123")}`,
+        sessionSecret: "session-secret-123",
+        sessionTtlMs: 60_000,
+        role: "admin",
+        sessionStoreProvider: "memory",
+        eventStoreProvider: "memory",
+        auditStoreProvider: "memory",
+      },
+      serviceVersion: "0.7.0-test",
+    },
+  );
+  await new Promise<void>((resolve, reject) => {
+    server.httpServer.listen(0, "127.0.0.1", () => resolve());
+    server.httpServer.once("error", reject);
+  });
+  const address = server.httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to determine test server address.");
+  }
+  const httpBaseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const response = await requestJson(httpBaseUrl, "/api/admin/auth/login", {
+        method: "POST",
+        body: { username: `user-${attempt}`, password: "wrong" },
+      });
+      assert.equal(response.status, 401);
+    }
+
+    const throttled = await requestJson(httpBaseUrl, "/api/admin/auth/login", {
+      method: "POST",
+      body: { username: "user-4", password: "wrong" },
+    });
+    assert.equal(throttled.status, 429);
+    assert.equal(
+      (throttled.body.error as { code: string }).code,
+      "too_many_login_attempts",
+    );
+    assert.equal(
+      (throttled.body.error as { details: { dimension: string } }).details
+        .dimension,
+      "ip",
+    );
+
+    const blockedForValid = await requestJson(
+      httpBaseUrl,
+      "/api/admin/auth/login",
+      {
+        method: "POST",
+        body: { username: "admin", password: "secret-123" },
+      },
+    );
+    assert.equal(blockedForValid.status, 429);
+  } finally {
+    await server.close();
+  }
+});
+
+test("admin login failures are rate-limited per username case-insensitively", async () => {
+  const server = await createSyncServer(
+    {
+      ...getDefaultSecurityConfig(),
+      allowedOrigins: [ALLOWED_ORIGIN],
+      rateLimits: {
+        ...getDefaultSecurityConfig().rateLimits,
+        adminLoginFailuresPerIpPerMinute: 1000,
+        adminLoginFailuresPerUsernamePerMinute: 2,
+      },
+    },
+    getDefaultPersistenceConfig(),
+    {
+      adminConfig: {
+        username: "admin",
+        passwordHash: `sha256:${sha256Hex("secret-123")}`,
+        sessionSecret: "session-secret-123",
+        sessionTtlMs: 60_000,
+        role: "admin",
+        sessionStoreProvider: "memory",
+        eventStoreProvider: "memory",
+        auditStoreProvider: "memory",
+      },
+      serviceVersion: "0.7.0-test",
+    },
+  );
+  await new Promise<void>((resolve, reject) => {
+    server.httpServer.listen(0, "127.0.0.1", () => resolve());
+    server.httpServer.once("error", reject);
+  });
+  const address = server.httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to determine test server address.");
+  }
+  const httpBaseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    const first = await requestJson(httpBaseUrl, "/api/admin/auth/login", {
+      method: "POST",
+      body: { username: "Admin", password: "wrong" },
+    });
+    assert.equal(first.status, 401);
+
+    const second = await requestJson(httpBaseUrl, "/api/admin/auth/login", {
+      method: "POST",
+      body: { username: "admin", password: "wrong" },
+    });
+    assert.equal(second.status, 401);
+
+    const third = await requestJson(httpBaseUrl, "/api/admin/auth/login", {
+      method: "POST",
+      body: { username: "ADMIN", password: "wrong" },
+    });
+    assert.equal(third.status, 429);
+    assert.equal(
+      (third.body.error as { details: { dimension: string } }).details
+        .dimension,
+      "username",
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+test("successful admin login resets the rate-limit counters", async () => {
+  const server = await createSyncServer(
+    {
+      ...getDefaultSecurityConfig(),
+      allowedOrigins: [ALLOWED_ORIGIN],
+      rateLimits: {
+        ...getDefaultSecurityConfig().rateLimits,
+        adminLoginFailuresPerIpPerMinute: 3,
+        adminLoginFailuresPerUsernamePerMinute: 3,
+      },
+    },
+    getDefaultPersistenceConfig(),
+    {
+      adminConfig: {
+        username: "admin",
+        passwordHash: `sha256:${sha256Hex("secret-123")}`,
+        sessionSecret: "session-secret-123",
+        sessionTtlMs: 60_000,
+        role: "admin",
+        sessionStoreProvider: "memory",
+        eventStoreProvider: "memory",
+        auditStoreProvider: "memory",
+      },
+      serviceVersion: "0.7.0-test",
+    },
+  );
+  await new Promise<void>((resolve, reject) => {
+    server.httpServer.listen(0, "127.0.0.1", () => resolve());
+    server.httpServer.once("error", reject);
+  });
+  const address = server.httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to determine test server address.");
+  }
+  const httpBaseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const fail = await requestJson(httpBaseUrl, "/api/admin/auth/login", {
+        method: "POST",
+        body: { username: "admin", password: "wrong" },
+      });
+      assert.equal(fail.status, 401);
+    }
+
+    const success = await requestJson(httpBaseUrl, "/api/admin/auth/login", {
+      method: "POST",
+      body: { username: "admin", password: "secret-123" },
+    });
+    assert.equal(success.status, 200);
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const again = await requestJson(httpBaseUrl, "/api/admin/auth/login", {
+        method: "POST",
+        body: { username: "admin", password: "wrong" },
+      });
+      assert.equal(again.status, 401);
+    }
+
+    const now429 = await requestJson(httpBaseUrl, "/api/admin/auth/login", {
+      method: "POST",
+      body: { username: "admin", password: "wrong" },
+    });
+    assert.equal(now429.status, 429);
   } finally {
     await server.close();
   }

--- a/server/test/admin-csrf.test.ts
+++ b/server/test/admin-csrf.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import type { IncomingMessage } from "node:http";
+import test from "node:test";
+import { evaluateAdminWriteOrigin } from "../src/admin/csrf.js";
+
+type FakeSocket = { encrypted?: boolean };
+
+function createRequest(args: {
+  host?: string;
+  origin?: string | null;
+  forwardedProto?: string;
+  encrypted?: boolean;
+}): IncomingMessage {
+  const headers: Record<string, string> = {};
+  if (args.host !== undefined) {
+    headers.host = args.host;
+  }
+  if (args.origin !== null && args.origin !== undefined) {
+    headers.origin = args.origin;
+  }
+  if (args.forwardedProto !== undefined) {
+    headers["x-forwarded-proto"] = args.forwardedProto;
+  }
+  const socket: FakeSocket = { encrypted: args.encrypted ?? false };
+  return {
+    headers,
+    socket,
+  } as unknown as IncomingMessage;
+}
+
+test("admin CSRF origin allows same-origin requests", () => {
+  const request = createRequest({
+    host: "admin.example.com",
+    origin: "https://admin.example.com",
+    forwardedProto: "https",
+  });
+  const result = evaluateAdminWriteOrigin(request, { allowedOrigins: [] });
+  assert.deepEqual(result, { ok: true });
+});
+
+test("admin CSRF origin rejects cross-origin requests", () => {
+  const request = createRequest({
+    host: "admin.example.com",
+    origin: "https://evil.example.com",
+    forwardedProto: "https",
+  });
+  const result = evaluateAdminWriteOrigin(request, { allowedOrigins: [] });
+  assert.deepEqual(result, { ok: false, reason: "origin_not_allowed" });
+});
+
+test("admin CSRF origin rejects when Origin header is missing", () => {
+  const request = createRequest({
+    host: "admin.example.com",
+    origin: null,
+  });
+  const result = evaluateAdminWriteOrigin(request, {
+    allowedOrigins: ["https://admin.example.com"],
+  });
+  assert.deepEqual(result, { ok: false, reason: "origin_missing" });
+});
+
+test("admin CSRF origin accepts Origin listed in the allow-list", () => {
+  const request = createRequest({
+    host: "admin.example.com",
+    origin: "https://trusted.example.com",
+    forwardedProto: "https",
+  });
+  const result = evaluateAdminWriteOrigin(request, {
+    allowedOrigins: ["https://trusted.example.com"],
+  });
+  assert.deepEqual(result, { ok: true });
+});
+
+test("admin CSRF origin honors x-forwarded-proto for scheme comparison", () => {
+  const request = createRequest({
+    host: "admin.example.com",
+    origin: "https://admin.example.com",
+    forwardedProto: "https,http",
+  });
+  const result = evaluateAdminWriteOrigin(request, { allowedOrigins: [] });
+  assert.deepEqual(result, { ok: true });
+});
+
+test("admin CSRF origin falls back to socket.encrypted when no forwarded-proto", () => {
+  const request = createRequest({
+    host: "admin.example.com",
+    origin: "http://admin.example.com",
+  });
+  const result = evaluateAdminWriteOrigin(request, { allowedOrigins: [] });
+  assert.deepEqual(result, { ok: true });
+});

--- a/server/test/admin-login-rate-limit.test.ts
+++ b/server/test/admin-login-rate-limit.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createAdminLoginRateLimiter } from "../src/admin/login-rate-limit.js";
+
+function makeClock() {
+  let current = 1_000_000;
+  return {
+    now: () => current,
+    advance: (deltaMs: number) => {
+      current += deltaMs;
+    },
+  };
+}
+
+test("login rate limiter enforces per-IP failure window", () => {
+  const clock = makeClock();
+  const limiter = createAdminLoginRateLimiter(
+    { failuresPerIpPerMinute: 3, failuresPerUsernamePerMinute: 1000 },
+    clock.now,
+  );
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    assert.equal(
+      limiter.check({ ipKey: "1.2.3.4", username: `user-${attempt}` }).ok,
+      true,
+    );
+    limiter.registerFailure({ ipKey: "1.2.3.4", username: `user-${attempt}` });
+  }
+
+  const blocked = limiter.check({ ipKey: "1.2.3.4", username: "anyone" });
+  assert.equal(blocked.ok, false);
+  assert.equal(blocked.ok === false && blocked.dimension, "ip");
+
+  const otherIp = limiter.check({ ipKey: "9.9.9.9", username: "user-0" });
+  assert.equal(otherIp.ok, true);
+});
+
+test("login rate limiter enforces per-username failure window across IPs", () => {
+  const clock = makeClock();
+  const limiter = createAdminLoginRateLimiter(
+    { failuresPerIpPerMinute: 1000, failuresPerUsernamePerMinute: 2 },
+    clock.now,
+  );
+
+  limiter.registerFailure({ ipKey: "1.1.1.1", username: "alice" });
+  limiter.registerFailure({ ipKey: "2.2.2.2", username: "alice" });
+
+  const blocked = limiter.check({ ipKey: "3.3.3.3", username: "alice" });
+  assert.equal(blocked.ok, false);
+  assert.equal(blocked.ok === false && blocked.dimension, "username");
+
+  const differentUser = limiter.check({ ipKey: "3.3.3.3", username: "bob" });
+  assert.equal(differentUser.ok, true);
+});
+
+test("login rate limiter resets after a successful login", () => {
+  const clock = makeClock();
+  const limiter = createAdminLoginRateLimiter(
+    { failuresPerIpPerMinute: 2, failuresPerUsernamePerMinute: 2 },
+    clock.now,
+  );
+
+  limiter.registerFailure({ ipKey: "1.2.3.4", username: "admin" });
+  limiter.registerFailure({ ipKey: "1.2.3.4", username: "admin" });
+  assert.equal(
+    limiter.check({ ipKey: "1.2.3.4", username: "admin" }).ok,
+    false,
+  );
+
+  limiter.registerSuccess({ ipKey: "1.2.3.4", username: "admin" });
+  assert.equal(limiter.check({ ipKey: "1.2.3.4", username: "admin" }).ok, true);
+});
+
+test("login rate limiter rolls the window after a full minute", () => {
+  const clock = makeClock();
+  const limiter = createAdminLoginRateLimiter(
+    { failuresPerIpPerMinute: 2, failuresPerUsernamePerMinute: 2 },
+    clock.now,
+  );
+
+  limiter.registerFailure({ ipKey: "1.2.3.4", username: "admin" });
+  limiter.registerFailure({ ipKey: "1.2.3.4", username: "admin" });
+  const blocked = limiter.check({ ipKey: "1.2.3.4", username: "admin" });
+  assert.equal(blocked.ok, false);
+
+  clock.advance(60_001);
+  const afterWindow = limiter.check({ ipKey: "1.2.3.4", username: "admin" });
+  assert.equal(afterWindow.ok, true);
+});
+
+test("login rate limiter normalizes usernames for consistent throttling", () => {
+  const clock = makeClock();
+  const limiter = createAdminLoginRateLimiter(
+    { failuresPerIpPerMinute: 1000, failuresPerUsernamePerMinute: 1 },
+    clock.now,
+  );
+
+  limiter.registerFailure({ ipKey: "1.1.1.1", username: "Admin" });
+  const blocked = limiter.check({ ipKey: "2.2.2.2", username: "ADMIN" });
+  assert.equal(blocked.ok, false);
+  assert.equal(blocked.ok === false && blocked.dimension, "username");
+});

--- a/server/test/admin-overview-cluster.test.ts
+++ b/server/test/admin-overview-cluster.test.ts
@@ -68,13 +68,17 @@ async function requestJson(
     method?: string;
     token?: string;
     body?: unknown;
+    origin?: string | null;
   } = {},
 ) {
+  const originHeader =
+    options.origin === null ? undefined : (options.origin ?? baseUrl);
   const response = await fetch(`${baseUrl}${path}`, {
     method: options.method ?? "GET",
     headers: {
       ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
       ...(options.body ? { "content-type": "application/json" } : {}),
+      ...(originHeader ? { Origin: originHeader } : {}),
     },
     body: options.body ? JSON.stringify(options.body) : undefined,
   });

--- a/server/test/admin-room-query-cluster.test.ts
+++ b/server/test/admin-room-query-cluster.test.ts
@@ -68,13 +68,17 @@ async function requestJson(
     method?: string;
     token?: string;
     body?: unknown;
+    origin?: string | null;
   } = {},
 ) {
+  const originHeader =
+    options.origin === null ? undefined : (options.origin ?? baseUrl);
   const response = await fetch(`${baseUrl}${path}`, {
     method: options.method ?? "GET",
     headers: {
       ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
       ...(options.body ? { "content-type": "application/json" } : {}),
+      ...(originHeader ? { Origin: originHeader } : {}),
     },
     body: options.body ? JSON.stringify(options.body) : undefined,
   });

--- a/server/test/admin-session-store.test.ts
+++ b/server/test/admin-session-store.test.ts
@@ -4,7 +4,10 @@ import {
   createInMemoryAdminSessionStore,
   type AuthStore,
 } from "../src/admin/auth-store.js";
-import { createAdminAuthService } from "../src/admin/auth-service.js";
+import {
+  createAdminAuthService,
+  InvalidCredentialsError,
+} from "../src/admin/auth-service.js";
 import type { AdminSession } from "../src/admin/types.js";
 
 test("in-memory admin session store keeps session copies", async () => {
@@ -81,5 +84,63 @@ test("admin auth service authenticates through injected admin session store", as
   assert.equal(
     calls.some((entry) => entry.startsWith("get:")),
     true,
+  );
+});
+
+test("admin auth service throws InvalidCredentialsError only for credential mismatches", async () => {
+  const store = createInMemoryAdminSessionStore();
+  const service = createAdminAuthService(
+    {
+      username: "admin",
+      passwordHash:
+        "sha256:300109590f69536a400b77ef698021586bfce6809dd8782da32ade9c45457231",
+      sessionSecret: "secret",
+      sessionTtlMs: 1000,
+      role: "admin",
+    },
+    store,
+    () => 100,
+  );
+
+  await assert.rejects(
+    service.login("admin", "wrong-password"),
+    (error: unknown) => error instanceof InvalidCredentialsError,
+  );
+
+  await assert.rejects(
+    service.login("nobody", "secret-123"),
+    (error: unknown) => error instanceof InvalidCredentialsError,
+  );
+});
+
+test("admin auth service surfaces session-store outages as non-credential errors", async () => {
+  const brokenStore: AuthStore = {
+    async save() {
+      throw new Error("session-store-down");
+    },
+    async get() {
+      return null;
+    },
+    async delete() {},
+  };
+  const service = createAdminAuthService(
+    {
+      username: "admin",
+      passwordHash:
+        "sha256:300109590f69536a400b77ef698021586bfce6809dd8782da32ade9c45457231",
+      sessionSecret: "secret",
+      sessionTtlMs: 1000,
+      role: "admin",
+    },
+    brokenStore,
+    () => 100,
+  );
+
+  await assert.rejects(
+    service.login("admin", "secret-123"),
+    (error: unknown) =>
+      error instanceof Error &&
+      !(error instanceof InvalidCredentialsError) &&
+      error.message === "session-store-down",
   );
 });

--- a/server/test/global-admin-app.test.ts
+++ b/server/test/global-admin-app.test.ts
@@ -23,13 +23,17 @@ async function requestJson(
     method?: string;
     token?: string;
     body?: unknown;
+    origin?: string | null;
   } = {},
 ) {
+  const originHeader =
+    options.origin === null ? undefined : (options.origin ?? baseUrl);
   const response = await fetch(`${baseUrl}${path}`, {
     method: options.method ?? "GET",
     headers: {
       ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
       ...(options.body ? { "content-type": "application/json" } : {}),
+      ...(originHeader ? { Origin: originHeader } : {}),
     },
     body: options.body ? JSON.stringify(options.body) : undefined,
   });

--- a/server/test/multi-node-test-kit.ts
+++ b/server/test/multi-node-test-kit.ts
@@ -51,13 +51,17 @@ export async function requestJson(
     method?: string;
     token?: string;
     body?: unknown;
+    origin?: string | null;
   } = {},
 ) {
+  const originHeader =
+    options.origin === null ? undefined : (options.origin ?? baseUrl);
   const response = await fetch(`${baseUrl}${path}`, {
     method: options.method ?? "GET",
     headers: {
       ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
       ...(options.body ? { "content-type": "application/json" } : {}),
+      ...(originHeader ? { Origin: originHeader } : {}),
     },
     body: options.body ? JSON.stringify(options.body) : undefined,
   });


### PR DESCRIPTION
## Summary

针对 issue #69 提出的三条要求，在 admin 层补齐会话安全防护：

- **CSRF 防护**：对所有 admin 写操作（`/api/admin/auth/login`、`/api/admin/auth/logout`、`/api/admin/rooms/:code/close|expire|clear-video`、`/api/admin/rooms/:code/members/:id/kick`、`/api/admin/sessions/:id/disconnect`）强制检查 `Origin` 头，只接受同源（`scheme+host` 匹配，尊重 `x-forwarded-proto`）或白名单 Origin，缺失 / 跨源一律 403。
- **登录失败限流**：新增独立的双维度限流器 `createAdminLoginRateLimiter`（IP + 大小写归一化后的 username），默认 10/min per IP、5/min per username；与 `SecurityConfig.connectionAttemptsPerMinute`（WS）完全解耦，过限返回 429 + `Retry-After`。
- **Cookie 策略**：现网 admin 会话就是 Bearer（localStorage），不走 cookie；在 `auth-routes.ts` 里显式写明这条策略，并加测试锁死：登录响应绝不带 `Set-Cookie`，请求中夹带的 `Cookie` 不会被当作凭据。

既有 admin 面板用户无需任何配置改动：浏览器同源 fetch 会自动带 `Origin`；WS 限流阈值也没动。

## Changes

**新增**
- `server/src/admin/csrf.ts` — `evaluateAdminWriteOrigin` + `requireAdminWriteOrigin`，含同源与白名单两条放行路径。
- `server/src/admin/login-rate-limit.ts` — 双维度 fixed-window 限流器，带成功即重置和懒惰 sweep。
- `server/test/admin-csrf.test.ts` + `server/test/admin-login-rate-limit.test.ts` — 单元测试。

**修改**
- `server/src/admin/router.ts`、`router-types.ts` — 新增 `requireWriteOrigin`、`getIpKey` 两个 helper；把 `writeOriginPolicy`、`loginRateLimiter`、`getRequestIpKey` 接入路由选项。
- `server/src/admin/routes/{auth,action}-routes.ts` — 每个 POST 入口先跑 CSRF；登录路径串联限流 check / register。
- `server/src/bootstrap/{admin-services,admin-http-bootstrap,server-bootstrap}.ts` — 构造限流器，传入 securityPolicy 的 `getRemoteAddress` 作为 IP key 来源。
- `server/src/types.ts`、`server/src/config/runtime-config-schema.ts`、`server/src/messages.ts` — 新增两个速率字段 + 两条文案。
- `server/test/{admin-backend,admin-overview-cluster,admin-room-query-cluster,global-admin-app,multi-node-test-kit}.ts` — 测试 `requestJson` helper 增加 `origin` 参数（默认同源，传 `null` 故意不带 Origin 用于负例）。
- `server/test/admin-backend.test.ts` — 新增 CSRF 三类场景、cookie 策略、IP/username 双维度限流 + 成功即重置的回归测试。

Fixes #69

## Test plan

- [x] `npm run format:check` / `lint` / `typecheck` / `build`：全绿。
- [x] `npm test`：245 server + 56 protocol + 187 extension，全部通过（28 个 Redis 相关测试因未设 `REDIS_URL` 跳过，与本 PR 无关）。
- [x] 新增针对性测试：
  - 登录缺 `Origin` → 403 `csrf_origin_missing`
  - 登录跨源 Origin → 403 `csrf_origin_not_allowed`
  - 三个典型写操作（`close`、`kick`、`sessions/:id/disconnect`）同上
  - 登录响应不包含 `Set-Cookie`，`Cookie` 头不被当作凭据
  - 3 次/min IP 失败后第 4 次 429，且成功的登录不被连带误伤
  - username 维度大小写归一化（Admin/ADMIN/admin 共享窗口）
  - 成功登录后限流计数清零
- [ ] 手动验证（浏览器访问 admin 面板 → 登录/关闭房间/踢人仍然正常，跨源攻击页面 POST 被 403 拦截）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)