### PR TITLE
docs: clarify protocol change workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- Briefly describe the change. -->
+
+## Protocol Changes
+
+- [ ] This PR does not change protocol fields, protocol semantics, protocol guards, or protocol versions.
+- [ ] This PR changes the protocol and follows the checklist in `CONTRIBUTING.md`.
+
+When the second box is checked, include:
+
+- Change type: additive/backward compatible or breaking.
+- Version plan: `PROTOCOL_VERSION`, `CURRENT_PROTOCOL_VERSION`, and whether `MIN_PROTOCOL_VERSION` changes.
+- Compatibility window: how long old clients remain supported, or why they cannot be supported.
+- Test matrix updates: protocol guards, server version handling, extension message paths, and popup/user-facing upgrade prompts when applicable.
+
+## Test Plan
+
+- [ ] `npm run format:check`
+- [ ] `npm run lint`
+- [ ] `npm run typecheck`
+- [ ] `npm run build`
+- [ ] `npm test`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,35 @@ This repository uses a monorepo structure with shared protocol code, a browser e
 - Server environment parsing must remain centralized in the server config layer.
 - Preserve public import stability for `@bili-syncplay/protocol`; internal refactors should still export through the package root.
 
+## Protocol Changes
+
+Protocol changes are any changes to client/server wire messages, room state fields, playback state fields, shared video fields, error codes, protocol guards, or the meaning of an existing field. Treat removals, renames, type narrowing, required-field changes, and semantic changes as breaking even when TypeScript can compile locally.
+
+Keep protocol edits centered on these sources of truth:
+
+- `packages/protocol/src/types/common.ts` for the extension/client `PROTOCOL_VERSION`.
+- `server/src/messages.ts` for `CURRENT_PROTOCOL_VERSION` and `MIN_PROTOCOL_VERSION`.
+- `packages/protocol/src/types/` and `packages/protocol/src/guards/` for message/domain shapes and validation.
+- Extension popup/user-facing messages in `extension/src/shared/i18n.ts` when old clients can be rejected or users need upgrade guidance.
+
+Use this checklist for every PR that adds, removes, renames, retypes, or changes the semantics of a protocol field:
+
+- Classify the change as additive/backward compatible or breaking in the PR description.
+- Bump `PROTOCOL_VERSION` in `packages/protocol/src/types/common.ts` and `CURRENT_PROTOCOL_VERSION` in `server/src/messages.ts` for every wire-shape or semantic protocol change.
+- Decide whether `MIN_PROTOCOL_VERSION` must also be bumped. Leave it at the previous accepted version when the server can still safely handle old clients.
+- When `MIN_PROTOCOL_VERSION` changes, update the unsupported-version user prompt and any popup state that surfaces upgrade guidance.
+- Update protocol type-guard tests for both accepted and rejected payloads.
+- Update the server protocol-version test matrix for `room:create`, `room:join`, legacy clients without `protocolVersion`, and clients below the minimum supported version.
+- Update extension tests for every message path that sends `protocolVersion`.
+- Document the compatibility window and rollout order in the PR description.
+
+Compatibility policy:
+
+- Prefer additive changes that let the server accept the previous released protocol version while new clients roll out.
+- Keep `MIN_PROTOCOL_VERSION` lower than or equal to the previous released extension protocol version until old clients are intentionally retired.
+- Raise `MIN_PROTOCOL_VERSION` only in a follow-up PR or release step after documenting why old clients can no longer be supported.
+- Security, data-loss, or server-safety fixes may shorten the compatibility window, but the PR must state the reason and include the user-facing upgrade prompt update.
+
 ## Testing Focus
 
 Refactors that touch these areas should include regression coverage:


### PR DESCRIPTION
## Summary
- Add protocol-change guidance to CONTRIBUTING.md, including version bump and compatibility-window rules.
- Add a PR template section so protocol-impacting changes must document version plans, test matrix updates, and upgrade prompts.

Fixes #73

## Test Plan
- [x] npm run format:check
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run build
- [x] npm test