### PR TITLE
feat(protocol): introduce protocolVersion in handshake phase (#72)

### DIFF
--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -208,7 +208,7 @@ export function createRoomSessionController(args: {
         ) {
           await clearCurrentRoomContext(
             `server rejected stored room context: ${message.payload.code}`,
-            message.payload.message,
+            args.connectionState.lastError,
           );
           args.logServerError(message.payload.code, message.payload.message);
           return;

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -3,6 +3,7 @@ import type {
   ServerMessage,
   ClientMessage,
 } from "@bili-syncplay/protocol";
+import { PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import type { BackgroundToContentMessage } from "../shared/messages";
 import {
   decideIncomingRoomState,
@@ -99,6 +100,7 @@ export function createRoomSessionController(args: {
           ? { memberToken: args.roomSessionState.memberToken }
           : {}),
         displayName: args.roomSessionState.displayName ?? undefined,
+        protocolVersion: PROTOCOL_VERSION,
       },
     });
   }
@@ -179,7 +181,8 @@ export function createRoomSessionController(args: {
           args.roomSessionState.pendingJoinRoomCode &&
           (message.payload.code === "room_not_found" ||
             message.payload.code === "join_token_invalid" ||
-            message.payload.code === "invalid_message")
+            message.payload.code === "invalid_message" ||
+            message.payload.code === "unsupported_protocol_version")
         ) {
           args.log(
             "background",
@@ -200,7 +203,8 @@ export function createRoomSessionController(args: {
           args.roomSessionState.roomCode &&
           !args.roomSessionState.pendingJoinRoomCode &&
           (message.payload.code === "room_not_found" ||
-            message.payload.code === "join_token_invalid")
+            message.payload.code === "join_token_invalid" ||
+            message.payload.code === "unsupported_protocol_version")
         ) {
           await clearCurrentRoomContext(
             `server rejected stored room context: ${message.payload.code}`,
@@ -351,6 +355,7 @@ export function createRoomSessionController(args: {
         type: "room:create",
         payload: {
           displayName: args.roomSessionState.displayName ?? undefined,
+          protocolVersion: PROTOCOL_VERSION,
         },
       });
       return;

--- a/extension/src/background/share-controller.ts
+++ b/extension/src/background/share-controller.ts
@@ -1,6 +1,7 @@
 import {
   parseBilibiliVideoRef,
   type PlaybackState,
+  PROTOCOL_VERSION,
   type SharedVideo,
 } from "@bili-syncplay/protocol";
 import { t } from "../shared/i18n";
@@ -47,6 +48,7 @@ export function createShareController(args: {
           video?: SharedVideo;
           playback?: PlaybackState;
           displayName?: string;
+          protocolVersion?: number;
         }
       | undefined;
   }) => void;
@@ -179,6 +181,7 @@ export function createShareController(args: {
         type: "room:create",
         payload: {
           displayName: args.roomSessionState.displayName ?? undefined,
+          protocolVersion: PROTOCOL_VERSION,
         },
       });
     } else {

--- a/extension/src/background/socket-controller.ts
+++ b/extension/src/background/socket-controller.ts
@@ -1,5 +1,5 @@
 import type { ClientMessage, ServerMessage } from "@bili-syncplay/protocol";
-import { isServerMessage } from "@bili-syncplay/protocol";
+import { isServerMessage, PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import type { DebugLogEntry } from "../shared/messages";
 import type { ConnectionState, RoomSessionState } from "./runtime-state";
 import { getConnectionErrorMessage } from "./connection-error";
@@ -179,6 +179,7 @@ export function createSocketController(args: {
           type: "room:create",
           payload: {
             displayName: args.roomSessionState.displayName ?? undefined,
+            protocolVersion: PROTOCOL_VERSION,
           },
         });
       } else if (

--- a/extension/src/shared/i18n.ts
+++ b/extension/src/shared/i18n.ts
@@ -75,6 +75,8 @@ const MESSAGES: Record<"zh" | "en", MessageCatalog> = {
     serverErrorRoomFull: "房间已满。",
     serverErrorInvalidMessage: "当前请求无效。",
     serverErrorInternal: "服务器内部错误。",
+    serverErrorUnsupportedProtocolVersion:
+      "扩展版本过低，请升级 Bili-SyncPlay 到最新版本。",
     toastMemberJoined: "{name} 加入了房间",
     toastMemberLeft: "{name} 离开了房间",
     toastStartedPlaying: "{name} 开始播放",
@@ -158,6 +160,8 @@ const MESSAGES: Record<"zh" | "en", MessageCatalog> = {
     serverErrorRoomFull: "Room is full.",
     serverErrorInvalidMessage: "The request was rejected as invalid.",
     serverErrorInternal: "Internal server error.",
+    serverErrorUnsupportedProtocolVersion:
+      "Your extension version is too old. Please update Bili-SyncPlay to the latest version.",
     toastMemberJoined: "{name} joined the room",
     toastMemberLeft: "{name} left the room",
     toastStartedPlaying: "{name} started playback",
@@ -234,6 +238,8 @@ export function localizeServerError(
       return t("serverErrorRoomFull");
     case "invalid_message":
       return t("serverErrorInvalidMessage");
+    case "unsupported_protocol_version":
+      return t("serverErrorUnsupportedProtocolVersion");
     case "internal_error":
       return t("serverErrorInternal");
     default:

--- a/extension/test/background-share-controller.test.ts
+++ b/extension/test/background-share-controller.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import { createBackgroundRuntimeState } from "../src/background/runtime-state";
 import { createShareController } from "../src/background/share-controller";
 
@@ -100,6 +101,40 @@ test("background share controller forwards a share without playback when content
       },
     ]);
     assert.equal(harness.notifyAllCalls, 0);
+  } finally {
+    selfHarness.restore();
+  }
+});
+
+test("background share controller sends create request with protocolVersion when sharing outside a room", async () => {
+  const selfHarness = installSelfStub();
+  const harness = createControllerHarness();
+  harness.runtimeState.connection.connected = true;
+  harness.runtimeState.room.displayName = "Alice";
+
+  try {
+    await harness.controller.queueOrSendSharedVideo(
+      {
+        video: {
+          videoId: "BV199W9zEEcH",
+          url: "https://www.bilibili.com/video/BV199W9zEEcH",
+          title: "New Video",
+        },
+        playback: null,
+      },
+      123,
+    );
+
+    assert.deepEqual(harness.sendToServerCalls, [
+      {
+        type: "room:create",
+        payload: {
+          displayName: "Alice",
+          protocolVersion: PROTOCOL_VERSION,
+        },
+      },
+    ]);
+    assert.equal(harness.runtimeState.room.pendingCreateRoom, false);
   } finally {
     selfHarness.restore();
   }

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -95,6 +95,68 @@ function createControllerHarness() {
   };
 }
 
+test("room session controller sends create request with protocolVersion", async () => {
+  const harness = createControllerHarness();
+  harness.runtimeState.room.displayName = "Bob";
+
+  await harness.controller.requestCreateRoom();
+
+  assert.equal(harness.connectCalls, 1);
+  assert.equal(harness.runtimeState.room.pendingCreateRoom, false);
+  assert.equal(harness.sendToServerCalls.length, 1);
+  assert.deepEqual(harness.sendToServerCalls[0], {
+    type: "room:create",
+    payload: {
+      displayName: "Bob",
+      protocolVersion: 1,
+    },
+  });
+});
+
+test("room session controller clears pending join on unsupported_protocol_version error", async () => {
+  const harness = createControllerHarness();
+  harness.runtimeState.room.pendingJoinRoomCode = "ROOM-PV";
+  harness.runtimeState.room.pendingJoinToken = "join-token-pv";
+  harness.runtimeState.room.pendingJoinRequestSent = true;
+
+  const resultPromise = harness.controller.waitForJoinAttemptResult(50);
+  await harness.controller.handleServerMessage({
+    type: "error",
+    payload: {
+      code: "unsupported_protocol_version",
+      message: "Your extension version is too old.",
+    },
+  } satisfies ServerMessage);
+
+  assert.equal(await resultPromise, "failed");
+  assert.equal(harness.runtimeState.room.pendingJoinRoomCode, null);
+  assert.equal(harness.runtimeState.room.pendingJoinToken, null);
+  assert.equal(harness.runtimeState.room.pendingJoinRequestSent, false);
+  assert.equal(harness.runtimeState.room.roomCode, null);
+});
+
+test("room session controller clears stored room on unsupported_protocol_version error", async () => {
+  const harness = createControllerHarness();
+  harness.runtimeState.room.roomCode = "ROOM-ST";
+  harness.runtimeState.room.joinToken = "join-token-st";
+  harness.runtimeState.room.memberToken = "member-token-st";
+  harness.runtimeState.room.memberId = "member-st";
+
+  await harness.controller.handleServerMessage({
+    type: "error",
+    payload: {
+      code: "unsupported_protocol_version",
+      message: "Your extension version is too old.",
+    },
+  } satisfies ServerMessage);
+
+  assert.equal(harness.runtimeState.room.roomCode, null);
+  assert.equal(harness.runtimeState.room.joinToken, null);
+  assert.equal(harness.runtimeState.room.memberToken, null);
+  assert.equal(harness.runtimeState.room.memberId, null);
+  assert.equal(harness.runtimeState.room.roomState, null);
+});
+
 test("room session controller sends join request after connect and normalizes pending room data", async () => {
   const harness = createControllerHarness();
   harness.runtimeState.room.displayName = "Alice";
@@ -113,6 +175,7 @@ test("room session controller sends join request after connect and normalizes pe
       roomCode: "ROOM01",
       joinToken: "token-1",
       displayName: "Alice",
+      protocolVersion: 1,
     },
   });
   assert.equal(harness.persistReasons.length, 1);

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import type { RoomState, ServerMessage } from "@bili-syncplay/protocol";
 import { createBackgroundRuntimeState } from "../src/background/runtime-state";
 import { createRoomSessionController } from "../src/background/room-session-controller";
+import { setLocaleForTests } from "../src/shared/i18n";
 
 function createControllerHarness() {
   const runtimeState = createBackgroundRuntimeState();
@@ -141,20 +142,29 @@ test("room session controller clears stored room on unsupported_protocol_version
   harness.runtimeState.room.joinToken = "join-token-st";
   harness.runtimeState.room.memberToken = "member-token-st";
   harness.runtimeState.room.memberId = "member-st";
+  setLocaleForTests("en-US");
 
-  await harness.controller.handleServerMessage({
-    type: "error",
-    payload: {
-      code: "unsupported_protocol_version",
-      message: "Your extension version is too old.",
-    },
-  } satisfies ServerMessage);
+  try {
+    await harness.controller.handleServerMessage({
+      type: "error",
+      payload: {
+        code: "unsupported_protocol_version",
+        message: "Your extension version is too old.",
+      },
+    } satisfies ServerMessage);
+  } finally {
+    setLocaleForTests(null);
+  }
 
   assert.equal(harness.runtimeState.room.roomCode, null);
   assert.equal(harness.runtimeState.room.joinToken, null);
   assert.equal(harness.runtimeState.room.memberToken, null);
   assert.equal(harness.runtimeState.room.memberId, null);
   assert.equal(harness.runtimeState.room.roomState, null);
+  assert.equal(
+    harness.runtimeState.connection.lastError,
+    "Your extension version is too old. Please update Bili-SyncPlay to the latest version.",
+  );
 });
 
 test("room session controller sends join request after connect and normalizes pending room data", async () => {

--- a/packages/protocol/src/guards/client-message.ts
+++ b/packages/protocol/src/guards/client-message.ts
@@ -16,7 +16,7 @@ import {
   isActorId,
   isBilibiliUrl,
   isFiniteNumber,
-  isOptionalPositiveInteger,
+  isOptionalNonNegativeInteger,
   isPlaybackPlayState,
   isRecord,
   isRoomCode,
@@ -46,7 +46,7 @@ export function isClientHelloPayload(
   return (
     isRecord(value) &&
     isOptionalBoundedString(value.displayName, DISPLAY_NAME_MAX_LENGTH) &&
-    isOptionalPositiveInteger(value.protocolVersion)
+    isOptionalNonNegativeInteger(value.protocolVersion)
   );
 }
 
@@ -96,7 +96,7 @@ function isJoinRoomPayload(
     isToken(value.joinToken) &&
     (value.memberToken === undefined || isToken(value.memberToken)) &&
     isOptionalBoundedString(value.displayName, DISPLAY_NAME_MAX_LENGTH) &&
-    isOptionalPositiveInteger(value.protocolVersion)
+    isOptionalNonNegativeInteger(value.protocolVersion)
   );
 }
 

--- a/packages/protocol/src/guards/client-message.ts
+++ b/packages/protocol/src/guards/client-message.ts
@@ -16,6 +16,7 @@ import {
   isActorId,
   isBilibiliUrl,
   isFiniteNumber,
+  isOptionalPositiveInteger,
   isPlaybackPlayState,
   isRecord,
   isRoomCode,
@@ -44,7 +45,8 @@ export function isClientHelloPayload(
 ): value is ClientHelloPayload {
   return (
     isRecord(value) &&
-    isOptionalBoundedString(value.displayName, DISPLAY_NAME_MAX_LENGTH)
+    isOptionalBoundedString(value.displayName, DISPLAY_NAME_MAX_LENGTH) &&
+    isOptionalPositiveInteger(value.protocolVersion)
   );
 }
 
@@ -93,7 +95,8 @@ function isJoinRoomPayload(
     isRoomCode(value.roomCode) &&
     isToken(value.joinToken) &&
     (value.memberToken === undefined || isToken(value.memberToken)) &&
-    isOptionalBoundedString(value.displayName, DISPLAY_NAME_MAX_LENGTH)
+    isOptionalBoundedString(value.displayName, DISPLAY_NAME_MAX_LENGTH) &&
+    isOptionalPositiveInteger(value.protocolVersion)
   );
 }
 

--- a/packages/protocol/src/guards/primitives.ts
+++ b/packages/protocol/src/guards/primitives.ts
@@ -37,6 +37,22 @@ export function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
+export function isOptionalFiniteNumber(
+  value: unknown,
+): value is number | undefined {
+  return value === undefined || isFiniteNumber(value);
+}
+
+export function isPositiveInteger(value: unknown): value is number {
+  return isFiniteNumber(value) && value >= 1 && Number.isInteger(value);
+}
+
+export function isOptionalPositiveInteger(
+  value: unknown,
+): value is number | undefined {
+  return value === undefined || isPositiveInteger(value);
+}
+
 export function isRoomCode(value: unknown): value is RoomCode {
   return isString(value) && ROOM_CODE_PATTERN.test(value);
 }

--- a/packages/protocol/src/guards/primitives.ts
+++ b/packages/protocol/src/guards/primitives.ts
@@ -47,10 +47,20 @@ export function isPositiveInteger(value: unknown): value is number {
   return isFiniteNumber(value) && value >= 1 && Number.isInteger(value);
 }
 
+export function isNonNegativeInteger(value: unknown): value is number {
+  return isFiniteNumber(value) && value >= 0 && Number.isInteger(value);
+}
+
 export function isOptionalPositiveInteger(
   value: unknown,
 ): value is number | undefined {
   return value === undefined || isPositiveInteger(value);
+}
+
+export function isOptionalNonNegativeInteger(
+  value: unknown,
+): value is number | undefined {
+  return value === undefined || isNonNegativeInteger(value);
 }
 
 export function isRoomCode(value: unknown): value is RoomCode {

--- a/packages/protocol/src/guards/server-message.ts
+++ b/packages/protocol/src/guards/server-message.ts
@@ -18,6 +18,7 @@ import {
   isBilibiliUrl,
   isFiniteNumber,
   isOptionalString,
+  isOptionalPositiveInteger,
   isPlaybackPlayState,
   isRecord,
   isRoomCode,
@@ -90,7 +91,8 @@ function isRoomCreatedMessage(value: unknown): value is RoomCreatedMessage {
     isRoomCode(value.payload.roomCode) &&
     isActorId(value.payload.memberId) &&
     isToken(value.payload.joinToken) &&
-    isToken(value.payload.memberToken)
+    isToken(value.payload.memberToken) &&
+    isOptionalPositiveInteger(value.payload.serverProtocolVersion)
   );
 }
 
@@ -101,7 +103,8 @@ function isRoomJoinedMessage(value: unknown): value is RoomJoinedMessage {
     isRecord(value.payload) &&
     isRoomCode(value.payload.roomCode) &&
     isActorId(value.payload.memberId) &&
-    isToken(value.payload.memberToken)
+    isToken(value.payload.memberToken) &&
+    isOptionalPositiveInteger(value.payload.serverProtocolVersion)
   );
 }
 

--- a/packages/protocol/src/types/client-message.ts
+++ b/packages/protocol/src/types/client-message.ts
@@ -3,6 +3,7 @@ import type { PlaybackState, SharedVideo } from "./domain.js";
 
 export interface ClientHelloPayload {
   displayName?: string;
+  protocolVersion?: number;
 }
 
 export interface CreateRoomMessage {
@@ -17,6 +18,7 @@ export interface JoinRoomMessage {
     joinToken: string;
     memberToken?: string;
     displayName?: string;
+    protocolVersion?: number;
   };
 }
 

--- a/packages/protocol/src/types/common.ts
+++ b/packages/protocol/src/types/common.ts
@@ -1,3 +1,5 @@
+export const PROTOCOL_VERSION = 1;
+
 export type RoomCode = string;
 export type PlaybackPlayState = "playing" | "paused" | "buffering";
 export type ErrorCode =
@@ -10,4 +12,5 @@ export type ErrorCode =
   | "invalid_message"
   | "payload_too_large"
   | "room_full"
+  | "unsupported_protocol_version"
   | "internal_error";

--- a/packages/protocol/src/types/server-message.ts
+++ b/packages/protocol/src/types/server-message.ts
@@ -8,6 +8,7 @@ export interface RoomCreatedMessage {
     memberId: string;
     joinToken: string;
     memberToken: string;
+    serverProtocolVersion?: number;
   };
 }
 
@@ -17,6 +18,7 @@ export interface RoomJoinedMessage {
     roomCode: RoomCode;
     memberId: string;
     memberToken: string;
+    serverProtocolVersion?: number;
   };
 }
 

--- a/packages/protocol/test/client-message.test.ts
+++ b/packages/protocol/test/client-message.test.ts
@@ -589,3 +589,72 @@ test("accepts a valid room:join message", () => {
     true,
   );
 });
+
+test("accepts room:create with protocolVersion", () => {
+  assert.equal(
+    isClientMessage({
+      type: "room:create",
+      payload: {
+        displayName: "Alice",
+        protocolVersion: 1,
+      },
+    }),
+    true,
+  );
+});
+
+test("accepts room:join with protocolVersion", () => {
+  assert.equal(
+    isClientMessage({
+      type: "room:join",
+      payload: {
+        roomCode: "ABC123",
+        joinToken: VALID_TOKEN,
+        displayName: "Alice",
+        protocolVersion: 1,
+      },
+    }),
+    true,
+  );
+});
+
+test("rejects room:create when protocolVersion is not a positive integer", () => {
+  assert.equal(
+    isClientMessage({
+      type: "room:create",
+      payload: {
+        displayName: "Alice",
+        protocolVersion: 0,
+      },
+    }),
+    false,
+  );
+});
+
+test("rejects room:join when protocolVersion is negative", () => {
+  assert.equal(
+    isClientMessage({
+      type: "room:join",
+      payload: {
+        roomCode: "ABC123",
+        joinToken: VALID_TOKEN,
+        protocolVersion: -1,
+      },
+    }),
+    false,
+  );
+});
+
+test("rejects room:join when protocolVersion is a float", () => {
+  assert.equal(
+    isClientMessage({
+      type: "room:join",
+      payload: {
+        roomCode: "ABC123",
+        joinToken: VALID_TOKEN,
+        protocolVersion: 1.5,
+      },
+    }),
+    false,
+  );
+});

--- a/packages/protocol/test/client-message.test.ts
+++ b/packages/protocol/test/client-message.test.ts
@@ -618,7 +618,7 @@ test("accepts room:join with protocolVersion", () => {
   );
 });
 
-test("rejects room:create when protocolVersion is not a positive integer", () => {
+test("accepts room:create with protocolVersion below the server minimum", () => {
   assert.equal(
     isClientMessage({
       type: "room:create",
@@ -627,7 +627,7 @@ test("rejects room:create when protocolVersion is not a positive integer", () =>
         protocolVersion: 0,
       },
     }),
-    false,
+    true,
   );
 });
 

--- a/packages/protocol/test/server-message.test.ts
+++ b/packages/protocol/test/server-message.test.ts
@@ -272,3 +272,65 @@ test("accepts a valid sync:pong message", () => {
     true,
   );
 });
+
+test("accepts room:created with serverProtocolVersion", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:created",
+      payload: {
+        roomCode: "ABC123",
+        memberId: "member-1",
+        joinToken: VALID_TOKEN,
+        memberToken: VALID_TOKEN,
+        serverProtocolVersion: 1,
+      },
+    }),
+    true,
+  );
+});
+
+test("accepts room:joined with serverProtocolVersion", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:joined",
+      payload: {
+        roomCode: "ABC123",
+        memberId: "member-1",
+        memberToken: VALID_TOKEN,
+        serverProtocolVersion: 1,
+      },
+    }),
+    true,
+  );
+});
+
+test("rejects room:created when serverProtocolVersion is not a positive integer", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:created",
+      payload: {
+        roomCode: "ABC123",
+        memberId: "member-1",
+        joinToken: VALID_TOKEN,
+        memberToken: VALID_TOKEN,
+        serverProtocolVersion: 0,
+      },
+    }),
+    false,
+  );
+});
+
+test("rejects room:joined when serverProtocolVersion is negative", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:joined",
+      payload: {
+        roomCode: "ABC123",
+        memberId: "member-1",
+        memberToken: VALID_TOKEN,
+        serverProtocolVersion: -1,
+      },
+    }),
+    false,
+  );
+});

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -228,15 +228,6 @@ export function createMessageHandler(options: {
         case "room:create": {
           const previousRoomCode = session.roomCode;
           if (
-            !checkProtocolVersion(
-              session,
-              socket,
-              message.payload?.protocolVersion,
-            )
-          ) {
-            return;
-          }
-          if (
             !consumeFixedWindow(
               session.rateLimitState.roomCreate,
               config.rateLimits.roomCreatePerMinute,
@@ -246,6 +237,15 @@ export function createMessageHandler(options: {
           ) {
             handleRateLimitedMessage(session, message.type);
             sendError(socket, "rate_limited", RATE_LIMITED_MESSAGE);
+            return;
+          }
+          if (
+            !checkProtocolVersion(
+              session,
+              socket,
+              message.payload?.protocolVersion,
+            )
+          ) {
             return;
           }
 
@@ -280,15 +280,6 @@ export function createMessageHandler(options: {
         case "room:join": {
           const previousRoomCode = session.roomCode;
           if (
-            !checkProtocolVersion(
-              session,
-              socket,
-              message.payload.protocolVersion,
-            )
-          ) {
-            return;
-          }
-          if (
             !consumeFixedWindow(
               session.rateLimitState.roomJoin,
               config.rateLimits.roomJoinPerMinute,
@@ -298,6 +289,15 @@ export function createMessageHandler(options: {
           ) {
             handleRateLimitedMessage(session, message.type);
             sendError(socket, "rate_limited", RATE_LIMITED_MESSAGE);
+            return;
+          }
+          if (
+            !checkProtocolVersion(
+              session,
+              socket,
+              message.payload.protocolVersion,
+            )
+          ) {
             return;
           }
 

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -1,4 +1,5 @@
 import type { ClientMessage } from "@bili-syncplay/protocol";
+import type { WebSocket } from "ws";
 import { performance } from "node:perf_hooks";
 import type {
   MetricsCollector,
@@ -13,6 +14,9 @@ import {
 import {
   MEMBER_TOKEN_INVALID_MESSAGE,
   RATE_LIMITED_MESSAGE,
+  UNSUPPORTED_PROTOCOL_VERSION_MESSAGE,
+  MIN_PROTOCOL_VERSION,
+  CURRENT_PROTOCOL_VERSION,
 } from "./messages.js";
 import { RoomServiceError } from "./room-service.js";
 import type { RoomEventBusMessage } from "./room-event-bus.js";
@@ -172,6 +176,41 @@ export function createMessageHandler(options: {
     }
   }
 
+  function checkProtocolVersion(
+    session: Session,
+    socket: WebSocket,
+    clientVersion: number | undefined,
+  ): boolean {
+    if (clientVersion === undefined) {
+      // Old extension without protocolVersion — compatible baseline, log deprecation
+      logEvent("protocol_version_missing", {
+        sessionId: session.id,
+        remoteAddress: session.remoteAddress,
+        origin: session.origin,
+        result: "accepted",
+        reason: "legacy_client",
+      });
+      return true;
+    }
+    if (clientVersion < MIN_PROTOCOL_VERSION) {
+      sendError(
+        socket,
+        "unsupported_protocol_version",
+        UNSUPPORTED_PROTOCOL_VERSION_MESSAGE,
+      );
+      logEvent("protocol_version_rejected", {
+        sessionId: session.id,
+        remoteAddress: session.remoteAddress,
+        origin: session.origin,
+        result: "rejected",
+        clientVersion,
+        minVersion: MIN_PROTOCOL_VERSION,
+      });
+      return false;
+    }
+    return true;
+  }
+
   async function handleClientMessage(
     session: Session,
     message: ClientMessage,
@@ -188,6 +227,15 @@ export function createMessageHandler(options: {
       switch (message.type) {
         case "room:create": {
           const previousRoomCode = session.roomCode;
+          if (
+            !checkProtocolVersion(
+              session,
+              socket,
+              message.payload?.protocolVersion,
+            )
+          ) {
+            return;
+          }
           if (
             !consumeFixedWindow(
               session.rateLimitState.roomCreate,
@@ -216,6 +264,7 @@ export function createMessageHandler(options: {
               memberId: session.memberId ?? session.id,
               joinToken: room.joinToken,
               memberToken,
+              serverProtocolVersion: CURRENT_PROTOCOL_VERSION,
             },
           });
           await publishRoomEvent("room_member_changed", room.code);
@@ -230,6 +279,15 @@ export function createMessageHandler(options: {
         }
         case "room:join": {
           const previousRoomCode = session.roomCode;
+          if (
+            !checkProtocolVersion(
+              session,
+              socket,
+              message.payload.protocolVersion,
+            )
+          ) {
+            return;
+          }
           if (
             !consumeFixedWindow(
               session.rateLimitState.roomJoin,
@@ -261,6 +319,7 @@ export function createMessageHandler(options: {
                 roomCode: room.code,
                 memberId: session.memberId ?? session.id,
                 memberToken,
+                serverProtocolVersion: CURRENT_PROTOCOL_VERSION,
               },
             });
             await publishRoomEvent("room_member_changed", room.code);

--- a/server/src/messages.ts
+++ b/server/src/messages.ts
@@ -27,3 +27,11 @@ export const ROOM_ACTIVE_MESSAGE =
   "Room still has active members. Close the room instead of expiring it early.";
 export const MEMBER_NOT_FOUND_MESSAGE = "Member not found.";
 export const SESSION_NOT_FOUND_MESSAGE = "Session not found.";
+export const UNSUPPORTED_PROTOCOL_VERSION_MESSAGE =
+  "Your extension version is too old. Please update Bili-SyncPlay to the latest version.";
+
+/** Minimum protocol version this server accepts. */
+export const MIN_PROTOCOL_VERSION = 1;
+
+/** Current protocol version this server implements. */
+export const CURRENT_PROTOCOL_VERSION = 1;

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -418,3 +418,260 @@ test("message handler records monitored duration metrics for critical room paths
     "room:leave",
   ]);
 });
+
+test("message handler accepts room:create without protocolVersion (legacy client)", async () => {
+  const events: string[] = [];
+  const sent: Array<{ type: string; serverProtocolVersion?: number }> = [];
+  const session = createSession("legacy-creator");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession(currentSession, _displayName) {
+        currentSession.roomCode = "ROOM-L1";
+        currentSession.memberId = "member-l1";
+        currentSession.memberToken = "member-token-l1";
+        return {
+          room: { code: "ROOM-L1", joinToken: "join-token-l1" },
+          memberToken: "member-token-l1",
+        };
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent(event) {
+      events.push(event);
+    },
+    send(_socket, message) {
+      if (
+        "payload" in message &&
+        message.payload &&
+        "serverProtocolVersion" in message.payload
+      ) {
+        sent.push({
+          type: message.type,
+          serverProtocolVersion: (
+            message.payload as { serverProtocolVersion?: number }
+          ).serverProtocolVersion,
+        });
+      } else {
+        sent.push({ type: message.type });
+      }
+    },
+    sendError() {
+      throw new Error("sendError should not be called");
+    },
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:create",
+    payload: { displayName: "Alice" },
+  });
+
+  assert.ok(events.includes("protocol_version_missing"));
+  assert.ok(events.includes("room_created"));
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].type, "room:created");
+  assert.equal(sent[0].serverProtocolVersion, 1);
+});
+
+test("message handler rejects room:create with protocolVersion below minimum", async () => {
+  const events: string[] = [];
+  const errors: Array<{ code: string; message: string }> = [];
+  const session = createSession("old-creator");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent(event) {
+      events.push(event);
+    },
+    send() {
+      throw new Error("send should not be called");
+    },
+    sendError(_socket, code, message) {
+      errors.push({ code, message });
+    },
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:create",
+    payload: { displayName: "Alice", protocolVersion: 0 },
+  });
+
+  assert.ok(events.includes("protocol_version_rejected"));
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].code, "unsupported_protocol_version");
+});
+
+test("message handler rejects room:join with protocolVersion below minimum", async () => {
+  const events: string[] = [];
+  const errors: Array<{ code: string; message: string }> = [];
+  const session = createSession("old-joiner");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent(event) {
+      events.push(event);
+    },
+    send() {
+      throw new Error("send should not be called");
+    },
+    sendError(_socket, code, message) {
+      errors.push({ code, message });
+    },
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      protocolVersion: 0,
+    },
+  });
+
+  assert.ok(events.includes("protocol_version_rejected"));
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].code, "unsupported_protocol_version");
+});
+
+test("message handler accepts room:join with matching protocolVersion and returns serverProtocolVersion", async () => {
+  const sent: Array<{ type: string; serverProtocolVersion?: number }> = [];
+  const session = createSession("modern-joiner");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession(currentSession) {
+        currentSession.roomCode = "ROOM-M1";
+        currentSession.memberId = "member-m1";
+        currentSession.memberToken = "member-token-m1";
+        return {
+          room: { code: "ROOM-M1" },
+          memberToken: "member-token-m1",
+        };
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent() {},
+    send(_socket, message) {
+      if (
+        "payload" in message &&
+        message.payload &&
+        "serverProtocolVersion" in message.payload
+      ) {
+        sent.push({
+          type: message.type,
+          serverProtocolVersion: (
+            message.payload as { serverProtocolVersion?: number }
+          ).serverProtocolVersion,
+        });
+      } else {
+        sent.push({ type: message.type });
+      }
+    },
+    sendError() {
+      throw new Error("sendError should not be called");
+    },
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      protocolVersion: 1,
+    },
+  });
+
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].type, "room:joined");
+  assert.equal(sent[0].serverProtocolVersion, 1);
+});

--- a/server/test/message-validation.ts
+++ b/server/test/message-validation.ts
@@ -318,6 +318,66 @@ test("rejects invalid client message payloads before entering business logic", a
   }
 });
 
+test("rejects unsupported room:create protocolVersion through the websocket entrypoint", async () => {
+  const server = await startTestServer();
+  try {
+    const socket = await connectClient(server.url);
+    try {
+      socket.send(
+        JSON.stringify({
+          type: "room:create",
+          payload: { displayName: "Alice", protocolVersion: 0 },
+        }),
+      );
+      const response = await waitForJsonMessage(socket);
+      assert.equal(response.type, "error");
+      assert.equal(response.payload.code, "unsupported_protocol_version");
+    } finally {
+      await closeClient(socket);
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test("rejects unsupported room:join protocolVersion through the websocket entrypoint", async () => {
+  const server = await startTestServer();
+  try {
+    const owner = await connectClient(server.url);
+    const joiner = await connectClient(server.url);
+    try {
+      owner.send(
+        JSON.stringify({
+          type: "room:create",
+          payload: { displayName: "Alice" },
+        }),
+      );
+      const created = await waitForJsonMessage(owner);
+      assert.equal(created.type, "room:created");
+
+      joiner.send(
+        JSON.stringify({
+          type: "room:join",
+          payload: {
+            roomCode: created.payload.roomCode,
+            joinToken: created.payload.joinToken,
+            displayName: "Bob",
+            protocolVersion: 0,
+          },
+        }),
+      );
+      const response = await waitForJsonMessage(joiner);
+      assert.equal(response.type, "error");
+      assert.equal(response.payload.code, "unsupported_protocol_version");
+    } finally {
+      await closeClient(owner);
+      await closeClient(joiner);
+    }
+  } finally {
+    await server.close();
+  }
+});
+
 test("rejects non-whitelisted origins during the websocket handshake", async () => {
   const server = await startTestServer();
   try {


### PR DESCRIPTION
## Summary
- 在协议包添加 `PROTOCOL_VERSION` 常量和 `unsupported_protocol_version` 错误码
- `room:create` / `room:join` 消息新增可选 `protocolVersion` 字段
- `room:created` / `room:joined` 响应新增可选 `serverProtocolVersion` 字段
- 服务端在处理 `room:create` / `room:join` 时校验 `protocolVersion`，低于 `MIN_PROTOCOL_VERSION` 时拒绝
- 旧扩展（无 `protocolVersion`）按兼容 baseline 处理并产出废弃日志
- 扩展在发送 `room:create` / `room:join` 时携带 `PROTOCOL_VERSION`
- popup 可本地化的"请升级扩展"提示（中/英）
- Room session controller 在收到 `unsupported_protocol_version` 错误时清理房间上下文

Fixes #72

## Test plan
- [x] 协议守卫测试：`room:create` / `room:join` 带 `protocolVersion`；拒绝非法值（0、负数、浮点数）
- [x] 服务端消息处理测试：legacy 客户端接受；低版本拒绝；正确版本返回 `serverProtocolVersion`
- [x] 扩展端测试：join 请求携带 `protocolVersion`；create 请求携带 `protocolVersion`；`unsupported_protocol_version` 错误清理房间上下文
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` 全部通过