### PR TITLE
fix: omit room context in room detail events

### DIFF
--- a/server/admin-ui/page-renderers.js
+++ b/server/admin-ui/page-renderers.js
@@ -781,7 +781,7 @@ export function createPageLoaders(options) {
                           (event) => `
                         <tr>
                           <td>${renderTimeBlock(event.timestamp, "事件")}</td>
-                          <td>${renderRuntimeEventStoryCell(event)}</td>
+                          <td>${renderRuntimeEventStoryCell(event, { omitRoomContext: true })}</td>
                           <td>${event.sessionId ? `<span class="code">${escapeHtml(event.sessionId)}</span>` : renderEmptyValue()}</td>
                           <td>${event.result ? renderResultBadge(event.result) : renderEmptyValue()}</td>
                           <td><button class="button link" type="button" data-view-json='${escapeHtml(JSON.stringify(event.details))}'>查看 JSON</button></td>

--- a/server/test/admin-ui-page-renderers.test.ts
+++ b/server/test/admin-ui-page-renderers.test.ts
@@ -300,7 +300,17 @@ test("room detail renders playback position as media timestamp", async () => {
             },
           },
           members: [],
-          recentEvents: [],
+          recentEvents: [
+            {
+              id: "event-1",
+              timestamp: Date.now(),
+              event: "room_joined",
+              roomCode: "ROOM8A",
+              sessionId: "session-1",
+              result: "ok",
+              details: { displayName: "Alice" },
+            },
+          ],
         };
       },
     },
@@ -327,6 +337,8 @@ test("room detail renders playback position as media timestamp", async () => {
 
   assert.equal(page.html.includes("<dt>当前时间</dt><dd>1:02:03</dd>"), true);
   assert.equal(page.html.includes("3723.4s"), false);
+  assert.equal(page.html.includes("Alice 加入了房间"), true);
+  assert.equal(page.html.includes("Alice 加入了房间 · 房间 ROOM8A"), false);
 });
 
 test("danger room actions require confirmed config before execution", async () => {


### PR DESCRIPTION
## Summary
- hide redundant room-code context in room detail recent event stories
- add a regression assertion for room detail recent events

## Verification
- npm run --ignore-scripts test -w @bili-syncplay/server -- test/admin-ui-page-renderers.test.ts
- npm run format:check && npm run lint && npm run typecheck && npm run build && npm test