### PR TITLE
fix(popup): keep shared video owner visible after rejoin

### DIFF
--- a/extension/src/popup/popup-render.ts
+++ b/extension/src/popup/popup-render.ts
@@ -142,6 +142,7 @@ export function renderPopup(args: {
   const ownerText = formatVideoOwner(
     args.state.roomState?.members ?? [],
     args.state.roomState?.sharedVideo?.sharedByMemberId ?? null,
+    args.state.roomState?.sharedVideo?.sharedByDisplayName ?? null,
   );
   args.refs.sharedVideoOwner.textContent = ownerText;
   args.refs.sharedVideoOwner.hidden =
@@ -196,11 +197,12 @@ function formatClockMetricValue(value: number | null): string {
 function formatVideoOwner(
   members: RoomMember[],
   actorId: string | null,
+  fallbackDisplayName: string | null,
 ): string {
-  if (!actorId) {
-    return "";
-  }
-  const owner = members.find((member) => member.id === actorId)?.name;
+  const liveName = actorId
+    ? members.find((member) => member.id === actorId)?.name
+    : undefined;
+  const owner = liveName ?? fallbackDisplayName?.trim();
   return owner ? t("ownerSharedBy", { owner }) : "";
 }
 

--- a/extension/test/popup-render.test.ts
+++ b/extension/test/popup-render.test.ts
@@ -310,3 +310,68 @@ test("renderPopup only logs once for repeated identical pending renders", async 
     Object.assign(globalThis, { document: originalDocument });
   }
 });
+
+test("renderPopup falls back to sharedByDisplayName when the sharer is no longer in members", async () => {
+  resetPopupRenderDebugStateForTests();
+  setLocaleForTests("en-US");
+  const originalDocument = globalThis.document;
+  const refs = createPopupRefs();
+
+  Object.assign(globalThis, {
+    document: {
+      activeElement: null,
+    },
+  });
+
+  try {
+    renderPopup({
+      refs,
+      state: {
+        connected: true,
+        serverUrl: "ws://localhost:8787",
+        error: null,
+        roomCode: "ROOM01",
+        joinToken: "join-token-1",
+        memberId: "member-1",
+        displayName: "Alice",
+        roomState: {
+          roomCode: "ROOM01",
+          sharedVideo: {
+            videoId: "BV1xx411c7mD",
+            url: "https://www.bilibili.com/video/BV1xx411c7mD?p=2",
+            title: "Shared Video",
+            sharedByMemberId: "stale-member-99",
+            sharedByDisplayName: "Bob",
+          },
+          playback: null,
+          members: [{ id: "member-1", name: "Alice" }],
+        },
+        pendingCreateRoom: false,
+        pendingJoinRoomCode: null,
+        retryInMs: null,
+        retryAttempt: 0,
+        retryAttemptMax: 5,
+        clockOffsetMs: null,
+        rttMs: null,
+        logs: [],
+      },
+      serverUrlDraft: { value: "", dirty: false },
+      roomCodeDraft: "",
+      setRoomCodeDraft: () => {},
+      localStatusMessage: null,
+      roomActionPending: false,
+      lastKnownPendingCreateRoom: false,
+      lastKnownPendingJoinRoomCode: null,
+      lastKnownRoomCode: "ROOM01",
+      copyRoomSuccess: false,
+      copyLogsSuccess: false,
+      sendPopupLog: async () => {},
+    });
+
+    assert.equal(refs.sharedVideoOwner.textContent, "Shared by Bob");
+    assert.equal(refs.sharedVideoOwner.hidden, false);
+  } finally {
+    setLocaleForTests(null);
+    Object.assign(globalThis, { document: originalDocument });
+  }
+});

--- a/packages/protocol/src/guards/client-message.ts
+++ b/packages/protocol/src/guards/client-message.ts
@@ -59,7 +59,9 @@ export function isSharedVideo(value: unknown): value is SharedVideo {
     isBilibiliUrl(value.url) &&
     isBoundedString(value.title, TITLE_MAX_LENGTH) &&
     isOptionalBoundedString(value.sharedByMemberId, DISPLAY_NAME_MAX_LENGTH) &&
-    (value.sharedByMemberId === undefined || isActorId(value.sharedByMemberId))
+    (value.sharedByMemberId === undefined ||
+      isActorId(value.sharedByMemberId)) &&
+    isOptionalBoundedString(value.sharedByDisplayName, DISPLAY_NAME_MAX_LENGTH)
   );
 }
 

--- a/packages/protocol/src/guards/server-message.ts
+++ b/packages/protocol/src/guards/server-message.ts
@@ -44,7 +44,10 @@ function isSharedVideo(value: unknown): value is SharedVideo {
     isBilibiliUrl(value.url) &&
     isBoundedString(value.title, TITLE_MAX_LENGTH) &&
     isOptionalString(value.sharedByMemberId) &&
-    (value.sharedByMemberId === undefined || isActorId(value.sharedByMemberId))
+    (value.sharedByMemberId === undefined ||
+      isActorId(value.sharedByMemberId)) &&
+    (value.sharedByDisplayName === undefined ||
+      isBoundedString(value.sharedByDisplayName, DISPLAY_NAME_MAX_LENGTH))
   );
 }
 

--- a/packages/protocol/src/types/domain.ts
+++ b/packages/protocol/src/types/domain.ts
@@ -27,6 +27,7 @@ export interface SharedVideo {
   url: string;
   title: string;
   sharedByMemberId?: string;
+  sharedByDisplayName?: string;
 }
 
 export interface PlaybackState {

--- a/packages/protocol/test/server-message.test.ts
+++ b/packages/protocol/test/server-message.test.ts
@@ -169,6 +169,48 @@ test("rejects room:state when playback sync intent is invalid", () => {
   );
 });
 
+test("accepts room:state when sharedByDisplayName is set on the shared video", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:state",
+      payload: {
+        roomCode: "ABC123",
+        sharedVideo: {
+          videoId: "BV1xx411c7mD",
+          url: "https://www.bilibili.com/video/BV1xx411c7mD",
+          title: "Video",
+          sharedByMemberId: "member-1",
+          sharedByDisplayName: "Alice",
+        },
+        playback: null,
+        members: [{ id: "member-1", name: "Alice" }],
+      },
+    }),
+    true,
+  );
+});
+
+test("rejects room:state when sharedByDisplayName exceeds the display-name bound", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:state",
+      payload: {
+        roomCode: "ABC123",
+        sharedVideo: {
+          videoId: "BV1xx411c7mD",
+          url: "https://www.bilibili.com/video/BV1xx411c7mD",
+          title: "Video",
+          sharedByMemberId: "member-1",
+          sharedByDisplayName: "x".repeat(33),
+        },
+        playback: null,
+        members: [{ id: "member-1", name: "Alice" }],
+      },
+    }),
+    false,
+  );
+});
+
 test("rejects room:state when sharedByMemberId format is invalid", () => {
   assert.equal(
     isServerMessage({

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -958,6 +958,7 @@ export function createRoomService(options: {
                 sharedVideo: {
                   ...video,
                   sharedByMemberId: session.memberId ?? session.id,
+                  sharedByDisplayName: session.displayName,
                 },
                 playback: nextPlayback,
                 expiresAt: null,

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -1993,3 +1993,80 @@ test("concurrent duplicate video:share requests are deduplicated to a single wri
     "exactly one updateRoom write must have occurred; version must advance by 1",
   );
 });
+
+test("shareVideoForSession persists the sharer's display name so popups survive rejoin", async () => {
+  const currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const activeRooms = createActiveRoomRegistry(() => currentTime);
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: {
+      ...getDefaultPersistenceConfig(),
+      emptyRoomTtlMs: 5_000,
+    },
+    roomStore,
+    activeRooms,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOM19",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  await service.shareVideoForSession(
+    owner,
+    created.memberToken,
+    createSharedVideo(),
+  );
+
+  const persisted = await roomStore.getRoom(created.room.code);
+  assert.equal(persisted?.sharedVideo?.sharedByDisplayName, "Alice");
+
+  // Owner leaves and rejoins as a fresh member; sharedByMemberId no longer
+  // matches a current member, but sharedByDisplayName must still be present so
+  // the popup can render the sharer hint.
+  await service.leaveRoomForSession(owner);
+  const rejoined = await service.joinRoomForSession(
+    createSession("owner-2"),
+    created.room.code,
+    created.room.joinToken,
+    "Alice",
+  );
+  assert.equal(rejoined.room.sharedVideo?.sharedByDisplayName, "Alice");
+});
+
+test("shareVideoForSession rejects client-supplied sharedByDisplayName", async () => {
+  const currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: createActiveRoomRegistry(() => currentTime),
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOM20",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  await service.shareVideoForSession(owner, created.memberToken, {
+    ...createSharedVideo(),
+    sharedByDisplayName: "Spoofed",
+  });
+
+  const persisted = await roomStore.getRoom(created.room.code);
+  assert.equal(
+    persisted?.sharedVideo?.sharedByDisplayName,
+    "Alice",
+    "server must overwrite client-supplied sharedByDisplayName with session.displayName",
+  );
+});


### PR DESCRIPTION
## Summary

- Bug：房间已有共享视频时，popup「当前共享视频」会显示共享者；用户离开房间再加入后该行消失，直到分享一次新视频才会重新出现。
- 根因：客户端 leave 时清空 `memberToken` 并断开 WS，rejoin 拿到全新 `memberId`，但持久化的 `sharedVideo.sharedByMemberId` 仍是旧 id；popup 用 `members.find(m => m.id === sharedByMemberId)` 查不到名字，整行被 `hidden`。下一次 `video:share` 才会把 `sharedByMemberId` 改写成当前成员 id 并恢复显示。
- Fix：协议为 `SharedVideo` 增加可选 `sharedByDisplayName`，服务端在 `shareVideoForSession` 持久化时用 `session.displayName` 写入并覆写客户端伪造值；popup `formatVideoOwner` 在按 id 查不到成员时回退使用 `sharedByDisplayName`。

## Backwards compatibility

- 协议字段为可选；老客户端 → 新服务端、新客户端 → 老服务端均无破坏性影响（详见提交说明）。
- 升级前已分享的视频字段为空，需下一次 share 才回填，与现状一致，不引入额外回退。

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`
- [x] 协议守卫：接受 `sharedByDisplayName`、超长拒绝
- [x] 服务端：share 持久化 displayName；leave→rejoin 后字段保留；客户端伪造值被覆写
- [x] 扩展 popup：`sharedByMemberId` 失配时回退到 `sharedByDisplayName` 仍能显示 owner
- [ ] 手动：装载新构建在 Edge/Chrome，加入房间→分享→leave→rejoin，确认「由 X 共享」仍显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)