### PR TITLE
[codex] fix bangumi episode share identity

### DIFF
--- a/extension/src/content/festival-bridge.ts
+++ b/extension/src/content/festival-bridge.ts
@@ -10,8 +10,15 @@ export interface FestivalSnapshot {
   url: string;
   title: string;
   updatedAt: number;
+  epId?: string;
+  cid?: string;
   pathname?: string;
   pageUrl?: string;
+}
+
+interface PageVideoSnapshot extends SharedVideo {
+  epId?: string;
+  cid?: string;
 }
 
 export interface FestivalBridgeController {
@@ -31,11 +38,11 @@ export function createFestivalBridgeController(): FestivalBridgeController {
   async function readFestivalSnapshotFromPageContext(
     pathname: string,
     pageUrl: string,
-  ): Promise<SharedVideo | null> {
+  ): Promise<PageVideoSnapshot | null> {
     ensureFestivalBridge();
     const requestId = `bili-syncplay-festival-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
-    return await new Promise<SharedVideo | null>((resolve) => {
+    return await new Promise<PageVideoSnapshot | null>((resolve) => {
       const timeoutId = window.setTimeout(() => {
         cleanup();
         resolve(null);
@@ -76,10 +83,13 @@ export function createFestivalBridgeController(): FestivalBridgeController {
 
         if (pathname.startsWith("/bangumi/play/") && detail.epId) {
           const epId = String(detail.epId);
+          const normalizedEpId = epId.startsWith("ep") ? epId : `ep${epId}`;
           resolve({
-            videoId: epId.startsWith("ep") ? epId : `ep${epId}`,
+            videoId: normalizedEpId,
             url: buildBangumiEpisodeShareUrl(epId),
             title: detail.title.trim(),
+            epId: normalizedEpId,
+            cid: detail.cid === undefined ? undefined : String(detail.cid),
           });
           return;
         }
@@ -95,6 +105,7 @@ export function createFestivalBridgeController(): FestivalBridgeController {
             ? buildFestivalShareUrl(pageUrl, detail.bvid, String(detail.cid))
             : buildBvidCidShareUrl(detail.bvid, String(detail.cid)),
           title: detail.title.trim(),
+          cid: String(detail.cid),
         });
       };
 

--- a/extension/src/content/festival-bridge.ts
+++ b/extension/src/content/festival-bridge.ts
@@ -117,6 +117,14 @@ export function createFestivalBridgeController(): FestivalBridgeController {
     });
   }
 
+  function canUseCachedFestivalSnapshot(pathname: string): boolean {
+    return (
+      pathname.startsWith("/festival/") &&
+      festivalSnapshot?.pathname?.startsWith("/festival/") === true &&
+      festivalSnapshot.pathname === pathname
+    );
+  }
+
   function ensureFestivalBridge(): void {
     if (festivalBridgeReady) {
       return;
@@ -145,6 +153,7 @@ export function createFestivalBridgeController(): FestivalBridgeController {
       if (
         !isBangumiPage &&
         festivalSnapshot &&
+        canUseCachedFestivalSnapshot(pathname) &&
         Date.now() - festivalSnapshot.updatedAt < maxAgeMs
       ) {
         return {
@@ -159,7 +168,9 @@ export function createFestivalBridgeController(): FestivalBridgeController {
         pageUrl,
       );
       if (!nextSnapshot) {
-        return !isBangumiPage && festivalSnapshot
+        return !isBangumiPage &&
+          festivalSnapshot &&
+          canUseCachedFestivalSnapshot(pathname)
           ? {
               videoId: festivalSnapshot.videoId,
               url: festivalSnapshot.url,

--- a/extension/src/content/festival-bridge.ts
+++ b/extension/src/content/festival-bridge.ts
@@ -10,6 +10,8 @@ export interface FestivalSnapshot {
   url: string;
   title: string;
   updatedAt: number;
+  pathname?: string;
+  pageUrl?: string;
 }
 
 export interface FestivalBridgeController {
@@ -158,6 +160,8 @@ export function createFestivalBridgeController(): FestivalBridgeController {
       festivalSnapshot = {
         ...nextSnapshot,
         updatedAt: Date.now(),
+        pathname,
+        pageUrl,
       };
       return nextSnapshot;
     },

--- a/extension/src/content/festival-bridge.ts
+++ b/extension/src/content/festival-bridge.ts
@@ -1,5 +1,9 @@
 import type { SharedVideo } from "@bili-syncplay/protocol";
-import { buildFestivalShareUrl } from "./page-video";
+import {
+  buildBangumiEpisodeShareUrl,
+  buildBvidCidShareUrl,
+  buildFestivalShareUrl,
+} from "./page-video";
 
 export interface FestivalSnapshot {
   videoId: string;
@@ -23,6 +27,7 @@ export function createFestivalBridgeController(): FestivalBridgeController {
   let festivalSnapshot: FestivalSnapshot | null = null;
 
   async function readFestivalSnapshotFromPageContext(
+    pathname: string,
     pageUrl: string,
   ): Promise<SharedVideo | null> {
     ensureFestivalBridge();
@@ -44,6 +49,7 @@ export function createFestivalBridgeController(): FestivalBridgeController {
           type?: string;
           requestId?: string;
           detail?: {
+            epId?: string | number;
             bvid?: string;
             cid?: string | number;
             title?: string;
@@ -61,14 +67,31 @@ export function createFestivalBridgeController(): FestivalBridgeController {
         const detail = messageEvent.data.detail;
         cleanup();
 
-        if (!detail?.bvid || detail.cid === undefined || !detail.title) {
+        if (!detail?.title) {
+          resolve(null);
+          return;
+        }
+
+        if (pathname.startsWith("/bangumi/play/") && detail.epId) {
+          const epId = String(detail.epId);
+          resolve({
+            videoId: epId.startsWith("ep") ? epId : `ep${epId}`,
+            url: buildBangumiEpisodeShareUrl(epId),
+            title: detail.title.trim(),
+          });
+          return;
+        }
+
+        if (!detail.bvid || detail.cid === undefined) {
           resolve(null);
           return;
         }
 
         resolve({
           videoId: `${detail.bvid}:${detail.cid}`,
-          url: buildFestivalShareUrl(pageUrl, detail.bvid, String(detail.cid)),
+          url: pathname.startsWith("/festival/")
+            ? buildFestivalShareUrl(pageUrl, detail.bvid, String(detail.cid))
+            : buildBvidCidShareUrl(detail.bvid, String(detail.cid)),
           title: detail.title.trim(),
         });
       };
@@ -100,12 +123,14 @@ export function createFestivalBridgeController(): FestivalBridgeController {
     },
     getSnapshot: () => festivalSnapshot,
     refreshSnapshot: async ({ pathname, pageUrl, maxAgeMs }) => {
-      if (!pathname.startsWith("/festival/")) {
+      const isBangumiPage = pathname.startsWith("/bangumi/play/");
+      if (!pathname.startsWith("/festival/") && !isBangumiPage) {
         festivalSnapshot = null;
         return null;
       }
 
       if (
+        !isBangumiPage &&
         festivalSnapshot &&
         Date.now() - festivalSnapshot.updatedAt < maxAgeMs
       ) {
@@ -116,9 +141,12 @@ export function createFestivalBridgeController(): FestivalBridgeController {
         };
       }
 
-      const nextSnapshot = await readFestivalSnapshotFromPageContext(pageUrl);
+      const nextSnapshot = await readFestivalSnapshotFromPageContext(
+        pathname,
+        pageUrl,
+      );
       if (!nextSnapshot) {
-        return festivalSnapshot
+        return !isBangumiPage && festivalSnapshot
           ? {
               videoId: festivalSnapshot.videoId,
               url: festivalSnapshot.url,

--- a/extension/src/content/festival-bridge.ts
+++ b/extension/src/content/festival-bridge.ts
@@ -117,11 +117,16 @@ export function createFestivalBridgeController(): FestivalBridgeController {
     });
   }
 
+  function normalizeCachedPagePathname(pathname: string): string {
+    return pathname.replace(/\/+$/, "");
+  }
+
   function canUseCachedFestivalSnapshot(pathname: string): boolean {
     return (
       pathname.startsWith("/festival/") &&
       festivalSnapshot?.pathname?.startsWith("/festival/") === true &&
-      festivalSnapshot.pathname === pathname
+      normalizeCachedPagePathname(festivalSnapshot.pathname) ===
+        normalizeCachedPagePathname(pathname)
     );
   }
 

--- a/extension/src/content/page-bridge-detail.ts
+++ b/extension/src/content/page-bridge-detail.ts
@@ -1,0 +1,119 @@
+export interface PageVideoCandidate {
+  id?: string | number;
+  ep_id?: string | number;
+  epId?: string | number;
+  bvid?: string;
+  cid?: string | number;
+  title?: string;
+  long_title?: string;
+}
+
+export interface PageInitialState {
+  epInfo?: PageVideoCandidate;
+  sectionEpisodes?: PageVideoCandidate[];
+  episodes?: PageVideoCandidate[];
+  epList?: PageVideoCandidate[];
+  videoInfo?: {
+    bvid?: string;
+    cid?: string | number;
+    title?: string;
+  };
+}
+
+export interface PlayerInput {
+  bvid?: string;
+  cid?: string | number;
+  aid?: string | number;
+}
+
+export function readFestivalVideoDetailFromSources(args: {
+  initialState?: PageInitialState;
+  playerInput?: PlayerInput;
+  activeCid?: string | null;
+  activeEpId?: string | null;
+  activeTitle?: string | null;
+}): {
+  epId?: string | number;
+  bvid?: string;
+  cid?: string | number;
+  title?: string;
+} | null {
+  const {
+    initialState,
+    playerInput,
+    activeCid = null,
+    activeEpId = null,
+    activeTitle = null,
+  } = args;
+
+  const episodes = [
+    ...(Array.isArray(initialState?.sectionEpisodes)
+      ? initialState.sectionEpisodes
+      : []),
+    ...(Array.isArray(initialState?.episodes) ? initialState.episodes : []),
+    ...(Array.isArray(initialState?.epList) ? initialState.epList : []),
+  ];
+  const matchedByEpId = activeEpId
+    ? episodes.find(
+        (episode) =>
+          String(episode?.id ?? "") === activeEpId ||
+          String(episode?.ep_id ?? "") === activeEpId ||
+          String(episode?.epId ?? "") === activeEpId,
+      )
+    : null;
+  const matchedByCid = activeCid
+    ? episodes.find((episode) => String(episode?.cid ?? "") === activeCid)
+    : null;
+  const matchedByTitle =
+    !matchedByEpId && !matchedByCid && activeTitle
+      ? episodes.find(
+          (episode) =>
+            (episode?.title || "").trim() === activeTitle ||
+            (episode?.long_title || "").trim() === activeTitle,
+        )
+      : null;
+
+  const matched: PageVideoCandidate | null =
+    matchedByEpId ??
+    matchedByCid ??
+    matchedByTitle ??
+    initialState?.epInfo ??
+    playerInput ??
+    initialState?.videoInfo ??
+    null;
+  const epId =
+    typeof matched === "object" && matched !== null
+      ? (matched.epId ?? matched.ep_id ?? matched.id ?? activeEpId ?? undefined)
+      : undefined;
+  const cid =
+    typeof matched === "object" && matched !== null
+      ? (matched.cid ?? activeCid ?? undefined)
+      : undefined;
+
+  if (!epId && (!matched?.bvid || cid === undefined)) {
+    return null;
+  }
+
+  return {
+    epId,
+    bvid: matched.bvid,
+    cid,
+    title:
+      (typeof matched === "object" &&
+      matched !== null &&
+      "title" in matched &&
+      typeof matched.title === "string"
+        ? matched.title
+        : undefined) ||
+      (typeof matched === "object" &&
+      matched !== null &&
+      "long_title" in matched &&
+      typeof matched.long_title === "string"
+        ? matched.long_title
+        : undefined) ||
+      activeTitle ||
+      initialState?.epInfo?.title ||
+      initialState?.epInfo?.long_title ||
+      initialState?.videoInfo?.title,
+  };
+}

--- a/extension/src/content/page-bridge.ts
+++ b/extension/src/content/page-bridge.ts
@@ -1,15 +1,11 @@
+import {
+  readFestivalVideoDetailFromSources,
+  type PageInitialState,
+  type PlayerInput,
+} from "./page-bridge-detail";
+
 const REQUEST_TYPE = "bili-syncplay:get-festival-video";
 const RESPONSE_TYPE = "bili-syncplay:festival-video";
-
-interface PageVideoCandidate {
-  id?: string | number;
-  ep_id?: string | number;
-  epId?: string | number;
-  bvid?: string;
-  cid?: string | number;
-  title?: string;
-  long_title?: string;
-}
 
 window.addEventListener("message", (event) => {
   if (event.source !== window || event.data?.type !== REQUEST_TYPE) {
@@ -38,24 +34,10 @@ function readFestivalVideoDetail(): {
   try {
     const initialState = (
       window as typeof window & {
-        __INITIAL_STATE__?: {
-          epInfo?: PageVideoCandidate;
-          sectionEpisodes?: PageVideoCandidate[];
-          episodes?: PageVideoCandidate[];
-          epList?: PageVideoCandidate[];
-          videoInfo?: {
-            bvid?: string;
-            cid?: string | number;
-            title?: string;
-          };
-        };
+        __INITIAL_STATE__?: PageInitialState;
         player?: {
           __getUserParams?: () => {
-            input?: {
-              bvid?: string;
-              cid?: string | number;
-              aid?: string | number;
-            };
+            input?: PlayerInput;
           };
         };
       }
@@ -77,85 +59,23 @@ function readFestivalVideoDetail(): {
         ?.textContent?.trim() ||
       null;
 
-    const episodes = [
-      ...(Array.isArray(initialState?.sectionEpisodes)
-        ? initialState.sectionEpisodes
-        : []),
-      ...(Array.isArray(initialState?.episodes) ? initialState.episodes : []),
-      ...(Array.isArray(initialState?.epList) ? initialState.epList : []),
-    ];
-    const matchedByEpId = activeEpId
-      ? episodes.find(
-          (episode) =>
-            String(episode?.id ?? "") === activeEpId ||
-            String(episode?.ep_id ?? "") === activeEpId ||
-            String(episode?.epId ?? "") === activeEpId,
-        )
-      : null;
-    const matchedByCid = activeCid
-      ? episodes.find((episode) => String(episode?.cid ?? "") === activeCid)
-      : null;
-    const matchedByTitle =
-      !matchedByEpId && !matchedByCid && activeTitle
-        ? episodes.find(
-            (episode) =>
-              (episode?.title || "").trim() === activeTitle ||
-              (episode?.long_title || "").trim() === activeTitle,
-          )
-        : null;
-
     const playerInput = (
       window as typeof window & {
         player?: {
           __getUserParams?: () => {
-            input?: {
-              bvid?: string;
-              cid?: string | number;
-            };
+            input?: PlayerInput;
           };
         };
       }
     ).player?.__getUserParams?.()?.input;
 
-    const matched: PageVideoCandidate | null =
-      matchedByEpId ??
-      matchedByCid ??
-      matchedByTitle ??
-      initialState?.epInfo ??
-      playerInput ??
-      initialState?.videoInfo ??
-      null;
-    const epId =
-      typeof matched === "object" && matched !== null
-        ? (matched.epId ?? matched.ep_id ?? matched.id)
-        : undefined;
-
-    if (!epId && (!matched?.bvid || matched.cid === undefined)) {
-      return null;
-    }
-
-    return {
-      epId,
-      bvid: matched.bvid,
-      cid: matched.cid,
-      title:
-        (typeof matched === "object" &&
-        matched !== null &&
-        "title" in matched &&
-        typeof matched.title === "string"
-          ? matched.title
-          : undefined) ||
-        (typeof matched === "object" &&
-        matched !== null &&
-        "long_title" in matched &&
-        typeof matched.long_title === "string"
-          ? matched.long_title
-          : undefined) ||
-        activeTitle ||
-        initialState?.epInfo?.title ||
-        initialState?.epInfo?.long_title ||
-        initialState?.videoInfo?.title,
-    };
+    return readFestivalVideoDetailFromSources({
+      initialState,
+      playerInput,
+      activeCid,
+      activeEpId,
+      activeTitle,
+    });
   } catch {
     return null;
   }

--- a/extension/src/content/page-bridge.ts
+++ b/extension/src/content/page-bridge.ts
@@ -1,6 +1,16 @@
 const REQUEST_TYPE = "bili-syncplay:get-festival-video";
 const RESPONSE_TYPE = "bili-syncplay:festival-video";
 
+interface PageVideoCandidate {
+  id?: string | number;
+  ep_id?: string | number;
+  epId?: string | number;
+  bvid?: string;
+  cid?: string | number;
+  title?: string;
+  long_title?: string;
+}
+
 window.addEventListener("message", (event) => {
   if (event.source !== window || event.data?.type !== REQUEST_TYPE) {
     return;
@@ -20,6 +30,7 @@ window.addEventListener("message", (event) => {
 });
 
 function readFestivalVideoDetail(): {
+  epId?: string | number;
   bvid?: string;
   cid?: string | number;
   title?: string;
@@ -28,11 +39,10 @@ function readFestivalVideoDetail(): {
     const initialState = (
       window as typeof window & {
         __INITIAL_STATE__?: {
-          sectionEpisodes?: Array<{
-            bvid?: string;
-            cid?: string | number;
-            title?: string;
-          }>;
+          epInfo?: PageVideoCandidate;
+          sectionEpisodes?: PageVideoCandidate[];
+          episodes?: PageVideoCandidate[];
+          epList?: PageVideoCandidate[];
           videoInfo?: {
             bvid?: string;
             cid?: string | number;
@@ -52,9 +62,14 @@ function readFestivalVideoDetail(): {
     ).__INITIAL_STATE__;
 
     const active = document.querySelector<HTMLElement>(
-      "li[data-cid].bpx-state-active, [data-cid].bpx-state-active, [data-cid].active, [data-cid].selected",
+      "li[data-cid].bpx-state-active, [data-cid].bpx-state-active, [data-cid].active, [data-cid].selected, [data-ep-id].active, [data-episode-id].active, [data-epid].active",
     );
     const activeCid = active?.getAttribute("data-cid") ?? null;
+    const activeEpId =
+      active?.getAttribute("data-ep-id") ??
+      active?.getAttribute("data-episode-id") ??
+      active?.getAttribute("data-epid") ??
+      null;
     const activeTitle =
       active?.textContent?.trim() ||
       document
@@ -62,18 +77,30 @@ function readFestivalVideoDetail(): {
         ?.textContent?.trim() ||
       null;
 
-    const sectionEpisodes = Array.isArray(initialState?.sectionEpisodes)
-      ? initialState.sectionEpisodes
-      : [];
-    const matchedByCid = activeCid
-      ? sectionEpisodes.find(
-          (episode) => String(episode?.cid ?? "") === activeCid,
+    const episodes = [
+      ...(Array.isArray(initialState?.sectionEpisodes)
+        ? initialState.sectionEpisodes
+        : []),
+      ...(Array.isArray(initialState?.episodes) ? initialState.episodes : []),
+      ...(Array.isArray(initialState?.epList) ? initialState.epList : []),
+    ];
+    const matchedByEpId = activeEpId
+      ? episodes.find(
+          (episode) =>
+            String(episode?.id ?? "") === activeEpId ||
+            String(episode?.ep_id ?? "") === activeEpId ||
+            String(episode?.epId ?? "") === activeEpId,
         )
       : null;
+    const matchedByCid = activeCid
+      ? episodes.find((episode) => String(episode?.cid ?? "") === activeCid)
+      : null;
     const matchedByTitle =
-      !matchedByCid && activeTitle
-        ? sectionEpisodes.find(
-            (episode) => (episode?.title || "").trim() === activeTitle,
+      !matchedByEpId && !matchedByCid && activeTitle
+        ? episodes.find(
+            (episode) =>
+              (episode?.title || "").trim() === activeTitle ||
+              (episode?.long_title || "").trim() === activeTitle,
           )
         : null;
 
@@ -90,17 +117,25 @@ function readFestivalVideoDetail(): {
       }
     ).player?.__getUserParams?.()?.input;
 
-    const matched =
+    const matched: PageVideoCandidate | null =
+      matchedByEpId ??
       matchedByCid ??
       matchedByTitle ??
+      initialState?.epInfo ??
       playerInput ??
       initialState?.videoInfo ??
       null;
-    if (!matched?.bvid || matched.cid === undefined) {
+    const epId =
+      typeof matched === "object" && matched !== null
+        ? (matched.epId ?? matched.ep_id ?? matched.id)
+        : undefined;
+
+    if (!epId && (!matched?.bvid || matched.cid === undefined)) {
       return null;
     }
 
     return {
+      epId,
       bvid: matched.bvid,
       cid: matched.cid,
       title:
@@ -110,7 +145,15 @@ function readFestivalVideoDetail(): {
         typeof matched.title === "string"
           ? matched.title
           : undefined) ||
+        (typeof matched === "object" &&
+        matched !== null &&
+        "long_title" in matched &&
+        typeof matched.long_title === "string"
+          ? matched.long_title
+          : undefined) ||
         activeTitle ||
+        initialState?.epInfo?.title ||
+        initialState?.epInfo?.long_title ||
         initialState?.videoInfo?.title,
     };
   } catch {

--- a/extension/src/content/page-video.ts
+++ b/extension/src/content/page-video.ts
@@ -10,6 +10,11 @@ export interface PageVideoSource {
   documentTitle: string;
   headingTitle: string | null;
   currentPartTitle: string | null;
+  pageSnapshot?: {
+    videoId: string;
+    url: string;
+    title: string;
+  } | null;
   festivalSnapshot: {
     videoId: string;
     url: string;
@@ -26,6 +31,14 @@ export interface VideoPlaybackSnapshot {
 export function resolvePageSharedVideo(
   source: PageVideoSource,
 ): SharedVideo | null {
+  if (source.pageSnapshot) {
+    return {
+      videoId: source.pageSnapshot.videoId,
+      url: source.pageSnapshot.url,
+      title: source.pageSnapshot.title,
+    };
+  }
+
   if (source.pathname.startsWith("/festival/") && source.festivalSnapshot) {
     return {
       videoId: source.festivalSnapshot.videoId,
@@ -99,4 +112,13 @@ export function buildFestivalShareUrl(
   parsed.searchParams.set("cid", cid);
   parsed.hash = "";
   return parsed.toString();
+}
+
+export function buildBvidCidShareUrl(bvid: string, cid: string): string {
+  return `https://www.bilibili.com/video/${bvid}?cid=${cid}`;
+}
+
+export function buildBangumiEpisodeShareUrl(epId: string): string {
+  const normalizedEpId = epId.startsWith("ep") ? epId : `ep${epId}`;
+  return `https://www.bilibili.com/bangumi/play/${normalizedEpId}`;
 }

--- a/extension/src/content/share-controller.ts
+++ b/extension/src/content/share-controller.ts
@@ -65,6 +65,13 @@ export function createShareController(args: {
     return pathname.startsWith("/festival/");
   }
 
+  function hasMatchingCachedPagePathname(argsForMatch: {
+    pathname: string;
+    snapshot: CachedPageSnapshot;
+  }): boolean {
+    return argsForMatch.snapshot.pathname === argsForMatch.pathname;
+  }
+
   function canUseMatchingCachedPageSnapshot(argsForMatch: {
     pathname: string;
     snapshot: CachedPageSnapshot | null;
@@ -74,9 +81,11 @@ export function createShareController(args: {
       return false;
     }
     if (canUseCachedPageSnapshot(argsForMatch.pathname)) {
-      return true;
+      return (
+        argsForMatch.snapshot.pathname?.startsWith("/festival/") === true &&
+        hasMatchingCachedPagePathname(argsForMatch)
+      );
     }
-    const cachedPagePathname = argsForMatch.snapshot.pathname;
     const snapshotEpId =
       argsForMatch.snapshot.epId ??
       (argsForMatch.snapshot.videoId.startsWith("ep")
@@ -92,7 +101,7 @@ export function createShareController(args: {
       argsForMatch.snapshot.title.trim() === argsForMatch.currentPart.title;
     return (
       argsForMatch.pathname.startsWith("/bangumi/play/") &&
-      cachedPagePathname === argsForMatch.pathname &&
+      hasMatchingCachedPagePathname(argsForMatch) &&
       ((snapshotEpId !== null &&
         snapshotEpId === argsForMatch.currentPart.epId) ||
         (snapshotCid !== null &&
@@ -159,32 +168,27 @@ export function createShareController(args: {
     const pathname = window.location.pathname;
     const pageUrl = window.location.href.split("#")[0];
     const currentPart = getCurrentPartIdentity();
+    const matchingFestivalSnapshot =
+      festivalSnapshot &&
+      canUseMatchingCachedPageSnapshot({
+        pathname,
+        snapshot: festivalSnapshot,
+        currentPart,
+      })
+        ? {
+            videoId: festivalSnapshot.videoId,
+            url: festivalSnapshot.url,
+            title: festivalSnapshot.title,
+          }
+        : null;
     return resolvePageSharedVideo({
       pageUrl,
       pathname,
       documentTitle: document.title,
       headingTitle: document.querySelector("h1")?.textContent?.trim() ?? null,
       currentPartTitle: currentPart.title,
-      pageSnapshot:
-        festivalSnapshot &&
-        canUseMatchingCachedPageSnapshot({
-          pathname,
-          snapshot: festivalSnapshot,
-          currentPart,
-        })
-          ? {
-              videoId: festivalSnapshot.videoId,
-              url: festivalSnapshot.url,
-              title: festivalSnapshot.title,
-            }
-          : null,
-      festivalSnapshot: festivalSnapshot
-        ? {
-            videoId: festivalSnapshot.videoId,
-            url: festivalSnapshot.url,
-            title: festivalSnapshot.title,
-          }
-        : null,
+      pageSnapshot: matchingFestivalSnapshot,
+      festivalSnapshot: matchingFestivalSnapshot,
     });
   }
 

--- a/extension/src/content/share-controller.ts
+++ b/extension/src/content/share-controller.ts
@@ -22,8 +22,16 @@ export interface ShareController {
 
 interface CachedPageSnapshot extends SharedVideo {
   updatedAt: number;
+  epId?: string;
+  cid?: string;
   pathname?: string;
   pageUrl?: string;
+}
+
+interface CurrentPartIdentity {
+  title: string | null;
+  epId: string | null;
+  cid: string | null;
 }
 
 export function shouldIncludePlaybackInSharePayload(args: {
@@ -60,7 +68,7 @@ export function createShareController(args: {
   function canUseMatchingCachedPageSnapshot(argsForMatch: {
     pathname: string;
     snapshot: CachedPageSnapshot | null;
-    currentPartTitle: string | null;
+    currentPart: CurrentPartIdentity;
   }): boolean {
     if (!argsForMatch.snapshot) {
       return false;
@@ -69,26 +77,61 @@ export function createShareController(args: {
       return true;
     }
     const cachedPagePathname = argsForMatch.snapshot.pathname;
+    const snapshotEpId =
+      argsForMatch.snapshot.epId ??
+      (argsForMatch.snapshot.videoId.startsWith("ep")
+        ? argsForMatch.snapshot.videoId
+        : null);
+    const snapshotCid =
+      argsForMatch.snapshot.cid ??
+      (argsForMatch.snapshot.videoId.includes(":")
+        ? (argsForMatch.snapshot.videoId.split(":").at(-1) ?? null)
+        : null);
+    const titleMatches =
+      argsForMatch.currentPart.title !== null &&
+      argsForMatch.snapshot.title.trim() === argsForMatch.currentPart.title;
     return (
       argsForMatch.pathname.startsWith("/bangumi/play/") &&
       cachedPagePathname === argsForMatch.pathname &&
-      argsForMatch.currentPartTitle !== null &&
-      argsForMatch.snapshot.title.trim() === argsForMatch.currentPartTitle
+      ((snapshotEpId !== null &&
+        snapshotEpId === argsForMatch.currentPart.epId) ||
+        (snapshotCid !== null &&
+          snapshotCid === argsForMatch.currentPart.cid) ||
+        titleMatches)
     );
   }
 
-  function getCurrentPartTitle(): string | null {
-    return (
-      document
-        .querySelector("li.bpx-state-multi-active-item")
-        ?.textContent?.trim() ||
-      document
-        .querySelector(
-          ".video-section-list li.on, .video-section-list li.active, [data-cid].bpx-state-multi-active-item",
-        )
-        ?.textContent?.trim() ||
-      null
+  function getCurrentPartIdentity(): CurrentPartIdentity {
+    const active = document.querySelector<HTMLElement>(
+      [
+        "li.bpx-state-multi-active-item",
+        ".video-section-list li.on",
+        ".video-section-list li.active",
+        "li[data-cid].bpx-state-active",
+        "[data-cid].bpx-state-active",
+        "[data-cid].bpx-state-multi-active-item",
+        "[data-cid].active",
+        "[data-cid].selected",
+        "[data-ep-id].active",
+        "[data-episode-id].active",
+        "[data-epid].active",
+      ].join(", "),
     );
+    const rawEpId =
+      active?.getAttribute("data-ep-id") ??
+      active?.getAttribute("data-episode-id") ??
+      active?.getAttribute("data-epid") ??
+      null;
+    const title = active?.textContent?.trim() || null;
+    return {
+      title,
+      epId: rawEpId
+        ? rawEpId.startsWith("ep")
+          ? rawEpId
+          : `ep${rawEpId}`
+        : null,
+      cid: active?.getAttribute("data-cid") ?? null,
+    };
   }
 
   function createSharePayload(sharedVideo: SharedVideo): {
@@ -115,19 +158,19 @@ export function createShareController(args: {
     const festivalSnapshot = args.getFestivalSnapshot();
     const pathname = window.location.pathname;
     const pageUrl = window.location.href.split("#")[0];
-    const currentPartTitle = getCurrentPartTitle();
+    const currentPart = getCurrentPartIdentity();
     return resolvePageSharedVideo({
       pageUrl,
       pathname,
       documentTitle: document.title,
       headingTitle: document.querySelector("h1")?.textContent?.trim() ?? null,
-      currentPartTitle,
+      currentPartTitle: currentPart.title,
       pageSnapshot:
         festivalSnapshot &&
         canUseMatchingCachedPageSnapshot({
           pathname,
           snapshot: festivalSnapshot,
-          currentPartTitle,
+          currentPart,
         })
           ? {
               videoId: festivalSnapshot.videoId,

--- a/extension/src/content/share-controller.ts
+++ b/extension/src/content/share-controller.ts
@@ -65,11 +65,19 @@ export function createShareController(args: {
     return pathname.startsWith("/festival/");
   }
 
+  function normalizeCachedPagePathname(pathname: string): string {
+    return pathname.replace(/\/+$/, "");
+  }
+
   function hasMatchingCachedPagePathname(argsForMatch: {
     pathname: string;
     snapshot: CachedPageSnapshot;
   }): boolean {
-    return argsForMatch.snapshot.pathname === argsForMatch.pathname;
+    return (
+      argsForMatch.snapshot.pathname !== undefined &&
+      normalizeCachedPagePathname(argsForMatch.snapshot.pathname) ===
+        normalizeCachedPagePathname(argsForMatch.pathname)
+    );
   }
 
   function canUseMatchingCachedPageSnapshot(argsForMatch: {

--- a/extension/src/content/share-controller.ts
+++ b/extension/src/content/share-controller.ts
@@ -20,6 +20,12 @@ export interface ShareController {
   refreshFestivalSnapshot(maxAgeMs?: number): Promise<SharedVideo | null>;
 }
 
+interface CachedPageSnapshot extends SharedVideo {
+  updatedAt: number;
+  pathname?: string;
+  pageUrl?: string;
+}
+
 export function shouldIncludePlaybackInSharePayload(args: {
   activeRoomCode: string | null;
   activeSharedUrl: string | null;
@@ -33,12 +39,7 @@ export function createShareController(args: {
   runtimeState: ContentRuntimeState;
   festivalSnapshotTtlMs: number;
   nextSeq: () => number;
-  getFestivalSnapshot: () => {
-    videoId: string;
-    url: string;
-    title: string;
-    updatedAt: number;
-  } | null;
+  getFestivalSnapshot: () => CachedPageSnapshot | null;
   refreshFestivalBridge: (input: {
     pathname: string;
     pageUrl: string;
@@ -58,7 +59,7 @@ export function createShareController(args: {
 
   function canUseMatchingCachedPageSnapshot(argsForMatch: {
     pathname: string;
-    snapshot: SharedVideo | null;
+    snapshot: CachedPageSnapshot | null;
     currentPartTitle: string | null;
   }): boolean {
     if (!argsForMatch.snapshot) {
@@ -67,8 +68,10 @@ export function createShareController(args: {
     if (canUseCachedPageSnapshot(argsForMatch.pathname)) {
       return true;
     }
+    const cachedPagePathname = argsForMatch.snapshot.pathname;
     return (
       argsForMatch.pathname.startsWith("/bangumi/play/") &&
+      cachedPagePathname === argsForMatch.pathname &&
       argsForMatch.currentPartTitle !== null &&
       argsForMatch.snapshot.title.trim() === argsForMatch.currentPartTitle
     );
@@ -111,9 +114,10 @@ export function createShareController(args: {
   function getSharedVideo(): SharedVideo | null {
     const festivalSnapshot = args.getFestivalSnapshot();
     const pathname = window.location.pathname;
+    const pageUrl = window.location.href.split("#")[0];
     const currentPartTitle = getCurrentPartTitle();
     return resolvePageSharedVideo({
-      pageUrl: window.location.href.split("#")[0],
+      pageUrl,
       pathname,
       documentTitle: document.title,
       headingTitle: document.querySelector("h1")?.textContent?.trim() ?? null,

--- a/extension/src/content/share-controller.ts
+++ b/extension/src/content/share-controller.ts
@@ -46,6 +46,34 @@ export function createShareController(args: {
   }) => Promise<SharedVideo | null>;
   debugLog: (message: string) => void;
 }): ShareController {
+  function canUsePageSnapshot(pathname: string): boolean {
+    return (
+      pathname.startsWith("/festival/") || pathname.startsWith("/bangumi/play/")
+    );
+  }
+
+  function canUseCachedPageSnapshot(pathname: string): boolean {
+    return pathname.startsWith("/festival/");
+  }
+
+  function canUseMatchingCachedPageSnapshot(argsForMatch: {
+    pathname: string;
+    snapshot: SharedVideo | null;
+    currentPartTitle: string | null;
+  }): boolean {
+    if (!argsForMatch.snapshot) {
+      return false;
+    }
+    if (canUseCachedPageSnapshot(argsForMatch.pathname)) {
+      return true;
+    }
+    return (
+      argsForMatch.pathname.startsWith("/bangumi/play/") &&
+      argsForMatch.currentPartTitle !== null &&
+      argsForMatch.snapshot.title.trim() === argsForMatch.currentPartTitle
+    );
+  }
+
   function getCurrentPartTitle(): string | null {
     return (
       document
@@ -82,12 +110,27 @@ export function createShareController(args: {
 
   function getSharedVideo(): SharedVideo | null {
     const festivalSnapshot = args.getFestivalSnapshot();
+    const pathname = window.location.pathname;
+    const currentPartTitle = getCurrentPartTitle();
     return resolvePageSharedVideo({
       pageUrl: window.location.href.split("#")[0],
-      pathname: window.location.pathname,
+      pathname,
       documentTitle: document.title,
       headingTitle: document.querySelector("h1")?.textContent?.trim() ?? null,
-      currentPartTitle: getCurrentPartTitle(),
+      currentPartTitle,
+      pageSnapshot:
+        festivalSnapshot &&
+        canUseMatchingCachedPageSnapshot({
+          pathname,
+          snapshot: festivalSnapshot,
+          currentPartTitle,
+        })
+          ? {
+              videoId: festivalSnapshot.videoId,
+              url: festivalSnapshot.url,
+              title: festivalSnapshot.title,
+            }
+          : null,
       festivalSnapshot: festivalSnapshot
         ? {
             videoId: festivalSnapshot.videoId,
@@ -110,13 +153,13 @@ export function createShareController(args: {
       return null;
     }
     args.debugLog(
-      `Festival video detected id=${nextSnapshot.videoId} title=${nextSnapshot.title} url=${nextSnapshot.url}`,
+      `Page video snapshot detected id=${nextSnapshot.videoId} title=${nextSnapshot.title} url=${nextSnapshot.url}`,
     );
     return nextSnapshot;
   }
 
   async function getCurrentPlaybackVideo(): Promise<SharedVideo | null> {
-    if (window.location.pathname.startsWith("/festival/")) {
+    if (canUsePageSnapshot(window.location.pathname)) {
       const refreshed = await refreshFestivalSnapshot(0);
       if (refreshed) {
         return refreshed;
@@ -143,21 +186,23 @@ export function createShareController(args: {
     video: SharedVideo;
     playback: PlaybackState | null;
   } | null> {
-    if (window.location.pathname.startsWith("/festival/")) {
+    if (canUsePageSnapshot(window.location.pathname)) {
       for (let attempt = 1; attempt <= 8; attempt += 1) {
         const refreshed = await refreshFestivalSnapshot(
-          attempt === 1 ? 0 : args.festivalSnapshotTtlMs,
+          window.location.pathname.startsWith("/bangumi/play/") || attempt === 1
+            ? 0
+            : args.festivalSnapshotTtlMs,
         );
         if (refreshed) {
           args.debugLog(
-            `Festival payload stabilized after retry ${attempt}: ${refreshed.videoId}`,
+            `Page video payload stabilized after retry ${attempt}: ${refreshed.videoId}`,
           );
           return createSharePayload(refreshed);
         }
         await new Promise((resolve) => window.setTimeout(resolve, 150));
       }
 
-      args.debugLog("Festival payload fell back to URL-based detection");
+      args.debugLog("Page video payload fell back to URL-based detection");
     }
 
     return getCurrentSharePayload();

--- a/extension/test/festival-bridge.test.ts
+++ b/extension/test/festival-bridge.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createFestivalBridgeController } from "../src/content/festival-bridge";
+
+interface PageBridgeDetail {
+  epId?: string | number;
+  bvid?: string;
+  cid?: string | number;
+  title?: string;
+}
+
+function installBridgeDomStub(details: Array<PageBridgeDetail | null>): {
+  restore: () => void;
+} {
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  const originalChrome = globalThis.chrome;
+  let listener: EventListener | null = null;
+  const pendingTimeouts = new Map<number, boolean>();
+  let timeoutSeq = 0;
+
+  const windowStub = {
+    setTimeout(callback: () => void) {
+      const id = (timeoutSeq += 1);
+      pendingTimeouts.set(id, true);
+      queueMicrotask(() => {
+        if (pendingTimeouts.get(id)) {
+          callback();
+        }
+      });
+      return id;
+    },
+    clearTimeout(id: number) {
+      pendingTimeouts.set(id, false);
+    },
+    addEventListener(_type: string, nextListener: EventListener) {
+      listener = nextListener;
+    },
+    removeEventListener(_type: string, nextListener: EventListener) {
+      if (listener === nextListener) {
+        listener = null;
+      }
+    },
+    postMessage(message: { requestId?: string }) {
+      const detail = details.shift();
+      if (!detail || !listener) {
+        return;
+      }
+      listener({
+        source: windowStub,
+        data: {
+          type: "bili-syncplay:festival-video",
+          requestId: message.requestId,
+          detail,
+        },
+      } as MessageEvent);
+    },
+  };
+
+  Object.assign(globalThis, {
+    window: windowStub,
+    document: {
+      createElement() {
+        return { dataset: {} };
+      },
+      head: {
+        appendChild() {
+          return undefined;
+        },
+      },
+      documentElement: {
+        appendChild() {
+          return undefined;
+        },
+      },
+    },
+    chrome: {
+      runtime: {
+        getURL(path: string) {
+          return path;
+        },
+      },
+    },
+  });
+
+  return {
+    restore() {
+      Object.assign(globalThis, {
+        window: originalWindow,
+        document: originalDocument,
+        chrome: originalChrome,
+      });
+    },
+  };
+}
+
+test("festival bridge does not reuse cached bangumi snapshot on festival page", async () => {
+  const dom = installBridgeDomStub([
+    {
+      epId: 508404,
+      cid: 987654,
+      title: "第46话",
+    },
+    null,
+  ]);
+  const controller = createFestivalBridgeController();
+
+  try {
+    const bangumiSnapshot = await controller.refreshSnapshot({
+      pathname: "/bangumi/play/ss357",
+      pageUrl: "https://www.bilibili.com/bangumi/play/ss357",
+      maxAgeMs: 0,
+    });
+    assert.equal(bangumiSnapshot?.videoId, "ep508404");
+
+    const festivalSnapshot = await controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl: "https://www.bilibili.com/festival/demo",
+      maxAgeMs: 60_000,
+    });
+
+    assert.equal(festivalSnapshot, null);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("festival bridge reuses cached festival snapshot for the same festival page", async () => {
+  const dom = installBridgeDomStub([
+    {
+      bvid: "BVfestival",
+      cid: 123,
+      title: "Festival Episode",
+    },
+  ]);
+  const controller = createFestivalBridgeController();
+
+  try {
+    const firstSnapshot = await controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl: "https://www.bilibili.com/festival/demo",
+      maxAgeMs: 0,
+    });
+    const cachedSnapshot = await controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl: "https://www.bilibili.com/festival/demo",
+      maxAgeMs: 60_000,
+    });
+
+    assert.deepEqual(cachedSnapshot, {
+      videoId: firstSnapshot?.videoId,
+      url: firstSnapshot?.url,
+      title: firstSnapshot?.title,
+    });
+  } finally {
+    dom.restore();
+  }
+});
+
+test("festival bridge does not fall back to another festival page snapshot", async () => {
+  const dom = installBridgeDomStub([
+    {
+      bvid: "BVfestival",
+      cid: 123,
+      title: "Festival Episode",
+    },
+    null,
+  ]);
+  const controller = createFestivalBridgeController();
+
+  try {
+    const firstSnapshot = await controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl: "https://www.bilibili.com/festival/demo",
+      maxAgeMs: 0,
+    });
+    assert.equal(firstSnapshot?.videoId, "BVfestival:123");
+
+    const nextSnapshot = await controller.refreshSnapshot({
+      pathname: "/festival/other",
+      pageUrl: "https://www.bilibili.com/festival/other",
+      maxAgeMs: 0,
+    });
+
+    assert.equal(nextSnapshot, null);
+  } finally {
+    dom.restore();
+  }
+});

--- a/extension/test/festival-bridge.test.ts
+++ b/extension/test/festival-bridge.test.ts
@@ -157,6 +157,38 @@ test("festival bridge reuses cached festival snapshot for the same festival page
   }
 });
 
+test("festival bridge reuses cached festival snapshot across trailing slash path variants", async () => {
+  const dom = installBridgeDomStub([
+    {
+      bvid: "BVfestival",
+      cid: 123,
+      title: "Festival Episode",
+    },
+  ]);
+  const controller = createFestivalBridgeController();
+
+  try {
+    const firstSnapshot = await controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl: "https://www.bilibili.com/festival/demo",
+      maxAgeMs: 0,
+    });
+    const cachedSnapshot = await controller.refreshSnapshot({
+      pathname: "/festival/demo/",
+      pageUrl: "https://www.bilibili.com/festival/demo/",
+      maxAgeMs: 60_000,
+    });
+
+    assert.deepEqual(cachedSnapshot, {
+      videoId: firstSnapshot?.videoId,
+      url: firstSnapshot?.url,
+      title: firstSnapshot?.title,
+    });
+  } finally {
+    dom.restore();
+  }
+});
+
 test("festival bridge does not fall back to another festival page snapshot", async () => {
   const dom = installBridgeDomStub([
     {

--- a/extension/test/page-bridge.test.ts
+++ b/extension/test/page-bridge.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFestivalVideoDetailFromSources } from "../src/content/page-bridge-detail";
+
+test("page bridge preserves active episode id when falling back to player input", () => {
+  const detail = readFestivalVideoDetailFromSources({
+    initialState: {
+      episodes: [
+        {
+          id: 1,
+          bvid: "BVold",
+          cid: 11,
+          title: "上一话",
+        },
+      ],
+    },
+    playerInput: {
+      bvid: "BVcurrent",
+      cid: 987654,
+    },
+    activeEpId: "508404",
+    activeCid: "987654",
+    activeTitle: "第46话",
+  });
+
+  assert.deepEqual(detail, {
+    epId: "508404",
+    bvid: "BVcurrent",
+    cid: 987654,
+    title: "第46话",
+  });
+});
+
+test("page bridge preserves active cid when matched candidate lacks cid", () => {
+  const detail = readFestivalVideoDetailFromSources({
+    initialState: {
+      videoInfo: {
+        bvid: "BVcurrent",
+        title: "第46话",
+      },
+    },
+    activeCid: "987654",
+    activeTitle: "第46话",
+  });
+
+  assert.deepEqual(detail, {
+    epId: undefined,
+    bvid: "BVcurrent",
+    cid: "987654",
+    title: "第46话",
+  });
+});

--- a/extension/test/page-video.test.ts
+++ b/extension/test/page-video.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildBangumiEpisodeShareUrl,
+  buildBvidCidShareUrl,
   buildFestivalShareUrl,
   createSharePayload,
   resolvePageSharedVideo,
@@ -39,6 +41,28 @@ test("normalizes standard video share url and strips tracking query params", () 
     videoId: "BV199W9zEEcH",
     url: "https://www.bilibili.com/video/BV199W9zEEcH",
     title: "Heading Title",
+  });
+});
+
+test("resolves page snapshot ahead of bangumi season URL fallback", () => {
+  const video = resolvePageSharedVideo({
+    pageUrl: "https://www.bilibili.com/bangumi/play/ss357",
+    pathname: "/bangumi/play/ss357",
+    documentTitle: "猫和老鼠_番剧_bilibili",
+    headingTitle: "猫和老鼠",
+    currentPartTitle: "第46话",
+    pageSnapshot: {
+      videoId: "ep508404",
+      url: "https://www.bilibili.com/bangumi/play/ep508404",
+      title: "第46话",
+    },
+    festivalSnapshot: null,
+  });
+
+  assert.deepEqual(video, {
+    videoId: "ep508404",
+    url: "https://www.bilibili.com/bangumi/play/ep508404",
+    title: "第46话",
   });
 });
 
@@ -112,5 +136,20 @@ test("builds festival share URL with bvid and cid", () => {
       "22",
     ),
     "https://www.bilibili.com/festival/demo?foo=1&bvid=BV1abc&cid=22",
+  );
+});
+
+test("builds canonical episode and cid share URLs", () => {
+  assert.equal(
+    buildBangumiEpisodeShareUrl("508404"),
+    "https://www.bilibili.com/bangumi/play/ep508404",
+  );
+  assert.equal(
+    buildBangumiEpisodeShareUrl("ep508404"),
+    "https://www.bilibili.com/bangumi/play/ep508404",
+  );
+  assert.equal(
+    buildBvidCidShareUrl("BV1abc", "22"),
+    "https://www.bilibili.com/video/BV1abc?cid=22",
   );
 });

--- a/extension/test/share-controller.test.ts
+++ b/extension/test/share-controller.test.ts
@@ -11,6 +11,8 @@ function installDomStub(args: {
   pathname: string;
   title: string;
   currentPartTitle?: string | null;
+  currentPartEpId?: string | null;
+  currentPartCid?: string | null;
   video?: HTMLVideoElement | null;
 }): { restore: () => void } {
   const originalWindow = globalThis.window;
@@ -31,10 +33,22 @@ function installDomStub(args: {
           return args.video ?? null;
         }
         if (
-          args.currentPartTitle &&
-          selector.includes("bpx-state-multi-active-item")
+          args.currentPartTitle ||
+          args.currentPartEpId ||
+          args.currentPartCid
         ) {
-          return { textContent: args.currentPartTitle };
+          return {
+            textContent: args.currentPartTitle ?? "",
+            getAttribute(name: string) {
+              if (name === "data-ep-id") {
+                return args.currentPartEpId ?? null;
+              }
+              if (name === "data-cid") {
+                return args.currentPartCid ?? null;
+              }
+              return null;
+            },
+          };
         }
         return null;
       },
@@ -242,6 +256,7 @@ test("share controller reuses matching cached bangumi snapshot for current page 
       url: "https://www.bilibili.com/bangumi/play/ep508404",
       title: "第46话",
       updatedAt: Date.now(),
+      epId: "ep508404",
       pathname: "/bangumi/play/ss357",
       pageUrl:
         "https://www.bilibili.com/bangumi/play/ss357?from_spmid=666.25.series.0",
@@ -258,6 +273,98 @@ test("share controller reuses matching cached bangumi snapshot for current page 
     assert.equal(
       payload.video.url,
       "https://www.bilibili.com/bangumi/play/ep508404",
+    );
+  } finally {
+    dom.restore();
+  }
+});
+
+test("share controller reuses cached bangumi snapshot by active episode id without title", () => {
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/bangumi/play/ss357",
+    pathname: "/bangumi/play/ss357",
+    title: "猫和老鼠_番剧_bilibili",
+    currentPartEpId: "508404",
+    video: {
+      currentTime: 10.01,
+      playbackRate: 1,
+      paused: true,
+      readyState: 4,
+    } as HTMLVideoElement,
+  });
+
+  const runtimeState = createContentRuntimeState();
+  const controller = createShareController({
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 6,
+    getFestivalSnapshot: () => ({
+      videoId: "ep508404",
+      url: "https://www.bilibili.com/bangumi/play/ep508404",
+      title: "第46话",
+      updatedAt: Date.now(),
+      epId: "ep508404",
+      pathname: "/bangumi/play/ss357",
+      pageUrl: "https://www.bilibili.com/bangumi/play/ss357",
+    }),
+    refreshFestivalBridge: async () => null,
+    debugLog: () => undefined,
+  });
+
+  try {
+    const payload = controller.getCurrentSharePayload();
+
+    assert.ok(payload);
+    assert.equal(payload.video.videoId, "ep508404");
+    assert.equal(
+      payload.video.url,
+      "https://www.bilibili.com/bangumi/play/ep508404",
+    );
+  } finally {
+    dom.restore();
+  }
+});
+
+test("share controller reuses cached bangumi snapshot by active cid without title", () => {
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/bangumi/play/ss357",
+    pathname: "/bangumi/play/ss357",
+    title: "猫和老鼠_番剧_bilibili",
+    currentPartCid: "987654",
+    video: {
+      currentTime: 10.01,
+      playbackRate: 1,
+      paused: true,
+      readyState: 4,
+    } as HTMLVideoElement,
+  });
+
+  const runtimeState = createContentRuntimeState();
+  const controller = createShareController({
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 7,
+    getFestivalSnapshot: () => ({
+      videoId: "BV1abc:987654",
+      url: "https://www.bilibili.com/video/BV1abc?cid=987654",
+      title: "第46话",
+      updatedAt: Date.now(),
+      cid: "987654",
+      pathname: "/bangumi/play/ss357",
+      pageUrl: "https://www.bilibili.com/bangumi/play/ss357",
+    }),
+    refreshFestivalBridge: async () => null,
+    debugLog: () => undefined,
+  });
+
+  try {
+    const payload = controller.getCurrentSharePayload();
+
+    assert.ok(payload);
+    assert.equal(payload.video.videoId, "BV1abc:987654");
+    assert.equal(
+      payload.video.url,
+      "https://www.bilibili.com/video/BV1abc?cid=987654",
     );
   } finally {
     dom.restore();

--- a/extension/test/share-controller.test.ts
+++ b/extension/test/share-controller.test.ts
@@ -10,6 +10,7 @@ function installDomStub(args: {
   href: string;
   pathname: string;
   title: string;
+  currentPartTitle?: string | null;
   video?: HTMLVideoElement | null;
 }): { restore: () => void } {
   const originalWindow = globalThis.window;
@@ -28,6 +29,12 @@ function installDomStub(args: {
       querySelector(selector: string) {
         if (selector === "video") {
           return args.video ?? null;
+        }
+        if (
+          args.currentPartTitle &&
+          selector.includes("bpx-state-multi-active-item")
+        ) {
+          return { textContent: args.currentPartTitle };
         }
         return null;
       },
@@ -119,6 +126,136 @@ test("share controller keeps playback snapshot while switching to another shared
     assert.equal(payload?.playback?.playbackRate, 1.08);
     assert.equal(payload?.playback?.playState, "playing");
     assert.equal(debugLogs.length, 0);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("share controller resolves bangumi season pages through page snapshot", async () => {
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/bangumi/play/ss357?from_spmid=666.25.series.0",
+    pathname: "/bangumi/play/ss357",
+    title: "猫和老鼠_番剧_bilibili",
+    video: {
+      currentTime: 10.01,
+      playbackRate: 1,
+      paused: true,
+      readyState: 4,
+    } as HTMLVideoElement,
+  });
+
+  const runtimeState = createContentRuntimeState();
+  runtimeState.intendedPlayState = "paused";
+
+  const controller = createShareController({
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 3,
+    getFestivalSnapshot: () => null,
+    refreshFestivalBridge: async () => ({
+      videoId: "ep508404",
+      url: "https://www.bilibili.com/bangumi/play/ep508404",
+      title: "第46话",
+    }),
+    debugLog: () => undefined,
+  });
+
+  try {
+    const payload = await controller.resolveCurrentSharePayload();
+
+    assert.ok(payload);
+    assert.equal(
+      payload.video.url,
+      "https://www.bilibili.com/bangumi/play/ep508404",
+    );
+    assert.equal(payload.video.videoId, "ep508404");
+    assert.equal(payload.playback?.url, payload.video.url);
+    assert.equal(payload.playback?.currentTime, 10.01);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("share controller does not reuse cached bangumi snapshot synchronously", () => {
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/bangumi/play/ss357?from_spmid=666.25.series.0",
+    pathname: "/bangumi/play/ss357",
+    title: "猫和老鼠_番剧_bilibili",
+    video: {
+      currentTime: 10.01,
+      playbackRate: 1,
+      paused: true,
+      readyState: 4,
+    } as HTMLVideoElement,
+  });
+
+  const runtimeState = createContentRuntimeState();
+  const controller = createShareController({
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 4,
+    getFestivalSnapshot: () => ({
+      videoId: "ep-old",
+      url: "https://www.bilibili.com/bangumi/play/ep-old",
+      title: "上一话",
+      updatedAt: Date.now(),
+    }),
+    refreshFestivalBridge: async () => null,
+    debugLog: () => undefined,
+  });
+
+  try {
+    const payload = controller.getCurrentSharePayload();
+
+    assert.ok(payload);
+    assert.equal(payload.video.videoId, "ss357");
+    assert.equal(
+      payload.video.url,
+      "https://www.bilibili.com/bangumi/play/ss357",
+    );
+  } finally {
+    dom.restore();
+  }
+});
+
+test("share controller reuses matching cached bangumi snapshot for current page identity", () => {
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/bangumi/play/ss357?from_spmid=666.25.series.0",
+    pathname: "/bangumi/play/ss357",
+    title: "猫和老鼠_番剧_bilibili",
+    currentPartTitle: "第46话",
+    video: {
+      currentTime: 10.01,
+      playbackRate: 1,
+      paused: true,
+      readyState: 4,
+    } as HTMLVideoElement,
+  });
+
+  const runtimeState = createContentRuntimeState();
+  const controller = createShareController({
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 5,
+    getFestivalSnapshot: () => ({
+      videoId: "ep508404",
+      url: "https://www.bilibili.com/bangumi/play/ep508404",
+      title: "第46话",
+      updatedAt: Date.now(),
+    }),
+    refreshFestivalBridge: async () => null,
+    debugLog: () => undefined,
+  });
+
+  try {
+    const payload = controller.getCurrentSharePayload();
+
+    assert.ok(payload);
+    assert.equal(payload.video.videoId, "ep508404");
+    assert.equal(
+      payload.video.url,
+      "https://www.bilibili.com/bangumi/play/ep508404",
+    );
   } finally {
     dom.restore();
   }

--- a/extension/test/share-controller.test.ts
+++ b/extension/test/share-controller.test.ts
@@ -242,6 +242,9 @@ test("share controller reuses matching cached bangumi snapshot for current page 
       url: "https://www.bilibili.com/bangumi/play/ep508404",
       title: "第46话",
       updatedAt: Date.now(),
+      pathname: "/bangumi/play/ss357",
+      pageUrl:
+        "https://www.bilibili.com/bangumi/play/ss357?from_spmid=666.25.series.0",
     }),
     refreshFestivalBridge: async () => null,
     debugLog: () => undefined,
@@ -255,6 +258,51 @@ test("share controller reuses matching cached bangumi snapshot for current page 
     assert.equal(
       payload.video.url,
       "https://www.bilibili.com/bangumi/play/ep508404",
+    );
+  } finally {
+    dom.restore();
+  }
+});
+
+test("share controller rejects same-title cached bangumi snapshot from another page", () => {
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/bangumi/play/ss39837",
+    pathname: "/bangumi/play/ss39837",
+    title: "另一部番剧_番剧_bilibili",
+    currentPartTitle: "第1话",
+    video: {
+      currentTime: 10.01,
+      playbackRate: 1,
+      paused: true,
+      readyState: 4,
+    } as HTMLVideoElement,
+  });
+
+  const runtimeState = createContentRuntimeState();
+  const controller = createShareController({
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 6,
+    getFestivalSnapshot: () => ({
+      videoId: "ep-old",
+      url: "https://www.bilibili.com/bangumi/play/ep-old",
+      title: "第1话",
+      updatedAt: Date.now(),
+      pathname: "/bangumi/play/ss357",
+      pageUrl: "https://www.bilibili.com/bangumi/play/ss357",
+    }),
+    refreshFestivalBridge: async () => null,
+    debugLog: () => undefined,
+  });
+
+  try {
+    const payload = controller.getCurrentSharePayload();
+
+    assert.ok(payload);
+    assert.equal(payload.video.videoId, "ss39837");
+    assert.equal(
+      payload.video.url,
+      "https://www.bilibili.com/bangumi/play/ss39837",
     );
   } finally {
     dom.restore();

--- a/extension/test/share-controller.test.ts
+++ b/extension/test/share-controller.test.ts
@@ -415,3 +415,45 @@ test("share controller rejects same-title cached bangumi snapshot from another p
     dom.restore();
   }
 });
+
+test("share controller rejects cached bangumi snapshot on festival page", () => {
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/festival/demo",
+    pathname: "/festival/demo",
+    title: "Festival_哔哩哔哩",
+    video: {
+      currentTime: 10.01,
+      playbackRate: 1,
+      paused: true,
+      readyState: 4,
+    } as HTMLVideoElement,
+  });
+
+  const runtimeState = createContentRuntimeState();
+  const controller = createShareController({
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 8,
+    getFestivalSnapshot: () => ({
+      videoId: "ep508404",
+      url: "https://www.bilibili.com/bangumi/play/ep508404",
+      title: "第46话",
+      updatedAt: Date.now(),
+      epId: "ep508404",
+      pathname: "/bangumi/play/ss357",
+      pageUrl: "https://www.bilibili.com/bangumi/play/ss357",
+    }),
+    refreshFestivalBridge: async () => null,
+    debugLog: () => undefined,
+  });
+
+  try {
+    const payload = controller.getCurrentSharePayload();
+
+    assert.ok(payload);
+    assert.equal(payload.video.videoId, "/festival/demo");
+    assert.equal(payload.video.url, "https://www.bilibili.com/festival/demo");
+  } finally {
+    dom.restore();
+  }
+});

--- a/extension/test/share-controller.test.ts
+++ b/extension/test/share-controller.test.ts
@@ -457,3 +457,48 @@ test("share controller rejects cached bangumi snapshot on festival page", () => 
     dom.restore();
   }
 });
+
+test("share controller reuses cached festival snapshot across trailing slash path variants", () => {
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/festival/demo/",
+    pathname: "/festival/demo/",
+    title: "Festival_哔哩哔哩",
+    video: {
+      currentTime: 10.01,
+      playbackRate: 1,
+      paused: true,
+      readyState: 4,
+    } as HTMLVideoElement,
+  });
+
+  const runtimeState = createContentRuntimeState();
+  const controller = createShareController({
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 9,
+    getFestivalSnapshot: () => ({
+      videoId: "BVfestival:123",
+      url: "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123",
+      title: "Festival Episode",
+      updatedAt: Date.now(),
+      cid: "123",
+      pathname: "/festival/demo",
+      pageUrl: "https://www.bilibili.com/festival/demo",
+    }),
+    refreshFestivalBridge: async () => null,
+    debugLog: () => undefined,
+  });
+
+  try {
+    const payload = controller.getCurrentSharePayload();
+
+    assert.ok(payload);
+    assert.equal(payload.video.videoId, "BVfestival:123");
+    assert.equal(
+      payload.video.url,
+      "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123",
+    );
+  } finally {
+    dom.restore();
+  }
+});


### PR DESCRIPTION
## What changed

- Resolve bangumi season pages through the injected page bridge before sharing.
- Prefer episode-level `ep...` URLs when available, with `BV + cid` as a stable fallback.
- Reuse the snapshot path for playback/share payloads so `/bangumi/play/ss...` does not get broadcast as the shared video identity.
- Add regression coverage for bangumi season pages resolving to an episode-level shared URL.

## Root cause

Bangumi season URLs such as `/bangumi/play/ss357` were treated as a valid shared video identity. Different clients could open the same season URL but land on different episodes, while playback controls still synced because the normalized URL matched.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test`