### PR TITLE
feat(config): 强化 ALLOWED_ORIGINS 启动校验 (#70)

### DIFF
--- a/server/src/config/runtime-config.ts
+++ b/server/src/config/runtime-config.ts
@@ -18,7 +18,10 @@ import {
   SERVER_CONFIG_FIELDS,
   SERVER_CONFIG_SCHEMA_TREE,
 } from "./runtime-config-schema.js";
-import { loadSecurityConfig } from "./security-config.js";
+import {
+  assertAllowedOriginsStartupPolicy,
+  loadSecurityConfig,
+} from "./security-config.js";
 
 const LOG_LEVEL_FIELD = SERVER_CONFIG_FIELDS.find(
   (field) => field.path[0] === "logLevel",
@@ -263,7 +266,7 @@ export async function loadRuntimeConfig(
     ...env,
   };
 
-  return {
+  const runtimeConfig: RuntimeConfig = {
     port: parseIntegerEnv(mergedEnv, "PORT", 8787),
     globalAdminPort: parseIntegerEnv(
       mergedEnv,
@@ -284,4 +287,8 @@ export async function loadRuntimeConfig(
     adminConfig: loadAdminConfig(env),
     adminUiConfig: loadAdminUiConfig(mergedEnv),
   };
+
+  assertAllowedOriginsStartupPolicy(runtimeConfig.securityConfig);
+
+  return runtimeConfig;
 }

--- a/server/src/config/security-config.ts
+++ b/server/src/config/security-config.ts
@@ -5,12 +5,84 @@ import {
   SECURITY_CONFIG_FIELDS,
 } from "./runtime-config-schema.js";
 
+const SUPPORTED_ORIGIN_PROTOCOLS = new Set([
+  "http:",
+  "https:",
+  "chrome-extension:",
+]);
+
+export class SecurityConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SecurityConfigError";
+  }
+}
+
+export function validateAllowedOriginValues(origins: readonly string[]): void {
+  for (const origin of origins) {
+    if (typeof origin !== "string" || origin.length === 0) {
+      throw new SecurityConfigError(
+        `ALLOWED_ORIGINS contains an empty or non-string entry.`,
+      );
+    }
+    if (origin.includes("*")) {
+      throw new SecurityConfigError(
+        `ALLOWED_ORIGINS entry "${origin}" uses a wildcard, which is not supported.`,
+      );
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(origin);
+    } catch {
+      throw new SecurityConfigError(
+        `ALLOWED_ORIGINS entry "${origin}" is not a valid absolute URL.`,
+      );
+    }
+
+    if (!SUPPORTED_ORIGIN_PROTOCOLS.has(parsed.protocol)) {
+      throw new SecurityConfigError(
+        `ALLOWED_ORIGINS entry "${origin}" uses unsupported scheme "${parsed.protocol.replace(/:$/, "")}"; expected one of http, https, chrome-extension.`,
+      );
+    }
+  }
+}
+
+export function assertAllowedOriginsStartupPolicy(
+  config: SecurityConfig,
+): void {
+  if (config.allowedOrigins.length === 0 && !config.allowMissingOriginInDev) {
+    throw new SecurityConfigError(
+      "ALLOWED_ORIGINS is empty; set ALLOW_MISSING_ORIGIN_IN_DEV=true to run without origin restrictions in development, or configure ALLOWED_ORIGINS for production.",
+    );
+  }
+}
+
+export type OriginPolicyLogger = (message: string) => void;
+
+export function logEffectiveOriginPolicy(
+  config: SecurityConfig,
+  log: OriginPolicyLogger = (message) => {
+    console.log(message);
+  },
+): void {
+  const origins =
+    config.allowedOrigins.length === 0
+      ? "<none>"
+      : config.allowedOrigins.join(", ");
+  log(
+    `[security] ALLOWED_ORIGINS=${origins}; ALLOW_MISSING_ORIGIN_IN_DEV=${String(config.allowMissingOriginInDev)}`,
+  );
+}
+
 export function loadSecurityConfig(
   env: EnvSource = process.env,
 ): SecurityConfig {
-  return loadSectionConfigFromEnv(
+  const config = loadSectionConfigFromEnv(
     env,
     getDefaultSecurityConfig(),
     SECURITY_CONFIG_FIELDS,
   );
+  validateAllowedOriginValues(config.allowedOrigins);
+  return config;
 }

--- a/server/src/config/security-config.ts
+++ b/server/src/config/security-config.ts
@@ -45,6 +45,19 @@ export function validateAllowedOriginValues(origins: readonly string[]): void {
         `ALLOWED_ORIGINS entry "${origin}" uses unsupported scheme "${parsed.protocol.replace(/:$/, "")}"; expected one of http, https, chrome-extension.`,
       );
     }
+
+    if (parsed.host.length === 0) {
+      throw new SecurityConfigError(
+        `ALLOWED_ORIGINS entry "${origin}" must include a host.`,
+      );
+    }
+
+    const canonical = `${parsed.protocol}//${parsed.host}`;
+    if (origin !== canonical) {
+      throw new SecurityConfigError(
+        `ALLOWED_ORIGINS entry "${origin}" must be a bare origin like "${canonical}" — no path, query, fragment, userinfo, trailing slash, or mixed-case host (HTTP Origin headers are exact-matched).`,
+      );
+    }
   }
 }
 

--- a/server/src/global-admin-index.ts
+++ b/server/src/global-admin-index.ts
@@ -2,6 +2,7 @@ import {
   assertMetricsPortDoesNotCollide,
   loadRuntimeConfig,
 } from "./config/runtime-config.js";
+import { logEffectiveOriginPolicy } from "./config/security-config.js";
 import { createGlobalAdminServer } from "./global-admin-app.js";
 
 const {
@@ -15,6 +16,7 @@ const {
 } = await loadRuntimeConfig();
 
 assertMetricsPortDoesNotCollide(metricsPort, port, "GLOBAL_ADMIN_PORT");
+logEffectiveOriginPolicy(securityConfig);
 
 const { httpServer, metricsHttpServer } = await createGlobalAdminServer(
   securityConfig,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,6 +3,7 @@ import {
   assertMetricsPortDoesNotCollide,
   loadRuntimeConfig,
 } from "./config/runtime-config.js";
+import { logEffectiveOriginPolicy } from "./config/security-config.js";
 
 const {
   port,
@@ -15,6 +16,7 @@ const {
 } = await loadRuntimeConfig();
 
 assertMetricsPortDoesNotCollide(metricsPort, port, "PORT");
+logEffectiveOriginPolicy(securityConfig);
 
 const { httpServer, metricsHttpServer } = await createSyncServer(
   securityConfig,

--- a/server/test/config-env.test.ts
+++ b/server/test/config-env.test.ts
@@ -142,6 +142,58 @@ test("security config accepts chrome-extension origins", () => {
   ]);
 });
 
+test("security config rejects origins that include a path", () => {
+  assert.throws(
+    () => loadSecurityConfig({ ALLOWED_ORIGINS: "https://a.example/app" }),
+    /must be a bare origin/,
+  );
+});
+
+test("security config rejects origins with a trailing slash", () => {
+  assert.throws(
+    () => loadSecurityConfig({ ALLOWED_ORIGINS: "https://a.example/" }),
+    /must be a bare origin/,
+  );
+});
+
+test("security config rejects origins with a query string or fragment", () => {
+  assert.throws(
+    () => loadSecurityConfig({ ALLOWED_ORIGINS: "https://a.example?x=1" }),
+    /must be a bare origin/,
+  );
+  assert.throws(
+    () => loadSecurityConfig({ ALLOWED_ORIGINS: "https://a.example#frag" }),
+    /must be a bare origin/,
+  );
+});
+
+test("security config rejects origins with userinfo", () => {
+  assert.throws(
+    () =>
+      loadSecurityConfig({
+        ALLOWED_ORIGINS: "https://user:pass@a.example",
+      }),
+    /must be a bare origin/,
+  );
+});
+
+test("security config rejects chrome-extension origins with a path", () => {
+  assert.throws(
+    () =>
+      loadSecurityConfig({
+        ALLOWED_ORIGINS: "chrome-extension://abcdef/popup.html",
+      }),
+    /must be a bare origin/,
+  );
+});
+
+test("security config rejects origins with a mixed-case host", () => {
+  assert.throws(
+    () => loadSecurityConfig({ ALLOWED_ORIGINS: "https://A.Example" }),
+    /must be a bare origin/,
+  );
+});
+
 test("startup policy rejects empty origins outside of dev override", () => {
   const config = loadSecurityConfig({});
   assert.deepEqual(config.allowedOrigins, []);

--- a/server/test/config-env.test.ts
+++ b/server/test/config-env.test.ts
@@ -6,7 +6,11 @@ import {
 } from "../src/config/admin-config.js";
 import { parseBooleanEnv, parseIntegerEnv } from "../src/config/env.js";
 import { loadPersistenceConfig } from "../src/config/persistence-config.js";
-import { loadSecurityConfig } from "../src/config/security-config.js";
+import {
+  assertAllowedOriginsStartupPolicy,
+  logEffectiveOriginPolicy,
+  loadSecurityConfig,
+} from "../src/config/security-config.js";
 
 test("security config reads overrides and keeps defaults for missing values", () => {
   const config = loadSecurityConfig({
@@ -106,4 +110,76 @@ test("env helpers keep integer and boolean validation semantics", () => {
     () => parseIntegerEnv({ PORT: "87.5" }, "PORT", 8787),
     /must be an integer/,
   );
+});
+
+test("security config rejects origins without a scheme", () => {
+  assert.throws(
+    () => loadSecurityConfig({ ALLOWED_ORIGINS: "bilibili.com" }),
+    /not a valid absolute URL/,
+  );
+});
+
+test("security config rejects origins with unsupported schemes", () => {
+  assert.throws(
+    () => loadSecurityConfig({ ALLOWED_ORIGINS: "ftp://bilibili.com" }),
+    /unsupported scheme "ftp"/,
+  );
+});
+
+test("security config rejects wildcard origins", () => {
+  assert.throws(
+    () => loadSecurityConfig({ ALLOWED_ORIGINS: "https://*.bilibili.com" }),
+    /wildcard, which is not supported/,
+  );
+});
+
+test("security config accepts chrome-extension origins", () => {
+  const config = loadSecurityConfig({
+    ALLOWED_ORIGINS: "chrome-extension://abcdefghijklmnop",
+  });
+  assert.deepEqual(config.allowedOrigins, [
+    "chrome-extension://abcdefghijklmnop",
+  ]);
+});
+
+test("startup policy rejects empty origins outside of dev override", () => {
+  const config = loadSecurityConfig({});
+  assert.deepEqual(config.allowedOrigins, []);
+  assert.equal(config.allowMissingOriginInDev, false);
+  assert.throws(
+    () => assertAllowedOriginsStartupPolicy(config),
+    /ALLOWED_ORIGINS is empty/,
+  );
+});
+
+test("startup policy allows empty origins when dev override is enabled", () => {
+  const config = loadSecurityConfig({ ALLOW_MISSING_ORIGIN_IN_DEV: "true" });
+  assert.doesNotThrow(() => assertAllowedOriginsStartupPolicy(config));
+});
+
+test("logEffectiveOriginPolicy prints final origins and dev override once", () => {
+  const entries: string[] = [];
+  const log = (message: string): void => {
+    entries.push(message);
+  };
+
+  logEffectiveOriginPolicy(
+    {
+      allowedOrigins: ["https://a.example", "https://b.example"],
+      allowMissingOriginInDev: false,
+    } as ReturnType<typeof loadSecurityConfig>,
+    log,
+  );
+  logEffectiveOriginPolicy(
+    {
+      allowedOrigins: [],
+      allowMissingOriginInDev: true,
+    } as ReturnType<typeof loadSecurityConfig>,
+    log,
+  );
+
+  assert.deepEqual(entries, [
+    "[security] ALLOWED_ORIGINS=https://a.example, https://b.example; ALLOW_MISSING_ORIGIN_IN_DEV=false",
+    "[security] ALLOWED_ORIGINS=<none>; ALLOW_MISSING_ORIGIN_IN_DEV=true",
+  ]);
 });

--- a/server/test/runtime-config.test.ts
+++ b/server/test/runtime-config.test.ts
@@ -70,6 +70,7 @@ test("runtime config falls back to defaults and env when config file is missing"
       {
         PORT: "9001",
         GLOBAL_ADMIN_ENABLED: "false",
+        ALLOW_MISSING_ORIGIN_IN_DEV: "true",
       },
       { cwd: tempDir },
     );
@@ -87,7 +88,7 @@ test("runtime config falls back to defaults and env when config file is missing"
 test("runtime config loads METRICS_PORT from env and config file", async () => {
   await withTempDir(async (tempDir) => {
     const envConfig = await loadRuntimeConfig(
-      { METRICS_PORT: "9200" },
+      { METRICS_PORT: "9200", ALLOW_MISSING_ORIGIN_IN_DEV: "true" },
       { cwd: tempDir },
     );
     assert.equal(envConfig.metricsPort, 9200);
@@ -97,11 +98,14 @@ test("runtime config loads METRICS_PORT from env and config file", async () => {
       JSON.stringify({ metricsPort: 9300 }),
       "utf8",
     );
-    const fileConfig = await loadRuntimeConfig({}, { cwd: tempDir });
+    const fileConfig = await loadRuntimeConfig(
+      { ALLOW_MISSING_ORIGIN_IN_DEV: "true" },
+      { cwd: tempDir },
+    );
     assert.equal(fileConfig.metricsPort, 9300);
 
     const envOverride = await loadRuntimeConfig(
-      { METRICS_PORT: "9400" },
+      { METRICS_PORT: "9400", ALLOW_MISSING_ORIGIN_IN_DEV: "true" },
       { cwd: tempDir },
     );
     assert.equal(envOverride.metricsPort, 9400);
@@ -111,7 +115,7 @@ test("runtime config loads METRICS_PORT from env and config file", async () => {
 test("runtime config keeps metricsPort undefined when METRICS_PORT is blank", async () => {
   await withTempDir(async (tempDir) => {
     const config = await loadRuntimeConfig(
-      { METRICS_PORT: "   " },
+      { METRICS_PORT: "   ", ALLOW_MISSING_ORIGIN_IN_DEV: "true" },
       { cwd: tempDir },
     );
     assert.equal(config.metricsPort, undefined);
@@ -233,6 +237,7 @@ test("environment variables override config file values", async () => {
         ROOM_STORE_PROVIDER: "redis",
         REDIS_NAMESPACE: "env-ns",
         INSTANCE_ID: "room-node-b",
+        ALLOW_MISSING_ORIGIN_IN_DEV: "true",
       },
       { cwd: tempDir },
     );
@@ -263,6 +268,7 @@ test("runtime config ignores file values for sensitive admin secrets", async () 
         ADMIN_USERNAME: "admin",
         ADMIN_PASSWORD_HASH: "hash",
         ADMIN_SESSION_SECRET: "secret",
+        ALLOW_MISSING_ORIGIN_IN_DEV: "true",
       },
       { cwd: tempDir },
     );
@@ -341,11 +347,14 @@ test("redisNamespace is loaded from config file and passable through env overrid
       "utf8",
     );
 
-    const configFromFile = await loadRuntimeConfig({}, { cwd: tempDir });
+    const configFromFile = await loadRuntimeConfig(
+      { ALLOW_MISSING_ORIGIN_IN_DEV: "true" },
+      { cwd: tempDir },
+    );
     assert.equal(configFromFile.persistenceConfig.redisNamespace, "from-file");
 
     const configFromEnv = await loadRuntimeConfig(
-      { REDIS_NAMESPACE: "from-env" },
+      { REDIS_NAMESPACE: "from-env", ALLOW_MISSING_ORIGIN_IN_DEV: "true" },
       { cwd: tempDir },
     );
     assert.equal(configFromEnv.persistenceConfig.redisNamespace, "from-env");
@@ -355,7 +364,7 @@ test("redisNamespace is loaded from config file and passable through env overrid
 test("runtime config loads logLevel from env and config file", async () => {
   await withTempDir(async (tempDir) => {
     const envConfig = await loadRuntimeConfig(
-      { LOG_LEVEL: "warn" },
+      { LOG_LEVEL: "warn", ALLOW_MISSING_ORIGIN_IN_DEV: "true" },
       { cwd: tempDir },
     );
     assert.equal(envConfig.logLevel, "warn");
@@ -365,11 +374,14 @@ test("runtime config loads logLevel from env and config file", async () => {
       JSON.stringify({ logLevel: "debug" }),
       "utf8",
     );
-    const fileConfig = await loadRuntimeConfig({}, { cwd: tempDir });
+    const fileConfig = await loadRuntimeConfig(
+      { ALLOW_MISSING_ORIGIN_IN_DEV: "true" },
+      { cwd: tempDir },
+    );
     assert.equal(fileConfig.logLevel, "debug");
 
     const envOverride = await loadRuntimeConfig(
-      { LOG_LEVEL: "error" },
+      { LOG_LEVEL: "error", ALLOW_MISSING_ORIGIN_IN_DEV: "true" },
       { cwd: tempDir },
     );
     assert.equal(envOverride.logLevel, "error");
@@ -381,6 +393,41 @@ test("runtime config rejects invalid LOG_LEVEL values", async () => {
     await assert.rejects(
       () => loadRuntimeConfig({ LOG_LEVEL: "verbose" }, { cwd: tempDir }),
       /LOG_LEVEL/,
+    );
+  });
+});
+
+test("runtime config rejects empty ALLOWED_ORIGINS without dev override", async () => {
+  await withTempDir(async (tempDir) => {
+    await assert.rejects(
+      () => loadRuntimeConfig({}, { cwd: tempDir }),
+      /ALLOWED_ORIGINS is empty/,
+    );
+  });
+});
+
+test("runtime config rejects ALLOWED_ORIGINS entries with invalid URLs", async () => {
+  await withTempDir(async (tempDir) => {
+    await assert.rejects(
+      () =>
+        loadRuntimeConfig(
+          { ALLOWED_ORIGINS: "bilibili.com" },
+          { cwd: tempDir },
+        ),
+      /not a valid absolute URL/,
+    );
+  });
+});
+
+test("runtime config rejects ALLOWED_ORIGINS entries with unsupported schemes", async () => {
+  await withTempDir(async (tempDir) => {
+    await assert.rejects(
+      () =>
+        loadRuntimeConfig(
+          { ALLOWED_ORIGINS: "ws://bilibili.com" },
+          { cwd: tempDir },
+        ),
+      /unsupported scheme "ws"/,
     );
   });
 });
@@ -399,6 +446,7 @@ test("runtime config resolves explicit config file path from env", async () => {
     const config = await loadRuntimeConfig(
       {
         BILI_SYNCPLAY_CONFIG: "custom-config.json",
+        ALLOW_MISSING_ORIGIN_IN_DEV: "true",
       },
       { cwd: tempDir },
     );


### PR DESCRIPTION
## Summary
- 在 `loadSecurityConfig` 阶段校验每个 origin：URL 可解析、scheme 只允许 `http`/`https`/`chrome-extension`、不接受 `*` 通配符。
- `loadRuntimeConfig` 在 return 前通过 `assertAllowedOriginsStartupPolicy` 强制要求：`ALLOWED_ORIGINS` 为空时必须显式设置 `ALLOW_MISSING_ORIGIN_IN_DEV=true`，否则启动直接失败并给出可读错误。
- 启动脚本 (`index.ts` / `global-admin-index.ts`) 通过 `logEffectiveOriginPolicy` 打印一次最终生效的 origin 列表与 dev 覆盖状态。
- 扩展 `config-env.test.ts` 与 `runtime-config.test.ts` 覆盖：缺 scheme、非 `http(s)/chrome-extension` 的 scheme、通配符、空 + 非 dev 拒绝、dev 放行、以及 `logEffectiveOriginPolicy` 日志格式。原本依赖空 origins 静默放过的测试补齐 `ALLOW_MISSING_ORIGIN_IN_DEV=true`。

Fixes #70

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`