### PR TITLE
[codex] Fix synced playback rate default

### DIFF
--- a/extension/src/content/player-binding.ts
+++ b/extension/src/content/player-binding.ts
@@ -53,6 +53,14 @@ export function canApplyPlaybackImmediately(video: HTMLVideoElement): boolean {
   return Number.isFinite(video.duration) && video.readyState >= 1;
 }
 
+export function setVideoPlaybackRate(
+  video: HTMLVideoElement,
+  playbackRate: number,
+): void {
+  video.defaultPlaybackRate = playbackRate;
+  video.playbackRate = playbackRate;
+}
+
 export function createProgrammaticPlaybackSignature(
   playback: PlaybackState,
 ): ProgrammaticPlaybackSignature {
@@ -165,7 +173,7 @@ export function syncPlaybackPosition(
       Math.abs(video.playbackRate - playbackRate) > 0.01;
     video.currentTime = targetTime;
     if (shouldWritePlaybackRate) {
-      video.playbackRate = playbackRate;
+      setVideoPlaybackRate(video, playbackRate);
     }
     return {
       mode: "hard-seek",
@@ -197,7 +205,7 @@ export function syncPlaybackPosition(
       video.currentTime = softApplied.currentTime;
     }
     if (shouldWritePlaybackRate) {
-      video.playbackRate = softApplied.playbackRate;
+      setVideoPlaybackRate(video, softApplied.playbackRate);
     }
     return {
       mode: "soft-apply",
@@ -222,7 +230,7 @@ export function syncPlaybackPosition(
     const shouldWritePlaybackRate =
       Math.abs(video.playbackRate - adjustedPlaybackRate) > 0.01;
     if (shouldWritePlaybackRate) {
-      video.playbackRate = adjustedPlaybackRate;
+      setVideoPlaybackRate(video, adjustedPlaybackRate);
     }
     return {
       mode: "rate-only",
@@ -241,7 +249,7 @@ export function syncPlaybackPosition(
   const shouldWritePlaybackRate =
     Math.abs(video.playbackRate - playbackRate) > 0.01;
   if (shouldWritePlaybackRate) {
-    video.playbackRate = playbackRate;
+    setVideoPlaybackRate(video, playbackRate);
   }
   return {
     mode: "ignore",

--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -6,6 +6,7 @@ import {
 import {
   createProgrammaticPlaybackSignature,
   getPlayState,
+  setVideoPlaybackRate,
 } from "./player-binding";
 import type {
   ContentRuntimeState,
@@ -124,7 +125,7 @@ export function createSoftApplyController(args: {
       video &&
       Math.abs(video.playbackRate - session.restorePlaybackRate) > 0.01
     ) {
-      video.playbackRate = session.restorePlaybackRate;
+      setVideoPlaybackRate(video, session.restorePlaybackRate);
       args.armProgrammaticApplyWindow(
         {
           url: session.normalizedUrl,

--- a/extension/test/player-binding.test.ts
+++ b/extension/test/player-binding.test.ts
@@ -14,6 +14,7 @@ function createVideo(
     readyState: 4,
     duration: 120,
     currentTime: 12,
+    defaultPlaybackRate: 1,
     playbackRate: 1,
     pause() {},
     play: async () => undefined,
@@ -218,6 +219,7 @@ test("ignore-window playback update still restores playbackRate when only the ra
   const video = createVideo({
     paused: false,
     currentTime: 12,
+    defaultPlaybackRate: 1.1,
     playbackRate: 1.1,
   });
 
@@ -243,6 +245,7 @@ test("ignore-window playback update still restores playbackRate when only the ra
   assert.equal(applied.adjustment?.didWriteCurrentTime, false);
   assert.equal(applied.adjustment?.didWritePlaybackRate, true);
   assert.ok(Math.abs(video.playbackRate - 1) < 0.001);
+  assert.ok(Math.abs(video.defaultPlaybackRate - 1) < 0.001);
 });
 
 test("buffering playback update does not force-pause an already playing video", () => {

--- a/extension/test/soft-apply-controller.test.ts
+++ b/extension/test/soft-apply-controller.test.ts
@@ -48,6 +48,7 @@ function createVideo(
     readyState: 4,
     duration: 120,
     currentTime: 24,
+    defaultPlaybackRate: 1,
     playbackRate: 1,
     pause() {},
     play: async () => undefined,
@@ -59,7 +60,11 @@ test("chained upsertActiveSoftApply preserves the first session's restore rate",
   const windowStub = installWindowStub();
   try {
     const runtimeState = createContentRuntimeState();
-    const video = createVideo({ currentTime: 24, playbackRate: 1.3 });
+    const video = createVideo({
+      currentTime: 24,
+      defaultPlaybackRate: 1.3,
+      playbackRate: 1.3,
+    });
     let now = 10_000;
     const controller = createSoftApplyController({
       runtimeState,
@@ -89,6 +94,10 @@ test("chained upsertActiveSoftApply preserves the first session's restore rate",
     assert.ok(
       Math.abs(video.playbackRate - 1) < 0.001,
       `expected restore to original rate 1, got ${video.playbackRate}`,
+    );
+    assert.ok(
+      Math.abs(video.defaultPlaybackRate - 1) < 0.001,
+      `expected default restore rate 1, got ${video.defaultPlaybackRate}`,
     );
   } finally {
     windowStub.restore();


### PR DESCRIPTION
## What changed

- Added a shared helper for programmatic playback rate writes that updates both `playbackRate` and `defaultPlaybackRate`.
- Routed remote playback application and soft-apply rate restoration through that helper.
- Added regression coverage for restoring the current and default playback rates back to 1x.

## Why

When one member changed to 2x and another member later synced everyone back to 1x, the current video element changed to 1x but its default playback rate could remain at 2x. When the same player loaded a new video, Bilibili could initialize that video from the stale default rate and jump back to 2x.

## Validation

- `npm test -- extension/test/player-binding.test.ts extension/test/soft-apply-controller.test.ts`
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run build`