### PR TITLE
feat: add incremental member room events

### DIFF
--- a/bench/lib/room-bench.ts
+++ b/bench/lib/room-bench.ts
@@ -287,7 +287,12 @@ async function connectParticipants(
         wsUrl,
         socket,
         inbox: createBenchMessageCollector(socket, {
-          trackedTypes: ["room:created", "room:joined", "room:state"],
+          trackedTypes: [
+            "room:created",
+            "room:joined",
+            "room:state",
+            "room:member-joined",
+          ],
         }),
       };
     }),
@@ -386,7 +391,7 @@ async function initializeRoom(
 
     const joined = await joinerSeed.inbox.next("room:joined");
     await joinerSeed.inbox.next("room:state");
-    await ownerSeed.inbox.next("room:state");
+    await ownerSeed.inbox.next("room:member-joined");
 
     const joinedPayload = joined.payload as {
       memberToken: string;

--- a/bench/lib/room-bench.ts
+++ b/bench/lib/room-bench.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import {
   createSyncServer,
   getDefaultPersistenceConfig,
@@ -362,7 +363,10 @@ async function initializeRoom(
   ownerSeed.socket.send(
     JSON.stringify({
       type: "room:create",
-      payload: { displayName: ownerSeed.displayName },
+      payload: {
+        displayName: ownerSeed.displayName,
+        protocolVersion: PROTOCOL_VERSION,
+      },
     }),
   );
 
@@ -385,6 +389,7 @@ async function initializeRoom(
           roomCode: createdPayload.roomCode,
           joinToken: createdPayload.joinToken,
           displayName: joinerSeed.displayName,
+          protocolVersion: PROTOCOL_VERSION,
         },
       }),
     );
@@ -691,6 +696,7 @@ export async function runReconnectStormBenchmark(input: {
                 joinToken: environment.joinToken,
                 displayName: seed.displayName,
                 memberToken: seed.memberToken,
+                protocolVersion: PROTOCOL_VERSION,
               },
             }),
           );

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -74,9 +74,14 @@ export function createRoomSessionController(args: {
   let pendingJoinAttemptResolvers: Array<(result: JoinAttemptResult) => void> =
     [];
   let pendingMemberDeltas: PendingMemberDelta[] = [];
+  let waitingForBootstrapRoomState = false;
 
   function clearPendingMemberDeltas(): void {
     pendingMemberDeltas = [];
+  }
+
+  function queueMemberDelta(delta: PendingMemberDelta): void {
+    pendingMemberDeltas.push(delta);
   }
 
   function applyMemberDelta(
@@ -198,6 +203,7 @@ export function createRoomSessionController(args: {
     switch (message.type) {
       case "room:created":
         clearPendingMemberDeltas();
+        waitingForBootstrapRoomState = true;
         args.roomSessionState.pendingJoinRoomCode = null;
         args.roomSessionState.pendingJoinToken = null;
         args.roomSessionState.roomCode = message.payload.roomCode;
@@ -212,6 +218,7 @@ export function createRoomSessionController(args: {
         return;
       case "room:joined":
         clearPendingMemberDeltas();
+        waitingForBootstrapRoomState = true;
         args.roomSessionState.roomCode = message.payload.roomCode;
         args.roomSessionState.joinToken =
           args.roomSessionState.pendingJoinToken ??
@@ -259,6 +266,7 @@ export function createRoomSessionController(args: {
             "background",
             `Join failed for room ${args.roomSessionState.pendingJoinRoomCode}`,
           );
+          waitingForBootstrapRoomState = false;
           settlePendingJoinAttempt("failed");
           args.roomSessionState.pendingJoinRequestSent = false;
           args.roomSessionState.pendingJoinRoomCode = null;
@@ -316,9 +324,16 @@ export function createRoomSessionController(args: {
     member: RoomMember,
   ): Promise<void> {
     const currentState = args.roomSessionState.roomState;
+    if (
+      waitingForBootstrapRoomState &&
+      args.roomSessionState.roomCode === roomCode
+    ) {
+      queueMemberDelta({ type: "joined", roomCode, member });
+      return;
+    }
     if (!currentState || currentState.roomCode !== roomCode) {
       if (!currentState && args.roomSessionState.roomCode === roomCode) {
-        pendingMemberDeltas.push({ type: "joined", roomCode, member });
+        queueMemberDelta({ type: "joined", roomCode, member });
       }
       return;
     }
@@ -333,9 +348,16 @@ export function createRoomSessionController(args: {
     member: RoomMember,
   ): Promise<void> {
     const currentState = args.roomSessionState.roomState;
+    if (
+      waitingForBootstrapRoomState &&
+      args.roomSessionState.roomCode === roomCode
+    ) {
+      queueMemberDelta({ type: "left", roomCode, member });
+      return;
+    }
     if (!currentState || currentState.roomCode !== roomCode) {
       if (!currentState && args.roomSessionState.roomCode === roomCode) {
-        pendingMemberDeltas.push({ type: "left", roomCode, member });
+        queueMemberDelta({ type: "left", roomCode, member });
       }
       return;
     }
@@ -382,6 +404,7 @@ export function createRoomSessionController(args: {
     }
 
     const resolvedState = consumePendingMemberDeltas(nextState);
+    waitingForBootstrapRoomState = false;
     args.roomSessionState.roomState = resolvedState;
     args.roomSessionState.roomCode = resolvedState.roomCode;
     args.connectionState.lastError = null;
@@ -437,6 +460,7 @@ export function createRoomSessionController(args: {
     errorMessage: string | null = null,
   ): Promise<void> {
     clearPendingMemberDeltas();
+    waitingForBootstrapRoomState = false;
     args.log("background", `Clearing current room context (${reason})`);
     args.roomSessionState.roomCode = null;
     args.roomSessionState.joinToken = null;
@@ -458,6 +482,7 @@ export function createRoomSessionController(args: {
   async function requestCreateRoom(): Promise<void> {
     args.resetReconnectState();
     clearPendingMemberDeltas();
+    waitingForBootstrapRoomState = false;
     args.roomSessionState.roomCode = null;
     args.roomSessionState.joinToken = null;
     args.roomSessionState.memberToken = null;
@@ -492,6 +517,7 @@ export function createRoomSessionController(args: {
   ): Promise<void> {
     args.resetReconnectState();
     clearPendingMemberDeltas();
+    waitingForBootstrapRoomState = false;
     args.roomSessionState.pendingCreateRoom = false;
     args.roomSessionState.pendingJoinRoomCode = roomCode.trim().toUpperCase();
     args.roomSessionState.pendingJoinToken = joinToken.trim();
@@ -525,6 +551,7 @@ export function createRoomSessionController(args: {
 
   async function requestLeaveRoom(): Promise<void> {
     clearPendingMemberDeltas();
+    waitingForBootstrapRoomState = false;
     args.log(
       "background",
       `Popup requested leave for ${args.roomSessionState.roomCode ?? "none"}`,

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -94,6 +94,12 @@ export function createRoomSessionController(args: {
     );
   }
 
+  function clearPendingMemberDeltasExceptRoom(roomCode: string): void {
+    pendingMemberDeltas = pendingMemberDeltas.filter(
+      (delta) => delta.roomCode === roomCode,
+    );
+  }
+
   function queueMemberDelta(delta: PendingMemberDelta): void {
     pendingMemberDeltas.push(delta);
   }
@@ -146,6 +152,22 @@ export function createRoomSessionController(args: {
     }
     pendingMemberDeltas = remainingDeltas;
     return resolvedState;
+  }
+
+  function isAwaitingRoomBootstrapFor(roomCode: string): boolean {
+    if (
+      waitingForBootstrapRoomState &&
+      args.roomSessionState.roomCode === roomCode
+    ) {
+      return true;
+    }
+    if (!args.roomSessionState.pendingJoinRequestSent) {
+      return false;
+    }
+    return (
+      args.roomSessionState.roomCode === roomCode ||
+      args.roomSessionState.pendingJoinRoomCode === roomCode
+    );
   }
 
   function stopWaitingForBootstrapRoomState(): void {
@@ -322,7 +344,7 @@ export function createRoomSessionController(args: {
         args.notifyAll();
         return;
       case "room:joined":
-        clearPendingMemberDeltas();
+        clearPendingMemberDeltasExceptRoom(message.payload.roomCode);
         startWaitingForBootstrapRoomState();
         args.roomSessionState.roomCode = message.payload.roomCode;
         args.roomSessionState.joinToken =
@@ -429,10 +451,7 @@ export function createRoomSessionController(args: {
     member: RoomMember,
   ): Promise<void> {
     const currentState = args.roomSessionState.roomState;
-    if (
-      waitingForBootstrapRoomState &&
-      args.roomSessionState.roomCode === roomCode
-    ) {
+    if (isAwaitingRoomBootstrapFor(roomCode)) {
       queueMemberDelta({ type: "joined", roomCode, member });
       return;
     }
@@ -450,10 +469,7 @@ export function createRoomSessionController(args: {
     member: RoomMember,
   ): Promise<void> {
     const currentState = args.roomSessionState.roomState;
-    if (
-      waitingForBootstrapRoomState &&
-      args.roomSessionState.roomCode === roomCode
-    ) {
+    if (isAwaitingRoomBootstrapFor(roomCode)) {
       queueMemberDelta({ type: "left", roomCode, member });
       return;
     }

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -1,4 +1,5 @@
 import type {
+  RoomMember,
   RoomState,
   ServerMessage,
   ClientMessage,
@@ -172,6 +173,18 @@ export function createRoomSessionController(args: {
       case "room:state":
         await handleRoomStateMessage(message.payload);
         return;
+      case "room:member-joined":
+        await handleRoomMemberJoined(
+          message.payload.roomCode,
+          message.payload.member,
+        );
+        return;
+      case "room:member-left":
+        await handleRoomMemberLeft(
+          message.payload.roomCode,
+          message.payload.member,
+        );
+        return;
       case "error":
         args.connectionState.lastError = localizeServerError(
           message.payload.code,
@@ -223,6 +236,62 @@ export function createRoomSessionController(args: {
       case "sync:pong":
         return;
     }
+  }
+
+  async function applyRoomMemberState(nextState: RoomState): Promise<void> {
+    args.roomSessionState.roomState = nextState;
+    args.roomSessionState.roomCode = nextState.roomCode;
+    args.connectionState.lastError = null;
+
+    await args.persistState();
+    const compensatedRoomState = args.compensateRoomState(nextState);
+    await args.notifyContentScripts({
+      type: "background:apply-room-state",
+      payload: compensatedRoomState,
+      shareToast: null,
+    });
+    args.notifyAll();
+  }
+
+  async function handleRoomMemberJoined(
+    roomCode: string,
+    member: RoomMember,
+  ): Promise<void> {
+    const currentState = args.roomSessionState.roomState;
+    if (!currentState || currentState.roomCode !== roomCode) {
+      return;
+    }
+
+    const existingMemberIndex = currentState.members.findIndex(
+      (candidate) => candidate.id === member.id,
+    );
+    const members =
+      existingMemberIndex === -1
+        ? [...currentState.members, member]
+        : currentState.members.map((candidate, index) =>
+            index === existingMemberIndex ? member : candidate,
+          );
+    await applyRoomMemberState({
+      ...currentState,
+      members,
+    });
+  }
+
+  async function handleRoomMemberLeft(
+    roomCode: string,
+    member: RoomMember,
+  ): Promise<void> {
+    const currentState = args.roomSessionState.roomState;
+    if (!currentState || currentState.roomCode !== roomCode) {
+      return;
+    }
+
+    await applyRoomMemberState({
+      ...currentState,
+      members: currentState.members.filter(
+        (candidate) => candidate.id !== member.id,
+      ),
+    });
   }
 
   async function handleRoomStateMessage(nextState: RoomState): Promise<void> {

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -30,6 +30,8 @@ type PendingMemberDelta = {
   member: RoomMember;
 };
 
+const DEFAULT_BOOTSTRAP_ROOM_STATE_TIMEOUT_MS = 5_000;
+
 export interface RoomSessionController {
   sendJoinRequest(targetRoomCode: string, targetJoinToken: string): void;
   waitForJoinAttemptResult(timeoutMs?: number): Promise<JoinAttemptResult>;
@@ -70,18 +72,33 @@ export function createRoomSessionController(args: {
   normalizeUrl: (url: string | undefined | null) => string | null;
   logServerError: (code: string, message: string) => void;
   shareToastTtlMs: number;
+  bootstrapRoomStateTimeoutMs?: number;
 }): RoomSessionController {
   let pendingJoinAttemptResolvers: Array<(result: JoinAttemptResult) => void> =
     [];
   let pendingMemberDeltas: PendingMemberDelta[] = [];
   let waitingForBootstrapRoomState = false;
+  let bootstrapRoomStateTimer: ReturnType<typeof globalThis.setTimeout> | null =
+    null;
+  const bootstrapRoomStateTimeoutMs =
+    args.bootstrapRoomStateTimeoutMs ?? DEFAULT_BOOTSTRAP_ROOM_STATE_TIMEOUT_MS;
 
   function clearPendingMemberDeltas(): void {
     pendingMemberDeltas = [];
   }
 
+  function clearPendingMemberDeltasForRoom(roomCode: string): void {
+    pendingMemberDeltas = pendingMemberDeltas.filter(
+      (delta) => delta.roomCode !== roomCode,
+    );
+  }
+
   function queueMemberDelta(delta: PendingMemberDelta): void {
     pendingMemberDeltas.push(delta);
+  }
+
+  function hasPendingMemberDeltasForRoom(roomCode: string): boolean {
+    return pendingMemberDeltas.some((delta) => delta.roomCode === roomCode);
   }
 
   function applyMemberDelta(
@@ -128,6 +145,60 @@ export function createRoomSessionController(args: {
     }
     pendingMemberDeltas = remainingDeltas;
     return resolvedState;
+  }
+
+  function stopWaitingForBootstrapRoomState(): void {
+    waitingForBootstrapRoomState = false;
+    if (bootstrapRoomStateTimer !== null) {
+      globalThis.clearTimeout(bootstrapRoomStateTimer);
+      bootstrapRoomStateTimer = null;
+    }
+  }
+
+  async function expireBootstrapRoomStateWait(): Promise<void> {
+    if (!waitingForBootstrapRoomState) {
+      return;
+    }
+
+    waitingForBootstrapRoomState = false;
+    bootstrapRoomStateTimer = null;
+    const roomCode = args.roomSessionState.roomCode;
+    if (!roomCode) {
+      clearPendingMemberDeltas();
+      return;
+    }
+    if (!hasPendingMemberDeltasForRoom(roomCode)) {
+      return;
+    }
+
+    const currentState = args.roomSessionState.roomState;
+    if (!currentState || currentState.roomCode !== roomCode) {
+      clearPendingMemberDeltasForRoom(roomCode);
+      args.log(
+        "background",
+        `Dropped member deltas after bootstrap room state timeout for ${roomCode}`,
+      );
+      return;
+    }
+
+    const resolvedState = consumePendingMemberDeltas(currentState);
+    args.log(
+      "background",
+      `Applied queued member deltas after bootstrap room state timeout for ${roomCode}`,
+    );
+    await applyRoomMemberState(resolvedState);
+  }
+
+  function startWaitingForBootstrapRoomState(): void {
+    stopWaitingForBootstrapRoomState();
+    waitingForBootstrapRoomState = true;
+    bootstrapRoomStateTimer = globalThis.setTimeout(() => {
+      void expireBootstrapRoomStateWait();
+    }, bootstrapRoomStateTimeoutMs);
+    const timerControls = bootstrapRoomStateTimer as {
+      unref?: () => void;
+    } | null;
+    timerControls?.unref?.();
   }
 
   function syncProfileAfterRoomEstablished(): void {
@@ -203,7 +274,7 @@ export function createRoomSessionController(args: {
     switch (message.type) {
       case "room:created":
         clearPendingMemberDeltas();
-        waitingForBootstrapRoomState = true;
+        startWaitingForBootstrapRoomState();
         args.roomSessionState.pendingJoinRoomCode = null;
         args.roomSessionState.pendingJoinToken = null;
         args.roomSessionState.roomCode = message.payload.roomCode;
@@ -218,7 +289,7 @@ export function createRoomSessionController(args: {
         return;
       case "room:joined":
         clearPendingMemberDeltas();
-        waitingForBootstrapRoomState = true;
+        startWaitingForBootstrapRoomState();
         args.roomSessionState.roomCode = message.payload.roomCode;
         args.roomSessionState.joinToken =
           args.roomSessionState.pendingJoinToken ??
@@ -266,7 +337,7 @@ export function createRoomSessionController(args: {
             "background",
             `Join failed for room ${args.roomSessionState.pendingJoinRoomCode}`,
           );
-          waitingForBootstrapRoomState = false;
+          stopWaitingForBootstrapRoomState();
           settlePendingJoinAttempt("failed");
           args.roomSessionState.pendingJoinRequestSent = false;
           args.roomSessionState.pendingJoinRoomCode = null;
@@ -332,9 +403,6 @@ export function createRoomSessionController(args: {
       return;
     }
     if (!currentState || currentState.roomCode !== roomCode) {
-      if (!currentState && args.roomSessionState.roomCode === roomCode) {
-        queueMemberDelta({ type: "joined", roomCode, member });
-      }
       return;
     }
 
@@ -356,9 +424,6 @@ export function createRoomSessionController(args: {
       return;
     }
     if (!currentState || currentState.roomCode !== roomCode) {
-      if (!currentState && args.roomSessionState.roomCode === roomCode) {
-        queueMemberDelta({ type: "left", roomCode, member });
-      }
       return;
     }
 
@@ -404,7 +469,7 @@ export function createRoomSessionController(args: {
     }
 
     const resolvedState = consumePendingMemberDeltas(nextState);
-    waitingForBootstrapRoomState = false;
+    stopWaitingForBootstrapRoomState();
     args.roomSessionState.roomState = resolvedState;
     args.roomSessionState.roomCode = resolvedState.roomCode;
     args.connectionState.lastError = null;
@@ -460,7 +525,7 @@ export function createRoomSessionController(args: {
     errorMessage: string | null = null,
   ): Promise<void> {
     clearPendingMemberDeltas();
-    waitingForBootstrapRoomState = false;
+    stopWaitingForBootstrapRoomState();
     args.log("background", `Clearing current room context (${reason})`);
     args.roomSessionState.roomCode = null;
     args.roomSessionState.joinToken = null;
@@ -482,7 +547,7 @@ export function createRoomSessionController(args: {
   async function requestCreateRoom(): Promise<void> {
     args.resetReconnectState();
     clearPendingMemberDeltas();
-    waitingForBootstrapRoomState = false;
+    stopWaitingForBootstrapRoomState();
     args.roomSessionState.roomCode = null;
     args.roomSessionState.joinToken = null;
     args.roomSessionState.memberToken = null;
@@ -517,7 +582,7 @@ export function createRoomSessionController(args: {
   ): Promise<void> {
     args.resetReconnectState();
     clearPendingMemberDeltas();
-    waitingForBootstrapRoomState = false;
+    stopWaitingForBootstrapRoomState();
     args.roomSessionState.pendingCreateRoom = false;
     args.roomSessionState.pendingJoinRoomCode = roomCode.trim().toUpperCase();
     args.roomSessionState.pendingJoinToken = joinToken.trim();
@@ -551,7 +616,7 @@ export function createRoomSessionController(args: {
 
   async function requestLeaveRoom(): Promise<void> {
     clearPendingMemberDeltas();
-    waitingForBootstrapRoomState = false;
+    stopWaitingForBootstrapRoomState();
     args.log(
       "background",
       `Popup requested leave for ${args.roomSessionState.roomCode ?? "none"}`,

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -24,6 +24,11 @@ import {
 import { localizeServerError } from "../shared/i18n";
 
 type JoinAttemptResult = "joined" | "failed" | "timeout";
+type PendingMemberDelta = {
+  type: "joined" | "left";
+  roomCode: string;
+  member: RoomMember;
+};
 
 export interface RoomSessionController {
   sendJoinRequest(targetRoomCode: string, targetJoinToken: string): void;
@@ -68,6 +73,57 @@ export function createRoomSessionController(args: {
 }): RoomSessionController {
   let pendingJoinAttemptResolvers: Array<(result: JoinAttemptResult) => void> =
     [];
+  let pendingMemberDeltas: PendingMemberDelta[] = [];
+
+  function clearPendingMemberDeltas(): void {
+    pendingMemberDeltas = [];
+  }
+
+  function applyMemberDelta(
+    currentState: RoomState,
+    delta: PendingMemberDelta,
+  ): RoomState {
+    if (currentState.roomCode !== delta.roomCode) {
+      return currentState;
+    }
+
+    if (delta.type === "left") {
+      return {
+        ...currentState,
+        members: currentState.members.filter(
+          (candidate) => candidate.id !== delta.member.id,
+        ),
+      };
+    }
+
+    const existingMemberIndex = currentState.members.findIndex(
+      (candidate) => candidate.id === delta.member.id,
+    );
+    const members =
+      existingMemberIndex === -1
+        ? [...currentState.members, delta.member]
+        : currentState.members.map((candidate, index) =>
+            index === existingMemberIndex ? delta.member : candidate,
+          );
+    return {
+      ...currentState,
+      members,
+    };
+  }
+
+  function consumePendingMemberDeltas(nextState: RoomState): RoomState {
+    let resolvedState = nextState;
+    const remainingDeltas: PendingMemberDelta[] = [];
+    for (const delta of pendingMemberDeltas) {
+      if (delta.roomCode === nextState.roomCode) {
+        resolvedState = applyMemberDelta(resolvedState, delta);
+      } else {
+        remainingDeltas.push(delta);
+      }
+    }
+    pendingMemberDeltas = remainingDeltas;
+    return resolvedState;
+  }
 
   function syncProfileAfterRoomEstablished(): void {
     if (
@@ -141,6 +197,7 @@ export function createRoomSessionController(args: {
   async function handleServerMessage(message: ServerMessage): Promise<void> {
     switch (message.type) {
       case "room:created":
+        clearPendingMemberDeltas();
         args.roomSessionState.pendingJoinRoomCode = null;
         args.roomSessionState.pendingJoinToken = null;
         args.roomSessionState.roomCode = message.payload.roomCode;
@@ -154,6 +211,7 @@ export function createRoomSessionController(args: {
         args.notifyAll();
         return;
       case "room:joined":
+        clearPendingMemberDeltas();
         args.roomSessionState.roomCode = message.payload.roomCode;
         args.roomSessionState.joinToken =
           args.roomSessionState.pendingJoinToken ??
@@ -259,22 +317,15 @@ export function createRoomSessionController(args: {
   ): Promise<void> {
     const currentState = args.roomSessionState.roomState;
     if (!currentState || currentState.roomCode !== roomCode) {
+      if (!currentState && args.roomSessionState.roomCode === roomCode) {
+        pendingMemberDeltas.push({ type: "joined", roomCode, member });
+      }
       return;
     }
 
-    const existingMemberIndex = currentState.members.findIndex(
-      (candidate) => candidate.id === member.id,
+    await applyRoomMemberState(
+      applyMemberDelta(currentState, { type: "joined", roomCode, member }),
     );
-    const members =
-      existingMemberIndex === -1
-        ? [...currentState.members, member]
-        : currentState.members.map((candidate, index) =>
-            index === existingMemberIndex ? member : candidate,
-          );
-    await applyRoomMemberState({
-      ...currentState,
-      members,
-    });
   }
 
   async function handleRoomMemberLeft(
@@ -283,15 +334,15 @@ export function createRoomSessionController(args: {
   ): Promise<void> {
     const currentState = args.roomSessionState.roomState;
     if (!currentState || currentState.roomCode !== roomCode) {
+      if (!currentState && args.roomSessionState.roomCode === roomCode) {
+        pendingMemberDeltas.push({ type: "left", roomCode, member });
+      }
       return;
     }
 
-    await applyRoomMemberState({
-      ...currentState,
-      members: currentState.members.filter(
-        (candidate) => candidate.id !== member.id,
-      ),
-    });
+    await applyRoomMemberState(
+      applyMemberDelta(currentState, { type: "left", roomCode, member }),
+    );
   }
 
   async function handleRoomStateMessage(nextState: RoomState): Promise<void> {
@@ -330,8 +381,9 @@ export function createRoomSessionController(args: {
       args.shareState.pendingShareToast = createPendingShareToast(nextState);
     }
 
-    args.roomSessionState.roomState = nextState;
-    args.roomSessionState.roomCode = nextState.roomCode;
+    const resolvedState = consumePendingMemberDeltas(nextState);
+    args.roomSessionState.roomState = resolvedState;
+    args.roomSessionState.roomCode = resolvedState.roomCode;
     args.connectionState.lastError = null;
 
     if (decision.confirmedPendingLocalShare) {
@@ -384,6 +436,7 @@ export function createRoomSessionController(args: {
     reason: string,
     errorMessage: string | null = null,
   ): Promise<void> {
+    clearPendingMemberDeltas();
     args.log("background", `Clearing current room context (${reason})`);
     args.roomSessionState.roomCode = null;
     args.roomSessionState.joinToken = null;
@@ -404,6 +457,7 @@ export function createRoomSessionController(args: {
 
   async function requestCreateRoom(): Promise<void> {
     args.resetReconnectState();
+    clearPendingMemberDeltas();
     args.roomSessionState.roomCode = null;
     args.roomSessionState.joinToken = null;
     args.roomSessionState.memberToken = null;
@@ -437,6 +491,7 @@ export function createRoomSessionController(args: {
     joinToken: string,
   ): Promise<void> {
     args.resetReconnectState();
+    clearPendingMemberDeltas();
     args.roomSessionState.pendingCreateRoom = false;
     args.roomSessionState.pendingJoinRoomCode = roomCode.trim().toUpperCase();
     args.roomSessionState.pendingJoinToken = joinToken.trim();
@@ -469,6 +524,7 @@ export function createRoomSessionController(args: {
   }
 
   async function requestLeaveRoom(): Promise<void> {
+    clearPendingMemberDeltas();
     args.log(
       "background",
       `Popup requested leave for ${args.roomSessionState.roomCode ?? "none"}`,

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -78,6 +78,7 @@ export function createRoomSessionController(args: {
     [];
   let pendingMemberDeltas: PendingMemberDelta[] = [];
   let waitingForBootstrapRoomState = false;
+  let bootstrapRoomStateGeneration = 0;
   let bootstrapRoomStateTimer: ReturnType<typeof globalThis.setTimeout> | null =
     null;
   const bootstrapRoomStateTimeoutMs =
@@ -149,14 +150,20 @@ export function createRoomSessionController(args: {
 
   function stopWaitingForBootstrapRoomState(): void {
     waitingForBootstrapRoomState = false;
+    bootstrapRoomStateGeneration += 1;
     if (bootstrapRoomStateTimer !== null) {
       globalThis.clearTimeout(bootstrapRoomStateTimer);
       bootstrapRoomStateTimer = null;
     }
   }
 
-  async function expireBootstrapRoomStateWait(): Promise<void> {
-    if (!waitingForBootstrapRoomState) {
+  async function expireBootstrapRoomStateWait(
+    generation: number,
+  ): Promise<void> {
+    if (
+      !waitingForBootstrapRoomState ||
+      generation !== bootstrapRoomStateGeneration
+    ) {
       return;
     }
 
@@ -182,18 +189,45 @@ export function createRoomSessionController(args: {
     }
 
     const resolvedState = consumePendingMemberDeltas(currentState);
+    if (
+      generation !== bootstrapRoomStateGeneration ||
+      args.roomSessionState.roomCode !== roomCode ||
+      args.roomSessionState.roomState !== currentState
+    ) {
+      return;
+    }
+
     args.log(
       "background",
       `Applied queued member deltas after bootstrap room state timeout for ${roomCode}`,
     );
-    await applyRoomMemberState(resolvedState);
+    args.roomSessionState.roomState = resolvedState;
+    args.roomSessionState.roomCode = resolvedState.roomCode;
+    args.connectionState.lastError = null;
+    await args.persistState();
+    if (
+      generation !== bootstrapRoomStateGeneration ||
+      args.roomSessionState.roomState !== resolvedState
+    ) {
+      await args.persistState();
+      return;
+    }
+    const compensatedRoomState = args.compensateRoomState(resolvedState);
+    await args.notifyContentScripts({
+      type: "background:apply-room-state",
+      payload: compensatedRoomState,
+      shareToast: null,
+    });
+    args.notifyAll();
   }
 
   function startWaitingForBootstrapRoomState(): void {
     stopWaitingForBootstrapRoomState();
     waitingForBootstrapRoomState = true;
+    bootstrapRoomStateGeneration += 1;
+    const generation = bootstrapRoomStateGeneration;
     bootstrapRoomStateTimer = globalThis.setTimeout(() => {
-      void expireBootstrapRoomStateWait();
+      void expireBootstrapRoomStateWait(generation);
     }, bootstrapRoomStateTimeoutMs);
     const timerControls = bootstrapRoomStateTimer as {
       unref?: () => void;

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -5,7 +5,9 @@ import { createBackgroundRuntimeState } from "../src/background/runtime-state";
 import { createRoomSessionController } from "../src/background/room-session-controller";
 import { setLocaleForTests } from "../src/shared/i18n";
 
-function createControllerHarness() {
+function createControllerHarness(options?: {
+  bootstrapRoomStateTimeoutMs?: number;
+}) {
   const runtimeState = createBackgroundRuntimeState();
   const sendToServerCalls: Array<unknown> = [];
   const notifyContentMessages: Array<unknown> = [];
@@ -69,6 +71,7 @@ function createControllerHarness() {
       logs.push(`server-error:${code}:${message}`);
     },
     shareToastTtlMs: 8_000,
+    bootstrapRoomStateTimeoutMs: options?.bootstrapRoomStateTimeoutMs,
   });
 
   return {
@@ -343,7 +346,16 @@ test("room session controller applies room member join and leave deltas", async 
 
 test("room session controller replays member deltas received before bootstrap state", async () => {
   const harness = createControllerHarness();
-  harness.runtimeState.room.roomCode = "ROOM04";
+
+  await harness.controller.handleServerMessage({
+    type: "room:created",
+    payload: {
+      roomCode: "ROOM04",
+      joinToken: "join-token-4",
+      memberToken: "member-token-4",
+      memberId: "member-1",
+    },
+  } satisfies ServerMessage);
 
   await harness.controller.handleServerMessage({
     type: "room:member-joined",
@@ -373,8 +385,67 @@ test("room session controller replays member deltas received before bootstrap st
   assert.deepEqual(harness.runtimeState.room.roomState?.members, [
     { id: "member-2", name: "Bob" },
   ]);
-  assert.equal(harness.persistReasons.length, 1);
+  assert.equal(harness.persistReasons.length, 2);
   assert.equal(harness.notifyContentMessages.length, 1);
+});
+
+test("room session controller releases queued reconnect deltas when bootstrap state times out", async () => {
+  const harness = createControllerHarness({ bootstrapRoomStateTimeoutMs: 1 });
+  harness.runtimeState.room.roomCode = "ROOM04";
+  harness.runtimeState.room.roomState = {
+    roomCode: "ROOM04",
+    sharedVideo: {
+      videoId: "BV1old",
+      url: "https://www.bilibili.com/video/BV1old",
+      title: "Old Video",
+      sharedByMemberId: "member-1",
+    },
+    playback: null,
+    members: [{ id: "member-1", name: "Alice" }],
+  };
+
+  await harness.controller.handleServerMessage({
+    type: "room:joined",
+    payload: {
+      roomCode: "ROOM04",
+      memberToken: "member-token-1",
+      memberId: "member-1",
+    },
+  } satisfies ServerMessage);
+  await harness.controller.handleServerMessage({
+    type: "room:member-joined",
+    payload: {
+      roomCode: "ROOM04",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 10));
+
+  assert.deepEqual(harness.runtimeState.room.roomState?.members, [
+    { id: "member-1", name: "Alice" },
+    { id: "member-2", name: "Bob" },
+  ]);
+  assert.equal(
+    harness.runtimeState.room.roomState?.sharedVideo?.url,
+    "https://www.bilibili.com/video/BV1old",
+  );
+  assert.equal(harness.persistReasons.length, 2);
+  assert.equal(harness.notifyContentMessages.length, 1);
+
+  await harness.controller.handleServerMessage({
+    type: "room:member-left",
+    payload: {
+      roomCode: "ROOM04",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  assert.deepEqual(harness.runtimeState.room.roomState?.members, [
+    { id: "member-1", name: "Alice" },
+  ]);
+  assert.equal(harness.persistReasons.length, 3);
+  assert.equal(harness.notifyContentMessages.length, 2);
 });
 
 test("room session controller queues reconnect deltas until fresh bootstrap state", async () => {

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -109,7 +109,7 @@ test("room session controller sends create request with protocolVersion", async 
     type: "room:create",
     payload: {
       displayName: "Bob",
-      protocolVersion: 1,
+      protocolVersion: 2,
     },
   });
 });
@@ -185,7 +185,7 @@ test("room session controller sends join request after connect and normalizes pe
       roomCode: "ROOM01",
       joinToken: "token-1",
       displayName: "Alice",
-      protocolVersion: 1,
+      protocolVersion: 2,
     },
   });
   assert.equal(harness.persistReasons.length, 1);
@@ -341,8 +341,9 @@ test("room session controller applies room member join and leave deltas", async 
   assert.equal(harness.notifyContentMessages.length, 2);
 });
 
-test("room session controller ignores member deltas before bootstrap state", async () => {
+test("room session controller replays member deltas received before bootstrap state", async () => {
   const harness = createControllerHarness();
+  harness.runtimeState.room.roomCode = "ROOM04";
 
   await harness.controller.handleServerMessage({
     type: "room:member-joined",
@@ -351,10 +352,29 @@ test("room session controller ignores member deltas before bootstrap state", asy
       member: { id: "member-2", name: "Bob" },
     },
   } satisfies ServerMessage);
+  await harness.controller.handleServerMessage({
+    type: "room:member-left",
+    payload: {
+      roomCode: "ROOM04",
+      member: { id: "member-1", name: "Alice" },
+    },
+  } satisfies ServerMessage);
 
-  assert.equal(harness.runtimeState.room.roomState, null);
-  assert.equal(harness.persistReasons.length, 0);
-  assert.equal(harness.notifyContentMessages.length, 0);
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: {
+      roomCode: "ROOM04",
+      sharedVideo: null,
+      playback: null,
+      members: [{ id: "member-1", name: "Alice" }],
+    },
+  } satisfies ServerMessage);
+
+  assert.deepEqual(harness.runtimeState.room.roomState?.members, [
+    { id: "member-2", name: "Bob" },
+  ]);
+  assert.equal(harness.persistReasons.length, 1);
+  assert.equal(harness.notifyContentMessages.length, 1);
 });
 
 test("room session controller syncs display name after room creation completes", async () => {

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -377,6 +377,74 @@ test("room session controller replays member deltas received before bootstrap st
   assert.equal(harness.notifyContentMessages.length, 1);
 });
 
+test("room session controller queues reconnect deltas until fresh bootstrap state", async () => {
+  const harness = createControllerHarness();
+  harness.runtimeState.room.roomCode = "ROOM04";
+  harness.runtimeState.room.roomState = {
+    roomCode: "ROOM04",
+    sharedVideo: {
+      videoId: "BV1old",
+      url: "https://www.bilibili.com/video/BV1old",
+      title: "Old Video",
+      sharedByMemberId: "member-1",
+    },
+    playback: null,
+    members: [{ id: "member-1", name: "Alice" }],
+  };
+
+  await harness.controller.handleServerMessage({
+    type: "room:joined",
+    payload: {
+      roomCode: "ROOM04",
+      memberToken: "member-token-1",
+      memberId: "member-1",
+    },
+  } satisfies ServerMessage);
+  await harness.controller.handleServerMessage({
+    type: "room:member-joined",
+    payload: {
+      roomCode: "ROOM04",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  assert.deepEqual(harness.runtimeState.room.roomState.members, [
+    { id: "member-1", name: "Alice" },
+  ]);
+  assert.equal(
+    harness.runtimeState.room.roomState.sharedVideo?.url,
+    "https://www.bilibili.com/video/BV1old",
+  );
+  assert.equal(harness.persistReasons.length, 1);
+  assert.equal(harness.notifyContentMessages.length, 0);
+
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: {
+      roomCode: "ROOM04",
+      sharedVideo: {
+        videoId: "BV1new",
+        url: "https://www.bilibili.com/video/BV1new",
+        title: "New Video",
+        sharedByMemberId: "member-2",
+      },
+      playback: null,
+      members: [{ id: "member-1", name: "Alice" }],
+    },
+  } satisfies ServerMessage);
+
+  assert.deepEqual(harness.runtimeState.room.roomState?.members, [
+    { id: "member-1", name: "Alice" },
+    { id: "member-2", name: "Bob" },
+  ]);
+  assert.equal(
+    harness.runtimeState.room.roomState?.sharedVideo?.url,
+    "https://www.bilibili.com/video/BV1new",
+  );
+  assert.equal(harness.persistReasons.length, 2);
+  assert.equal(harness.notifyContentMessages.length, 1);
+});
+
 test("room session controller syncs display name after room creation completes", async () => {
   const harness = createControllerHarness();
   harness.runtimeState.connection.connected = true;

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -608,6 +608,75 @@ test("room session controller queues reconnect deltas until fresh bootstrap stat
   assert.equal(harness.notifyContentMessages.length, 1);
 });
 
+test("room session controller queues member deltas that arrive before room joined", async () => {
+  const harness = createControllerHarness();
+  harness.runtimeState.room.roomCode = "ROOM04";
+  harness.runtimeState.room.pendingJoinRequestSent = true;
+  harness.runtimeState.room.roomState = {
+    roomCode: "ROOM04",
+    sharedVideo: {
+      videoId: "BV1old",
+      url: "https://www.bilibili.com/video/BV1old",
+      title: "Old Video",
+      sharedByMemberId: "member-1",
+    },
+    playback: null,
+    members: [{ id: "member-1", name: "Alice" }],
+  };
+
+  await harness.controller.handleServerMessage({
+    type: "room:member-joined",
+    payload: {
+      roomCode: "ROOM04",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  assert.deepEqual(harness.runtimeState.room.roomState.members, [
+    { id: "member-1", name: "Alice" },
+  ]);
+  assert.equal(
+    harness.runtimeState.room.roomState.sharedVideo?.url,
+    "https://www.bilibili.com/video/BV1old",
+  );
+  assert.equal(harness.persistReasons.length, 0);
+  assert.equal(harness.notifyContentMessages.length, 0);
+
+  await harness.controller.handleServerMessage({
+    type: "room:joined",
+    payload: {
+      roomCode: "ROOM04",
+      memberToken: "member-token-1",
+      memberId: "member-1",
+    },
+  } satisfies ServerMessage);
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: {
+      roomCode: "ROOM04",
+      sharedVideo: {
+        videoId: "BV1new",
+        url: "https://www.bilibili.com/video/BV1new",
+        title: "New Video",
+        sharedByMemberId: "member-2",
+      },
+      playback: null,
+      members: [{ id: "member-1", name: "Alice" }],
+    },
+  } satisfies ServerMessage);
+
+  assert.deepEqual(harness.runtimeState.room.roomState?.members, [
+    { id: "member-1", name: "Alice" },
+    { id: "member-2", name: "Bob" },
+  ]);
+  assert.equal(
+    harness.runtimeState.room.roomState?.sharedVideo?.url,
+    "https://www.bilibili.com/video/BV1new",
+  );
+  assert.equal(harness.persistReasons.length, 2);
+  assert.equal(harness.notifyContentMessages.length, 1);
+});
+
 test("room session controller syncs display name after room creation completes", async () => {
   const harness = createControllerHarness();
   harness.runtimeState.connection.connected = true;

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -302,6 +302,61 @@ test("room session controller confirms pending local share and notifies content 
   assert.equal(harness.notifyAllCalls, 1);
 });
 
+test("room session controller applies room member join and leave deltas", async () => {
+  const harness = createControllerHarness();
+  harness.runtimeState.room.roomState = {
+    roomCode: "ROOM04",
+    sharedVideo: null,
+    playback: null,
+    members: [{ id: "member-1", name: "Alice" }],
+  };
+
+  await harness.controller.handleServerMessage({
+    type: "room:member-joined",
+    payload: {
+      roomCode: "ROOM04",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  assert.deepEqual(harness.runtimeState.room.roomState.members, [
+    { id: "member-1", name: "Alice" },
+    { id: "member-2", name: "Bob" },
+  ]);
+  assert.equal(harness.persistReasons.length, 1);
+  assert.equal(harness.notifyContentMessages.length, 1);
+
+  await harness.controller.handleServerMessage({
+    type: "room:member-left",
+    payload: {
+      roomCode: "ROOM04",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  assert.deepEqual(harness.runtimeState.room.roomState.members, [
+    { id: "member-1", name: "Alice" },
+  ]);
+  assert.equal(harness.persistReasons.length, 2);
+  assert.equal(harness.notifyContentMessages.length, 2);
+});
+
+test("room session controller ignores member deltas before bootstrap state", async () => {
+  const harness = createControllerHarness();
+
+  await harness.controller.handleServerMessage({
+    type: "room:member-joined",
+    payload: {
+      roomCode: "ROOM04",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  assert.equal(harness.runtimeState.room.roomState, null);
+  assert.equal(harness.persistReasons.length, 0);
+  assert.equal(harness.notifyContentMessages.length, 0);
+});
+
 test("room session controller syncs display name after room creation completes", async () => {
   const harness = createControllerHarness();
   harness.runtimeState.connection.connected = true;

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -7,6 +7,7 @@ import { setLocaleForTests } from "../src/shared/i18n";
 
 function createControllerHarness(options?: {
   bootstrapRoomStateTimeoutMs?: number;
+  persistState?: (callCount: number) => Promise<void> | void;
 }) {
   const runtimeState = createBackgroundRuntimeState();
   const sendToServerCalls: Array<unknown> = [];
@@ -33,6 +34,7 @@ function createControllerHarness(options?: {
     },
     persistState: async () => {
       persistReasons.push("persisted");
+      await options?.persistState?.(persistReasons.length);
     },
     sendToServer: (message) => {
       sendToServerCalls.push(message);
@@ -446,6 +448,96 @@ test("room session controller releases queued reconnect deltas when bootstrap st
   ]);
   assert.equal(harness.persistReasons.length, 3);
   assert.equal(harness.notifyContentMessages.length, 2);
+});
+
+test("room session controller does not let timeout replay overwrite a late bootstrap state", async () => {
+  let resolveTimeoutPersistStarted: (() => void) | null = null;
+  let releaseTimeoutPersist: (() => void) | null = null;
+  const timeoutPersistStarted = new Promise<void>((resolve) => {
+    resolveTimeoutPersistStarted = resolve;
+  });
+  const timeoutPersistRelease = new Promise<void>((resolve) => {
+    releaseTimeoutPersist = resolve;
+  });
+  const harness = createControllerHarness({
+    bootstrapRoomStateTimeoutMs: 1,
+    async persistState(callCount) {
+      if (callCount === 2) {
+        resolveTimeoutPersistStarted?.();
+        await timeoutPersistRelease;
+      }
+    },
+  });
+  harness.runtimeState.room.roomCode = "ROOM04";
+  harness.runtimeState.room.roomState = {
+    roomCode: "ROOM04",
+    sharedVideo: {
+      videoId: "BV1old",
+      url: "https://www.bilibili.com/video/BV1old",
+      title: "Old Video",
+      sharedByMemberId: "member-1",
+    },
+    playback: null,
+    members: [{ id: "member-1", name: "Alice" }],
+  };
+
+  await harness.controller.handleServerMessage({
+    type: "room:joined",
+    payload: {
+      roomCode: "ROOM04",
+      memberToken: "member-token-1",
+      memberId: "member-1",
+    },
+  } satisfies ServerMessage);
+  await harness.controller.handleServerMessage({
+    type: "room:member-joined",
+    payload: {
+      roomCode: "ROOM04",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  await Promise.race([
+    timeoutPersistStarted,
+    new Promise((_, reject) =>
+      globalThis.setTimeout(
+        () => reject(new Error("Timed out waiting for timeout persist")),
+        50,
+      ),
+    ),
+  ]);
+  const freshBootstrapState: RoomState = {
+    roomCode: "ROOM04",
+    sharedVideo: {
+      videoId: "BV1new",
+      url: "https://www.bilibili.com/video/BV1new",
+      title: "New Video",
+      sharedByMemberId: "member-3",
+    },
+    playback: null,
+    members: [
+      { id: "member-1", name: "Alice" },
+      { id: "member-3", name: "Carol" },
+    ],
+  };
+
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: freshBootstrapState,
+  } satisfies ServerMessage);
+  releaseTimeoutPersist?.();
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+
+  assert.deepEqual(harness.runtimeState.room.roomState, freshBootstrapState);
+  assert.equal(harness.notifyContentMessages.length, 1);
+  assert.deepEqual(
+    (
+      harness.notifyContentMessages[0] as {
+        payload: RoomState;
+      }
+    ).payload,
+    freshBootstrapState,
+  );
 });
 
 test("room session controller queues reconnect deltas until fresh bootstrap state", async () => {

--- a/packages/protocol/src/guards/server-message.ts
+++ b/packages/protocol/src/guards/server-message.ts
@@ -2,6 +2,8 @@ import type {
   ErrorMessage,
   RoomCreatedMessage,
   RoomJoinedMessage,
+  RoomMemberJoinedMessage,
+  RoomMemberLeftMessage,
   RoomStateMessage,
   ServerMessage,
   SyncPongMessage,
@@ -117,6 +119,30 @@ function isRoomStateMessage(value: unknown): value is RoomStateMessage {
   );
 }
 
+function isRoomMemberJoinedMessage(
+  value: unknown,
+): value is RoomMemberJoinedMessage {
+  return (
+    isRecord(value) &&
+    value.type === "room:member-joined" &&
+    isRecord(value.payload) &&
+    isRoomCode(value.payload.roomCode) &&
+    isRoomMember(value.payload.member)
+  );
+}
+
+function isRoomMemberLeftMessage(
+  value: unknown,
+): value is RoomMemberLeftMessage {
+  return (
+    isRecord(value) &&
+    value.type === "room:member-left" &&
+    isRecord(value.payload) &&
+    isRoomCode(value.payload.roomCode) &&
+    isRoomMember(value.payload.member)
+  );
+}
+
 export function isErrorMessage(value: unknown): value is ErrorMessage {
   return (
     isRecord(value) &&
@@ -150,6 +176,10 @@ export function isServerMessage(value: unknown): value is ServerMessage {
       return isRoomJoinedMessage(value);
     case "room:state":
       return isRoomStateMessage(value);
+    case "room:member-joined":
+      return isRoomMemberJoinedMessage(value);
+    case "room:member-left":
+      return isRoomMemberLeftMessage(value);
     case "error":
       return isErrorMessage(value);
     case "sync:pong":

--- a/packages/protocol/src/types/common.ts
+++ b/packages/protocol/src/types/common.ts
@@ -1,4 +1,4 @@
-export const PROTOCOL_VERSION = 1;
+export const PROTOCOL_VERSION = 2;
 
 export type RoomCode = string;
 export type PlaybackPlayState = "playing" | "paused" | "buffering";

--- a/packages/protocol/src/types/server-message.ts
+++ b/packages/protocol/src/types/server-message.ts
@@ -1,5 +1,5 @@
 import type { ErrorCode, RoomCode } from "./common.js";
-import type { RoomState } from "./domain.js";
+import type { RoomMember, RoomState } from "./domain.js";
 
 export interface RoomCreatedMessage {
   type: "room:created";
@@ -27,6 +27,22 @@ export interface RoomStateMessage {
   payload: RoomState;
 }
 
+export interface RoomMemberJoinedMessage {
+  type: "room:member-joined";
+  payload: {
+    roomCode: RoomCode;
+    member: RoomMember;
+  };
+}
+
+export interface RoomMemberLeftMessage {
+  type: "room:member-left";
+  payload: {
+    roomCode: RoomCode;
+    member: RoomMember;
+  };
+}
+
 export interface ErrorMessage {
   type: "error";
   payload: {
@@ -48,5 +64,7 @@ export type ServerMessage =
   | RoomCreatedMessage
   | RoomJoinedMessage
   | RoomStateMessage
+  | RoomMemberJoinedMessage
+  | RoomMemberLeftMessage
   | ErrorMessage
   | SyncPongMessage;

--- a/packages/protocol/test/server-message.test.ts
+++ b/packages/protocol/test/server-message.test.ts
@@ -125,6 +125,52 @@ test("accepts room:joined when memberId uses max-compatible actor format", () =>
   );
 });
 
+test("accepts room member delta messages", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:member-joined",
+      payload: {
+        roomCode: "ABC123",
+        member: { id: "member-1", name: "Alice" },
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    isServerMessage({
+      type: "room:member-left",
+      payload: {
+        roomCode: "ABC123",
+        member: { id: "member-2", name: "Bob" },
+      },
+    }),
+    true,
+  );
+});
+
+test("rejects room member delta messages with invalid member payloads", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:member-joined",
+      payload: {
+        roomCode: "ABC123",
+        member: { id: "member 1", name: "Alice" },
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    isServerMessage({
+      type: "room:member-left",
+      payload: {
+        roomCode: "ABC123",
+        member: { id: "member-2", name: "x".repeat(33) },
+      },
+    }),
+    false,
+  );
+});
+
 test("rejects room:created when memberId format is invalid", () => {
   assert.equal(
     isServerMessage({

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -227,9 +227,10 @@ export async function createSyncServer(
     publishRoomEvent,
     instanceId: persistenceConfig.instanceId,
     metricsCollector,
-    onRoomJoined: (session, roomCode) => {
+    onRoomJoined: async (session, roomCode) => {
       runtimeStore.registerSession(session);
       runtimeStore.markSessionJoinedRoom(session.id, roomCode);
+      await runtimeStore.flush?.();
     },
     onRoomLeft: (session, roomCode) => {
       runtimeStore.registerSession(session);

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -141,6 +141,9 @@ export function createMessageHandler(options: {
         memberToken,
         messageType,
       );
+      if (!hasAttachedSocket(session)) {
+        return;
+      }
       send(session.socket, {
         type: "room:state",
         payload: state,
@@ -365,27 +368,45 @@ export function createMessageHandler(options: {
               options.onRoomLeft?.(session, previousRoomCode);
             }
             options.onRoomJoined?.(session, room.code, previousRoomCode);
+            const joinedRoomCode = room.code;
+            const joinedMemberId = session.memberId ?? session.id;
+            const joinedDisplayName = session.displayName;
             send(socket, {
               type: "room:joined",
               payload: {
-                roomCode: room.code,
-                memberId: session.memberId ?? session.id,
+                roomCode: joinedRoomCode,
+                memberId: joinedMemberId,
                 memberToken,
                 serverProtocolVersion: CURRENT_PROTOCOL_VERSION,
               },
             });
             await sendRoomStateToSession(session, memberToken, message.type);
+            if (
+              session.roomCode !== joinedRoomCode ||
+              session.memberId !== joinedMemberId
+            ) {
+              logEvent("room_join_delta_skipped", {
+                sessionId: session.id,
+                roomCode: joinedRoomCode,
+                memberId: joinedMemberId,
+                remoteAddress: session.remoteAddress,
+                origin: session.origin,
+                result: "skipped",
+                reason: "session_no_longer_joined",
+              });
+              return;
+            }
             await publishRoomEvent({
               type: "room_member_joined",
-              roomCode: room.code,
-              memberId: session.memberId ?? session.id,
-              displayName: session.displayName,
+              roomCode: joinedRoomCode,
+              memberId: joinedMemberId,
+              displayName: joinedDisplayName,
             });
             logEvent("room_joined", {
               sessionId: session.id,
-              roomCode: room.code,
-              memberId: session.memberId ?? session.id,
-              displayName: session.displayName,
+              roomCode: joinedRoomCode,
+              memberId: joinedMemberId,
+              displayName: joinedDisplayName,
               remoteAddress: session.remoteAddress,
               origin: session.origin,
               result: "ok",

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -103,7 +103,7 @@ export function createMessageHandler(options: {
     session: Session,
     roomCode: string,
     previousRoomCode: string | null,
-  ) => void;
+  ) => void | Promise<void>;
   onRoomLeft?: (session: Session, roomCode: string) => void;
   now?: () => number;
 }): {
@@ -309,7 +309,7 @@ export function createMessageHandler(options: {
           if (previousRoomCode && previousRoomCode !== room.code) {
             options.onRoomLeft?.(session, previousRoomCode);
           }
-          options.onRoomJoined?.(session, room.code, previousRoomCode);
+          await options.onRoomJoined?.(session, room.code, previousRoomCode);
           send(socket, {
             type: "room:created",
             payload: {
@@ -367,7 +367,7 @@ export function createMessageHandler(options: {
             if (previousRoomCode && previousRoomCode !== room.code) {
               options.onRoomLeft?.(session, previousRoomCode);
             }
-            options.onRoomJoined?.(session, room.code, previousRoomCode);
+            await options.onRoomJoined?.(session, room.code, previousRoomCode);
             const joinedRoomCode = room.code;
             const joinedMemberId = session.memberId ?? session.id;
             const joinedDisplayName = session.displayName;

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -23,6 +23,10 @@ import type { RoomEventBusMessage } from "./room-event-bus.js";
 import { hasAttachedSocket } from "./types.js";
 import type { LogEvent, SendError, SendMessage, Session } from "./types.js";
 
+type RoomEventBusPublishInput<T> = T extends unknown
+  ? Omit<T, "sourceInstanceId" | "emittedAt">
+  : never;
+
 export function createMessageHandler(options: {
   config: {
     maxMembersPerRoom: number;
@@ -112,19 +116,38 @@ export function createMessageHandler(options: {
   const metricsCollector = options.metricsCollector;
 
   async function publishRoomEvent(
-    type: RoomEventBusMessage["type"],
-    roomCode: string,
+    message: RoomEventBusPublishInput<RoomEventBusMessage>,
   ): Promise<void> {
     await options.publishRoomEvent({
-      type,
-      roomCode,
+      ...message,
       sourceInstanceId: options.instanceId,
       emittedAt: now(),
+    } as RoomEventBusMessage);
+  }
+
+  async function sendRoomStateToSession(
+    session: Session,
+    memberToken: string,
+    messageType: ClientMessage["type"],
+  ): Promise<void> {
+    if (!hasAttachedSocket(session)) {
+      return;
+    }
+    const state = await roomService.getRoomStateForSession(
+      session,
+      memberToken,
+      messageType,
+    );
+    send(session.socket, {
+      type: "room:state",
+      payload: state,
     });
   }
 
   async function leaveRoom(session: Session): Promise<void> {
     const roomCode = session.roomCode;
+    const memberId = session.memberId ?? session.id;
+    const displayName = session.displayName;
     const { room, notifyRoom } = await roomService.leaveRoomForSession(session);
     if (!roomCode || (!room && !notifyRoom)) {
       return;
@@ -132,7 +155,12 @@ export function createMessageHandler(options: {
     options.onRoomLeft?.(session, roomCode);
 
     try {
-      await publishRoomEvent("room_member_changed", roomCode);
+      await publishRoomEvent({
+        type: "room_member_left",
+        roomCode,
+        memberId,
+        displayName,
+      });
     } catch (error) {
       logEvent("room_event_publish_failed", {
         sessionId: session.id,
@@ -141,7 +169,7 @@ export function createMessageHandler(options: {
         origin: session.origin,
         result: "error",
         reason: "leave_room_broadcast_failed",
-        eventType: "room_member_changed",
+        eventType: "room_member_left",
         error: error instanceof Error ? error.message : String(error),
       });
     }
@@ -267,7 +295,7 @@ export function createMessageHandler(options: {
               serverProtocolVersion: CURRENT_PROTOCOL_VERSION,
             },
           });
-          await publishRoomEvent("room_member_changed", room.code);
+          await sendRoomStateToSession(session, memberToken, message.type);
           logEvent("room_created", {
             sessionId: session.id,
             roomCode: room.code,
@@ -324,7 +352,13 @@ export function createMessageHandler(options: {
                 serverProtocolVersion: CURRENT_PROTOCOL_VERSION,
               },
             });
-            await publishRoomEvent("room_member_changed", room.code);
+            await sendRoomStateToSession(session, memberToken, message.type);
+            await publishRoomEvent({
+              type: "room_member_joined",
+              roomCode: room.code,
+              memberId: session.memberId ?? session.id,
+              displayName: session.displayName,
+            });
             logEvent("room_joined", {
               sessionId: session.id,
               roomCode: room.code,
@@ -359,7 +393,10 @@ export function createMessageHandler(options: {
             message.payload.memberToken,
             message.payload.displayName,
           );
-          await publishRoomEvent("room_state_updated", room.code);
+          await publishRoomEvent({
+            type: "room_state_updated",
+            roomCode: room.code,
+          });
           return;
         }
         case "video:share": {
@@ -383,7 +420,10 @@ export function createMessageHandler(options: {
               message.payload.video,
               message.payload.playback,
             );
-            await publishRoomEvent("room_state_updated", room.code);
+            await publishRoomEvent({
+              type: "room_state_updated",
+              roomCode: room.code,
+            });
           });
           return;
         }
@@ -407,7 +447,10 @@ export function createMessageHandler(options: {
               message.payload.playback,
             );
             if (!result.ignored && result.room) {
-              await publishRoomEvent("room_state_updated", result.room.code);
+              await publishRoomEvent({
+                type: "room_state_updated",
+                roomCode: result.room.code,
+              });
             }
           });
           return;

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -217,6 +217,7 @@ export function createMessageHandler(options: {
   ): boolean {
     if (clientVersion === undefined) {
       // Old extension without protocolVersion — compatible baseline, log deprecation
+      session.protocolVersion = MIN_PROTOCOL_VERSION;
       logEvent("protocol_version_missing", {
         sessionId: session.id,
         remoteAddress: session.remoteAddress,
@@ -242,6 +243,7 @@ export function createMessageHandler(options: {
       });
       return false;
     }
+    session.protocolVersion = clientVersion;
     return true;
   }
 

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -135,15 +135,29 @@ export function createMessageHandler(options: {
     if (!hasAttachedSocket(session)) {
       return;
     }
-    const state = await roomService.getRoomStateForSession(
-      session,
-      memberToken,
-      messageType,
-    );
-    send(session.socket, {
-      type: "room:state",
-      payload: state,
-    });
+    try {
+      const state = await roomService.getRoomStateForSession(
+        session,
+        memberToken,
+        messageType,
+      );
+      send(session.socket, {
+        type: "room:state",
+        payload: state,
+      });
+    } catch (error) {
+      logEvent("room_state_bootstrap_failed", {
+        sessionId: session.id,
+        roomCode: session.roomCode,
+        remoteAddress: session.remoteAddress,
+        origin: session.origin,
+        result: "error",
+        reason:
+          error instanceof RoomServiceError
+            ? error.reason
+            : "room_state_bootstrap_failed",
+      });
+    }
   }
 
   async function leaveRoom(session: Session): Promise<void> {

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -56,9 +56,11 @@ export function createMessageHandler(options: {
       displayName?: string,
       previousMemberToken?: string,
     ) => Promise<{ room: { code: string }; memberToken: string }>;
-    leaveRoomForSession: (
-      session: Session,
-    ) => Promise<{ room: { code: string } | null; notifyRoom?: boolean }>;
+    leaveRoomForSession: (session: Session) => Promise<{
+      room: { code: string } | null;
+      notifyRoom?: boolean;
+      memberRemoved?: boolean;
+    }>;
     shareVideoForSession: (
       session: Session,
       memberToken: string,
@@ -148,11 +150,15 @@ export function createMessageHandler(options: {
     const roomCode = session.roomCode;
     const memberId = session.memberId ?? session.id;
     const displayName = session.displayName;
-    const { room, notifyRoom } = await roomService.leaveRoomForSession(session);
+    const { room, notifyRoom, memberRemoved } =
+      await roomService.leaveRoomForSession(session);
     if (!roomCode || (!room && !notifyRoom)) {
       return;
     }
     options.onRoomLeft?.(session, roomCode);
+    if (!memberRemoved && !notifyRoom) {
+      return;
+    }
 
     try {
       await publishRoomEvent({

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -127,6 +127,41 @@ export function createMessageHandler(options: {
     } as RoomEventBusMessage);
   }
 
+  async function runRoomJoinedHook(
+    session: Session,
+    roomCode: string,
+    previousRoomCode: string | null,
+  ): Promise<void> {
+    try {
+      await options.onRoomJoined?.(session, roomCode, previousRoomCode);
+    } catch (error) {
+      logEvent("room_join_hook_failed", {
+        sessionId: session.id,
+        roomCode,
+        previousRoomCode,
+        remoteAddress: session.remoteAddress,
+        origin: session.origin,
+        result: "error",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  function runRoomLeftHook(session: Session, roomCode: string): void {
+    try {
+      options.onRoomLeft?.(session, roomCode);
+    } catch (error) {
+      logEvent("room_left_hook_failed", {
+        sessionId: session.id,
+        roomCode,
+        remoteAddress: session.remoteAddress,
+        origin: session.origin,
+        result: "error",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   async function sendRoomStateToSession(
     session: Session,
     memberToken: string,
@@ -172,7 +207,7 @@ export function createMessageHandler(options: {
     if (!roomCode || (!room && !notifyRoom)) {
       return;
     }
-    options.onRoomLeft?.(session, roomCode);
+    runRoomLeftHook(session, roomCode);
     if (!memberRemoved && !notifyRoom) {
       return;
     }
@@ -307,9 +342,9 @@ export function createMessageHandler(options: {
             message.payload?.displayName,
           );
           if (previousRoomCode && previousRoomCode !== room.code) {
-            options.onRoomLeft?.(session, previousRoomCode);
+            runRoomLeftHook(session, previousRoomCode);
           }
-          await options.onRoomJoined?.(session, room.code, previousRoomCode);
+          await runRoomJoinedHook(session, room.code, previousRoomCode);
           send(socket, {
             type: "room:created",
             payload: {
@@ -365,9 +400,9 @@ export function createMessageHandler(options: {
               message.payload.memberToken,
             );
             if (previousRoomCode && previousRoomCode !== room.code) {
-              options.onRoomLeft?.(session, previousRoomCode);
+              runRoomLeftHook(session, previousRoomCode);
             }
-            await options.onRoomJoined?.(session, room.code, previousRoomCode);
+            await runRoomJoinedHook(session, room.code, previousRoomCode);
             const joinedRoomCode = room.code;
             const joinedMemberId = session.memberId ?? session.id;
             const joinedDisplayName = session.displayName;
@@ -396,12 +431,25 @@ export function createMessageHandler(options: {
               });
               return;
             }
-            await publishRoomEvent({
-              type: "room_member_joined",
-              roomCode: joinedRoomCode,
-              memberId: joinedMemberId,
-              displayName: joinedDisplayName,
-            });
+            try {
+              await publishRoomEvent({
+                type: "room_member_joined",
+                roomCode: joinedRoomCode,
+                memberId: joinedMemberId,
+                displayName: joinedDisplayName,
+              });
+            } catch (error) {
+              logEvent("room_event_publish_failed", {
+                sessionId: session.id,
+                roomCode: joinedRoomCode,
+                remoteAddress: session.remoteAddress,
+                origin: session.origin,
+                result: "error",
+                reason: "join_room_broadcast_failed",
+                eventType: "room_member_joined",
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
             logEvent("room_joined", {
               sessionId: session.id,
               roomCode: joinedRoomCode,

--- a/server/src/messages.ts
+++ b/server/src/messages.ts
@@ -34,4 +34,4 @@ export const UNSUPPORTED_PROTOCOL_VERSION_MESSAGE =
 export const MIN_PROTOCOL_VERSION = 1;
 
 /** Current protocol version this server implements. */
-export const CURRENT_PROTOCOL_VERSION = 1;
+export const CURRENT_PROTOCOL_VERSION = 2;

--- a/server/src/redis-room-event-bus.ts
+++ b/server/src/redis-room-event-bus.ts
@@ -22,9 +22,31 @@ function parseMessage(payload: string): RoomEventBusMessage | null {
     if (
       parsed.type !== "room_state_updated" &&
       parsed.type !== "room_member_changed" &&
+      parsed.type !== "room_member_joined" &&
+      parsed.type !== "room_member_left" &&
       parsed.type !== "room_deleted"
     ) {
       return null;
+    }
+
+    if (
+      parsed.type === "room_member_joined" ||
+      parsed.type === "room_member_left"
+    ) {
+      if (
+        typeof parsed.memberId !== "string" ||
+        typeof parsed.displayName !== "string"
+      ) {
+        return null;
+      }
+      return {
+        type: parsed.type,
+        roomCode: parsed.roomCode,
+        sourceInstanceId: parsed.sourceInstanceId,
+        emittedAt: parsed.emittedAt,
+        memberId: parsed.memberId,
+        displayName: parsed.displayName,
+      };
     }
 
     return {

--- a/server/src/room-event-bus.ts
+++ b/server/src/room-event-bus.ts
@@ -12,6 +12,22 @@ export type RoomEventBusMessage =
       emittedAt: number;
     }
   | {
+      type: "room_member_joined";
+      roomCode: string;
+      sourceInstanceId: string;
+      emittedAt: number;
+      memberId: string;
+      displayName: string;
+    }
+  | {
+      type: "room_member_left";
+      roomCode: string;
+      sourceInstanceId: string;
+      emittedAt: number;
+      memberId: string;
+      displayName: string;
+    }
+  | {
       type: "room_deleted";
       roomCode: string;
       sourceInstanceId: string;

--- a/server/src/room-event-consumer.ts
+++ b/server/src/room-event-consumer.ts
@@ -1,5 +1,36 @@
 import { hasAttachedSocket, type SendMessage, type Session } from "./types.js";
-import type { RoomEventBus } from "./room-event-bus.js";
+import type { RoomEventBus, RoomEventBusMessage } from "./room-event-bus.js";
+import type { ServerMessage } from "@bili-syncplay/protocol";
+
+function createMemberMessage(
+  message: RoomEventBusMessage,
+): ServerMessage | null {
+  if (message.type === "room_member_joined") {
+    return {
+      type: "room:member-joined",
+      payload: {
+        roomCode: message.roomCode,
+        member: {
+          id: message.memberId,
+          name: message.displayName,
+        },
+      },
+    };
+  }
+  if (message.type === "room_member_left") {
+    return {
+      type: "room:member-left",
+      payload: {
+        roomCode: message.roomCode,
+        member: {
+          id: message.memberId,
+          name: message.displayName,
+        },
+      },
+    };
+  }
+  return null;
+}
 
 export async function createRoomEventConsumer(options: {
   roomEventBus: RoomEventBus;
@@ -14,6 +45,35 @@ export async function createRoomEventConsumer(options: {
   const unsubscribe = await options.roomEventBus.subscribe(async (message) => {
     try {
       const localSessions = options.listLocalSessionsByRoom(message.roomCode);
+      if (
+        message.type === "room_member_joined" ||
+        message.type === "room_member_left"
+      ) {
+        const memberMessage = createMemberMessage(message);
+        if (!memberMessage) {
+          return;
+        }
+        for (const session of localSessions) {
+          if (
+            !hasAttachedSocket(session) ||
+            session.memberId === message.memberId
+          ) {
+            continue;
+          }
+          options.send(session.socket, memberMessage);
+        }
+
+        options.logEvent?.("room_event_consumed", {
+          roomCode: message.roomCode,
+          eventType: message.type,
+          sourceInstanceId: message.sourceInstanceId,
+          instanceId: options.instanceId ?? null,
+          localSessionCount: localSessions.length,
+          result: "ok",
+        });
+        return;
+      }
+
       const state =
         message.type === "room_deleted"
           ? {

--- a/server/src/room-event-consumer.ts
+++ b/server/src/room-event-consumer.ts
@@ -2,6 +2,12 @@ import { hasAttachedSocket, type SendMessage, type Session } from "./types.js";
 import type { RoomEventBus, RoomEventBusMessage } from "./room-event-bus.js";
 import type { ServerMessage } from "@bili-syncplay/protocol";
 
+const MEMBER_DELTA_PROTOCOL_VERSION = 2;
+
+function supportsIncrementalMemberEvents(session: Session): boolean {
+  return (session.protocolVersion ?? 1) >= MEMBER_DELTA_PROTOCOL_VERSION;
+}
+
 function createMemberMessage(
   message: RoomEventBusMessage,
 ): ServerMessage | null {
@@ -53,6 +59,9 @@ export async function createRoomEventConsumer(options: {
         if (!memberMessage) {
           return;
         }
+        let legacyRoomState:
+          | Awaited<ReturnType<typeof options.getRoomStateByCode>>
+          | undefined;
         for (const session of localSessions) {
           if (
             !hasAttachedSocket(session) ||
@@ -60,7 +69,20 @@ export async function createRoomEventConsumer(options: {
           ) {
             continue;
           }
-          options.send(session.socket, memberMessage);
+          if (supportsIncrementalMemberEvents(session)) {
+            options.send(session.socket, memberMessage);
+            continue;
+          }
+
+          legacyRoomState ??= await options.getRoomStateByCode(
+            message.roomCode,
+          );
+          if (legacyRoomState) {
+            options.send(session.socket, {
+              type: "room:state",
+              payload: legacyRoomState,
+            });
+          }
         }
 
         options.logEvent?.("room_event_consumed", {

--- a/server/src/room-event-consumer.ts
+++ b/server/src/room-event-consumer.ts
@@ -1,8 +1,17 @@
-import { hasAttachedSocket, type SendMessage, type Session } from "./types.js";
+import {
+  hasAttachedSocket,
+  type AttachedSession,
+  type SendMessage,
+  type Session,
+} from "./types.js";
 import type { RoomEventBus, RoomEventBusMessage } from "./room-event-bus.js";
 import type { ServerMessage } from "@bili-syncplay/protocol";
 
 const MEMBER_DELTA_PROTOCOL_VERSION = 2;
+type MemberDeltaMessage = Extract<
+  RoomEventBusMessage,
+  { type: "room_member_joined" | "room_member_left" }
+>;
 
 function supportsIncrementalMemberEvents(session: Session): boolean {
   return (session.protocolVersion ?? 1) >= MEMBER_DELTA_PROTOCOL_VERSION;
@@ -38,6 +47,23 @@ function createMemberMessage(
   return null;
 }
 
+function isRoomEventRecipient(
+  session: Session,
+  roomCode: string,
+): session is AttachedSession {
+  return hasAttachedSocket(session) && session.roomCode === roomCode;
+}
+
+function isMemberDeltaRecipient(
+  session: Session,
+  message: MemberDeltaMessage,
+): session is AttachedSession {
+  return (
+    isRoomEventRecipient(session, message.roomCode) &&
+    session.memberId !== message.memberId
+  );
+}
+
 export async function createRoomEventConsumer(options: {
   roomEventBus: RoomEventBus;
   getRoomStateByCode: (
@@ -62,11 +88,19 @@ export async function createRoomEventConsumer(options: {
         let legacyRoomState:
           | Awaited<ReturnType<typeof options.getRoomStateByCode>>
           | undefined;
+        let legacyRoomStateLoaded = false;
+        async function getLegacyRoomState() {
+          if (!legacyRoomStateLoaded) {
+            legacyRoomState = await options.getRoomStateByCode(
+              message.roomCode,
+            );
+            legacyRoomStateLoaded = true;
+          }
+          return legacyRoomState;
+        }
+
         for (const session of localSessions) {
-          if (
-            !hasAttachedSocket(session) ||
-            session.memberId === message.memberId
-          ) {
+          if (!isMemberDeltaRecipient(session, message)) {
             continue;
           }
           if (supportsIncrementalMemberEvents(session)) {
@@ -74,15 +108,14 @@ export async function createRoomEventConsumer(options: {
             continue;
           }
 
-          legacyRoomState ??= await options.getRoomStateByCode(
-            message.roomCode,
-          );
-          if (legacyRoomState) {
-            options.send(session.socket, {
-              type: "room:state",
-              payload: legacyRoomState,
-            });
+          const roomState = await getLegacyRoomState();
+          if (!roomState || !isMemberDeltaRecipient(session, message)) {
+            continue;
           }
+          options.send(session.socket, {
+            type: "room:state",
+            payload: roomState,
+          });
         }
 
         options.logEvent?.("room_event_consumed", {
@@ -110,7 +143,7 @@ export async function createRoomEventConsumer(options: {
       }
 
       for (const session of localSessions) {
-        if (!hasAttachedSocket(session)) {
+        if (!isRoomEventRecipient(session, message.roomCode)) {
           continue;
         }
         options.send(session.socket, {

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -114,9 +114,11 @@ export function createRoomService(options: {
     displayName?: string,
     previousMemberToken?: string,
   ) => Promise<{ room: PersistedRoom; memberToken: string }>;
-  leaveRoomForSession: (
-    session: Session,
-  ) => Promise<{ room: PersistedRoom | null; notifyRoom?: boolean }>;
+  leaveRoomForSession: (session: Session) => Promise<{
+    room: PersistedRoom | null;
+    notifyRoom?: boolean;
+    memberRemoved?: boolean;
+  }>;
   shareVideoForSession: (
     session: Session,
     memberToken: string,
@@ -620,9 +622,11 @@ export function createRoomService(options: {
     return readyState === OPEN;
   }
 
-  async function leaveCurrentRoom(
-    session: Session,
-  ): Promise<{ room: PersistedRoom | null; notifyRoom?: boolean }> {
+  async function leaveCurrentRoom(session: Session): Promise<{
+    room: PersistedRoom | null;
+    notifyRoom?: boolean;
+    memberRemoved?: boolean;
+  }> {
     if (!session.roomCode) {
       return { room: null };
     }
@@ -657,7 +661,7 @@ export function createRoomService(options: {
           origin: session.origin,
           result: "ok",
         });
-        return { room: persistedRoom };
+        return { room: persistedRoom, memberRemoved: removal.removed };
       }
 
       const expiresAt = now() + persistence.emptyRoomTtlMs;
@@ -698,7 +702,7 @@ export function createRoomService(options: {
         result: "ok",
       });
 
-      return { room: updatedRoom };
+      return { room: updatedRoom, memberRemoved: removal.removed };
     } catch (error) {
       const reason =
         error instanceof RoomServiceError &&
@@ -785,7 +789,7 @@ export function createRoomService(options: {
       });
 
       if (swallowWithNotifyRoom) {
-        return { room: null, notifyRoom: true };
+        return { room: null, notifyRoom: true, memberRemoved: removal.removed };
       }
 
       if (error instanceof RoomServiceError) {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -37,6 +37,7 @@ export type SessionBase = {
   memberId: string | null;
   displayName: string;
   memberToken: string | null;
+  protocolVersion?: number;
   joinedAt: number | null;
   invalidMessageCount: number;
   rateLimitState: SessionRateLimitState;

--- a/server/test/admin-backend.test.ts
+++ b/server/test/admin-backend.test.ts
@@ -999,7 +999,7 @@ test("operator can execute admin actions and query audit logs", async () => {
         kickedMemberToken = (joined.payload as { memberToken: string })
           .memberToken;
         await joinerCollector.next("room:state");
-        await ownerCollector.next("room:state");
+        await ownerCollector.next("room:member-joined");
 
         const kick = await requestJson(
           server.httpBaseUrl,

--- a/server/test/admin-backend.test.ts
+++ b/server/test/admin-backend.test.ts
@@ -4,6 +4,7 @@ import { once } from "node:events";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { WebSocket, type RawData } from "ws";
+import { PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import {
   createSyncServer,
   getDefaultPersistenceConfig,
@@ -301,7 +302,7 @@ test("admin endpoints support auth, overview, rooms, and events without breaking
       socket.send(
         JSON.stringify({
           type: "room:create",
-          payload: { displayName: "Alice" },
+          payload: { displayName: "Alice", protocolVersion: PROTOCOL_VERSION },
         }),
       );
       const created = await collector.next("room:created");
@@ -841,7 +842,7 @@ test("redis-backed admin events and audit logs are queryable across server insta
       socket.send(
         JSON.stringify({
           type: "room:create",
-          payload: { displayName: "Alice" },
+          payload: { displayName: "Alice", protocolVersion: PROTOCOL_VERSION },
         }),
       );
       const created = await collector.next("room:created");
@@ -937,7 +938,7 @@ test("operator can execute admin actions and query audit logs", async () => {
       owner.send(
         JSON.stringify({
           type: "room:create",
-          payload: { displayName: "Alice" },
+          payload: { displayName: "Alice", protocolVersion: PROTOCOL_VERSION },
         }),
       );
       const created = await ownerCollector.next("room:created");
@@ -992,6 +993,7 @@ test("operator can execute admin actions and query audit logs", async () => {
               roomCode,
               joinToken: (created.payload as { joinToken: string }).joinToken,
               displayName: "Bob",
+              protocolVersion: PROTOCOL_VERSION,
             },
           }),
         );
@@ -1027,6 +1029,7 @@ test("operator can execute admin actions and query audit logs", async () => {
               joinToken: (created.payload as { joinToken: string }).joinToken,
               memberToken: kickedMemberToken,
               displayName: "Bob",
+              protocolVersion: PROTOCOL_VERSION,
             },
           }),
         );

--- a/server/test/e2e-smoke.test.ts
+++ b/server/test/e2e-smoke.test.ts
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 import { once } from "node:events";
 import test from "node:test";
 import { WebSocket, type RawData } from "ws";
+import { PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import {
   createSyncServer,
   getDefaultPersistenceConfig,
@@ -114,7 +115,7 @@ test("e2e smoke: create room → join → share video → playback update → me
     ownerSocket.send(
       JSON.stringify({
         type: "room:create",
-        payload: { displayName: "Alice" },
+        payload: { displayName: "Alice", protocolVersion: PROTOCOL_VERSION },
       }),
     );
 
@@ -141,6 +142,7 @@ test("e2e smoke: create room → join → share video → playback update → me
           roomCode: createdPayload.roomCode,
           joinToken: createdPayload.joinToken,
           displayName: "Bob",
+          protocolVersion: PROTOCOL_VERSION,
         },
       }),
     );

--- a/server/test/e2e-smoke.test.ts
+++ b/server/test/e2e-smoke.test.ts
@@ -159,10 +159,10 @@ test("e2e smoke: create room → join → share video → playback update → me
       "joiner's room:state must list 2 members",
     );
 
-    const ownerStateAfterJoin = await ownerMsg.next("room:state");
+    const ownerStateAfterJoin = await ownerMsg.next("room:member-joined");
     assert.equal(
-      (ownerStateAfterJoin.payload as { members: unknown[] }).members.length,
-      2,
+      (ownerStateAfterJoin.payload as { member: { name: string } }).member.name,
+      "Bob",
       "owner must be notified of second member",
     );
 
@@ -267,10 +267,11 @@ test("e2e smoke: create room → join → share video → playback update → me
       }),
     );
 
-    const ownerStateAfterLeave = await ownerMsg.next("room:state");
+    const ownerStateAfterLeave = await ownerMsg.next("room:member-left");
     assert.equal(
-      (ownerStateAfterLeave.payload as { members: unknown[] }).members.length,
-      1,
+      (ownerStateAfterLeave.payload as { member: { name: string } }).member
+        .name,
+      "Bob",
       "owner must see member count drop to 1 after joiner leaves",
     );
 

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -916,3 +916,82 @@ test("message handler keeps room:join successful when bootstrap state fails", as
   assert.ok(events.includes("room_state_bootstrap_failed"));
   assert.ok(events.includes("room_joined"));
 });
+
+test("message handler skips joined delta when session leaves during bootstrap state", async () => {
+  const sent: string[] = [];
+  const errors: string[] = [];
+  const events: string[] = [];
+  const published: string[] = [];
+  const session = createSession("joiner");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession(currentSession) {
+        currentSession.roomCode = "ROOM01";
+        currentSession.memberId = "member-2";
+        currentSession.memberToken = "member-token-2";
+        return {
+          room: { code: "ROOM01" },
+          memberToken: "member-token-2",
+        };
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession(currentSession) {
+        currentSession.connectionState = "detached";
+        currentSession.socket = null;
+        currentSession.roomCode = null;
+        currentSession.memberId = null;
+        currentSession.memberToken = null;
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-2", name: "Alice" }],
+        };
+      },
+    },
+    logEvent(event) {
+      events.push(event);
+    },
+    send(_socket, message) {
+      sent.push(message.type);
+    },
+    sendError(_socket, code) {
+      errors.push(code);
+    },
+    async publishRoomEvent(message) {
+      published.push(message.type);
+    },
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      protocolVersion: 2,
+    },
+  });
+
+  assert.deepEqual(sent, ["room:joined"]);
+  assert.deepEqual(errors, []);
+  assert.deepEqual(published, []);
+  assert.ok(events.includes("room_join_delta_skipped"));
+  assert.ok(!events.includes("room_joined"));
+});

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -583,7 +583,7 @@ test("message handler accepts room:create without protocolVersion (legacy client
   assert.ok(events.includes("room_created"));
   assert.equal(sent.length, 2);
   assert.equal(sent[0].type, "room:created");
-  assert.equal(sent[0].serverProtocolVersion, 1);
+  assert.equal(sent[0].serverProtocolVersion, 2);
   assert.equal(sent[1].type, "room:state");
 });
 
@@ -776,12 +776,12 @@ test("message handler accepts room:join with matching protocolVersion and return
     payload: {
       roomCode: "ROOM01",
       joinToken: "join-token-1",
-      protocolVersion: 1,
+      protocolVersion: 2,
     },
   });
 
   assert.equal(sent.length, 2);
   assert.equal(sent[0].type, "room:joined");
-  assert.equal(sent[0].serverProtocolVersion, 1);
+  assert.equal(sent[0].serverProtocolVersion, 2);
   assert.equal(sent[1].type, "room:state");
 });

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -66,7 +66,12 @@ test("message handler rejects detached sessions before processing", async () => 
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-1", name: "Alice" }],
+        };
       },
     },
     logEvent() {},
@@ -92,7 +97,7 @@ test("message handler rejects detached sessions before processing", async () => 
   );
 });
 
-test("message handler creates a room, responds, and publishes member change", async () => {
+test("message handler creates a room and sends bootstrap state to the creator", async () => {
   const sent: Array<{ type: string; roomCode?: string }> = [];
   const published: string[] = [];
   const joined: Array<{ roomCode: string; previousRoomCode: string | null }> =
@@ -129,7 +134,12 @@ test("message handler creates a room, responds, and publishes member change", as
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-1", name: "Alice" }],
+        };
       },
     },
     logEvent(event) {
@@ -163,8 +173,11 @@ test("message handler creates a room, responds, and publishes member change", as
     payload: { displayName: "Alice" },
   });
 
-  assert.deepEqual(sent, [{ type: "room:created", roomCode: "ROOM01" }]);
-  assert.deepEqual(published, ["room_member_changed:ROOM01"]);
+  assert.deepEqual(sent, [
+    { type: "room:created", roomCode: "ROOM01" },
+    { type: "room:state", roomCode: "ROOM01" },
+  ]);
+  assert.deepEqual(published, []);
   assert.deepEqual(joined, [{ roomCode: "ROOM01", previousRoomCode: null }]);
   assert.ok(events.includes("room_created"));
 });
@@ -199,7 +212,12 @@ test("message handler skips room state publish when playback update is ignored",
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM-M1",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-m1", name: "Alice" }],
+        };
       },
     },
     logEvent() {},
@@ -276,7 +294,12 @@ test("message handler keeps leave completed when member change publish fails", a
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-1", name: "Alice" }],
+        };
       },
     },
     logEvent(event) {
@@ -345,7 +368,12 @@ test("message handler records monitored duration metrics for critical room paths
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-1", name: "Alice" }],
+        };
       },
     },
     logEvent() {},
@@ -452,7 +480,12 @@ test("message handler accepts room:create without protocolVersion (legacy client
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM-M1",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-m1", name: "Alice" }],
+        };
       },
     },
     logEvent(event) {
@@ -488,9 +521,10 @@ test("message handler accepts room:create without protocolVersion (legacy client
 
   assert.ok(events.includes("protocol_version_missing"));
   assert.ok(events.includes("room_created"));
-  assert.equal(sent.length, 1);
+  assert.equal(sent.length, 2);
   assert.equal(sent[0].type, "room:created");
   assert.equal(sent[0].serverProtocolVersion, 1);
+  assert.equal(sent[1].type, "room:state");
 });
 
 test("message handler rejects room:create with protocolVersion below minimum", async () => {
@@ -520,7 +554,12 @@ test("message handler rejects room:create with protocolVersion below minimum", a
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM-M1",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-m1", name: "Alice" }],
+        };
       },
     },
     logEvent(event) {
@@ -573,7 +612,12 @@ test("message handler rejects room:join with protocolVersion below minimum", asy
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM-M1",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-m1", name: "Alice" }],
+        };
       },
     },
     logEvent(event) {
@@ -635,7 +679,12 @@ test("message handler accepts room:join with matching protocolVersion and return
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM-M1",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-m1", name: "Alice" }],
+        };
       },
     },
     logEvent() {},
@@ -671,7 +720,8 @@ test("message handler accepts room:join with matching protocolVersion and return
     },
   });
 
-  assert.equal(sent.length, 1);
+  assert.equal(sent.length, 2);
   assert.equal(sent[0].type, "room:joined");
   assert.equal(sent[0].serverProtocolVersion, 1);
+  assert.equal(sent[1].type, "room:state");
 });

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -182,6 +182,68 @@ test("message handler creates a room and sends bootstrap state to the creator", 
   assert.ok(events.includes("room_created"));
 });
 
+test("message handler keeps room:create successful when bootstrap state fails", async () => {
+  const sent: string[] = [];
+  const errors: string[] = [];
+  const events: string[] = [];
+  const session = createSession("creator");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession(currentSession, displayName) {
+        currentSession.roomCode = "ROOM01";
+        currentSession.memberId = "member-1";
+        currentSession.displayName = displayName ?? currentSession.displayName;
+        currentSession.memberToken = "member-token-1";
+        return {
+          room: { code: "ROOM01", joinToken: "join-token-1" },
+          memberToken: "member-token-1",
+        };
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("transient room state read failure");
+      },
+    },
+    logEvent(event) {
+      events.push(event);
+    },
+    send(_socket, message) {
+      sent.push(message.type);
+    },
+    sendError(_socket, code) {
+      errors.push(code);
+    },
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:create",
+    payload: { displayName: "Alice" },
+  });
+
+  assert.deepEqual(sent, ["room:created"]);
+  assert.deepEqual(errors, []);
+  assert.ok(events.includes("room_state_bootstrap_failed"));
+  assert.ok(events.includes("room_created"));
+});
+
 test("message handler skips room state publish when playback update is ignored", async () => {
   const published: string[] = [];
   const session = createSession("member-1", {
@@ -784,4 +846,73 @@ test("message handler accepts room:join with matching protocolVersion and return
   assert.equal(sent[0].type, "room:joined");
   assert.equal(sent[0].serverProtocolVersion, 2);
   assert.equal(sent[1].type, "room:state");
+});
+
+test("message handler keeps room:join successful when bootstrap state fails", async () => {
+  const sent: string[] = [];
+  const errors: string[] = [];
+  const events: string[] = [];
+  const published: string[] = [];
+  const session = createSession("joiner");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession(currentSession) {
+        currentSession.roomCode = "ROOM01";
+        currentSession.memberId = "member-2";
+        currentSession.memberToken = "member-token-2";
+        return {
+          room: { code: "ROOM01" },
+          memberToken: "member-token-2",
+        };
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("transient room state read failure");
+      },
+    },
+    logEvent(event) {
+      events.push(event);
+    },
+    send(_socket, message) {
+      sent.push(message.type);
+    },
+    sendError(_socket, code) {
+      errors.push(code);
+    },
+    async publishRoomEvent(message) {
+      published.push(message.type);
+    },
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      protocolVersion: 2,
+    },
+  });
+
+  assert.deepEqual(sent, ["room:joined"]);
+  assert.deepEqual(errors, []);
+  assert.deepEqual(published, ["room_member_joined"]);
+  assert.ok(events.includes("room_state_bootstrap_failed"));
+  assert.ok(events.includes("room_joined"));
 });

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -282,6 +282,7 @@ test("message handler keeps leave completed when member change publish fails", a
             lastActiveAt: 1,
             expiresAt: null,
           },
+          memberRemoved: true,
         };
       },
       async shareVideoForSession() {
@@ -328,6 +329,64 @@ test("message handler keeps leave completed when member change publish fails", a
   assert.ok(events.includes("room_event_publish_failed"));
 });
 
+test("message handler skips member-left publish when leave did not remove the member", async () => {
+  const published: string[] = [];
+  const session = createSession("old-session", {
+    roomCode: "ROOM01",
+    memberId: "member-1",
+    memberToken: "member-token-1",
+  });
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession(currentSession) {
+        currentSession.roomCode = null;
+        currentSession.memberId = null;
+        currentSession.memberToken = null;
+        return {
+          room: { code: "ROOM01" },
+          memberRemoved: false,
+        };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent() {},
+    send() {},
+    sendError() {
+      throw new Error("sendError should not be called");
+    },
+    async publishRoomEvent(message) {
+      published.push(message.type);
+    },
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:leave",
+    payload: { memberToken: "member-token-1" },
+  });
+
+  assert.deepEqual(published, []);
+});
+
 test("message handler records monitored duration metrics for critical room paths", async () => {
   const observedTypes: string[] = [];
   const session = createSession("member-1", {
@@ -356,6 +415,7 @@ test("message handler records monitored duration metrics for critical room paths
         return {
           room: { code: "ROOM01" },
           notifyRoom: true,
+          memberRemoved: true,
         };
       },
       async shareVideoForSession() {

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -848,6 +848,77 @@ test("message handler accepts room:join with matching protocolVersion and return
   assert.equal(sent[1].type, "room:state");
 });
 
+test("message handler waits for room join hook before bootstrap state", async () => {
+  const sent: string[] = [];
+  const session = createSession("joiner");
+  let roomJoinHookFlushed = false;
+  let roomStateReadAfterFlush = false;
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession(currentSession) {
+        currentSession.roomCode = "ROOM01";
+        currentSession.memberId = "member-2";
+        currentSession.memberToken = "member-token-2";
+        return {
+          room: { code: "ROOM01" },
+          memberToken: "member-token-2",
+        };
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        roomStateReadAfterFlush = roomJoinHookFlushed;
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-2", name: "Alice" }],
+        };
+      },
+    },
+    logEvent() {},
+    send(_socket, message) {
+      sent.push(message.type);
+    },
+    sendError() {
+      throw new Error("sendError should not be called");
+    },
+    async publishRoomEvent() {},
+    async onRoomJoined() {
+      await Promise.resolve();
+      roomJoinHookFlushed = true;
+    },
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      protocolVersion: 2,
+    },
+  });
+
+  assert.deepEqual(sent, ["room:joined", "room:state"]);
+  assert.equal(roomStateReadAfterFlush, true);
+});
+
 test("message handler keeps room:join successful when bootstrap state fails", async () => {
   const sent: string[] = [];
   const errors: string[] = [];

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -244,6 +244,76 @@ test("message handler keeps room:create successful when bootstrap state fails", 
   assert.ok(events.includes("room_created"));
 });
 
+test("message handler keeps room:create successful when room join hook fails", async () => {
+  const sent: string[] = [];
+  const errors: string[] = [];
+  const events: string[] = [];
+  const session = createSession("creator");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession(currentSession, displayName) {
+        currentSession.roomCode = "ROOM01";
+        currentSession.memberId = "member-1";
+        currentSession.displayName = displayName ?? currentSession.displayName;
+        currentSession.memberToken = "member-token-1";
+        return {
+          room: { code: "ROOM01", joinToken: "join-token-1" },
+          memberToken: "member-token-1",
+        };
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-1", name: "Alice" }],
+        };
+      },
+    },
+    logEvent(event) {
+      events.push(event);
+    },
+    send(_socket, message) {
+      sent.push(message.type);
+    },
+    sendError(_socket, code) {
+      errors.push(code);
+    },
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+    async onRoomJoined() {
+      throw new Error("runtime index unavailable");
+    },
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:create",
+    payload: { displayName: "Alice" },
+  });
+
+  assert.deepEqual(sent, ["room:created", "room:state"]);
+  assert.deepEqual(errors, []);
+  assert.ok(events.includes("room_join_hook_failed"));
+  assert.ok(events.includes("room_created"));
+});
+
 test("message handler skips room state publish when playback update is ignored", async () => {
   const published: string[] = [];
   const session = createSession("member-1", {
@@ -389,6 +459,72 @@ test("message handler keeps leave completed when member change publish fails", a
   assert.equal(session.roomCode, null);
   assert.deepEqual(left, ["ROOM01"]);
   assert.ok(events.includes("room_event_publish_failed"));
+});
+
+test("message handler keeps leave completed when room left hook fails", async () => {
+  const events: string[] = [];
+  const published: string[] = [];
+  const session = createSession("member-1", {
+    roomCode: "ROOM01",
+    memberId: "member-1",
+    memberToken: "member-token-1",
+  });
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession(currentSession) {
+        currentSession.roomCode = null;
+        currentSession.memberId = null;
+        currentSession.memberToken = null;
+        return {
+          room: { code: "ROOM01" },
+          memberRemoved: true,
+        };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent(event) {
+      events.push(event);
+    },
+    send() {},
+    sendError() {
+      throw new Error("sendError should not be called");
+    },
+    async publishRoomEvent(message) {
+      published.push(message.type);
+    },
+    instanceId: "node-a",
+    onRoomLeft() {
+      throw new Error("runtime index unavailable");
+    },
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:leave",
+    payload: { memberToken: "member-token-1" },
+  });
+
+  assert.equal(session.roomCode, null);
+  assert.deepEqual(published, ["room_member_left"]);
+  assert.ok(events.includes("room_left_hook_failed"));
 });
 
 test("message handler skips member-left publish when leave did not remove the member", async () => {
@@ -985,6 +1121,155 @@ test("message handler keeps room:join successful when bootstrap state fails", as
   assert.deepEqual(errors, []);
   assert.deepEqual(published, ["room_member_joined"]);
   assert.ok(events.includes("room_state_bootstrap_failed"));
+  assert.ok(events.includes("room_joined"));
+});
+
+test("message handler keeps room:join successful when room join hook fails", async () => {
+  const sent: string[] = [];
+  const errors: string[] = [];
+  const events: string[] = [];
+  const published: string[] = [];
+  const session = createSession("joiner");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession(currentSession) {
+        currentSession.roomCode = "ROOM01";
+        currentSession.memberId = "member-2";
+        currentSession.memberToken = "member-token-2";
+        return {
+          room: { code: "ROOM01" },
+          memberToken: "member-token-2",
+        };
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-2", name: "Alice" }],
+        };
+      },
+    },
+    logEvent(event) {
+      events.push(event);
+    },
+    send(_socket, message) {
+      sent.push(message.type);
+    },
+    sendError(_socket, code) {
+      errors.push(code);
+    },
+    async publishRoomEvent(message) {
+      published.push(message.type);
+    },
+    async onRoomJoined() {
+      throw new Error("runtime index unavailable");
+    },
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      protocolVersion: 2,
+    },
+  });
+
+  assert.deepEqual(sent, ["room:joined", "room:state"]);
+  assert.deepEqual(errors, []);
+  assert.deepEqual(published, ["room_member_joined"]);
+  assert.ok(events.includes("room_join_hook_failed"));
+  assert.ok(events.includes("room_joined"));
+});
+
+test("message handler keeps room:join successful when member joined publish fails", async () => {
+  const sent: string[] = [];
+  const errors: string[] = [];
+  const events: string[] = [];
+  const session = createSession("joiner");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession(currentSession) {
+        currentSession.roomCode = "ROOM01";
+        currentSession.memberId = "member-2";
+        currentSession.memberToken = "member-token-2";
+        return {
+          room: { code: "ROOM01" },
+          memberToken: "member-token-2",
+        };
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-2", name: "Alice" }],
+        };
+      },
+    },
+    logEvent(event) {
+      events.push(event);
+    },
+    send(_socket, message) {
+      sent.push(message.type);
+    },
+    sendError(_socket, code) {
+      errors.push(code);
+    },
+    async publishRoomEvent() {
+      throw new Error("publish failed");
+    },
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      protocolVersion: 2,
+    },
+  });
+
+  assert.deepEqual(sent, ["room:joined", "room:state"]);
+  assert.deepEqual(errors, []);
+  assert.ok(events.includes("room_event_publish_failed"));
   assert.ok(events.includes("room_joined"));
 });
 

--- a/server/test/message-validation.ts
+++ b/server/test/message-validation.ts
@@ -1244,6 +1244,22 @@ test("reconnect join reuses the same member identity and does not emit a leave f
     const created = await ownerCollector.next("room:created");
     await ownerCollector.next("room:state");
 
+    const observer = await connectClient(server.url);
+    const observerCollector = createMessageCollector(observer);
+    observer.send(
+      JSON.stringify({
+        type: "room:join",
+        payload: {
+          roomCode: created.payload.roomCode,
+          joinToken: created.payload.joinToken,
+          displayName: "Bob",
+        },
+      }),
+    );
+    const observerJoined = await observerCollector.next("room:joined");
+    await observerCollector.next("room:state");
+    await ownerCollector.next("room:member-joined");
+
     const reconnectingOwner = await connectClient(server.url);
     const reconnectingCollector = createMessageCollector(reconnectingOwner);
     reconnectingOwner.send(
@@ -1265,9 +1281,20 @@ test("reconnect join reuses the same member identity and does not emit a leave f
     const firstState = await reconnectingCollector.next("room:state");
     assert.deepEqual(firstState.payload.members, [
       { id: created.payload.memberId, name: "Alice" },
+      { id: observerJoined.payload.memberId, name: "Bob" },
     ]);
+    const observerSawReconnect =
+      await observerCollector.next("room:member-joined");
+    assert.equal(
+      observerSawReconnect.payload.member.id,
+      created.payload.memberId,
+    );
 
     await once(owner, "close");
+    await assert.rejects(
+      observerCollector.next("room:member-left", 300),
+      /Timed out waiting for message type room:member-left/,
+    );
     const postReplaceState = await maybeWaitForMessageType(
       reconnectingOwner,
       "room:state",
@@ -1280,6 +1307,7 @@ test("reconnect join reuses the same member identity and does not emit a leave f
     }
 
     await closeClient(reconnectingOwner);
+    await closeClient(observer);
   } finally {
     await server.close();
   }

--- a/server/test/message-validation.ts
+++ b/server/test/message-validation.ts
@@ -611,7 +611,7 @@ test("updates member display names in room state after profile:update", async ()
       );
       const joined = await joinerCollector.next("room:joined");
       await joinerCollector.next("room:state");
-      await ownerCollector.next("room:state");
+      await ownerCollector.next("room:member-joined");
 
       owner.send(
         JSON.stringify({

--- a/server/test/message-validation.ts
+++ b/server/test/message-validation.ts
@@ -15,7 +15,7 @@ import {
   INVALID_JSON_MESSAGE,
 } from "../src/app.js";
 import { createInMemoryRoomStore, type RoomStore } from "../src/room-store.js";
-import type { ServerMessage } from "@bili-syncplay/protocol";
+import { PROTOCOL_VERSION, type ServerMessage } from "@bili-syncplay/protocol";
 
 const ALLOWED_ORIGIN = "chrome-extension://allowed-extension";
 
@@ -593,7 +593,10 @@ test("updates member display names in room state after profile:update", async ()
       owner.send(
         JSON.stringify({
           type: "room:create",
-          payload: { displayName: "Guest-123" },
+          payload: {
+            displayName: "Guest-123",
+            protocolVersion: PROTOCOL_VERSION,
+          },
         }),
       );
       const created = await ownerCollector.next("room:created");
@@ -606,6 +609,7 @@ test("updates member display names in room state after profile:update", async ()
             roomCode: created.payload.roomCode,
             joinToken: created.payload.joinToken,
             displayName: "Bob",
+            protocolVersion: PROTOCOL_VERSION,
           },
         }),
       );
@@ -1238,7 +1242,7 @@ test("reconnect join reuses the same member identity and does not emit a leave f
     owner.send(
       JSON.stringify({
         type: "room:create",
-        payload: { displayName: "Alice" },
+        payload: { displayName: "Alice", protocolVersion: PROTOCOL_VERSION },
       }),
     );
     const created = await ownerCollector.next("room:created");
@@ -1253,6 +1257,7 @@ test("reconnect join reuses the same member identity and does not emit a leave f
           roomCode: created.payload.roomCode,
           joinToken: created.payload.joinToken,
           displayName: "Bob",
+          protocolVersion: PROTOCOL_VERSION,
         },
       }),
     );
@@ -1270,6 +1275,7 @@ test("reconnect join reuses the same member identity and does not emit a leave f
           joinToken: created.payload.joinToken,
           memberToken: created.payload.memberToken,
           displayName: "Alice",
+          protocolVersion: PROTOCOL_VERSION,
         },
       }),
     );

--- a/server/test/multi-node-admin-actions.test.ts
+++ b/server/test/multi-node-admin-actions.test.ts
@@ -48,7 +48,7 @@ test("global admin executes cross-node kick_member and disconnect_session action
     );
     const joined = await joinerCollector.next("room:joined");
     await joinerCollector.next("room:state");
-    await ownerCollector.next("room:state");
+    await ownerCollector.next("room:member-joined");
 
     const roomCode = (created.payload as { roomCode: string }).roomCode;
     const roomDetail = await requestJson(

--- a/server/test/multi-node-room-broadcast.test.ts
+++ b/server/test/multi-node-room-broadcast.test.ts
@@ -45,14 +45,14 @@ test("cross-node room broadcasts sync join, shared video, playback updates, and 
 
     const joined = await joinerCollector.next("room:joined");
     const joinerJoinedState = await joinerCollector.next("room:state");
-    const ownerSawJoin = await ownerCollector.next("room:state");
+    const ownerSawJoin = await ownerCollector.next("room:member-joined");
     assert.equal(
       (joinerJoinedState.payload as { members: Array<unknown> }).members.length,
       2,
     );
     assert.equal(
-      (ownerSawJoin.payload as { members: Array<unknown> }).members.length,
-      2,
+      (ownerSawJoin.payload as { member: { name: string } }).member.name,
+      "Bob",
     );
 
     owner.send(
@@ -159,10 +159,10 @@ test("cross-node room broadcasts sync join, shared video, playback updates, and 
       }),
     );
 
-    const ownerSawLeave = await ownerCollector.next("room:state");
+    const ownerSawLeave = await ownerCollector.next("room:member-left");
     assert.equal(
-      (ownerSawLeave.payload as { members: Array<unknown> }).members.length,
-      1,
+      (ownerSawLeave.payload as { member: { name: string } }).member.name,
+      "Bob",
     );
     assert.equal(await ownerCollector.maybeNext("room:state", 150), null);
     assert.equal(await joinerCollector.maybeNext("room:state", 150), null);

--- a/server/test/room-event-consumer.test.ts
+++ b/server/test/room-event-consumer.test.ts
@@ -4,7 +4,11 @@ import { createInMemoryRoomEventBus } from "../src/room-event-bus.js";
 import { createRoomEventConsumer } from "../src/room-event-consumer.js";
 import type { Session } from "../src/types.js";
 
-function createSession(id: string, roomCode: string): Session {
+function createSession(
+  id: string,
+  roomCode: string,
+  protocolVersion = 2,
+): Session {
   return {
     id,
     connectionState: "attached",
@@ -22,6 +26,7 @@ function createSession(id: string, roomCode: string): Session {
     memberId: id,
     displayName: id,
     memberToken: `token-${id}`,
+    protocolVersion,
     joinedAt: 1_000,
     invalidMessageCount: 0,
     rateLimitState: {
@@ -166,6 +171,69 @@ test("room event consumer sends member join deltas to other local room sessions"
       type: "room:member-joined",
       memberId: "member-a",
       displayName: "Alice",
+    },
+  ]);
+});
+
+test("room event consumer sends full room state for legacy member event sessions", async () => {
+  const bus = createInMemoryRoomEventBus();
+  const joiningSession = createSession("member-a", "ROOM01", 2);
+  const legacySession = createSession("member-b", "ROOM01", 1);
+  const sent: Array<{
+    sessionId: string;
+    type: string;
+    memberCount: number;
+  }> = [];
+  let roomStateLoads = 0;
+
+  const consumer = await createRoomEventConsumer({
+    roomEventBus: bus,
+    async getRoomStateByCode(roomCode) {
+      roomStateLoads += 1;
+      return {
+        roomCode,
+        sharedVideo: null,
+        playback: null,
+        members: [
+          { id: "member-a", name: "Alice" },
+          { id: "member-b", name: "Bob" },
+        ],
+      };
+    },
+    listLocalSessionsByRoom() {
+      return [joiningSession, legacySession];
+    },
+    send(socket, message) {
+      const session =
+        socket === joiningSession.socket ? joiningSession : legacySession;
+      sent.push({
+        sessionId: session.id,
+        type: message.type,
+        memberCount:
+          message.type === "room:state" ? message.payload.members.length : 1,
+      });
+    },
+  });
+
+  try {
+    await bus.publish({
+      type: "room_member_joined",
+      roomCode: "ROOM01",
+      sourceInstanceId: "instance-b",
+      emittedAt: 1_100,
+      memberId: "member-a",
+      displayName: "Alice",
+    });
+  } finally {
+    await consumer.close();
+  }
+
+  assert.equal(roomStateLoads, 1);
+  assert.deepEqual(sent, [
+    {
+      sessionId: "member-b",
+      type: "room:state",
+      memberCount: 2,
     },
   ]);
 });

--- a/server/test/room-event-consumer.test.ts
+++ b/server/test/room-event-consumer.test.ts
@@ -111,6 +111,109 @@ test("room event consumer sends room state only to local room sessions", async (
   ]);
 });
 
+test("room event consumer sends member join deltas to other local room sessions", async () => {
+  const bus = createInMemoryRoomEventBus();
+  const joiningSession = createSession("member-a", "ROOM01");
+  const existingSession = createSession("member-b", "ROOM01");
+  const sent: Array<{
+    sessionId: string;
+    type: string;
+    memberId: string;
+    displayName: string;
+  }> = [];
+
+  const consumer = await createRoomEventConsumer({
+    roomEventBus: bus,
+    async getRoomStateByCode() {
+      throw new Error("member delta should not reload room state");
+    },
+    listLocalSessionsByRoom() {
+      return [joiningSession, existingSession];
+    },
+    send(socket, message) {
+      const session =
+        socket === joiningSession.socket ? joiningSession : existingSession;
+      if (
+        message.type === "room:member-joined" ||
+        message.type === "room:member-left"
+      ) {
+        sent.push({
+          sessionId: session.id,
+          type: message.type,
+          memberId: message.payload.member.id,
+          displayName: message.payload.member.name,
+        });
+      }
+    },
+  });
+
+  try {
+    await bus.publish({
+      type: "room_member_joined",
+      roomCode: "ROOM01",
+      sourceInstanceId: "instance-b",
+      emittedAt: 1_100,
+      memberId: "member-a",
+      displayName: "Alice",
+    });
+  } finally {
+    await consumer.close();
+  }
+
+  assert.deepEqual(sent, [
+    {
+      sessionId: "member-b",
+      type: "room:member-joined",
+      memberId: "member-a",
+      displayName: "Alice",
+    },
+  ]);
+});
+
+test("room event consumer sends member leave deltas to remaining room sessions", async () => {
+  const bus = createInMemoryRoomEventBus();
+  const remainingSession = createSession("member-b", "ROOM01");
+  const sent: Array<{ type: string; memberId: string }> = [];
+
+  const consumer = await createRoomEventConsumer({
+    roomEventBus: bus,
+    async getRoomStateByCode() {
+      throw new Error("member delta should not reload room state");
+    },
+    listLocalSessionsByRoom() {
+      return [remainingSession];
+    },
+    send(_socket, message) {
+      if (message.type === "room:member-left") {
+        sent.push({
+          type: message.type,
+          memberId: message.payload.member.id,
+        });
+      }
+    },
+  });
+
+  try {
+    await bus.publish({
+      type: "room_member_left",
+      roomCode: "ROOM01",
+      sourceInstanceId: "instance-b",
+      emittedAt: 1_100,
+      memberId: "member-a",
+      displayName: "Alice",
+    });
+  } finally {
+    await consumer.close();
+  }
+
+  assert.deepEqual(sent, [
+    {
+      type: "room:member-left",
+      memberId: "member-a",
+    },
+  ]);
+});
+
 test("room event consumer emits an empty state for deleted rooms", async () => {
   const bus = createInMemoryRoomEventBus();
   const localRoomSession = createSession("member-a", "ROOM01");

--- a/server/test/room-event-consumer.test.ts
+++ b/server/test/room-event-consumer.test.ts
@@ -238,6 +238,89 @@ test("room event consumer sends full room state for legacy member event sessions
   ]);
 });
 
+test("room event consumer re-checks legacy sessions after loading fallback room state", async () => {
+  const bus = createInMemoryRoomEventBus();
+  const joiningSession = createSession("member-a", "ROOM01", 2);
+  const detachingLegacySession = createSession("member-b", "ROOM01", 1);
+  const remainingLegacySession = createSession("member-c", "ROOM01", 1);
+  const sent: Array<{
+    sessionId: string;
+    type: string;
+    memberCount: number;
+  }> = [];
+  const logs: Array<{ event: string; result: string }> = [];
+  let roomStateLoads = 0;
+
+  const consumer = await createRoomEventConsumer({
+    roomEventBus: bus,
+    async getRoomStateByCode(roomCode) {
+      roomStateLoads += 1;
+      detachingLegacySession.connectionState = "detached";
+      detachingLegacySession.socket = null;
+      detachingLegacySession.roomCode = null;
+      return {
+        roomCode,
+        sharedVideo: null,
+        playback: null,
+        members: [
+          { id: "member-a", name: "Alice" },
+          { id: "member-c", name: "Carol" },
+        ],
+      };
+    },
+    listLocalSessionsByRoom() {
+      return [joiningSession, detachingLegacySession, remainingLegacySession];
+    },
+    send(socket, message) {
+      assert.notEqual(socket, null, "detached socket should not be used");
+      const session =
+        socket === remainingLegacySession.socket
+          ? remainingLegacySession
+          : detachingLegacySession;
+      sent.push({
+        sessionId: session.id,
+        type: message.type,
+        memberCount:
+          message.type === "room:state" ? message.payload.members.length : 1,
+      });
+    },
+    logEvent(event, data) {
+      logs.push({
+        event,
+        result: String(data.result),
+      });
+    },
+  });
+
+  try {
+    await bus.publish({
+      type: "room_member_joined",
+      roomCode: "ROOM01",
+      sourceInstanceId: "instance-b",
+      emittedAt: 1_100,
+      memberId: "member-a",
+      displayName: "Alice",
+    });
+  } finally {
+    await consumer.close();
+  }
+
+  assert.equal(roomStateLoads, 1);
+  assert.deepEqual(sent, [
+    {
+      sessionId: "member-c",
+      type: "room:state",
+      memberCount: 2,
+    },
+  ]);
+  assert.deepEqual(logs, [
+    {
+      event: "room_event_consumed",
+      result: "ok",
+    },
+  ]);
+});
+
 test("room event consumer sends member leave deltas to remaining room sessions", async () => {
   const bus = createInMemoryRoomEventBus();
   const remainingSession = createSession("member-b", "ROOM01");
@@ -359,6 +442,47 @@ test("room event consumer skips detached sessions", async () => {
   }
 
   assert.deepEqual(sent, ["member-a"]);
+});
+
+test("room event consumer re-checks room membership after loading room state", async () => {
+  const bus = createInMemoryRoomEventBus();
+  const movedSession = createSession("member-a", "ROOM01");
+  const remainingSession = createSession("member-b", "ROOM01");
+  const sent: string[] = [];
+
+  const consumer = await createRoomEventConsumer({
+    roomEventBus: bus,
+    async getRoomStateByCode(roomCode) {
+      movedSession.roomCode = "ROOM02";
+      return {
+        roomCode,
+        sharedVideo: null,
+        playback: null,
+        members: [{ id: "member-b", name: "Bob" }],
+      };
+    },
+    listLocalSessionsByRoom() {
+      return [movedSession, remainingSession];
+    },
+    send(socket) {
+      const session =
+        socket === movedSession.socket ? movedSession : remainingSession;
+      sent.push(session.id);
+    },
+  });
+
+  try {
+    await bus.publish({
+      type: "room_state_updated",
+      roomCode: "ROOM01",
+      sourceInstanceId: "instance-a",
+      emittedAt: 1_600,
+    });
+  } finally {
+    await consumer.close();
+  }
+
+  assert.deepEqual(sent, ["member-b"]);
 });
 
 test("room event consumer logs failures without throwing to the bus", async () => {

--- a/server/test/runtime-lifecycle.test.ts
+++ b/server/test/runtime-lifecycle.test.ts
@@ -335,7 +335,7 @@ test("profile updates are reflected in redis-backed room state views", async (t)
       );
       await joinerCollector.next("room:joined");
       await joinerCollector.next("room:state");
-      await ownerCollector.next("room:state");
+      await ownerCollector.next("room:member-joined");
 
       owner.send(
         JSON.stringify({


### PR DESCRIPTION
## Summary
- add `room:member-joined` and `room:member-left` server messages with protocol guards
- send full `room:state` directly only to the joining/creating socket for bootstrap, and broadcast member join/leave deltas to other room members
- update extension room session handling, reconnect benchmark setup, and server/e2e coverage for incremental member events

Refs #96

## Benchmark

`npx tsx bench/reconnect-storm.ts` on this branch (single-node, 500 members, reconnectTimeoutMs=5000):

```json
{
  "attempted": 500,
  "completed": 500,
  "errors": 0,
  "errorRatePercent": 0,
  "durationSeconds": 1.083,
  "latency": {
    "sampleCount": 500,
    "p50Ms": 294,
    "p95Ms": 984,
    "p99Ms": 1057,
    "maxMs": 1072
  },
  "phases": {
    "socketOpen": {
      "sampleCount": 500,
      "p50Ms": 286,
      "p95Ms": 972,
      "p99Ms": 1026,
      "maxMs": 1065
    },
    "roomJoined": {
      "sampleCount": 500,
      "p50Ms": 8,
      "p95Ms": 27,
      "p99Ms": 36,
      "maxMs": 39
    },
    "firstRoomState": {
      "sampleCount": 500,
      "p50Ms": 8,
      "p95Ms": 27,
      "p99Ms": 37,
      "maxMs": 42
    }
  }
}
```

Compared with the latest P3 baseline shared in #96 comments/context (246/500 completed, 50.8% errors, p50 1369ms, p95 4374ms, p99 4893ms), P0b removes the full-state member broadcast amplification and brings the run to 500/500 completed with no errors.

## Test plan
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`
- [x] `npx tsx bench/reconnect-storm.ts`