### PR TITLE
fix: throttle room activity writes on join

### DIFF
--- a/server/src/active-room-registry.ts
+++ b/server/src/active-room-registry.ts
@@ -13,6 +13,8 @@ export type ActiveRoomRegistry = {
   isMemberTokenBlocked: RuntimeStore["isMemberTokenBlocked"];
   tryClaimMessageSlot: RuntimeStore["tryClaimMessageSlot"];
   releaseMessageSlot: RuntimeStore["releaseMessageSlot"];
+  acquireRoomLock: RuntimeStore["acquireRoomLock"];
+  releaseRoomLock: RuntimeStore["releaseRoomLock"];
   removeMember: RuntimeStore["removeMember"];
   deleteRoom: RuntimeStore["deleteRoom"];
 };
@@ -33,6 +35,8 @@ export function createActiveRoomRegistry(
     isMemberTokenBlocked: store.isMemberTokenBlocked,
     tryClaimMessageSlot: store.tryClaimMessageSlot,
     releaseMessageSlot: store.releaseMessageSlot,
+    acquireRoomLock: store.acquireRoomLock,
+    releaseRoomLock: store.releaseRoomLock,
     removeMember: store.removeMember,
     deleteRoom: store.deleteRoom,
   };

--- a/server/src/mirrored-runtime-store.ts
+++ b/server/src/mirrored-runtime-store.ts
@@ -87,6 +87,8 @@ export function createMirroredRuntimeStore(
     isMemberTokenBlocked: readLocal(localRuntimeStore.isMemberTokenBlocked),
     tryClaimMessageSlot: readShared(sharedRuntimeStore.tryClaimMessageSlot),
     releaseMessageSlot: readShared(sharedRuntimeStore.releaseMessageSlot),
+    acquireRoomLock: readShared(sharedRuntimeStore.acquireRoomLock),
+    releaseRoomLock: readShared(sharedRuntimeStore.releaseRoomLock),
     removeMember: mirrorLocalResult(
       localRuntimeStore.removeMember,
       sharedRuntimeStore.removeMember,

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -45,6 +45,11 @@ type RedisClient = {
     px: "PX",
     milliseconds: number,
   ) => Promise<string | null>;
+  eval: (
+    script: string,
+    numKeys: number,
+    ...args: Array<string | number>
+  ) => Promise<unknown>;
   del: (...keys: string[]) => Promise<unknown>;
 };
 
@@ -107,6 +112,8 @@ const RUNTIME_STORE_METHOD_NAMES = [
   "blockMemberToken",
   "tryClaimMessageSlot",
   "releaseMessageSlot",
+  "acquireRoomLock",
+  "releaseRoomLock",
   "removeMember",
   "deleteRoom",
   "heartbeatNode",
@@ -166,6 +173,17 @@ function dedupSlotKey(prefix: string, roomCode: string, key: string): string {
 function dedupTrackingZsetKey(prefix: string, roomCode: string): string {
   return `${prefix}room:${roomCode}:dedup-slots`;
 }
+
+function roomLockKey(prefix: string, roomCode: string, key: string): string {
+  return `${prefix}room:${roomCode}:lock:${key}`;
+}
+
+const ROOM_LOCK_RELEASE_LUA = `
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+end
+return 0
+`;
 
 function nodesKey(prefix: string): string {
   return `${prefix}nodes`;
@@ -728,6 +746,23 @@ export async function createRedisRuntimeStore(
       const slotKey = dedupSlotKey(keyPrefix, roomCode, key);
       const trackingKey = dedupTrackingZsetKey(keyPrefix, roomCode);
       await Promise.all([redis.del(slotKey), redis.zrem(trackingKey, slotKey)]);
+    },
+    async acquireRoomLock(
+      roomCode: string,
+      key: string,
+      token: string,
+      expiresAt: number,
+    ) {
+      const currentTime = now();
+      const ttlMs = Math.max(expiresAt - currentTime, 1);
+      const lockKey = roomLockKey(keyPrefix, roomCode, key);
+      const result = await redis.set(lockKey, token, "NX", "PX", ttlMs);
+      return result !== null;
+    },
+    async releaseRoomLock(roomCode: string, key: string, token: string) {
+      const lockKey = roomLockKey(keyPrefix, roomCode, key);
+      const result = await redis.eval(ROOM_LOCK_RELEASE_LUA, 1, lockKey, token);
+      return result === 1;
     },
     removeMember(code: string, memberId: string, session?: Session) {
       ensurePendingCapacity("remove_member");

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -39,7 +39,7 @@ const PLAYBACK_AUTHORITY_WINDOW_MS = 1200;
 const MAX_VERSION_RETRIES = 3;
 const ROOM_LAST_ACTIVE_WRITE_INTERVAL_MS = 30_000;
 const JOIN_ADMISSION_LOCK_KEY = "join-admission";
-const JOIN_ADMISSION_LOCK_TTL_MS = 10_000;
+const JOIN_ADMISSION_LOCK_TTL_MS = 30_000;
 const JOIN_ADMISSION_LOCK_MAX_WAIT_MS = 5_000;
 const JOIN_ADMISSION_LOCK_RETRY_INTERVAL_MS = 25;
 
@@ -184,7 +184,7 @@ export function createRoomService(options: {
 
   async function acquireDistributedJoinLock(
     roomCode: string,
-  ): Promise<boolean> {
+  ): Promise<{ expiresAt: number } | null> {
     const deadline = now() + JOIN_ADMISSION_LOCK_MAX_WAIT_MS;
     while (true) {
       const expiresAt = now() + JOIN_ADMISSION_LOCK_TTL_MS;
@@ -195,10 +195,10 @@ export function createRoomService(options: {
           expiresAt,
         )
       ) {
-        return true;
+        return { expiresAt };
       }
       if (now() >= deadline) {
-        return false;
+        return null;
       }
       await new Promise((resolve) =>
         setTimeout(resolve, JOIN_ADMISSION_LOCK_RETRY_INTERVAL_MS),
@@ -218,19 +218,33 @@ export function createRoomService(options: {
     const tail = previous.catch(() => undefined).then(() => next);
     roomJoinLocks.set(roomCode, tail);
 
+    function releaseInProcessLock(): void {
+      releaseNext();
+      if (roomJoinLocks.get(roomCode) === tail) {
+        roomJoinLocks.delete(roomCode);
+      }
+    }
+
     await previous.catch(() => undefined);
-    const distributedLockHeld = await acquireDistributedJoinLock(roomCode);
-    if (!distributedLockHeld) {
-      logEvent("room_join_lock_busy", {
+    const distributedLock = await acquireDistributedJoinLock(roomCode);
+    if (!distributedLock) {
+      releaseInProcessLock();
+      logEvent("room_join_admission_lock_unavailable", {
         roomCode,
         result: "rejected",
         reason: "join_admission_lock_timeout",
       });
+      throw new RoomServiceError(
+        "internal_error",
+        INTERNAL_SERVER_ERROR_MESSAGE,
+        "internal_error",
+        { roomCode, reason: "join_admission_lock_timeout" },
+      );
     }
     try {
       return await action();
     } finally {
-      if (distributedLockHeld) {
+      if (now() < distributedLock.expiresAt) {
         try {
           await runtimeStore.releaseMessageSlot(
             roomCode,
@@ -239,11 +253,15 @@ export function createRoomService(options: {
         } catch {
           // Lock will expire via TTL.
         }
+      } else {
+        logEvent("room_join_admission_lock_ttl_exceeded", {
+          roomCode,
+          result: "warning",
+          reason: "join_admission_lock_ttl_exceeded",
+          ttlMs: JOIN_ADMISSION_LOCK_TTL_MS,
+        });
       }
-      releaseNext();
-      if (roomJoinLocks.get(roomCode) === tail) {
-        roomJoinLocks.delete(roomCode);
-      }
+      releaseInProcessLock();
     }
   }
 

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   normalizeBilibiliUrl,
   type ClientMessage,
@@ -83,6 +84,15 @@ type JoinIdentity = {
 type PersistJoinedRoomResult = {
   room: PersistedRoom;
   joinTargetState: JoinTargetState;
+};
+
+type JoinAdmissionLock = {
+  token: string;
+  expiresAt: number;
+};
+
+type JoinAdmissionLockGuard = {
+  assertActive: () => void;
 };
 
 type JoinedSessionSnapshot = {
@@ -184,18 +194,20 @@ export function createRoomService(options: {
 
   async function acquireDistributedJoinLock(
     roomCode: string,
-  ): Promise<{ expiresAt: number } | null> {
+  ): Promise<JoinAdmissionLock | null> {
     const deadline = now() + JOIN_ADMISSION_LOCK_MAX_WAIT_MS;
     while (true) {
       const expiresAt = now() + JOIN_ADMISSION_LOCK_TTL_MS;
+      const token = randomUUID();
       if (
-        await runtimeStore.tryClaimMessageSlot(
+        await runtimeStore.acquireRoomLock(
           roomCode,
           JOIN_ADMISSION_LOCK_KEY,
+          token,
           expiresAt,
         )
       ) {
-        return { expiresAt };
+        return { token, expiresAt };
       }
       if (now() >= deadline) {
         return null;
@@ -206,9 +218,20 @@ export function createRoomService(options: {
     }
   }
 
+  function createJoinAdmissionLockExpiredError(
+    roomCode: string,
+  ): RoomServiceError {
+    return new RoomServiceError(
+      "internal_error",
+      INTERNAL_SERVER_ERROR_MESSAGE,
+      "internal_error",
+      { roomCode, reason: "join_admission_lock_expired" },
+    );
+  }
+
   async function withRoomJoinLock<T>(
     roomCode: string,
-    action: () => Promise<T>,
+    action: (lock: JoinAdmissionLockGuard) => Promise<T>,
   ): Promise<T> {
     const previous = roomJoinLocks.get(roomCode) ?? Promise.resolve();
     let releaseNext: () => void = () => undefined;
@@ -225,41 +248,55 @@ export function createRoomService(options: {
       }
     }
 
-    await previous.catch(() => undefined);
-    const distributedLock = await acquireDistributedJoinLock(roomCode);
-    if (!distributedLock) {
-      releaseInProcessLock();
-      logEvent("room_join_admission_lock_unavailable", {
-        roomCode,
-        result: "rejected",
-        reason: "join_admission_lock_timeout",
-      });
-      throw new RoomServiceError(
-        "internal_error",
-        INTERNAL_SERVER_ERROR_MESSAGE,
-        "internal_error",
-        { roomCode, reason: "join_admission_lock_timeout" },
-      );
-    }
+    let distributedLock: JoinAdmissionLock | null = null;
     try {
-      return await action();
-    } finally {
-      if (now() < distributedLock.expiresAt) {
-        try {
-          await runtimeStore.releaseMessageSlot(
-            roomCode,
-            JOIN_ADMISSION_LOCK_KEY,
-          );
-        } catch {
-          // Lock will expire via TTL.
-        }
-      } else {
-        logEvent("room_join_admission_lock_ttl_exceeded", {
+      await previous.catch(() => undefined);
+      distributedLock = await acquireDistributedJoinLock(roomCode);
+      if (!distributedLock) {
+        logEvent("room_join_admission_lock_unavailable", {
           roomCode,
-          result: "warning",
-          reason: "join_admission_lock_ttl_exceeded",
-          ttlMs: JOIN_ADMISSION_LOCK_TTL_MS,
+          result: "rejected",
+          reason: "join_admission_lock_timeout",
         });
+        throw new RoomServiceError(
+          "internal_error",
+          INTERNAL_SERVER_ERROR_MESSAGE,
+          "internal_error",
+          { roomCode, reason: "join_admission_lock_timeout" },
+        );
+      }
+
+      const lockGuard: JoinAdmissionLockGuard = {
+        assertActive: () => {
+          if (!distributedLock || now() >= distributedLock.expiresAt) {
+            throw createJoinAdmissionLockExpiredError(roomCode);
+          }
+        },
+      };
+
+      const result = await action(lockGuard);
+      lockGuard.assertActive();
+      return result;
+    } finally {
+      if (distributedLock) {
+        if (now() < distributedLock.expiresAt) {
+          try {
+            await runtimeStore.releaseRoomLock(
+              roomCode,
+              JOIN_ADMISSION_LOCK_KEY,
+              distributedLock.token,
+            );
+          } catch {
+            // Lock will expire via TTL.
+          }
+        } else {
+          logEvent("room_join_admission_lock_ttl_exceeded", {
+            roomCode,
+            result: "rejected",
+            reason: "join_admission_lock_ttl_exceeded",
+            ttlMs: JOIN_ADMISSION_LOCK_TTL_MS,
+          });
+        }
       }
       releaseInProcessLock();
     }
@@ -660,7 +697,14 @@ export function createRoomService(options: {
         currentTime - room.lastActiveAt < ROOM_LAST_ACTIVE_WRITE_INTERVAL_MS &&
         !needsCapacitySerialization
       ) {
-        return { room, joinTargetState };
+        const latestRoom = await roomStore.getRoom(args.roomCode);
+        if (!latestRoom) {
+          return null;
+        }
+        if (latestRoom.version !== room.version) {
+          return null;
+        }
+        return { room: latestRoom, joinTargetState };
       }
 
       const result = await roomStore.updateRoom(args.roomCode, room.version, {
@@ -973,7 +1017,7 @@ export function createRoomService(options: {
       setSessionDisplayName(session, displayName);
       await leaveCurrentRoom(session);
 
-      return withRoomJoinLock(roomCode, async () => {
+      return withRoomJoinLock(roomCode, async (lock) => {
         const joined = await persistJoinedRoom({
           session,
           roomCode,
@@ -1002,19 +1046,31 @@ export function createRoomService(options: {
                 .getRoom(joinedRoom.code)
                 ?.members.get(reconnectMemberId) ?? null)
             : null;
+        lock.assertActive();
         runtimeStore.addMember(
           joinedRoom.code,
           joinIdentity.memberId,
           session,
           joinIdentity.memberToken,
         );
-        await runtimeStore.flush?.();
-        applyJoinedSessionState({
-          session,
-          roomCode: joinedRoom.code,
-          joinedAt: now(),
-          joinIdentity,
-        });
+        try {
+          await runtimeStore.flush?.();
+          lock.assertActive();
+          applyJoinedSessionState({
+            session,
+            roomCode: joinedRoom.code,
+            joinedAt: now(),
+            joinIdentity,
+          });
+        } catch (error) {
+          runtimeStore.removeMember(
+            joinedRoom.code,
+            joinIdentity.memberId,
+            session,
+          );
+          await runtimeStore.flush?.();
+          throw error;
+        }
         disconnectReplacedSession(session, previousSession);
 
         logEvent("room_restored", {

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -589,8 +589,7 @@ export function createRoomService(options: {
         previousMemberToken: args.previousMemberToken,
       });
       const needsCapacitySerialization =
-        joinTargetState.reconnectMemberId === null &&
-        joinTargetState.activeMemberCount >= config.maxMembersPerRoom - 1;
+        joinTargetState.reconnectMemberId === null;
 
       if (
         room.expiresAt === null &&
@@ -945,6 +944,7 @@ export function createRoomService(options: {
           session,
           joinIdentity.memberToken,
         );
+        await runtimeStore.flush?.();
         applyJoinedSessionState({
           session,
           roomCode: joinedRoom.code,

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -1072,15 +1072,25 @@ export function createRoomService(options: {
             joinIdentity.memberId,
             session,
           );
-          if (previousRuntimeSession) {
+          await runtimeStore.flush?.();
+
+          const currentRuntimeSession =
+            (await resolveActiveRoom(joinedRoom.code))?.members.get(
+              joinIdentity.memberId,
+            ) ?? null;
+          if (
+            previousRuntimeSession &&
+            (currentRuntimeSession === null ||
+              currentRuntimeSession === session)
+          ) {
             runtimeStore.addMember(
               joinedRoom.code,
               joinIdentity.memberId,
               previousRuntimeSession,
               joinIdentity.memberToken,
             );
+            await runtimeStore.flush?.();
           }
-          await runtimeStore.flush?.();
           throw error;
         }
         disconnectReplacedSession(session, previousLocalSession);

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -1038,11 +1038,17 @@ export function createRoomService(options: {
           reconnectMemberId,
           previousMemberToken,
         );
-        const previousSession =
+        const previousLocalSession =
           reconnectMemberId !== null
             ? (runtimeStore
                 .getRoom(joinedRoom.code)
                 ?.members.get(reconnectMemberId) ?? null)
+            : null;
+        const previousRuntimeSession =
+          reconnectMemberId !== null
+            ? (joined.joinTargetState.activeRoom?.members.get(
+                reconnectMemberId,
+              ) ?? previousLocalSession)
             : null;
         lock.assertActive();
         runtimeStore.addMember(
@@ -1066,18 +1072,18 @@ export function createRoomService(options: {
             joinIdentity.memberId,
             session,
           );
-          if (previousSession) {
+          if (previousRuntimeSession) {
             runtimeStore.addMember(
               joinedRoom.code,
               joinIdentity.memberId,
-              previousSession,
+              previousRuntimeSession,
               joinIdentity.memberToken,
             );
           }
           await runtimeStore.flush?.();
           throw error;
         }
-        disconnectReplacedSession(session, previousSession);
+        disconnectReplacedSession(session, previousLocalSession);
 
         logEvent("room_restored", {
           roomCode: joinedRoom.code,

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -38,6 +38,10 @@ import type {
 const PLAYBACK_AUTHORITY_WINDOW_MS = 1200;
 const MAX_VERSION_RETRIES = 3;
 const ROOM_LAST_ACTIVE_WRITE_INTERVAL_MS = 30_000;
+const JOIN_ADMISSION_LOCK_KEY = "join-admission";
+const JOIN_ADMISSION_LOCK_TTL_MS = 10_000;
+const JOIN_ADMISSION_LOCK_MAX_WAIT_MS = 5_000;
+const JOIN_ADMISSION_LOCK_RETRY_INTERVAL_MS = 25;
 
 type ServiceErrorReason =
   | "room_not_found"
@@ -178,6 +182,30 @@ export function createRoomService(options: {
       ));
   const roomJoinLocks = new Map<string, Promise<void>>();
 
+  async function acquireDistributedJoinLock(
+    roomCode: string,
+  ): Promise<boolean> {
+    const deadline = now() + JOIN_ADMISSION_LOCK_MAX_WAIT_MS;
+    while (true) {
+      const expiresAt = now() + JOIN_ADMISSION_LOCK_TTL_MS;
+      if (
+        await runtimeStore.tryClaimMessageSlot(
+          roomCode,
+          JOIN_ADMISSION_LOCK_KEY,
+          expiresAt,
+        )
+      ) {
+        return true;
+      }
+      if (now() >= deadline) {
+        return false;
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, JOIN_ADMISSION_LOCK_RETRY_INTERVAL_MS),
+      );
+    }
+  }
+
   async function withRoomJoinLock<T>(
     roomCode: string,
     action: () => Promise<T>,
@@ -191,9 +219,27 @@ export function createRoomService(options: {
     roomJoinLocks.set(roomCode, tail);
 
     await previous.catch(() => undefined);
+    const distributedLockHeld = await acquireDistributedJoinLock(roomCode);
+    if (!distributedLockHeld) {
+      logEvent("room_join_lock_busy", {
+        roomCode,
+        result: "rejected",
+        reason: "join_admission_lock_timeout",
+      });
+    }
     try {
       return await action();
     } finally {
+      if (distributedLockHeld) {
+        try {
+          await runtimeStore.releaseMessageSlot(
+            roomCode,
+            JOIN_ADMISSION_LOCK_KEY,
+          );
+        } catch {
+          // Lock will expire via TTL.
+        }
+      }
       releaseNext();
       if (roomJoinLocks.get(roomCode) === tail) {
         roomJoinLocks.delete(roomCode);

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -274,9 +274,7 @@ export function createRoomService(options: {
         },
       };
 
-      const result = await action(lockGuard);
-      lockGuard.assertActive();
-      return result;
+      return await action(lockGuard);
     } finally {
       if (distributedLock) {
         if (now() < distributedLock.expiresAt) {

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -37,6 +37,7 @@ import type {
 
 const PLAYBACK_AUTHORITY_WINDOW_MS = 1200;
 const MAX_VERSION_RETRIES = 3;
+const ROOM_LAST_ACTIVE_WRITE_INTERVAL_MS = 30_000;
 
 type ServiceErrorReason =
   | "room_not_found"
@@ -555,6 +556,7 @@ export function createRoomService(options: {
     previousMemberToken?: string;
   }): Promise<PersistJoinedRoomResult | null> {
     return withVersionRetry(args.roomCode, async (room) => {
+      const currentTime = now();
       const joinTargetState = await ensureJoinRequestAllowed({
         session: args.session,
         room,
@@ -562,10 +564,21 @@ export function createRoomService(options: {
         joinToken: args.joinToken,
         previousMemberToken: args.previousMemberToken,
       });
+      const needsCapacitySerialization =
+        joinTargetState.reconnectMemberId === null &&
+        joinTargetState.activeMemberCount >= config.maxMembersPerRoom - 1;
+
+      if (
+        room.expiresAt === null &&
+        currentTime - room.lastActiveAt < ROOM_LAST_ACTIVE_WRITE_INTERVAL_MS &&
+        !needsCapacitySerialization
+      ) {
+        return { room, joinTargetState };
+      }
 
       const result = await roomStore.updateRoom(args.roomCode, room.version, {
-        expiresAt: null,
-        lastActiveAt: now(),
+        ...(room.expiresAt === null ? {} : { expiresAt: null }),
+        lastActiveAt: currentTime,
       });
       if (!result.ok) {
         return null;

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -176,6 +176,30 @@ export function createRoomService(options: {
       Promise.resolve(
         runtimeStore.isMemberTokenBlocked(roomCode, memberToken, currentTime),
       ));
+  const roomJoinLocks = new Map<string, Promise<void>>();
+
+  async function withRoomJoinLock<T>(
+    roomCode: string,
+    action: () => Promise<T>,
+  ): Promise<T> {
+    const previous = roomJoinLocks.get(roomCode) ?? Promise.resolve();
+    let releaseNext: () => void = () => undefined;
+    const next = new Promise<void>((resolve) => {
+      releaseNext = resolve;
+    });
+    const tail = previous.catch(() => undefined).then(() => next);
+    roomJoinLocks.set(roomCode, tail);
+
+    await previous.catch(() => undefined);
+    try {
+      return await action();
+    } finally {
+      releaseNext();
+      if (roomJoinLocks.get(roomCode) === tail) {
+        roomJoinLocks.delete(roomCode);
+      }
+    }
+  }
 
   function setSessionDisplayName(
     session: Session,
@@ -886,57 +910,59 @@ export function createRoomService(options: {
       setSessionDisplayName(session, displayName);
       await leaveCurrentRoom(session);
 
-      const joined = await persistJoinedRoom({
-        session,
-        roomCode,
-        joinToken,
-        previousMemberToken,
-      });
+      return withRoomJoinLock(roomCode, async () => {
+        const joined = await persistJoinedRoom({
+          session,
+          roomCode,
+          joinToken,
+          previousMemberToken,
+        });
 
-      if (!joined) {
-        throw new RoomServiceError(
-          "room_not_found",
-          ROOM_NOT_FOUND_MESSAGE,
-          "room_not_found",
+        if (!joined) {
+          throw new RoomServiceError(
+            "room_not_found",
+            ROOM_NOT_FOUND_MESSAGE,
+            "room_not_found",
+          );
+        }
+
+        const joinedRoom = joined.room;
+        const reconnectMemberId = joined.joinTargetState.reconnectMemberId;
+        const joinIdentity = buildJoinIdentity(
+          session,
+          reconnectMemberId,
+          previousMemberToken,
         );
-      }
+        const previousSession =
+          reconnectMemberId !== null
+            ? (runtimeStore
+                .getRoom(joinedRoom.code)
+                ?.members.get(reconnectMemberId) ?? null)
+            : null;
+        runtimeStore.addMember(
+          joinedRoom.code,
+          joinIdentity.memberId,
+          session,
+          joinIdentity.memberToken,
+        );
+        applyJoinedSessionState({
+          session,
+          roomCode: joinedRoom.code,
+          joinedAt: now(),
+          joinIdentity,
+        });
+        disconnectReplacedSession(session, previousSession);
 
-      const joinedRoom = joined.room;
-      const reconnectMemberId = joined.joinTargetState.reconnectMemberId;
-      const joinIdentity = buildJoinIdentity(
-        session,
-        reconnectMemberId,
-        previousMemberToken,
-      );
-      const previousSession =
-        reconnectMemberId !== null
-          ? (runtimeStore
-              .getRoom(joinedRoom.code)
-              ?.members.get(reconnectMemberId) ?? null)
-          : null;
-      runtimeStore.addMember(
-        joinedRoom.code,
-        joinIdentity.memberId,
-        session,
-        joinIdentity.memberToken,
-      );
-      applyJoinedSessionState({
-        session,
-        roomCode: joinedRoom.code,
-        joinedAt: now(),
-        joinIdentity,
+        logEvent("room_restored", {
+          roomCode: joinedRoom.code,
+          version: joinedRoom.version,
+          sessionId: session.id,
+          provider: persistence.provider,
+          result: "ok",
+        });
+
+        return { room: joinedRoom, memberToken: joinIdentity.memberToken };
       });
-      disconnectReplacedSession(session, previousSession);
-
-      logEvent("room_restored", {
-        roomCode: joinedRoom.code,
-        version: joinedRoom.version,
-        sessionId: session.id,
-        provider: persistence.provider,
-        result: "ok",
-      });
-
-      return { room: joinedRoom, memberToken: joinIdentity.memberToken };
     },
 
     leaveRoomForSession: leaveCurrentRoom,

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -1066,6 +1066,14 @@ export function createRoomService(options: {
             joinIdentity.memberId,
             session,
           );
+          if (previousSession) {
+            runtimeStore.addMember(
+              joinedRoom.code,
+              joinIdentity.memberId,
+              previousSession,
+              joinIdentity.memberToken,
+            );
+          }
           await runtimeStore.flush?.();
           throw error;
         }

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -72,6 +72,17 @@ export type RuntimeStore = {
     expiresAt: number,
   ) => Promise<boolean>;
   releaseMessageSlot: (roomCode: string, key: string) => Promise<void>;
+  acquireRoomLock: (
+    roomCode: string,
+    key: string,
+    token: string,
+    expiresAt: number,
+  ) => Promise<boolean>;
+  releaseRoomLock: (
+    roomCode: string,
+    key: string,
+    token: string,
+  ) => Promise<boolean>;
 };
 
 export function createInMemoryRuntimeStore(
@@ -86,6 +97,10 @@ export function createInMemoryRuntimeStore(
   const rooms = new Map<string, ActiveRoom>();
   const blockedMemberTokensByRoom = new Map<string, KickedMemberBlock[]>();
   const claimedSlotsByRoom = new Map<string, Map<string, number>>();
+  const ownedRoomLocks = new Map<
+    string,
+    Map<string, { token: string; expiresAt: number }>
+  >();
   const nodeStatuses = new Map<string, ClusterNodeStatus>();
 
   function pruneEvents(currentTime: number): void {
@@ -268,6 +283,36 @@ export function createInMemoryRuntimeStore(
       claimedSlotsByRoom.get(roomCode)?.delete(key);
       return Promise.resolve();
     },
+    acquireRoomLock(roomCode, key, token, expiresAt) {
+      const currentTime = now();
+      const roomLocks =
+        ownedRoomLocks.get(roomCode) ??
+        new Map<string, { token: string; expiresAt: number }>();
+      for (const [k, lock] of roomLocks) {
+        if (lock.expiresAt <= currentTime) roomLocks.delete(k);
+      }
+      if (roomLocks.has(key)) {
+        return Promise.resolve(false);
+      }
+      roomLocks.set(key, { token, expiresAt });
+      ownedRoomLocks.set(roomCode, roomLocks);
+      return Promise.resolve(true);
+    },
+    releaseRoomLock(roomCode, key, token) {
+      const roomLocks = ownedRoomLocks.get(roomCode);
+      if (!roomLocks) {
+        return Promise.resolve(false);
+      }
+      const lock = roomLocks.get(key);
+      if (!lock || lock.token !== token) {
+        return Promise.resolve(false);
+      }
+      roomLocks.delete(key);
+      if (roomLocks.size === 0) {
+        ownedRoomLocks.delete(roomCode);
+      }
+      return Promise.resolve(true);
+    },
     removeMember(code, memberId, session) {
       return removeMemberFromRoom(rooms, code, memberId, session);
     },
@@ -276,6 +321,7 @@ export function createInMemoryRuntimeStore(
       roomSessionIds.delete(code);
       blockedMemberTokensByRoom.delete(code);
       claimedSlotsByRoom.delete(code);
+      ownedRoomLocks.delete(code);
     },
     async heartbeatNode(status) {
       nodeStatuses.set(status.instanceId, { ...status });

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -2503,6 +2503,60 @@ test("join admission rejects when action exceeds the lock TTL", async () => {
   );
 });
 
+test("join admission does not fail after successful action when lock expires before return", async () => {
+  let advancingNow = 1_000;
+  const baseStore = createInMemoryRuntimeStore(() => advancingNow);
+  let releaseCalls = 0;
+  const runtimeStore: RuntimeStore = {
+    ...baseStore,
+    releaseRoomLock: async (...args) => {
+      releaseCalls += 1;
+      return baseStore.releaseRoomLock(...args);
+    },
+  };
+  const roomStore = createInMemoryRoomStore({ now: () => advancingNow });
+  const service = createRoomService({
+    config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 3 },
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    runtimeStore,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (event) => {
+      if (event === "room_restored") {
+        advancingNow += 60_000;
+      }
+    },
+    now: () => advancingNow,
+    createRoomCode: () => "ROOM21B",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+
+  const joiner = createSession("joiner");
+  const joined = await service.joinRoomForSession(
+    joiner,
+    created.room.code,
+    created.room.joinToken,
+    "Bob",
+  );
+
+  assert.equal(joined.room.code, created.room.code);
+  assert.equal(joiner.roomCode, created.room.code);
+  assert.equal(
+    baseStore.getRoom(created.room.code)?.members.get(joiner.id),
+    joiner,
+  );
+  assert.equal(
+    releaseCalls,
+    0,
+    "expired locks should not be released after the action commits",
+  );
+});
+
 test("concurrent playback updates produce consistent final state without errors", async () => {
   // Two members simultaneously submit playback updates. Both calls must
   // complete (one may be ignored by authority arbitration) and the final

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -2569,6 +2569,94 @@ test("join admission restores previous reconnect session when rollback follows r
   assert.equal(reconnectingJoiner.memberToken, null);
 });
 
+test("join admission restores shared previous session when reconnect rollback happens on another node", async () => {
+  let advancingNow = 1_000;
+  const local = createInMemoryRuntimeStore(() => advancingNow);
+  const shared = createInMemoryRuntimeStore(() => advancingNow);
+  let expireAfterNextFlush = false;
+  const runtimeStore: RuntimeStore = {
+    ...local,
+    addMember: (code, memberId, session, memberToken) => {
+      const room = local.addMember(code, memberId, session, memberToken);
+      shared.addMember(code, memberId, session, memberToken);
+      return room;
+    },
+    removeMember: (code, memberId, session) => {
+      const removal = local.removeMember(code, memberId, session);
+      shared.removeMember(code, memberId, session);
+      return removal;
+    },
+    flush: async () => {
+      await local.flush?.();
+      await shared.flush?.();
+      if (expireAfterNextFlush) {
+        expireAfterNextFlush = false;
+        advancingNow += 60_000;
+      }
+    },
+  };
+  const roomStore = createInMemoryRoomStore({ now: () => advancingNow });
+  const service = createRoomService({
+    config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 3 },
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    runtimeStore,
+    resolveActiveRoom: async (roomCode) => shared.getRoom(roomCode),
+    resolveMemberIdByToken: async (roomCode, memberToken) =>
+      shared.findMemberIdByToken(roomCode, memberToken),
+    resolveBlockedMemberToken: async (roomCode, memberToken, currentTime) =>
+      shared.isMemberTokenBlocked(roomCode, memberToken, currentTime),
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => advancingNow,
+    createRoomCode: () => "ROOM21D",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  const remoteSession = createSession("remote-joiner");
+  const remoteMemberId = "remote-member";
+  const remoteMemberToken = "remote-token".padEnd(16, "x");
+  remoteSession.memberId = remoteMemberId;
+  remoteSession.roomCode = created.room.code;
+  remoteSession.memberToken = remoteMemberToken;
+  remoteSession.joinedAt = advancingNow;
+  shared.addMember(
+    created.room.code,
+    remoteMemberId,
+    remoteSession,
+    remoteMemberToken,
+  );
+  assert.equal(
+    local.getRoom(created.room.code)?.members.has(remoteMemberId),
+    false,
+  );
+
+  expireAfterNextFlush = true;
+
+  const reconnectingJoiner = createSession("joiner-reconnect");
+  await assert.rejects(
+    service.joinRoomForSession(
+      reconnectingJoiner,
+      created.room.code,
+      created.room.joinToken,
+      "Bob",
+      remoteMemberToken,
+    ),
+    /internal/i,
+  );
+
+  const sharedRoom = shared.getRoom(created.room.code);
+  assert.equal(sharedRoom?.members.get(remoteMemberId), remoteSession);
+  assert.equal(sharedRoom?.memberTokens.get(remoteMemberId), remoteMemberToken);
+  assert.equal(reconnectingJoiner.roomCode, null);
+  assert.equal(reconnectingJoiner.memberId, null);
+  assert.equal(reconnectingJoiner.memberToken, null);
+});
+
 test("join admission does not fail after successful action when lock expires before return", async () => {
   let advancingNow = 1_000;
   const baseStore = createInMemoryRuntimeStore(() => advancingNow);

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -2503,6 +2503,72 @@ test("join admission rejects when action exceeds the lock TTL", async () => {
   );
 });
 
+test("join admission restores previous reconnect session when rollback follows replacement", async () => {
+  let advancingNow = 1_000;
+  const baseStore = createInMemoryRuntimeStore(() => advancingNow);
+  let expireAfterNextFlush = false;
+  const runtimeStore: RuntimeStore = {
+    ...baseStore,
+    flush: async () => {
+      await baseStore.flush?.();
+      if (expireAfterNextFlush) {
+        expireAfterNextFlush = false;
+        advancingNow += 60_000;
+      }
+    },
+  };
+  const roomStore = createInMemoryRoomStore({ now: () => advancingNow });
+  const service = createRoomService({
+    config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 3 },
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    runtimeStore,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => advancingNow,
+    createRoomCode: () => "ROOM21C",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  const originalJoiner = createSession("joiner");
+  const joined = await service.joinRoomForSession(
+    originalJoiner,
+    created.room.code,
+    created.room.joinToken,
+    "Bob",
+  );
+  const originalMemberId = originalJoiner.memberId;
+
+  assert.notEqual(originalMemberId, null);
+  expireAfterNextFlush = true;
+
+  const reconnectingJoiner = createSession("joiner-reconnect");
+  await assert.rejects(
+    service.joinRoomForSession(
+      reconnectingJoiner,
+      created.room.code,
+      created.room.joinToken,
+      "Bob",
+      joined.memberToken,
+    ),
+    /internal/i,
+  );
+
+  const activeRoom = baseStore.getRoom(created.room.code);
+  assert.equal(activeRoom?.members.get(originalMemberId), originalJoiner);
+  assert.equal(
+    activeRoom?.memberTokens.get(originalMemberId),
+    joined.memberToken,
+  );
+  assert.equal(reconnectingJoiner.roomCode, null);
+  assert.equal(reconnectingJoiner.memberId, null);
+  assert.equal(reconnectingJoiner.memberToken, null);
+});
+
 test("join admission does not fail after successful action when lock expires before return", async () => {
   let advancingNow = 1_000;
   const baseStore = createInMemoryRuntimeStore(() => advancingNow);

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -10,7 +10,10 @@ import {
 import { createSessionRateLimitState } from "../src/rate-limit.js";
 import { createInMemoryRoomStore } from "../src/room-store.js";
 import { createRoomService } from "../src/room-service.js";
-import type { RuntimeStore } from "../src/runtime-store.js";
+import {
+  createInMemoryRuntimeStore,
+  type RuntimeStore,
+} from "../src/runtime-store.js";
 import type { LogEvent, Session } from "../src/types.js";
 
 function createSession(id: string): Session {
@@ -102,7 +105,7 @@ test("room service keeps empty rooms for TTL and allows rejoin before expiry", a
   assert.ok(joiner.memberToken);
 });
 
-test("room service skips lastActiveAt persistence for active room joins within refresh window", async () => {
+test("room service skips lastActiveAt persistence for reconnect joins within refresh window", async () => {
   let currentTime = 1_000;
   const baseRoomStore = createInMemoryRoomStore({ now: () => currentTime });
   let updateCount = 0;
@@ -132,17 +135,28 @@ test("room service skips lastActiveAt persistence for active room joins within r
 
   currentTime = 2_000;
   const joiner = createSession("joiner");
-  const joined = await service.joinRoomForSession(
+  const firstJoin = await service.joinRoomForSession(
     joiner,
     created.room.code,
     created.room.joinToken,
     "Bob",
   );
+  const writesAfterFirstJoin = updateCount;
+
+  currentTime = 5_000;
+  const reconnect = createSession("reconnect");
+  const rejoined = await service.joinRoomForSession(
+    reconnect,
+    created.room.code,
+    created.room.joinToken,
+    "Bob",
+    firstJoin.memberToken,
+  );
 
   const persisted = await baseRoomStore.getRoom(created.room.code);
-  assert.equal(updateCount, 0);
-  assert.equal(joined.room.version, created.room.version);
-  assert.equal(persisted?.lastActiveAt, created.room.lastActiveAt);
+  assert.equal(updateCount, writesAfterFirstJoin);
+  assert.equal(rejoined.room.version, firstJoin.room.version);
+  assert.equal(persisted?.lastActiveAt, firstJoin.room.lastActiveAt);
 });
 
 test("room service refreshes lastActiveAt for active room joins after refresh window", async () => {
@@ -1845,8 +1859,9 @@ test("room service deduplicates repeated playback:update with the same seq", asy
 
 test("concurrent joins both succeed when room has capacity for all", async () => {
   // Two sessions race to join the same room. The per-room join admission lock
-  // serializes capacity checks with runtime membership updates, so both land
-  // and the runtime has exactly owner + 2 members.
+  // and forced lastActiveAt persistence on non-reconnect joins serialize
+  // capacity checks with runtime membership updates, so both land and the
+  // runtime has exactly owner + 2 members.
   const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
   const activeRooms = createActiveRoomRegistry();
   const service = createRoomService({
@@ -1890,13 +1905,13 @@ test("concurrent joins both succeed when room has capacity for all", async () =>
   const runtimeRoom = activeRooms.getRoom(created.room.code);
   assert.equal(runtimeRoom?.members.size, 3);
 
-  // Active room joins below the capacity boundary should not write through to
-  // persistence just to bump lastActiveAt.
+  // Non-reconnect joins always persist lastActiveAt so the version-conflict
+  // retry path serializes capacity checks across nodes.
   const persistedRoom = await roomStore.getRoom(created.room.code);
   assert.equal(
     persistedRoom?.version,
-    0,
-    "persisted room version should stay unchanged after non-boundary joins",
+    2,
+    "persisted room version should bump once per non-reconnect join",
   );
 });
 
@@ -2011,6 +2026,100 @@ test("concurrent joins at capacity allow exactly one new member", async () => {
     runtimeRoom?.members.size,
     2,
     "runtime member count must not exceed maxMembersPerRoom",
+  );
+});
+
+test("concurrent joins respect capacity even when shared runtime store flushes asynchronously", async () => {
+  // Reproduces the production wiring where `runtimeStore.addMember` writes to
+  // the shared runtime store via a fire-and-forget async path, and
+  // `resolveActiveRoom` reads from that shared store. The per-room join lock
+  // must hold until the shared write is visible, otherwise concurrent joiners
+  // would all read a stale member count and overshoot `maxMembersPerRoom`.
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const local = createInMemoryRuntimeStore(() => 1_000);
+  const shared = createInMemoryRuntimeStore(() => 1_000);
+  const pendingSharedWrites: Promise<void>[] = [];
+  const runtimeStore: RuntimeStore = {
+    ...local,
+    addMember: (code, memberId, session, memberToken) => {
+      const room = local.addMember(code, memberId, session, memberToken);
+      pendingSharedWrites.push(
+        new Promise((resolve) => {
+          setImmediate(() => {
+            shared.addMember(code, memberId, session, memberToken);
+            resolve();
+          });
+        }),
+      );
+      return room;
+    },
+    flush: async () => {
+      await Promise.allSettled(pendingSharedWrites.splice(0));
+    },
+  };
+
+  const service = createRoomService({
+    config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 3 },
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    runtimeStore,
+    resolveActiveRoom: async (roomCode) => shared.getRoom(roomCode),
+    resolveMemberIdByToken: async (roomCode, memberToken) =>
+      shared.findMemberIdByToken(roomCode, memberToken),
+    resolveBlockedMemberToken: async (roomCode, memberToken, currentTime) =>
+      shared.isMemberTokenBlocked(roomCode, memberToken, currentTime),
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => 1_000,
+    createRoomCode: () => "ROOM18",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  await runtimeStore.flush?.();
+
+  const joiners = [
+    createSession("joiner-a"),
+    createSession("joiner-b"),
+    createSession("joiner-c"),
+  ];
+
+  const results = await Promise.allSettled(
+    joiners.map((joiner, index) =>
+      service.joinRoomForSession(
+        joiner,
+        created.room.code,
+        created.room.joinToken,
+        `User ${index}`,
+      ),
+    ),
+  );
+  await runtimeStore.flush?.();
+
+  const fulfilled = results.filter((r) => r.status === "fulfilled");
+  const rejected = results.filter((r) => r.status === "rejected");
+
+  assert.equal(fulfilled.length, 2, "two open slots should be filled");
+  assert.equal(rejected.length, 1, "overflow joiner should be rejected");
+  assert.match(
+    (rejected[0] as PromiseRejectedResult).reason.message,
+    /Room is full/,
+  );
+
+  const localRoom = local.getRoom(created.room.code);
+  assert.equal(
+    localRoom?.members.size,
+    3,
+    "local member count must stay at maxMembersPerRoom",
+  );
+  const sharedRoom = shared.getRoom(created.room.code);
+  assert.equal(
+    sharedRoom?.members.size,
+    3,
+    "shared member count must stay at maxMembersPerRoom",
   );
 });
 

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -1844,9 +1844,9 @@ test("room service deduplicates repeated playback:update with the same seq", asy
 });
 
 test("concurrent joins both succeed when room has capacity for all", async () => {
-  // Two sessions race to join the same room. withVersionRetry handles the
-  // version conflict on the second joiner's first attempt so both eventually
-  // land and the runtime has exactly owner + 2 members.
+  // Two sessions race to join the same room. The per-room join admission lock
+  // serializes capacity checks with runtime membership updates, so both land
+  // and the runtime has exactly owner + 2 members.
   const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
   const activeRooms = createActiveRoomRegistry();
   const service = createRoomService({
@@ -1900,11 +1900,65 @@ test("concurrent joins both succeed when room has capacity for all", async () =>
   );
 });
 
+test("concurrent joins with multiple open slots do not exceed room capacity", async () => {
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const activeRooms = createActiveRoomRegistry();
+  const service = createRoomService({
+    config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 3 },
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => 1_000,
+    createRoomCode: () => "ROOM16",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  const joiners = [
+    createSession("joiner-a"),
+    createSession("joiner-b"),
+    createSession("joiner-c"),
+  ];
+
+  const results = await Promise.allSettled(
+    joiners.map((joiner, index) =>
+      service.joinRoomForSession(
+        joiner,
+        created.room.code,
+        created.room.joinToken,
+        `User ${index}`,
+      ),
+    ),
+  );
+
+  const fulfilled = results.filter((r) => r.status === "fulfilled");
+  const rejected = results.filter((r) => r.status === "rejected");
+
+  assert.equal(fulfilled.length, 2, "two open slots should be filled");
+  assert.equal(rejected.length, 1, "overflow joiner should be rejected");
+  assert.match(
+    (rejected[0] as PromiseRejectedResult).reason.message,
+    /Room is full/,
+  );
+
+  const runtimeRoom = activeRooms.getRoom(created.room.code);
+  assert.equal(
+    runtimeRoom?.members.size,
+    3,
+    "runtime member count must stay at maxMembersPerRoom",
+  );
+});
+
 test("concurrent joins at capacity allow exactly one new member", async () => {
   // With maxMembersPerRoom=2 (owner already occupies 1 slot), two sessions
-  // race for the single remaining slot. The optimistic-locking retry causes
-  // the second joiner to re-check capacity after the first has been added,
-  // at which point the room is full and the second gets a room_full error.
+  // race for the single remaining slot. The per-room join admission lock
+  // causes the second joiner to re-check capacity after the first has been
+  // added, at which point the room is full and the second gets room_full.
   const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
   const activeRooms = createActiveRoomRegistry();
   const service = createRoomService({
@@ -1918,7 +1972,7 @@ test("concurrent joins at capacity allow exactly one new member", async () => {
     })(),
     logEvent: (() => undefined) satisfies LogEvent,
     now: () => 1_000,
-    createRoomCode: () => "ROOM16",
+    createRoomCode: () => "ROOM17",
   });
 
   const owner = createSession("owner");

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -2123,6 +2123,118 @@ test("concurrent joins respect capacity even when shared runtime store flushes a
   );
 });
 
+test("cross-node concurrent joins respect capacity via shared admission lock", async () => {
+  // Two `roomService` instances share the persistence and shared runtime store
+  // — each has its own in-process join lock (mirroring two nodes). The shared
+  // `tryClaimMessageSlot`/`releaseMessageSlot` mutex must serialize admission
+  // across both nodes; otherwise concurrent joiners would all read the same
+  // shared member count and overshoot `maxMembersPerRoom`.
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const shared = createInMemoryRuntimeStore(() => 1_000);
+
+  function buildNode(nodeId: string) {
+    const local = createInMemoryRuntimeStore(() => 1_000);
+    const pendingSharedWrites: Promise<void>[] = [];
+    const runtimeStore: RuntimeStore = {
+      ...local,
+      addMember: (code, memberId, session, memberToken) => {
+        const room = local.addMember(code, memberId, session, memberToken);
+        pendingSharedWrites.push(
+          new Promise((resolve) => {
+            setImmediate(() => {
+              shared.addMember(code, memberId, session, memberToken);
+              resolve();
+            });
+          }),
+        );
+        return room;
+      },
+      flush: async () => {
+        await Promise.allSettled(pendingSharedWrites.splice(0));
+      },
+      tryClaimMessageSlot: (roomCode, key, expiresAt) =>
+        shared.tryClaimMessageSlot(roomCode, key, expiresAt),
+      releaseMessageSlot: (roomCode, key) =>
+        shared.releaseMessageSlot(roomCode, key),
+    };
+    const service = createRoomService({
+      config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 3 },
+      persistence: getDefaultPersistenceConfig(),
+      roomStore,
+      runtimeStore,
+      resolveActiveRoom: async (roomCode) => shared.getRoom(roomCode),
+      resolveMemberIdByToken: async (roomCode, memberToken) =>
+        shared.findMemberIdByToken(roomCode, memberToken),
+      resolveBlockedMemberToken: async (roomCode, memberToken, currentTime) =>
+        shared.isMemberTokenBlocked(roomCode, memberToken, currentTime),
+      generateToken: (() => {
+        let id = 0;
+        return () => `${nodeId}-token-${++id}`.padEnd(16, "x");
+      })(),
+      logEvent: (() => undefined) satisfies LogEvent,
+      now: () => 1_000,
+      createRoomCode: () => "ROOM19",
+    });
+    return { service, runtimeStore };
+  }
+
+  const nodeA = buildNode("a");
+  const nodeB = buildNode("b");
+
+  const owner = createSession("owner");
+  const created = await nodeA.service.createRoomForSession(owner, "Alice");
+  await nodeA.runtimeStore.flush?.();
+
+  const joinPlans = [
+    { node: nodeA, session: createSession("joiner-a1") },
+    { node: nodeB, session: createSession("joiner-b1") },
+    { node: nodeA, session: createSession("joiner-a2") },
+    { node: nodeB, session: createSession("joiner-b2") },
+  ];
+
+  const results = await Promise.allSettled(
+    joinPlans.map(({ node, session }, index) =>
+      node.service.joinRoomForSession(
+        session,
+        created.room.code,
+        created.room.joinToken,
+        `User ${index}`,
+      ),
+    ),
+  );
+  await Promise.all([
+    nodeA.runtimeStore.flush?.(),
+    nodeB.runtimeStore.flush?.(),
+  ]);
+
+  const fulfilled = results.filter((r) => r.status === "fulfilled");
+  const rejected = results.filter((r) => r.status === "rejected");
+
+  assert.equal(
+    fulfilled.length,
+    2,
+    "exactly two joiners should fill the remaining slots",
+  );
+  assert.equal(
+    rejected.length,
+    2,
+    "exactly two joiners should be rejected as room_full",
+  );
+  for (const result of rejected) {
+    assert.match(
+      (result as PromiseRejectedResult).reason.message,
+      /Room is full/,
+    );
+  }
+
+  const sharedRoom = shared.getRoom(created.room.code);
+  assert.equal(
+    sharedRoom?.members.size,
+    3,
+    "shared member count must stay at maxMembersPerRoom across both nodes",
+  );
+});
+
 test("concurrent playback updates produce consistent final state without errors", async () => {
   // Two members simultaneously submit playback updates. Both calls must
   // complete (one may be ignored by authority arbitration) and the final

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -159,6 +159,73 @@ test("room service skips lastActiveAt persistence for reconnect joins within ref
   assert.equal(persisted?.lastActiveAt, firstJoin.room.lastActiveAt);
 });
 
+test("room service rejects reconnect skip path when room was deleted concurrently", async () => {
+  let currentTime = 1_000;
+  const baseRoomStore = createInMemoryRoomStore({ now: () => currentTime });
+  let validateDeletedRoom = false;
+  let validationReadCount = 0;
+  const roomStore = {
+    ...baseRoomStore,
+    async getRoom(code: string) {
+      const room = await baseRoomStore.getRoom(code);
+      if (validateDeletedRoom) {
+        validationReadCount += 1;
+        if (validationReadCount === 2) {
+          await baseRoomStore.deleteRoom(code);
+          return null;
+        }
+      }
+      return room;
+    },
+  };
+  const activeRooms = createActiveRoomRegistry();
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOM02B",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+
+  currentTime = 2_000;
+  const joiner = createSession("joiner");
+  const firstJoin = await service.joinRoomForSession(
+    joiner,
+    created.room.code,
+    created.room.joinToken,
+    "Bob",
+  );
+
+  currentTime = 5_000;
+  validateDeletedRoom = true;
+  const reconnect = createSession("reconnect");
+  await assert.rejects(
+    service.joinRoomForSession(
+      reconnect,
+      created.room.code,
+      created.room.joinToken,
+      "Bob",
+      firstJoin.memberToken,
+    ),
+    /Room not found/,
+  );
+
+  assert.equal(reconnect.roomCode, null);
+  assert.equal(
+    activeRooms.getRoom(created.room.code)?.members.get(joiner.id),
+    joiner,
+  );
+});
+
 test("room service refreshes lastActiveAt for active room joins after refresh window", async () => {
   let currentTime = 1_000;
   const baseRoomStore = createInMemoryRoomStore({ now: () => currentTime });
@@ -904,6 +971,18 @@ test("room service flushes pending runtime store writes before exposing updated 
     },
     isMemberTokenBlocked(code, memberToken, currentTime) {
       return activeRooms.isMemberTokenBlocked(code, memberToken, currentTime);
+    },
+    tryClaimMessageSlot() {
+      return Promise.resolve(true);
+    },
+    releaseMessageSlot() {
+      return Promise.resolve();
+    },
+    acquireRoomLock() {
+      return Promise.resolve(true);
+    },
+    releaseRoomLock() {
+      return Promise.resolve(true);
     },
     removeMember(code, memberId, session) {
       return activeRooms.removeMember(code, memberId, session);
@@ -2156,6 +2235,10 @@ test("cross-node concurrent joins respect capacity via shared admission lock", a
         shared.tryClaimMessageSlot(roomCode, key, expiresAt),
       releaseMessageSlot: (roomCode, key) =>
         shared.releaseMessageSlot(roomCode, key),
+      acquireRoomLock: (roomCode, key, token, expiresAt) =>
+        shared.acquireRoomLock(roomCode, key, token, expiresAt),
+      releaseRoomLock: (roomCode, key, token) =>
+        shared.releaseRoomLock(roomCode, key, token),
     };
     const service = createRoomService({
       config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 3 },
@@ -2246,16 +2329,17 @@ test("join admission rejects with internal error when shared mutex is unavailabl
     return advancingNow;
   };
   const baseStore = createInMemoryRuntimeStore(() => advancingNow);
-  let tryClaimCalls = 0;
+  let acquireCalls = 0;
   let releaseCalls = 0;
   const runtimeStore: RuntimeStore = {
     ...baseStore,
-    tryClaimMessageSlot: async () => {
-      tryClaimCalls += 1;
+    acquireRoomLock: async () => {
+      acquireCalls += 1;
       return false;
     },
-    releaseMessageSlot: async () => {
+    releaseRoomLock: async () => {
       releaseCalls += 1;
+      return true;
     },
   };
   const roomStore = createInMemoryRoomStore({ now: () => advancingNow });
@@ -2288,7 +2372,7 @@ test("join admission rejects with internal error when shared mutex is unavailabl
   );
 
   assert.ok(
-    tryClaimCalls >= 2,
+    acquireCalls >= 2,
     "lock acquisition should poll multiple times before timing out",
   );
   assert.equal(
@@ -2298,24 +2382,76 @@ test("join admission rejects with internal error when shared mutex is unavailabl
   );
 });
 
-test("join admission skips release when action exceeds the lock TTL", async () => {
+test("join admission releases local queue when shared mutex acquisition throws", async () => {
+  const currentTime = 1_000;
+  const baseStore = createInMemoryRuntimeStore(() => currentTime);
+  let acquireCalls = 0;
+  const runtimeStore: RuntimeStore = {
+    ...baseStore,
+    acquireRoomLock: async (...args) => {
+      acquireCalls += 1;
+      if (acquireCalls === 1) {
+        throw new Error("redis unavailable");
+      }
+      return baseStore.acquireRoomLock(...args);
+    },
+  };
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const service = createRoomService({
+    config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 3 },
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    runtimeStore,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOM20B",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+
+  await assert.rejects(
+    service.joinRoomForSession(
+      createSession("failing-joiner"),
+      created.room.code,
+      created.room.joinToken,
+      "Bob",
+    ),
+    /redis unavailable/,
+  );
+
+  const joined = await service.joinRoomForSession(
+    createSession("successful-joiner"),
+    created.room.code,
+    created.room.joinToken,
+    "Carol",
+  );
+
+  assert.equal(joined.room.code, created.room.code);
+});
+
+test("join admission rejects when action exceeds the lock TTL", async () => {
   // Simulate a join whose persistence write stalls past the distributed lock
-  // TTL. By the time the action returns, the slot is logically expired and
-  // could already belong to another node — so the release call must be
-  // skipped to avoid evicting the successor's lock.
+  // TTL. By the time the action returns, the lock is logically expired and
+  // could already belong to another node, so the join must be rejected instead
+  // of reporting success outside the serialization window.
   let advancingNow = 1_000;
   const baseStore = createInMemoryRuntimeStore(() => advancingNow);
-  let tryClaimCalls = 0;
+  let acquireCalls = 0;
   let releaseCalls = 0;
   const runtimeStore: RuntimeStore = {
     ...baseStore,
-    tryClaimMessageSlot: async (...args) => {
-      tryClaimCalls += 1;
-      return baseStore.tryClaimMessageSlot(...args);
+    acquireRoomLock: async (...args) => {
+      acquireCalls += 1;
+      return baseStore.acquireRoomLock(...args);
     },
-    releaseMessageSlot: async (...args) => {
+    releaseRoomLock: async (...args) => {
       releaseCalls += 1;
-      return baseStore.releaseMessageSlot(...args);
+      return baseStore.releaseRoomLock(...args);
     },
   };
   const baseRoomStore = createInMemoryRoomStore({ now: () => advancingNow });
@@ -2344,18 +2480,26 @@ test("join admission skips release when action exceeds the lock TTL", async () =
   const created = await service.createRoomForSession(owner, "Alice");
 
   const joiner = createSession("joiner");
-  await service.joinRoomForSession(
-    joiner,
-    created.room.code,
-    created.room.joinToken,
-    "Bob",
+  await assert.rejects(
+    service.joinRoomForSession(
+      joiner,
+      created.room.code,
+      created.room.joinToken,
+      "Bob",
+    ),
+    /internal/i,
   );
 
-  assert.equal(tryClaimCalls, 1, "lock should be acquired exactly once");
+  assert.equal(acquireCalls, 1, "lock should be acquired exactly once");
   assert.equal(
     releaseCalls,
     0,
     "release must be skipped when the held lock has already expired",
+  );
+  assert.equal(joiner.roomCode, null);
+  assert.equal(
+    baseStore.getRoom(created.room.code)?.members.has(joiner.id),
+    false,
   );
 });
 

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -2657,6 +2657,96 @@ test("join admission restores shared previous session when reconnect rollback ha
   assert.equal(reconnectingJoiner.memberToken, null);
 });
 
+test("join admission does not restore stale reconnect session over newer shared binding", async () => {
+  let advancingNow = 1_000;
+  const local = createInMemoryRuntimeStore(() => advancingNow);
+  const shared = createInMemoryRuntimeStore(() => advancingNow);
+  const newerSession = createSession("newer-reconnect");
+  let replaceSharedBindingAfterNextFlush = false;
+  const runtimeStore: RuntimeStore = {
+    ...local,
+    addMember: (code, memberId, session, memberToken) => {
+      const room = local.addMember(code, memberId, session, memberToken);
+      shared.addMember(code, memberId, session, memberToken);
+      return room;
+    },
+    removeMember: (code, memberId, session) => {
+      const removal = local.removeMember(code, memberId, session);
+      shared.removeMember(code, memberId, session);
+      return removal;
+    },
+    flush: async () => {
+      await local.flush?.();
+      await shared.flush?.();
+      if (replaceSharedBindingAfterNextFlush) {
+        replaceSharedBindingAfterNextFlush = false;
+        shared.addMember(
+          newerSession.roomCode ?? "",
+          newerSession.memberId ?? "",
+          newerSession,
+          newerSession.memberToken ?? "",
+        );
+        advancingNow += 60_000;
+      }
+    },
+  };
+  const roomStore = createInMemoryRoomStore({ now: () => advancingNow });
+  const service = createRoomService({
+    config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 3 },
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    runtimeStore,
+    resolveActiveRoom: async (roomCode) => shared.getRoom(roomCode),
+    resolveMemberIdByToken: async (roomCode, memberToken) =>
+      shared.findMemberIdByToken(roomCode, memberToken),
+    resolveBlockedMemberToken: async (roomCode, memberToken, currentTime) =>
+      shared.isMemberTokenBlocked(roomCode, memberToken, currentTime),
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => advancingNow,
+    createRoomCode: () => "ROOM21E",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  const previousSession = createSession("previous-joiner");
+  const memberId = "remote-member";
+  const memberToken = "remote-token".padEnd(16, "x");
+  previousSession.memberId = memberId;
+  previousSession.roomCode = created.room.code;
+  previousSession.memberToken = memberToken;
+  previousSession.joinedAt = advancingNow;
+  newerSession.memberId = memberId;
+  newerSession.roomCode = created.room.code;
+  newerSession.memberToken = memberToken;
+  newerSession.joinedAt = advancingNow;
+  shared.addMember(created.room.code, memberId, previousSession, memberToken);
+
+  replaceSharedBindingAfterNextFlush = true;
+
+  const reconnectingJoiner = createSession("joiner-reconnect");
+  await assert.rejects(
+    service.joinRoomForSession(
+      reconnectingJoiner,
+      created.room.code,
+      created.room.joinToken,
+      "Bob",
+      memberToken,
+    ),
+    /internal/i,
+  );
+
+  const sharedRoom = shared.getRoom(created.room.code);
+  assert.equal(sharedRoom?.members.get(memberId), newerSession);
+  assert.equal(sharedRoom?.memberTokens.get(memberId), memberToken);
+  assert.equal(reconnectingJoiner.roomCode, null);
+  assert.equal(reconnectingJoiner.memberId, null);
+  assert.equal(reconnectingJoiner.memberToken, null);
+});
+
 test("join admission does not fail after successful action when lock expires before return", async () => {
   let advancingNow = 1_000;
   const baseStore = createInMemoryRuntimeStore(() => advancingNow);

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -2235,6 +2235,130 @@ test("cross-node concurrent joins respect capacity via shared admission lock", a
   );
 });
 
+test("join admission rejects with internal error when shared mutex is unavailable", async () => {
+  // The distributed `tryClaimMessageSlot` slot is permanently held by another
+  // caller. The join flow must NOT silently fall back to single-node-only
+  // serialization — it should refuse the join after the bounded wait so cross
+  // node mutex is preserved instead of degrading correctness for availability.
+  let advancingNow = 1_000;
+  const advanceTime = () => {
+    advancingNow += 200;
+    return advancingNow;
+  };
+  const baseStore = createInMemoryRuntimeStore(() => advancingNow);
+  let tryClaimCalls = 0;
+  let releaseCalls = 0;
+  const runtimeStore: RuntimeStore = {
+    ...baseStore,
+    tryClaimMessageSlot: async () => {
+      tryClaimCalls += 1;
+      return false;
+    },
+    releaseMessageSlot: async () => {
+      releaseCalls += 1;
+    },
+  };
+  const roomStore = createInMemoryRoomStore({ now: () => advancingNow });
+  const service = createRoomService({
+    config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 3 },
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    runtimeStore,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: advanceTime,
+    createRoomCode: () => "ROOM20",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+
+  const joiner = createSession("joiner");
+  await assert.rejects(
+    service.joinRoomForSession(
+      joiner,
+      created.room.code,
+      created.room.joinToken,
+      "Bob",
+    ),
+    /unable|internal/i,
+  );
+
+  assert.ok(
+    tryClaimCalls >= 2,
+    "lock acquisition should poll multiple times before timing out",
+  );
+  assert.equal(
+    releaseCalls,
+    0,
+    "release must not be called when lock was never acquired",
+  );
+});
+
+test("join admission skips release when action exceeds the lock TTL", async () => {
+  // Simulate a join whose persistence write stalls past the distributed lock
+  // TTL. By the time the action returns, the slot is logically expired and
+  // could already belong to another node — so the release call must be
+  // skipped to avoid evicting the successor's lock.
+  let advancingNow = 1_000;
+  const baseStore = createInMemoryRuntimeStore(() => advancingNow);
+  let tryClaimCalls = 0;
+  let releaseCalls = 0;
+  const runtimeStore: RuntimeStore = {
+    ...baseStore,
+    tryClaimMessageSlot: async (...args) => {
+      tryClaimCalls += 1;
+      return baseStore.tryClaimMessageSlot(...args);
+    },
+    releaseMessageSlot: async (...args) => {
+      releaseCalls += 1;
+      return baseStore.releaseMessageSlot(...args);
+    },
+  };
+  const baseRoomStore = createInMemoryRoomStore({ now: () => advancingNow });
+  const roomStore = {
+    ...baseRoomStore,
+    async updateRoom(...args: Parameters<typeof baseRoomStore.updateRoom>) {
+      advancingNow += 60_000;
+      return baseRoomStore.updateRoom(...args);
+    },
+  };
+  const service = createRoomService({
+    config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 3 },
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    runtimeStore,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => advancingNow,
+    createRoomCode: () => "ROOM21",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+
+  const joiner = createSession("joiner");
+  await service.joinRoomForSession(
+    joiner,
+    created.room.code,
+    created.room.joinToken,
+    "Bob",
+  );
+
+  assert.equal(tryClaimCalls, 1, "lock should be acquired exactly once");
+  assert.equal(
+    releaseCalls,
+    0,
+    "release must be skipped when the held lock has already expired",
+  );
+});
+
 test("concurrent playback updates produce consistent final state without errors", async () => {
   // Two members simultaneously submit playback updates. Both calls must
   // complete (one may be ignored by authority arbitration) and the final

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -102,6 +102,92 @@ test("room service keeps empty rooms for TTL and allows rejoin before expiry", a
   assert.ok(joiner.memberToken);
 });
 
+test("room service skips lastActiveAt persistence for active room joins within refresh window", async () => {
+  let currentTime = 1_000;
+  const baseRoomStore = createInMemoryRoomStore({ now: () => currentTime });
+  let updateCount = 0;
+  const roomStore = {
+    ...baseRoomStore,
+    async updateRoom(...args: Parameters<typeof baseRoomStore.updateRoom>) {
+      updateCount += 1;
+      return baseRoomStore.updateRoom(...args);
+    },
+  };
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: createActiveRoomRegistry(),
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOM02",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+
+  currentTime = 2_000;
+  const joiner = createSession("joiner");
+  const joined = await service.joinRoomForSession(
+    joiner,
+    created.room.code,
+    created.room.joinToken,
+    "Bob",
+  );
+
+  const persisted = await baseRoomStore.getRoom(created.room.code);
+  assert.equal(updateCount, 0);
+  assert.equal(joined.room.version, created.room.version);
+  assert.equal(persisted?.lastActiveAt, created.room.lastActiveAt);
+});
+
+test("room service refreshes lastActiveAt for active room joins after refresh window", async () => {
+  let currentTime = 1_000;
+  const baseRoomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const patches: Array<Parameters<typeof baseRoomStore.updateRoom>[2]> = [];
+  const roomStore = {
+    ...baseRoomStore,
+    async updateRoom(...args: Parameters<typeof baseRoomStore.updateRoom>) {
+      patches.push(args[2]);
+      return baseRoomStore.updateRoom(...args);
+    },
+  };
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: createActiveRoomRegistry(),
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOM03",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+
+  currentTime = 31_000;
+  const joiner = createSession("joiner");
+  const joined = await service.joinRoomForSession(
+    joiner,
+    created.room.code,
+    created.room.joinToken,
+    "Bob",
+  );
+
+  const persisted = await baseRoomStore.getRoom(created.room.code);
+  assert.deepEqual(patches, [{ lastActiveAt: currentTime }]);
+  assert.equal(joined.room.version, created.room.version + 1);
+  assert.equal(persisted?.lastActiveAt, currentTime);
+});
+
 test("room service restores member state when empty-room expiry scheduling fails", async () => {
   const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
   const activeRooms = createActiveRoomRegistry();
@@ -1804,14 +1890,13 @@ test("concurrent joins both succeed when room has capacity for all", async () =>
   const runtimeRoom = activeRooms.getRoom(created.room.code);
   assert.equal(runtimeRoom?.members.size, 3);
 
-  // Persisted room version must reflect exactly two successful updateRoom calls
-  // (one per joiner). Concurrent version-conflict retries must not skip a bump
-  // or produce a torn write.
+  // Active room joins below the capacity boundary should not write through to
+  // persistence just to bump lastActiveAt.
   const persistedRoom = await roomStore.getRoom(created.room.code);
   assert.equal(
     persistedRoom?.version,
-    2,
-    "persisted room version must be 2 after two concurrent joins",
+    0,
+    "persisted room version should stay unchanged after non-boundary joins",
   );
 });
 


### PR DESCRIPTION
## Summary
- Suppress join-path `lastActiveAt` persistence for active rooms within a 30s refresh window.
- Keep persistence writes when clearing empty-room expiry, refreshing stale activity, or serializing near-capacity concurrent joins.
- Add a per-room join admission lock so capacity checks and runtime `addMember` updates cannot race past `maxMembersPerRoom`.
- Add room-service regressions for skipped activity writes, refresh-window updates, and concurrent capacity overflow.

Fixes #96 (P2b)

## Test plan
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`
- [x] `npm run bench:reconnect-storm`

## Benchmark
`bench/reconnect-storm.ts` single-node, 500 members, `reconnectTimeoutMs=5000`:

| Metric | Result |
|---|---:|
| Total duration | 0.999s |
| Completed | 500 / 500 |
| Throughput | 500.501/s |
| p50 | 283ms |
| p95 | 905ms |
| p99 | 973ms |
| max | 987ms |
| errorRatePercent | 0% |