### PR TITLE
[codex] fix popup immediate room leave

### DIFF
--- a/extension/src/popup/index.ts
+++ b/extension/src/popup/index.ts
@@ -15,6 +15,7 @@ import { createServerUrlDraftState } from "./server-url-draft";
 import {
   applyIncomingPopupState,
   createPopupStateSyncState,
+  getNextPopupRoomTrackingState,
 } from "./state-sync";
 import { getDocumentLanguage, t } from "../shared/i18n";
 
@@ -108,15 +109,9 @@ function applyState(
   if (!applyIncomingPopupState(popupStateSync, state, source)) {
     return false;
   }
-  const previousRoomCode = popupUiStateStore.getState().lastKnownRoomCode;
-  popupUiStateStore.patch({
-    lastKnownPendingCreateRoom: state.pendingCreateRoom,
-    lastKnownPendingJoinRoomCode: state.pendingJoinRoomCode,
-    lastKnownRoomCode: state.roomCode,
-  });
-  if (!previousRoomCode && state.roomCode) {
-    popupUiStateStore.patch({ lastRoomEnteredAt: Date.now() });
-  }
+  popupUiStateStore.patch(
+    getNextPopupRoomTrackingState(popupUiStateStore.getState(), state),
+  );
   return true;
 }
 

--- a/extension/src/popup/popup-actions.ts
+++ b/extension/src/popup/popup-actions.ts
@@ -48,7 +48,11 @@ export function bindPopupActions(args: {
       return;
     }
     void args.sendPopupLog("Create room button clicked");
-    patchUiState({ localStatusMessage: null, roomActionPending: true });
+    patchUiState({
+      localRoomEntryPending: true,
+      localStatusMessage: null,
+      roomActionPending: true,
+    });
     try {
       const state = await sendPopupAction({ type: "popup:create-room" });
       args.applyActionState(state);
@@ -299,6 +303,7 @@ export function bindPopupActions(args: {
       return;
     }
     patchUiState({
+      localRoomEntryPending: true,
       localStatusMessage: null,
       roomCodeDraft: `${invite.roomCode}:${invite.joinToken}`,
     });

--- a/extension/src/popup/popup-store.ts
+++ b/extension/src/popup/popup-store.ts
@@ -2,6 +2,7 @@ import { createStore, type StateStore } from "../shared/create-store";
 
 export interface PopupUiState {
   roomActionPending: boolean;
+  localRoomEntryPending: boolean;
   lastKnownPendingCreateRoom: boolean;
   lastKnownPendingJoinRoomCode: string | null;
   lastKnownRoomCode: string | null;
@@ -18,6 +19,7 @@ export type PopupUiStateStore = StateStore<PopupUiState>;
 export function createPopupUiState(): PopupUiState {
   return {
     roomActionPending: false,
+    localRoomEntryPending: false,
     lastKnownPendingCreateRoom: false,
     lastKnownPendingJoinRoomCode: null,
     lastKnownRoomCode: null,

--- a/extension/src/popup/state-sync.ts
+++ b/extension/src/popup/state-sync.ts
@@ -2,6 +2,7 @@ import type { BackgroundPopupState } from "../shared/messages";
 
 export interface PopupRoomTrackingState {
   roomActionPending: boolean;
+  localRoomEntryPending: boolean;
   lastKnownPendingCreateRoom: boolean;
   lastKnownPendingJoinRoomCode: string | null;
   lastKnownRoomCode: string | null;
@@ -46,11 +47,13 @@ export function getNextPopupRoomTrackingState(
   | "lastKnownPendingJoinRoomCode"
   | "lastKnownRoomCode"
   | "lastRoomEnteredAt"
+  | "localRoomEntryPending"
 > {
   const enteredRoomFromLocalAction =
     !currentState.lastKnownRoomCode &&
     Boolean(nextState.roomCode) &&
-    (currentState.roomActionPending ||
+    (currentState.localRoomEntryPending ||
+      currentState.roomActionPending ||
       currentState.lastKnownPendingCreateRoom ||
       Boolean(currentState.lastKnownPendingJoinRoomCode));
 
@@ -61,5 +64,8 @@ export function getNextPopupRoomTrackingState(
     lastRoomEnteredAt: enteredRoomFromLocalAction
       ? now
       : currentState.lastRoomEnteredAt,
+    localRoomEntryPending: enteredRoomFromLocalAction
+      ? false
+      : currentState.localRoomEntryPending,
   };
 }

--- a/extension/src/popup/state-sync.ts
+++ b/extension/src/popup/state-sync.ts
@@ -1,5 +1,13 @@
 import type { BackgroundPopupState } from "../shared/messages";
 
+export interface PopupRoomTrackingState {
+  roomActionPending: boolean;
+  lastKnownPendingCreateRoom: boolean;
+  lastKnownPendingJoinRoomCode: string | null;
+  lastKnownRoomCode: string | null;
+  lastRoomEnteredAt: number;
+}
+
 export interface PopupStateSyncState {
   popupState: BackgroundPopupState | null;
   hasReceivedPortState: boolean;
@@ -26,4 +34,32 @@ export function applyIncomingPopupState(
     state.hasReceivedPortState = true;
   }
   return true;
+}
+
+export function getNextPopupRoomTrackingState(
+  currentState: PopupRoomTrackingState,
+  nextState: BackgroundPopupState,
+  now = Date.now(),
+): Pick<
+  PopupRoomTrackingState,
+  | "lastKnownPendingCreateRoom"
+  | "lastKnownPendingJoinRoomCode"
+  | "lastKnownRoomCode"
+  | "lastRoomEnteredAt"
+> {
+  const enteredRoomFromLocalAction =
+    !currentState.lastKnownRoomCode &&
+    Boolean(nextState.roomCode) &&
+    (currentState.roomActionPending ||
+      currentState.lastKnownPendingCreateRoom ||
+      Boolean(currentState.lastKnownPendingJoinRoomCode));
+
+  return {
+    lastKnownPendingCreateRoom: nextState.pendingCreateRoom,
+    lastKnownPendingJoinRoomCode: nextState.pendingJoinRoomCode,
+    lastKnownRoomCode: nextState.roomCode,
+    lastRoomEnteredAt: enteredRoomFromLocalAction
+      ? now
+      : currentState.lastRoomEnteredAt,
+  };
 }

--- a/extension/test/popup-state-sync.test.ts
+++ b/extension/test/popup-state-sync.test.ts
@@ -62,6 +62,7 @@ test("room tracking does not start the leave guard for an already joined room", 
   const nextState = getNextPopupRoomTrackingState(
     {
       roomActionPending: false,
+      localRoomEntryPending: false,
       lastKnownPendingCreateRoom: false,
       lastKnownPendingJoinRoomCode: null,
       lastKnownRoomCode: null,
@@ -79,6 +80,7 @@ test("room tracking starts the leave guard after a local join resolves", () => {
   const nextState = getNextPopupRoomTrackingState(
     {
       roomActionPending: false,
+      localRoomEntryPending: false,
       lastKnownPendingCreateRoom: false,
       lastKnownPendingJoinRoomCode: "ROOM01",
       lastKnownRoomCode: null,
@@ -90,5 +92,42 @@ test("room tracking starts the leave guard after a local join resolves", () => {
 
   assert.equal(nextState.lastKnownRoomCode, "ROOM01");
   assert.equal(nextState.lastKnownPendingJoinRoomCode, null);
+  assert.equal(nextState.localRoomEntryPending, false);
   assert.equal(nextState.lastRoomEnteredAt, 1000);
+});
+
+test("room tracking keeps local create intent until the created room arrives", () => {
+  const pendingState = getNextPopupRoomTrackingState(
+    {
+      roomActionPending: true,
+      localRoomEntryPending: true,
+      lastKnownPendingCreateRoom: false,
+      lastKnownPendingJoinRoomCode: null,
+      lastKnownRoomCode: null,
+      lastRoomEnteredAt: 0,
+    },
+    createPopupState(null, { pendingCreateRoom: false }),
+    1000,
+  );
+
+  assert.equal(pendingState.localRoomEntryPending, true);
+  assert.equal(pendingState.lastKnownRoomCode, null);
+  assert.equal(pendingState.lastRoomEnteredAt, 0);
+
+  const enteredState = getNextPopupRoomTrackingState(
+    {
+      roomActionPending: false,
+      localRoomEntryPending: pendingState.localRoomEntryPending,
+      lastKnownPendingCreateRoom: pendingState.lastKnownPendingCreateRoom,
+      lastKnownPendingJoinRoomCode: pendingState.lastKnownPendingJoinRoomCode,
+      lastKnownRoomCode: pendingState.lastKnownRoomCode,
+      lastRoomEnteredAt: pendingState.lastRoomEnteredAt,
+    },
+    createPopupState("ROOM01"),
+    2000,
+  );
+
+  assert.equal(enteredState.localRoomEntryPending, false);
+  assert.equal(enteredState.lastKnownRoomCode, "ROOM01");
+  assert.equal(enteredState.lastRoomEnteredAt, 2000);
 });

--- a/extension/test/popup-state-sync.test.ts
+++ b/extension/test/popup-state-sync.test.ts
@@ -3,10 +3,14 @@ import test from "node:test";
 import {
   applyIncomingPopupState,
   createPopupStateSyncState,
+  getNextPopupRoomTrackingState,
 } from "../src/popup/state-sync";
 import type { BackgroundPopupState } from "../src/shared/messages";
 
-function createPopupState(roomCode: string | null): BackgroundPopupState {
+function createPopupState(
+  roomCode: string | null,
+  overrides: Partial<BackgroundPopupState> = {},
+): BackgroundPopupState {
   return {
     connected: Boolean(roomCode),
     serverUrl: "ws://localhost:8787",
@@ -31,6 +35,7 @@ function createPopupState(roomCode: string | null): BackgroundPopupState {
     clockOffsetMs: null,
     rttMs: null,
     logs: [],
+    ...overrides,
   };
 }
 
@@ -51,4 +56,39 @@ test("query snapshot is accepted as fallback before any port snapshot arrives", 
   assert.equal(applyIncomingPopupState(state, initialState, "query"), true);
   assert.equal(state.popupState?.roomCode, "ROOM01");
   assert.equal(state.hasReceivedPortState, false);
+});
+
+test("room tracking does not start the leave guard for an already joined room", () => {
+  const nextState = getNextPopupRoomTrackingState(
+    {
+      roomActionPending: false,
+      lastKnownPendingCreateRoom: false,
+      lastKnownPendingJoinRoomCode: null,
+      lastKnownRoomCode: null,
+      lastRoomEnteredAt: 0,
+    },
+    createPopupState("ROOM01"),
+    1000,
+  );
+
+  assert.equal(nextState.lastKnownRoomCode, "ROOM01");
+  assert.equal(nextState.lastRoomEnteredAt, 0);
+});
+
+test("room tracking starts the leave guard after a local join resolves", () => {
+  const nextState = getNextPopupRoomTrackingState(
+    {
+      roomActionPending: false,
+      lastKnownPendingCreateRoom: false,
+      lastKnownPendingJoinRoomCode: "ROOM01",
+      lastKnownRoomCode: null,
+      lastRoomEnteredAt: 0,
+    },
+    createPopupState("ROOM01", { pendingJoinRoomCode: null }),
+    1000,
+  );
+
+  assert.equal(nextState.lastKnownRoomCode, "ROOM01");
+  assert.equal(nextState.lastKnownPendingJoinRoomCode, null);
+  assert.equal(nextState.lastRoomEnteredAt, 1000);
 });


### PR DESCRIPTION
## Summary

Fixes a popup state-tracking bug where opening the popup while already in a room made the UI think the user had just joined that room.

## Root Cause

`lastRoomEnteredAt` was refreshed whenever popup-local state transitioned from no room to a room. Because popup-local state starts empty on every open, the initial background snapshot for an existing room incorrectly started the recent-join leave guard. Clicking “退出房间” immediately after opening the popup was then ignored for 1.5 seconds.

## Changes

- Added a popup room-tracking helper that only starts the leave guard when the room entry came from a create/join action initiated in the current popup session.
- Updated popup state application to use the helper.
- Added regression coverage for both existing-room popup opens and locally resolved joins.

## Validation

- `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`
- After rebuilding the branch from `origin/main`, re-ran `npm run format:check` and `git diff --check origin/main...HEAD`.