### PR TITLE
feat: expose reconnect benchmark phase timings

### DIFF
--- a/bench/lib/cli.ts
+++ b/bench/lib/cli.ts
@@ -19,6 +19,7 @@ export type BenchmarkResult = {
   metrics: {
     throughput: ThroughputSummary;
     latency: LatencySummary;
+    phases?: Record<string, LatencySummary>;
     errorRatePercent: number;
     errors: number;
   };
@@ -87,6 +88,7 @@ export function buildBenchmarkResult(input: {
   completed: number;
   errors: number;
   latencySamplesMs: number[];
+  phaseSamplesMs?: Record<string, number[]>;
   config: Record<string, unknown>;
   notes?: string[];
 }): BenchmarkResult {
@@ -105,6 +107,16 @@ export function buildBenchmarkResult(input: {
         durationMs: input.completedAtMs - input.startedAtMs,
       }),
       latency: summarizeLatencies(input.latencySamplesMs),
+      ...(input.phaseSamplesMs
+        ? {
+            phases: Object.fromEntries(
+              Object.entries(input.phaseSamplesMs).map(([phase, samples]) => [
+                phase,
+                summarizeLatencies(samples),
+              ]),
+            ),
+          }
+        : {}),
       errorRatePercent: calculateErrorRate(input.errors, totalObservations),
       errors: input.errors,
     },

--- a/bench/lib/room-bench.ts
+++ b/bench/lib/room-bench.ts
@@ -50,11 +50,40 @@ type BenchmarkServer = {
   cleanup: () => Promise<void>;
 };
 
+type ReconnectPhaseSamples = {
+  socketOpen: number[];
+  roomJoined: number[];
+  firstRoomState: number[];
+};
+
 const SHARED_VIDEO_URL = "https://www.bilibili.com/video/BV1xx411c7mD?p=1";
 const SHARED_VIDEO_TITLE = "Benchmark Episode";
 
 function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function recordReconnectJoinPhaseResults(input: {
+  phaseSamplesMs: ReconnectPhaseSamples;
+  joinSentAtMs: number;
+  joinedResult: PromiseSettledResult<number>;
+  firstStateResult: PromiseSettledResult<number>;
+}): boolean {
+  if (input.joinedResult.status === "fulfilled") {
+    input.phaseSamplesMs.roomJoined.push(
+      input.joinedResult.value - input.joinSentAtMs,
+    );
+  }
+  if (input.firstStateResult.status === "fulfilled") {
+    input.phaseSamplesMs.firstRoomState.push(
+      input.firstStateResult.value - input.joinSentAtMs,
+    );
+  }
+
+  return (
+    input.joinedResult.status === "fulfilled" &&
+    input.firstStateResult.status === "fulfilled"
+  );
 }
 
 type BenchMessageCollectorOptions = {
@@ -605,7 +634,7 @@ export async function runReconnectStormBenchmark(input: {
 
   const startedAtMs = Date.now();
   const latencySamplesMs: number[] = [];
-  const phaseSamplesMs: Record<string, number[]> = {
+  const phaseSamplesMs: ReconnectPhaseSamples = {
     socketOpen: [],
     roomJoined: [],
     firstRoomState: [],
@@ -661,12 +690,19 @@ export async function runReconnectStormBenchmark(input: {
             }),
           );
           const joinSentAtMs = Date.now();
-          const [joinedAtMs, firstStateAtMs] = await Promise.all([
+          const [joinedResult, firstStateResult] = await Promise.allSettled([
             joinedPromise,
             firstStatePromise,
           ]);
-          phaseSamplesMs.roomJoined?.push(joinedAtMs - joinSentAtMs);
-          phaseSamplesMs.firstRoomState?.push(firstStateAtMs - joinSentAtMs);
+          const completedRequiredPhases = recordReconnectJoinPhaseResults({
+            phaseSamplesMs,
+            joinSentAtMs,
+            joinedResult,
+            firstStateResult,
+          });
+          if (!completedRequiredPhases) {
+            throw new Error("Reconnect did not complete every required phase.");
+          }
           latencySamplesMs.push(Date.now() - reconnectStartedAtMs);
           completed += 1;
         } catch {

--- a/bench/lib/room-bench.ts
+++ b/bench/lib/room-bench.ts
@@ -605,6 +605,11 @@ export async function runReconnectStormBenchmark(input: {
 
   const startedAtMs = Date.now();
   const latencySamplesMs: number[] = [];
+  const phaseSamplesMs: Record<string, number[]> = {
+    socketOpen: [],
+    roomJoined: [],
+    firstRoomState: [],
+  };
   let completed = 0;
   let errors = 0;
   let completedAtMs = startedAtMs;
@@ -623,21 +628,27 @@ export async function runReconnectStormBenchmark(input: {
           socket = await connectClient(seed.wsUrl, {
             openTimeoutMs: input.reconnectTimeoutMs,
           });
+          const socketOpenedAtMs = Date.now();
+          phaseSamplesMs.socketOpen?.push(
+            socketOpenedAtMs - reconnectStartedAtMs,
+          );
           inbox = createBenchMessageCollector(socket, {
             trackedTypes: ["room:joined", "room:state"],
           });
           const remainingTimeoutMs =
-            input.reconnectTimeoutMs - (Date.now() - reconnectStartedAtMs);
+            input.reconnectTimeoutMs -
+            (socketOpenedAtMs - reconnectStartedAtMs);
           if (remainingTimeoutMs <= 0) {
             throw new Error(
               `Reconnect socket open consumed the ${input.reconnectTimeoutMs}ms timeout budget.`,
             );
           }
-          const joinedPromise = inbox.next("room:joined", remainingTimeoutMs);
-          const firstStatePromise = inbox.next(
-            "room:state",
-            remainingTimeoutMs,
-          );
+          const joinedPromise = inbox
+            .next("room:joined", remainingTimeoutMs)
+            .then(() => Date.now());
+          const firstStatePromise = inbox
+            .next("room:state", remainingTimeoutMs)
+            .then(() => Date.now());
           socket.send(
             JSON.stringify({
               type: "room:join",
@@ -649,7 +660,13 @@ export async function runReconnectStormBenchmark(input: {
               },
             }),
           );
-          await Promise.all([joinedPromise, firstStatePromise]);
+          const joinSentAtMs = Date.now();
+          const [joinedAtMs, firstStateAtMs] = await Promise.all([
+            joinedPromise,
+            firstStatePromise,
+          ]);
+          phaseSamplesMs.roomJoined?.push(joinedAtMs - joinSentAtMs);
+          phaseSamplesMs.firstRoomState?.push(firstStateAtMs - joinSentAtMs);
           latencySamplesMs.push(Date.now() - reconnectStartedAtMs);
           completed += 1;
         } catch {
@@ -673,6 +690,7 @@ export async function runReconnectStormBenchmark(input: {
     completed,
     errors,
     latencySamplesMs,
+    phaseSamplesMs,
     startedAtMs,
     completedAtMs,
   };

--- a/bench/lib/scenarios.ts
+++ b/bench/lib/scenarios.ts
@@ -109,6 +109,7 @@ export async function runReconnectStormScenario(
     completed: benchmark.completed,
     errors: benchmark.errors,
     latencySamplesMs: benchmark.latencySamplesMs,
+    phaseSamplesMs: benchmark.phaseSamplesMs,
     config: {
       memberCount: input.memberCount,
       reconnectTimeoutMs: input.reconnectTimeoutMs,
@@ -116,6 +117,7 @@ export async function runReconnectStormScenario(
     },
     notes: [
       "Each reconnect latency measures socket open plus room rejoin until the first room state arrives.",
+      "Phase latency summaries are partial: socketOpen records successful WebSocket opens, roomJoined records received join acknowledgements, and firstRoomState records received initial room states.",
     ],
   });
 }

--- a/server/test/bench-stats.test.ts
+++ b/server/test/bench-stats.test.ts
@@ -5,6 +5,7 @@ import { buildBenchmarkResult } from "../../bench/lib/cli.js";
 import { ensureRedis } from "../../bench/lib/redis-harness.js";
 import {
   createBenchMessageCollector,
+  recordReconnectJoinPhaseResults,
   runPlaybackBroadcastBenchmark,
   runReconnectStormBenchmark,
 } from "../../bench/lib/room-bench.js";
@@ -138,6 +139,28 @@ test("benchmark result includes optional phase latency summaries", () => {
       maxMs: 160,
     },
   });
+});
+
+test("reconnect phase recording preserves completed join ack when room state fails", () => {
+  const phaseSamplesMs = {
+    socketOpen: [],
+    roomJoined: [],
+    firstRoomState: [],
+  };
+
+  const completedRequiredPhases = recordReconnectJoinPhaseResults({
+    phaseSamplesMs,
+    joinSentAtMs: 1_000,
+    joinedResult: { status: "fulfilled", value: 1_050 },
+    firstStateResult: {
+      status: "rejected",
+      reason: new Error("Timed out waiting for room:state"),
+    },
+  });
+
+  assert.equal(completedRequiredPhases, false);
+  assert.deepEqual(phaseSamplesMs.roomJoined, [50]);
+  assert.deepEqual(phaseSamplesMs.firstRoomState, []);
 });
 
 test("playback benchmark skips drain bookkeeping when no watchers are sampled", async () => {

--- a/server/test/bench-stats.test.ts
+++ b/server/test/bench-stats.test.ts
@@ -92,6 +92,54 @@ test("benchmark result uses a stable JSON-friendly schema", () => {
   });
 });
 
+test("benchmark result includes optional phase latency summaries", () => {
+  const result = buildBenchmarkResult({
+    scenario: "reconnect-storm",
+    startedAtMs: Date.UTC(2026, 3, 22, 10, 0, 0),
+    completedAtMs: Date.UTC(2026, 3, 22, 10, 0, 5),
+    attempted: 4,
+    completed: 3,
+    errors: 1,
+    latencySamplesMs: [100, 200, 300],
+    phaseSamplesMs: {
+      socketOpen: [10, 20, 30, 40],
+      roomJoined: [50, 70, 90],
+      firstRoomState: [80, 120, 160],
+    },
+    config: { memberCount: 4, reconnectTimeoutMs: 5_000 },
+  });
+
+  assert.deepEqual(result.metrics.phases, {
+    socketOpen: {
+      sampleCount: 4,
+      minMs: 10,
+      meanMs: 25,
+      p50Ms: 20,
+      p95Ms: 40,
+      p99Ms: 40,
+      maxMs: 40,
+    },
+    roomJoined: {
+      sampleCount: 3,
+      minMs: 50,
+      meanMs: 70,
+      p50Ms: 70,
+      p95Ms: 90,
+      p99Ms: 90,
+      maxMs: 90,
+    },
+    firstRoomState: {
+      sampleCount: 3,
+      minMs: 80,
+      meanMs: 120,
+      p50Ms: 120,
+      p95Ms: 160,
+      p99Ms: 160,
+      maxMs: 160,
+    },
+  });
+});
+
 test("playback benchmark skips drain bookkeeping when no watchers are sampled", async () => {
   const benchmark = await runPlaybackBroadcastBenchmark({
     scenario: "single-node-room",
@@ -254,6 +302,23 @@ test("reconnect benchmark supports member counts above default room and IP limit
 
   assert.equal(benchmark.attempted, 12);
   assert.equal(benchmark.errors, 0);
+});
+
+test("reconnect benchmark records phase latency samples", async () => {
+  const benchmark = await runReconnectStormBenchmark({
+    memberCount: 4,
+    reconnectTimeoutMs: 3_000,
+  });
+
+  assert.equal(benchmark.phaseSamplesMs.socketOpen.length, 4);
+  assert.equal(benchmark.phaseSamplesMs.roomJoined.length, 4);
+  assert.equal(benchmark.phaseSamplesMs.firstRoomState.length, 4);
+  for (const samples of Object.values(benchmark.phaseSamplesMs)) {
+    assert.equal(
+      samples.every((sample) => sample >= 0),
+      true,
+    );
+  }
 });
 
 test("reconnect benchmark reports timeout failures without aborting the run", async () => {


### PR DESCRIPTION
## Summary
- add optional `metrics.phases` latency summaries to benchmark results
- record reconnect-storm phase samples for `socketOpen`, `roomJoined`, and `firstRoomState`
- keep phase summaries partial so failed reconnects can still contribute completed earlier stages

Refs #96

## Benchmark

`npx tsx bench/reconnect-storm.ts` on this branch (single-node, 500 members, reconnectTimeoutMs=5000):

```json
{
  "attempted": 500,
  "completed": 450,
  "errors": 50,
  "errorRatePercent": 10,
  "durationSeconds": 5.045,
  "latency": {
    "sampleCount": 450,
    "p50Ms": 781,
    "p95Ms": 4343,
    "p99Ms": 4874,
    "maxMs": 5013
  },
  "phases": {
    "socketOpen": {
      "sampleCount": 452,
      "p50Ms": 762,
      "p95Ms": 4344,
      "p99Ms": 4869,
      "maxMs": 4993
    },
    "roomJoined": {
      "sampleCount": 450,
      "p50Ms": 18,
      "p95Ms": 67,
      "p99Ms": 87,
      "maxMs": 90
    },
    "firstRoomState": {
      "sampleCount": 450,
      "p50Ms": 18,
      "p95Ms": 67,
      "p99Ms": 87,
      "maxMs": 128
    }
  }
}
```

This run shows the current timeout pressure is dominated by the WebSocket open phase, while join ack and initial room state are both tens of milliseconds for successful reconnects.

## Test plan
- [x] `npm run --ignore-scripts test -w @bili-syncplay/server -- test/bench-stats.test.ts`
- [x] `npm run typecheck`
- [x] `npx tsx bench/reconnect-storm.ts --members 20 --reconnect-timeout-ms 3000`
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`
- [x] `npx tsx bench/reconnect-storm.ts`
