### PR TITLE
fix: measure reconnect timeout across websocket open

### DIFF
--- a/bench/lib/room-bench.ts
+++ b/bench/lib/room-bench.ts
@@ -620,17 +620,23 @@ export async function runReconnectStormBenchmark(input: {
         let inbox: Collector | undefined;
 
         try {
-          socket = await connectClient(seed.wsUrl);
+          socket = await connectClient(seed.wsUrl, {
+            openTimeoutMs: input.reconnectTimeoutMs,
+          });
           inbox = createBenchMessageCollector(socket, {
             trackedTypes: ["room:joined", "room:state"],
           });
-          const joinedPromise = inbox.next(
-            "room:joined",
-            input.reconnectTimeoutMs,
-          );
+          const remainingTimeoutMs =
+            input.reconnectTimeoutMs - (Date.now() - reconnectStartedAtMs);
+          if (remainingTimeoutMs <= 0) {
+            throw new Error(
+              `Reconnect socket open consumed the ${input.reconnectTimeoutMs}ms timeout budget.`,
+            );
+          }
+          const joinedPromise = inbox.next("room:joined", remainingTimeoutMs);
           const firstStatePromise = inbox.next(
             "room:state",
-            input.reconnectTimeoutMs,
+            remainingTimeoutMs,
           );
           socket.send(
             JSON.stringify({

--- a/server/test/multi-node-test-kit.test.ts
+++ b/server/test/multi-node-test-kit.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createServer, type Socket } from "node:net";
 import test from "node:test";
 import {
   closeClient,
@@ -7,6 +8,39 @@ import {
   createMultiNodeTestKit,
   requestJson,
 } from "./multi-node-test-kit.js";
+
+test("connectClient rejects when WebSocket open exceeds the timeout", async () => {
+  const acceptedSockets = new Set<Socket>();
+  const server = createServer((socket) => {
+    acceptedSockets.add(socket);
+    socket.once("close", () => acceptedSockets.delete(socket));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.once("error", reject);
+  });
+
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+
+    await assert.rejects(
+      () =>
+        connectClient(`ws://127.0.0.1:${address.port}`, {
+          openTimeoutMs: 10,
+        }),
+      /Timed out opening WebSocket after 10ms\./,
+    );
+  } finally {
+    for (const socket of acceptedSockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
 
 test("multi-node test kit starts two room nodes and one global admin on the same redis namespace", async (t) => {
   const redisUrl = process.env.REDIS_URL;

--- a/server/test/multi-node-test-kit.ts
+++ b/server/test/multi-node-test-kit.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { createHash, randomUUID } from "node:crypto";
-import { once } from "node:events";
 import { Redis } from "ioredis";
 import { WebSocket, type RawData } from "ws";
 import { createGlobalAdminServer } from "../src/global-admin-app.js";
@@ -72,11 +71,82 @@ export async function requestJson(
   };
 }
 
-export async function connectClient(wsUrl: string): Promise<WebSocket> {
+export async function connectClient(
+  wsUrl: string,
+  options: { openTimeoutMs?: number } = {},
+): Promise<WebSocket> {
   const socket = new WebSocket(wsUrl, {
     origin: MULTI_NODE_ALLOWED_ORIGIN,
   });
-  await once(socket, "open");
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      let timeout: NodeJS.Timeout | undefined;
+
+      const cleanup = () => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        socket.off("open", handleOpen);
+        socket.off("error", handleError);
+        socket.off("close", handleClose);
+      };
+
+      const handleOpen = () => {
+        cleanup();
+        resolve();
+      };
+
+      const handleError = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+
+      const handleClose = () => {
+        cleanup();
+        reject(new Error("WebSocket closed before opening."));
+      };
+
+      const terminateOpeningSocket = () => {
+        socket.on("error", () => {});
+        try {
+          socket.terminate();
+        } catch {
+          // Ignore close-time failures after the connect attempt has timed out.
+        }
+      };
+
+      socket.once("open", handleOpen);
+      socket.once("error", handleError);
+      socket.once("close", handleClose);
+
+      if (options.openTimeoutMs !== undefined) {
+        timeout = setTimeout(() => {
+          cleanup();
+          terminateOpeningSocket();
+          reject(
+            new Error(
+              `Timed out opening WebSocket after ${options.openTimeoutMs}ms.`,
+            ),
+          );
+        }, options.openTimeoutMs);
+      }
+    });
+  } catch (error) {
+    if (
+      socket.readyState !== WebSocket.CLOSING &&
+      socket.readyState !== WebSocket.CLOSED
+    ) {
+      socket.on("error", () => {});
+      try {
+        socket.terminate();
+      } catch {
+        // Ignore close-time failures after the connect attempt has failed.
+      }
+    }
+    throw error;
+  }
+
   return socket;
 }
 


### PR DESCRIPTION
## Summary
- add an optional WebSocket open timeout to the shared test/bench connectClient helper
- make reconnect-storm spend one reconnectTimeoutMs budget across socket open, room:joined, and first room:state
- cover stalled WebSocket handshakes with a regression test

Refs #96

## Benchmark

`npx tsx bench/reconnect-storm.ts` on this branch (single-node, 500 members, reconnectTimeoutMs=5000):

```json
{
  "attempted": 500,
  "completed": 446,
  "errors": 54,
  "errorRatePercent": 10.8,
  "durationSeconds": 5.067,
  "latency": {
    "sampleCount": 446,
    "minMs": 29,
    "meanMs": 1328.013,
    "p50Ms": 742,
    "p95Ms": 4275,
    "p99Ms": 4860,
    "maxMs": 5015
  },
  "throughput": {
    "attemptedPerSecond": 98.678,
    "completedPerSecond": 88.021
  }
}
```

This replaces the earlier misleading 40s / 0% error result with a timeout-bounded run that counts handshake and rejoin wait time against the same budget.

## Test plan
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`
- [x] `npx tsx bench/reconnect-storm.ts`
