### PR TITLE
fix: reuse join target state during reconnect

### DIFF
--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -75,6 +75,11 @@ type JoinIdentity = {
   memberToken: string;
 };
 
+type PersistJoinedRoomResult = {
+  room: PersistedRoom;
+  joinTargetState: JoinTargetState;
+};
+
 type JoinedSessionSnapshot = {
   roomCode: string;
   memberId: string;
@@ -435,10 +440,10 @@ export function createRoomService(options: {
     return { session, persistedRoom, activeRoom };
   }
 
-  async function withVersionRetry(
+  async function withVersionRetry<T = PersistedRoom>(
     roomCode: string,
-    action: (room: PersistedRoom) => Promise<PersistedRoom | null>,
-  ): Promise<PersistedRoom | null> {
+    action: (room: PersistedRoom) => Promise<T | null>,
+  ): Promise<T | null> {
     for (let attempt = 0; attempt < MAX_VERSION_RETRIES; attempt += 1) {
       const room = await resolveRoom(roomCode);
       if (!room) {
@@ -548,9 +553,9 @@ export function createRoomService(options: {
     roomCode: string;
     joinToken: string;
     previousMemberToken?: string;
-  }): Promise<PersistedRoom | null> {
+  }): Promise<PersistJoinedRoomResult | null> {
     return withVersionRetry(args.roomCode, async (room) => {
-      await ensureJoinRequestAllowed({
+      const joinTargetState = await ensureJoinRequestAllowed({
         session: args.session,
         room,
         roomCode: args.roomCode,
@@ -565,7 +570,7 @@ export function createRoomService(options: {
       if (!result.ok) {
         return null;
       }
-      return result.room;
+      return { room: result.room, joinTargetState };
     });
   }
 
@@ -868,14 +873,14 @@ export function createRoomService(options: {
       setSessionDisplayName(session, displayName);
       await leaveCurrentRoom(session);
 
-      const joinedRoom = await persistJoinedRoom({
+      const joined = await persistJoinedRoom({
         session,
         roomCode,
         joinToken,
         previousMemberToken,
       });
 
-      if (!joinedRoom) {
+      if (!joined) {
         throw new RoomServiceError(
           "room_not_found",
           ROOM_NOT_FOUND_MESSAGE,
@@ -883,10 +888,8 @@ export function createRoomService(options: {
         );
       }
 
-      const reconnectMemberId = previousMemberToken
-        ? (await resolveJoinTargetState(joinedRoom.code, previousMemberToken))
-            .reconnectMemberId
-        : null;
+      const joinedRoom = joined.room;
+      const reconnectMemberId = joined.joinTargetState.reconnectMemberId;
       const joinIdentity = buildJoinIdentity(
         session,
         reconnectMemberId,
@@ -949,7 +952,7 @@ export function createRoomService(options: {
         return { room: access.persistedRoom };
       }
 
-      let room: Awaited<ReturnType<typeof withVersionRetry>>;
+      let room: PersistedRoom | null;
       try {
         room = await withVersionRetry(
           access.persistedRoom.code,

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -1590,6 +1590,7 @@ test("room service consults shared kick blocks when rejoining through another no
 
 test("room service reuses shared member identity during reconnect checks", async () => {
   const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  let resolveMemberIdCalls = 0;
   const service = createRoomService({
     config: getDefaultSecurityConfig(),
     persistence: getDefaultPersistenceConfig(),
@@ -1607,8 +1608,10 @@ test("room service reuses shared member identity during reconnect checks", async
       members: new Map(),
       memberTokens: new Map([["shared-member", "shared-token"]]),
     }),
-    resolveMemberIdByToken: async (_roomCode, memberToken) =>
-      memberToken === "shared-token" ? "shared-member" : null,
+    resolveMemberIdByToken: async (_roomCode, memberToken) => {
+      resolveMemberIdCalls += 1;
+      return memberToken === "shared-token" ? "shared-member" : null;
+    },
   });
 
   const owner = createSession("owner");
@@ -1624,6 +1627,7 @@ test("room service reuses shared member identity during reconnect checks", async
 
   assert.equal(reconnecting.memberId, "shared-member");
   assert.equal(joined.memberToken, "shared-token");
+  assert.equal(resolveMemberIdCalls, 1);
 });
 
 test("room service enforces room capacity from shared room membership", async () => {


### PR DESCRIPTION
## Summary
- Reuse the `JoinTargetState` produced during join admission instead of resolving the reconnect member token a second time after persistence succeeds.
- Keep `withVersionRetry` typed for callers that return richer successful results, and add regression coverage that reconnect member-token resolution runs once.

Fixes part of #96 (P2a)

## Test plan
- [x] `npm test -- server/test/room-service.test.ts`
- [x] `npm run typecheck`
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`
- [x] `npm run bench:reconnect-storm -- --members 500 --reconnect-timeout-ms 5000`

## Benchmark
Issue baseline: duration 40.4s, p50 4.9s, p95 33.3s, p99 38.8s, throughput 12.4/s, errors 0%.

Current branch, single-node 500 reconnect storm:
- Duration: 0.839s
- Throughput: 595.948/s
- Latency: p50 249ms, p95 748ms, p99 815ms, max 825ms
- Room joined phase: p50 6ms, p95 56ms, p99 60ms, max 60ms
- Errors: 0%