### PR TITLE
[codex] Fix synced playback rate default

### DIFF
--- a/bench/lib/room-bench.ts
+++ b/bench/lib/room-bench.ts
@@ -287,7 +287,12 @@ async function connectParticipants(
         wsUrl,
         socket,
         inbox: createBenchMessageCollector(socket, {
-          trackedTypes: ["room:created", "room:joined", "room:state"],
+          trackedTypes: [
+            "room:created",
+            "room:joined",
+            "room:state",
+            "room:member-joined",
+          ],
         }),
       };
     }),
@@ -386,7 +391,7 @@ async function initializeRoom(
 
     const joined = await joinerSeed.inbox.next("room:joined");
     await joinerSeed.inbox.next("room:state");
-    await ownerSeed.inbox.next("room:state");
+    await ownerSeed.inbox.next("room:member-joined");
 
     const joinedPayload = joined.payload as {
       memberToken: string;

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -1,4 +1,5 @@
 import type {
+  RoomMember,
   RoomState,
   ServerMessage,
   ClientMessage,
@@ -172,6 +173,18 @@ export function createRoomSessionController(args: {
       case "room:state":
         await handleRoomStateMessage(message.payload);
         return;
+      case "room:member-joined":
+        await handleRoomMemberJoined(
+          message.payload.roomCode,
+          message.payload.member,
+        );
+        return;
+      case "room:member-left":
+        await handleRoomMemberLeft(
+          message.payload.roomCode,
+          message.payload.member,
+        );
+        return;
       case "error":
         args.connectionState.lastError = localizeServerError(
           message.payload.code,
@@ -223,6 +236,62 @@ export function createRoomSessionController(args: {
       case "sync:pong":
         return;
     }
+  }
+
+  async function applyRoomMemberState(nextState: RoomState): Promise<void> {
+    args.roomSessionState.roomState = nextState;
+    args.roomSessionState.roomCode = nextState.roomCode;
+    args.connectionState.lastError = null;
+
+    await args.persistState();
+    const compensatedRoomState = args.compensateRoomState(nextState);
+    await args.notifyContentScripts({
+      type: "background:apply-room-state",
+      payload: compensatedRoomState,
+      shareToast: null,
+    });
+    args.notifyAll();
+  }
+
+  async function handleRoomMemberJoined(
+    roomCode: string,
+    member: RoomMember,
+  ): Promise<void> {
+    const currentState = args.roomSessionState.roomState;
+    if (!currentState || currentState.roomCode !== roomCode) {
+      return;
+    }
+
+    const existingMemberIndex = currentState.members.findIndex(
+      (candidate) => candidate.id === member.id,
+    );
+    const members =
+      existingMemberIndex === -1
+        ? [...currentState.members, member]
+        : currentState.members.map((candidate, index) =>
+            index === existingMemberIndex ? member : candidate,
+          );
+    await applyRoomMemberState({
+      ...currentState,
+      members,
+    });
+  }
+
+  async function handleRoomMemberLeft(
+    roomCode: string,
+    member: RoomMember,
+  ): Promise<void> {
+    const currentState = args.roomSessionState.roomState;
+    if (!currentState || currentState.roomCode !== roomCode) {
+      return;
+    }
+
+    await applyRoomMemberState({
+      ...currentState,
+      members: currentState.members.filter(
+        (candidate) => candidate.id !== member.id,
+      ),
+    });
   }
 
   async function handleRoomStateMessage(nextState: RoomState): Promise<void> {

--- a/extension/src/content/player-binding.ts
+++ b/extension/src/content/player-binding.ts
@@ -53,6 +53,14 @@ export function canApplyPlaybackImmediately(video: HTMLVideoElement): boolean {
   return Number.isFinite(video.duration) && video.readyState >= 1;
 }
 
+export function setVideoPlaybackRate(
+  video: HTMLVideoElement,
+  playbackRate: number,
+): void {
+  video.defaultPlaybackRate = playbackRate;
+  video.playbackRate = playbackRate;
+}
+
 export function createProgrammaticPlaybackSignature(
   playback: PlaybackState,
 ): ProgrammaticPlaybackSignature {
@@ -165,7 +173,7 @@ export function syncPlaybackPosition(
       Math.abs(video.playbackRate - playbackRate) > 0.01;
     video.currentTime = targetTime;
     if (shouldWritePlaybackRate) {
-      video.playbackRate = playbackRate;
+      setVideoPlaybackRate(video, playbackRate);
     }
     return {
       mode: "hard-seek",
@@ -197,7 +205,7 @@ export function syncPlaybackPosition(
       video.currentTime = softApplied.currentTime;
     }
     if (shouldWritePlaybackRate) {
-      video.playbackRate = softApplied.playbackRate;
+      setVideoPlaybackRate(video, softApplied.playbackRate);
     }
     return {
       mode: "soft-apply",
@@ -222,7 +230,7 @@ export function syncPlaybackPosition(
     const shouldWritePlaybackRate =
       Math.abs(video.playbackRate - adjustedPlaybackRate) > 0.01;
     if (shouldWritePlaybackRate) {
-      video.playbackRate = adjustedPlaybackRate;
+      setVideoPlaybackRate(video, adjustedPlaybackRate);
     }
     return {
       mode: "rate-only",
@@ -241,7 +249,7 @@ export function syncPlaybackPosition(
   const shouldWritePlaybackRate =
     Math.abs(video.playbackRate - playbackRate) > 0.01;
   if (shouldWritePlaybackRate) {
-    video.playbackRate = playbackRate;
+    setVideoPlaybackRate(video, playbackRate);
   }
   return {
     mode: "ignore",

--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -6,6 +6,7 @@ import {
 import {
   createProgrammaticPlaybackSignature,
   getPlayState,
+  setVideoPlaybackRate,
 } from "./player-binding";
 import type {
   ContentRuntimeState,
@@ -124,7 +125,7 @@ export function createSoftApplyController(args: {
       video &&
       Math.abs(video.playbackRate - session.restorePlaybackRate) > 0.01
     ) {
-      video.playbackRate = session.restorePlaybackRate;
+      setVideoPlaybackRate(video, session.restorePlaybackRate);
       args.armProgrammaticApplyWindow(
         {
           url: session.normalizedUrl,

--- a/extension/test/player-binding.test.ts
+++ b/extension/test/player-binding.test.ts
@@ -14,6 +14,7 @@ function createVideo(
     readyState: 4,
     duration: 120,
     currentTime: 12,
+    defaultPlaybackRate: 1,
     playbackRate: 1,
     pause() {},
     play: async () => undefined,
@@ -218,6 +219,7 @@ test("ignore-window playback update still restores playbackRate when only the ra
   const video = createVideo({
     paused: false,
     currentTime: 12,
+    defaultPlaybackRate: 1.1,
     playbackRate: 1.1,
   });
 
@@ -243,6 +245,7 @@ test("ignore-window playback update still restores playbackRate when only the ra
   assert.equal(applied.adjustment?.didWriteCurrentTime, false);
   assert.equal(applied.adjustment?.didWritePlaybackRate, true);
   assert.ok(Math.abs(video.playbackRate - 1) < 0.001);
+  assert.ok(Math.abs(video.defaultPlaybackRate - 1) < 0.001);
 });
 
 test("buffering playback update does not force-pause an already playing video", () => {

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -302,6 +302,61 @@ test("room session controller confirms pending local share and notifies content 
   assert.equal(harness.notifyAllCalls, 1);
 });
 
+test("room session controller applies room member join and leave deltas", async () => {
+  const harness = createControllerHarness();
+  harness.runtimeState.room.roomState = {
+    roomCode: "ROOM04",
+    sharedVideo: null,
+    playback: null,
+    members: [{ id: "member-1", name: "Alice" }],
+  };
+
+  await harness.controller.handleServerMessage({
+    type: "room:member-joined",
+    payload: {
+      roomCode: "ROOM04",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  assert.deepEqual(harness.runtimeState.room.roomState.members, [
+    { id: "member-1", name: "Alice" },
+    { id: "member-2", name: "Bob" },
+  ]);
+  assert.equal(harness.persistReasons.length, 1);
+  assert.equal(harness.notifyContentMessages.length, 1);
+
+  await harness.controller.handleServerMessage({
+    type: "room:member-left",
+    payload: {
+      roomCode: "ROOM04",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  assert.deepEqual(harness.runtimeState.room.roomState.members, [
+    { id: "member-1", name: "Alice" },
+  ]);
+  assert.equal(harness.persistReasons.length, 2);
+  assert.equal(harness.notifyContentMessages.length, 2);
+});
+
+test("room session controller ignores member deltas before bootstrap state", async () => {
+  const harness = createControllerHarness();
+
+  await harness.controller.handleServerMessage({
+    type: "room:member-joined",
+    payload: {
+      roomCode: "ROOM04",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  assert.equal(harness.runtimeState.room.roomState, null);
+  assert.equal(harness.persistReasons.length, 0);
+  assert.equal(harness.notifyContentMessages.length, 0);
+});
+
 test("room session controller syncs display name after room creation completes", async () => {
   const harness = createControllerHarness();
   harness.runtimeState.connection.connected = true;

--- a/extension/test/soft-apply-controller.test.ts
+++ b/extension/test/soft-apply-controller.test.ts
@@ -48,6 +48,7 @@ function createVideo(
     readyState: 4,
     duration: 120,
     currentTime: 24,
+    defaultPlaybackRate: 1,
     playbackRate: 1,
     pause() {},
     play: async () => undefined,
@@ -59,7 +60,11 @@ test("chained upsertActiveSoftApply preserves the first session's restore rate",
   const windowStub = installWindowStub();
   try {
     const runtimeState = createContentRuntimeState();
-    const video = createVideo({ currentTime: 24, playbackRate: 1.3 });
+    const video = createVideo({
+      currentTime: 24,
+      defaultPlaybackRate: 1.3,
+      playbackRate: 1.3,
+    });
     let now = 10_000;
     const controller = createSoftApplyController({
       runtimeState,
@@ -89,6 +94,10 @@ test("chained upsertActiveSoftApply preserves the first session's restore rate",
     assert.ok(
       Math.abs(video.playbackRate - 1) < 0.001,
       `expected restore to original rate 1, got ${video.playbackRate}`,
+    );
+    assert.ok(
+      Math.abs(video.defaultPlaybackRate - 1) < 0.001,
+      `expected default restore rate 1, got ${video.defaultPlaybackRate}`,
     );
   } finally {
     windowStub.restore();

--- a/packages/protocol/src/guards/server-message.ts
+++ b/packages/protocol/src/guards/server-message.ts
@@ -2,6 +2,8 @@ import type {
   ErrorMessage,
   RoomCreatedMessage,
   RoomJoinedMessage,
+  RoomMemberJoinedMessage,
+  RoomMemberLeftMessage,
   RoomStateMessage,
   ServerMessage,
   SyncPongMessage,
@@ -117,6 +119,30 @@ function isRoomStateMessage(value: unknown): value is RoomStateMessage {
   );
 }
 
+function isRoomMemberJoinedMessage(
+  value: unknown,
+): value is RoomMemberJoinedMessage {
+  return (
+    isRecord(value) &&
+    value.type === "room:member-joined" &&
+    isRecord(value.payload) &&
+    isRoomCode(value.payload.roomCode) &&
+    isRoomMember(value.payload.member)
+  );
+}
+
+function isRoomMemberLeftMessage(
+  value: unknown,
+): value is RoomMemberLeftMessage {
+  return (
+    isRecord(value) &&
+    value.type === "room:member-left" &&
+    isRecord(value.payload) &&
+    isRoomCode(value.payload.roomCode) &&
+    isRoomMember(value.payload.member)
+  );
+}
+
 export function isErrorMessage(value: unknown): value is ErrorMessage {
   return (
     isRecord(value) &&
@@ -150,6 +176,10 @@ export function isServerMessage(value: unknown): value is ServerMessage {
       return isRoomJoinedMessage(value);
     case "room:state":
       return isRoomStateMessage(value);
+    case "room:member-joined":
+      return isRoomMemberJoinedMessage(value);
+    case "room:member-left":
+      return isRoomMemberLeftMessage(value);
     case "error":
       return isErrorMessage(value);
     case "sync:pong":

--- a/packages/protocol/src/types/server-message.ts
+++ b/packages/protocol/src/types/server-message.ts
@@ -1,5 +1,5 @@
 import type { ErrorCode, RoomCode } from "./common.js";
-import type { RoomState } from "./domain.js";
+import type { RoomMember, RoomState } from "./domain.js";
 
 export interface RoomCreatedMessage {
   type: "room:created";
@@ -27,6 +27,22 @@ export interface RoomStateMessage {
   payload: RoomState;
 }
 
+export interface RoomMemberJoinedMessage {
+  type: "room:member-joined";
+  payload: {
+    roomCode: RoomCode;
+    member: RoomMember;
+  };
+}
+
+export interface RoomMemberLeftMessage {
+  type: "room:member-left";
+  payload: {
+    roomCode: RoomCode;
+    member: RoomMember;
+  };
+}
+
 export interface ErrorMessage {
   type: "error";
   payload: {
@@ -48,5 +64,7 @@ export type ServerMessage =
   | RoomCreatedMessage
   | RoomJoinedMessage
   | RoomStateMessage
+  | RoomMemberJoinedMessage
+  | RoomMemberLeftMessage
   | ErrorMessage
   | SyncPongMessage;

--- a/packages/protocol/test/server-message.test.ts
+++ b/packages/protocol/test/server-message.test.ts
@@ -125,6 +125,52 @@ test("accepts room:joined when memberId uses max-compatible actor format", () =>
   );
 });
 
+test("accepts room member delta messages", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:member-joined",
+      payload: {
+        roomCode: "ABC123",
+        member: { id: "member-1", name: "Alice" },
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    isServerMessage({
+      type: "room:member-left",
+      payload: {
+        roomCode: "ABC123",
+        member: { id: "member-2", name: "Bob" },
+      },
+    }),
+    true,
+  );
+});
+
+test("rejects room member delta messages with invalid member payloads", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:member-joined",
+      payload: {
+        roomCode: "ABC123",
+        member: { id: "member 1", name: "Alice" },
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    isServerMessage({
+      type: "room:member-left",
+      payload: {
+        roomCode: "ABC123",
+        member: { id: "member-2", name: "x".repeat(33) },
+      },
+    }),
+    false,
+  );
+});
+
 test("rejects room:created when memberId format is invalid", () => {
   assert.equal(
     isServerMessage({

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -23,6 +23,10 @@ import type { RoomEventBusMessage } from "./room-event-bus.js";
 import { hasAttachedSocket } from "./types.js";
 import type { LogEvent, SendError, SendMessage, Session } from "./types.js";
 
+type RoomEventBusPublishInput<T> = T extends unknown
+  ? Omit<T, "sourceInstanceId" | "emittedAt">
+  : never;
+
 export function createMessageHandler(options: {
   config: {
     maxMembersPerRoom: number;
@@ -112,19 +116,38 @@ export function createMessageHandler(options: {
   const metricsCollector = options.metricsCollector;
 
   async function publishRoomEvent(
-    type: RoomEventBusMessage["type"],
-    roomCode: string,
+    message: RoomEventBusPublishInput<RoomEventBusMessage>,
   ): Promise<void> {
     await options.publishRoomEvent({
-      type,
-      roomCode,
+      ...message,
       sourceInstanceId: options.instanceId,
       emittedAt: now(),
+    } as RoomEventBusMessage);
+  }
+
+  async function sendRoomStateToSession(
+    session: Session,
+    memberToken: string,
+    messageType: ClientMessage["type"],
+  ): Promise<void> {
+    if (!hasAttachedSocket(session)) {
+      return;
+    }
+    const state = await roomService.getRoomStateForSession(
+      session,
+      memberToken,
+      messageType,
+    );
+    send(session.socket, {
+      type: "room:state",
+      payload: state,
     });
   }
 
   async function leaveRoom(session: Session): Promise<void> {
     const roomCode = session.roomCode;
+    const memberId = session.memberId ?? session.id;
+    const displayName = session.displayName;
     const { room, notifyRoom } = await roomService.leaveRoomForSession(session);
     if (!roomCode || (!room && !notifyRoom)) {
       return;
@@ -132,7 +155,12 @@ export function createMessageHandler(options: {
     options.onRoomLeft?.(session, roomCode);
 
     try {
-      await publishRoomEvent("room_member_changed", roomCode);
+      await publishRoomEvent({
+        type: "room_member_left",
+        roomCode,
+        memberId,
+        displayName,
+      });
     } catch (error) {
       logEvent("room_event_publish_failed", {
         sessionId: session.id,
@@ -141,7 +169,7 @@ export function createMessageHandler(options: {
         origin: session.origin,
         result: "error",
         reason: "leave_room_broadcast_failed",
-        eventType: "room_member_changed",
+        eventType: "room_member_left",
         error: error instanceof Error ? error.message : String(error),
       });
     }
@@ -267,7 +295,7 @@ export function createMessageHandler(options: {
               serverProtocolVersion: CURRENT_PROTOCOL_VERSION,
             },
           });
-          await publishRoomEvent("room_member_changed", room.code);
+          await sendRoomStateToSession(session, memberToken, message.type);
           logEvent("room_created", {
             sessionId: session.id,
             roomCode: room.code,
@@ -324,7 +352,13 @@ export function createMessageHandler(options: {
                 serverProtocolVersion: CURRENT_PROTOCOL_VERSION,
               },
             });
-            await publishRoomEvent("room_member_changed", room.code);
+            await sendRoomStateToSession(session, memberToken, message.type);
+            await publishRoomEvent({
+              type: "room_member_joined",
+              roomCode: room.code,
+              memberId: session.memberId ?? session.id,
+              displayName: session.displayName,
+            });
             logEvent("room_joined", {
               sessionId: session.id,
               roomCode: room.code,
@@ -359,7 +393,10 @@ export function createMessageHandler(options: {
             message.payload.memberToken,
             message.payload.displayName,
           );
-          await publishRoomEvent("room_state_updated", room.code);
+          await publishRoomEvent({
+            type: "room_state_updated",
+            roomCode: room.code,
+          });
           return;
         }
         case "video:share": {
@@ -383,7 +420,10 @@ export function createMessageHandler(options: {
               message.payload.video,
               message.payload.playback,
             );
-            await publishRoomEvent("room_state_updated", room.code);
+            await publishRoomEvent({
+              type: "room_state_updated",
+              roomCode: room.code,
+            });
           });
           return;
         }
@@ -407,7 +447,10 @@ export function createMessageHandler(options: {
               message.payload.playback,
             );
             if (!result.ignored && result.room) {
-              await publishRoomEvent("room_state_updated", result.room.code);
+              await publishRoomEvent({
+                type: "room_state_updated",
+                roomCode: result.room.code,
+              });
             }
           });
           return;

--- a/server/src/redis-room-event-bus.ts
+++ b/server/src/redis-room-event-bus.ts
@@ -22,9 +22,31 @@ function parseMessage(payload: string): RoomEventBusMessage | null {
     if (
       parsed.type !== "room_state_updated" &&
       parsed.type !== "room_member_changed" &&
+      parsed.type !== "room_member_joined" &&
+      parsed.type !== "room_member_left" &&
       parsed.type !== "room_deleted"
     ) {
       return null;
+    }
+
+    if (
+      parsed.type === "room_member_joined" ||
+      parsed.type === "room_member_left"
+    ) {
+      if (
+        typeof parsed.memberId !== "string" ||
+        typeof parsed.displayName !== "string"
+      ) {
+        return null;
+      }
+      return {
+        type: parsed.type,
+        roomCode: parsed.roomCode,
+        sourceInstanceId: parsed.sourceInstanceId,
+        emittedAt: parsed.emittedAt,
+        memberId: parsed.memberId,
+        displayName: parsed.displayName,
+      };
     }
 
     return {

--- a/server/src/room-event-bus.ts
+++ b/server/src/room-event-bus.ts
@@ -12,6 +12,22 @@ export type RoomEventBusMessage =
       emittedAt: number;
     }
   | {
+      type: "room_member_joined";
+      roomCode: string;
+      sourceInstanceId: string;
+      emittedAt: number;
+      memberId: string;
+      displayName: string;
+    }
+  | {
+      type: "room_member_left";
+      roomCode: string;
+      sourceInstanceId: string;
+      emittedAt: number;
+      memberId: string;
+      displayName: string;
+    }
+  | {
       type: "room_deleted";
       roomCode: string;
       sourceInstanceId: string;

--- a/server/src/room-event-consumer.ts
+++ b/server/src/room-event-consumer.ts
@@ -1,5 +1,36 @@
 import { hasAttachedSocket, type SendMessage, type Session } from "./types.js";
-import type { RoomEventBus } from "./room-event-bus.js";
+import type { RoomEventBus, RoomEventBusMessage } from "./room-event-bus.js";
+import type { ServerMessage } from "@bili-syncplay/protocol";
+
+function createMemberMessage(
+  message: RoomEventBusMessage,
+): ServerMessage | null {
+  if (message.type === "room_member_joined") {
+    return {
+      type: "room:member-joined",
+      payload: {
+        roomCode: message.roomCode,
+        member: {
+          id: message.memberId,
+          name: message.displayName,
+        },
+      },
+    };
+  }
+  if (message.type === "room_member_left") {
+    return {
+      type: "room:member-left",
+      payload: {
+        roomCode: message.roomCode,
+        member: {
+          id: message.memberId,
+          name: message.displayName,
+        },
+      },
+    };
+  }
+  return null;
+}
 
 export async function createRoomEventConsumer(options: {
   roomEventBus: RoomEventBus;
@@ -14,6 +45,35 @@ export async function createRoomEventConsumer(options: {
   const unsubscribe = await options.roomEventBus.subscribe(async (message) => {
     try {
       const localSessions = options.listLocalSessionsByRoom(message.roomCode);
+      if (
+        message.type === "room_member_joined" ||
+        message.type === "room_member_left"
+      ) {
+        const memberMessage = createMemberMessage(message);
+        if (!memberMessage) {
+          return;
+        }
+        for (const session of localSessions) {
+          if (
+            !hasAttachedSocket(session) ||
+            session.memberId === message.memberId
+          ) {
+            continue;
+          }
+          options.send(session.socket, memberMessage);
+        }
+
+        options.logEvent?.("room_event_consumed", {
+          roomCode: message.roomCode,
+          eventType: message.type,
+          sourceInstanceId: message.sourceInstanceId,
+          instanceId: options.instanceId ?? null,
+          localSessionCount: localSessions.length,
+          result: "ok",
+        });
+        return;
+      }
+
       const state =
         message.type === "room_deleted"
           ? {

--- a/server/test/admin-backend.test.ts
+++ b/server/test/admin-backend.test.ts
@@ -999,7 +999,7 @@ test("operator can execute admin actions and query audit logs", async () => {
         kickedMemberToken = (joined.payload as { memberToken: string })
           .memberToken;
         await joinerCollector.next("room:state");
-        await ownerCollector.next("room:state");
+        await ownerCollector.next("room:member-joined");
 
         const kick = await requestJson(
           server.httpBaseUrl,

--- a/server/test/e2e-smoke.test.ts
+++ b/server/test/e2e-smoke.test.ts
@@ -159,10 +159,10 @@ test("e2e smoke: create room → join → share video → playback update → me
       "joiner's room:state must list 2 members",
     );
 
-    const ownerStateAfterJoin = await ownerMsg.next("room:state");
+    const ownerStateAfterJoin = await ownerMsg.next("room:member-joined");
     assert.equal(
-      (ownerStateAfterJoin.payload as { members: unknown[] }).members.length,
-      2,
+      (ownerStateAfterJoin.payload as { member: { name: string } }).member.name,
+      "Bob",
       "owner must be notified of second member",
     );
 
@@ -267,10 +267,11 @@ test("e2e smoke: create room → join → share video → playback update → me
       }),
     );
 
-    const ownerStateAfterLeave = await ownerMsg.next("room:state");
+    const ownerStateAfterLeave = await ownerMsg.next("room:member-left");
     assert.equal(
-      (ownerStateAfterLeave.payload as { members: unknown[] }).members.length,
-      1,
+      (ownerStateAfterLeave.payload as { member: { name: string } }).member
+        .name,
+      "Bob",
       "owner must see member count drop to 1 after joiner leaves",
     );
 

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -66,7 +66,12 @@ test("message handler rejects detached sessions before processing", async () => 
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-1", name: "Alice" }],
+        };
       },
     },
     logEvent() {},
@@ -92,7 +97,7 @@ test("message handler rejects detached sessions before processing", async () => 
   );
 });
 
-test("message handler creates a room, responds, and publishes member change", async () => {
+test("message handler creates a room and sends bootstrap state to the creator", async () => {
   const sent: Array<{ type: string; roomCode?: string }> = [];
   const published: string[] = [];
   const joined: Array<{ roomCode: string; previousRoomCode: string | null }> =
@@ -129,7 +134,12 @@ test("message handler creates a room, responds, and publishes member change", as
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-1", name: "Alice" }],
+        };
       },
     },
     logEvent(event) {
@@ -163,8 +173,11 @@ test("message handler creates a room, responds, and publishes member change", as
     payload: { displayName: "Alice" },
   });
 
-  assert.deepEqual(sent, [{ type: "room:created", roomCode: "ROOM01" }]);
-  assert.deepEqual(published, ["room_member_changed:ROOM01"]);
+  assert.deepEqual(sent, [
+    { type: "room:created", roomCode: "ROOM01" },
+    { type: "room:state", roomCode: "ROOM01" },
+  ]);
+  assert.deepEqual(published, []);
   assert.deepEqual(joined, [{ roomCode: "ROOM01", previousRoomCode: null }]);
   assert.ok(events.includes("room_created"));
 });
@@ -199,7 +212,12 @@ test("message handler skips room state publish when playback update is ignored",
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM-M1",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-m1", name: "Alice" }],
+        };
       },
     },
     logEvent() {},
@@ -276,7 +294,12 @@ test("message handler keeps leave completed when member change publish fails", a
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-1", name: "Alice" }],
+        };
       },
     },
     logEvent(event) {
@@ -345,7 +368,12 @@ test("message handler records monitored duration metrics for critical room paths
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-1", name: "Alice" }],
+        };
       },
     },
     logEvent() {},
@@ -452,7 +480,12 @@ test("message handler accepts room:create without protocolVersion (legacy client
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM-M1",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-m1", name: "Alice" }],
+        };
       },
     },
     logEvent(event) {
@@ -488,9 +521,10 @@ test("message handler accepts room:create without protocolVersion (legacy client
 
   assert.ok(events.includes("protocol_version_missing"));
   assert.ok(events.includes("room_created"));
-  assert.equal(sent.length, 1);
+  assert.equal(sent.length, 2);
   assert.equal(sent[0].type, "room:created");
   assert.equal(sent[0].serverProtocolVersion, 1);
+  assert.equal(sent[1].type, "room:state");
 });
 
 test("message handler rejects room:create with protocolVersion below minimum", async () => {
@@ -520,7 +554,12 @@ test("message handler rejects room:create with protocolVersion below minimum", a
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM-M1",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-m1", name: "Alice" }],
+        };
       },
     },
     logEvent(event) {
@@ -573,7 +612,12 @@ test("message handler rejects room:join with protocolVersion below minimum", asy
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM-M1",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-m1", name: "Alice" }],
+        };
       },
     },
     logEvent(event) {
@@ -635,7 +679,12 @@ test("message handler accepts room:join with matching protocolVersion and return
         throw new Error("unreachable");
       },
       async getRoomStateForSession() {
-        throw new Error("unreachable");
+        return {
+          roomCode: "ROOM-M1",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-m1", name: "Alice" }],
+        };
       },
     },
     logEvent() {},
@@ -671,7 +720,8 @@ test("message handler accepts room:join with matching protocolVersion and return
     },
   });
 
-  assert.equal(sent.length, 1);
+  assert.equal(sent.length, 2);
   assert.equal(sent[0].type, "room:joined");
   assert.equal(sent[0].serverProtocolVersion, 1);
+  assert.equal(sent[1].type, "room:state");
 });

--- a/server/test/message-validation.ts
+++ b/server/test/message-validation.ts
@@ -611,7 +611,7 @@ test("updates member display names in room state after profile:update", async ()
       );
       const joined = await joinerCollector.next("room:joined");
       await joinerCollector.next("room:state");
-      await ownerCollector.next("room:state");
+      await ownerCollector.next("room:member-joined");
 
       owner.send(
         JSON.stringify({

--- a/server/test/multi-node-admin-actions.test.ts
+++ b/server/test/multi-node-admin-actions.test.ts
@@ -48,7 +48,7 @@ test("global admin executes cross-node kick_member and disconnect_session action
     );
     const joined = await joinerCollector.next("room:joined");
     await joinerCollector.next("room:state");
-    await ownerCollector.next("room:state");
+    await ownerCollector.next("room:member-joined");
 
     const roomCode = (created.payload as { roomCode: string }).roomCode;
     const roomDetail = await requestJson(

--- a/server/test/multi-node-room-broadcast.test.ts
+++ b/server/test/multi-node-room-broadcast.test.ts
@@ -45,14 +45,14 @@ test("cross-node room broadcasts sync join, shared video, playback updates, and 
 
     const joined = await joinerCollector.next("room:joined");
     const joinerJoinedState = await joinerCollector.next("room:state");
-    const ownerSawJoin = await ownerCollector.next("room:state");
+    const ownerSawJoin = await ownerCollector.next("room:member-joined");
     assert.equal(
       (joinerJoinedState.payload as { members: Array<unknown> }).members.length,
       2,
     );
     assert.equal(
-      (ownerSawJoin.payload as { members: Array<unknown> }).members.length,
-      2,
+      (ownerSawJoin.payload as { member: { name: string } }).member.name,
+      "Bob",
     );
 
     owner.send(
@@ -159,10 +159,10 @@ test("cross-node room broadcasts sync join, shared video, playback updates, and 
       }),
     );
 
-    const ownerSawLeave = await ownerCollector.next("room:state");
+    const ownerSawLeave = await ownerCollector.next("room:member-left");
     assert.equal(
-      (ownerSawLeave.payload as { members: Array<unknown> }).members.length,
-      1,
+      (ownerSawLeave.payload as { member: { name: string } }).member.name,
+      "Bob",
     );
     assert.equal(await ownerCollector.maybeNext("room:state", 150), null);
     assert.equal(await joinerCollector.maybeNext("room:state", 150), null);

--- a/server/test/room-event-consumer.test.ts
+++ b/server/test/room-event-consumer.test.ts
@@ -111,6 +111,109 @@ test("room event consumer sends room state only to local room sessions", async (
   ]);
 });
 
+test("room event consumer sends member join deltas to other local room sessions", async () => {
+  const bus = createInMemoryRoomEventBus();
+  const joiningSession = createSession("member-a", "ROOM01");
+  const existingSession = createSession("member-b", "ROOM01");
+  const sent: Array<{
+    sessionId: string;
+    type: string;
+    memberId: string;
+    displayName: string;
+  }> = [];
+
+  const consumer = await createRoomEventConsumer({
+    roomEventBus: bus,
+    async getRoomStateByCode() {
+      throw new Error("member delta should not reload room state");
+    },
+    listLocalSessionsByRoom() {
+      return [joiningSession, existingSession];
+    },
+    send(socket, message) {
+      const session =
+        socket === joiningSession.socket ? joiningSession : existingSession;
+      if (
+        message.type === "room:member-joined" ||
+        message.type === "room:member-left"
+      ) {
+        sent.push({
+          sessionId: session.id,
+          type: message.type,
+          memberId: message.payload.member.id,
+          displayName: message.payload.member.name,
+        });
+      }
+    },
+  });
+
+  try {
+    await bus.publish({
+      type: "room_member_joined",
+      roomCode: "ROOM01",
+      sourceInstanceId: "instance-b",
+      emittedAt: 1_100,
+      memberId: "member-a",
+      displayName: "Alice",
+    });
+  } finally {
+    await consumer.close();
+  }
+
+  assert.deepEqual(sent, [
+    {
+      sessionId: "member-b",
+      type: "room:member-joined",
+      memberId: "member-a",
+      displayName: "Alice",
+    },
+  ]);
+});
+
+test("room event consumer sends member leave deltas to remaining room sessions", async () => {
+  const bus = createInMemoryRoomEventBus();
+  const remainingSession = createSession("member-b", "ROOM01");
+  const sent: Array<{ type: string; memberId: string }> = [];
+
+  const consumer = await createRoomEventConsumer({
+    roomEventBus: bus,
+    async getRoomStateByCode() {
+      throw new Error("member delta should not reload room state");
+    },
+    listLocalSessionsByRoom() {
+      return [remainingSession];
+    },
+    send(_socket, message) {
+      if (message.type === "room:member-left") {
+        sent.push({
+          type: message.type,
+          memberId: message.payload.member.id,
+        });
+      }
+    },
+  });
+
+  try {
+    await bus.publish({
+      type: "room_member_left",
+      roomCode: "ROOM01",
+      sourceInstanceId: "instance-b",
+      emittedAt: 1_100,
+      memberId: "member-a",
+      displayName: "Alice",
+    });
+  } finally {
+    await consumer.close();
+  }
+
+  assert.deepEqual(sent, [
+    {
+      type: "room:member-left",
+      memberId: "member-a",
+    },
+  ]);
+});
+
 test("room event consumer emits an empty state for deleted rooms", async () => {
   const bus = createInMemoryRoomEventBus();
   const localRoomSession = createSession("member-a", "ROOM01");

--- a/server/test/runtime-lifecycle.test.ts
+++ b/server/test/runtime-lifecycle.test.ts
@@ -335,7 +335,7 @@ test("profile updates are reflected in redis-backed room state views", async (t)
       );
       await joinerCollector.next("room:joined");
       await joinerCollector.next("room:state");
-      await ownerCollector.next("room:state");
+      await ownerCollector.next("room:member-joined");
 
       owner.send(
         JSON.stringify({


### PR DESCRIPTION
## What changed

- Added a shared helper for programmatic playback rate writes that updates both `playbackRate` and `defaultPlaybackRate`.
- Routed remote playback application and soft-apply rate restoration through that helper.
- Added regression coverage for restoring the current and default playback rates back to 1x.

## Why

When one member changed to 2x and another member later synced everyone back to 1x, the current video element changed to 1x but its default playback rate could remain at 2x. When the same player loaded a new video, Bilibili could initialize that video from the stale default rate and jump back to 2x.

## Validation

- `npm test -- extension/test/player-binding.test.ts extension/test/soft-apply-controller.test.ts`
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run build`