### PR TITLE
fix: resolve bangumi season pages to episodes

### DIFF
--- a/extension/src/content/page-bridge-detail.ts
+++ b/extension/src/content/page-bridge-detail.ts
@@ -26,8 +26,32 @@ export interface PlayerInput {
   aid?: string | number;
 }
 
+export interface PagePlayInfo {
+  result?: {
+    arc?: {
+      bvid?: string;
+      cid?: string | number;
+    };
+    supplement?: {
+      ogv_episode_info?: {
+        episode_id?: string | number;
+        ep_id?: string | number;
+        index_title?: string;
+        long_title?: string;
+      };
+      play_view_business_info?: {
+        episode_info?: {
+          ep_id?: string | number;
+          cid?: string | number;
+        };
+      };
+    };
+  };
+}
+
 export function readFestivalVideoDetailFromSources(args: {
   initialState?: PageInitialState;
+  playInfo?: PagePlayInfo;
   playerInput?: PlayerInput;
   activeCid?: string | null;
   activeEpId?: string | null;
@@ -40,6 +64,7 @@ export function readFestivalVideoDetailFromSources(args: {
 } | null {
   const {
     initialState,
+    playInfo,
     playerInput,
     activeCid = null,
     activeEpId = null,
@@ -77,6 +102,7 @@ export function readFestivalVideoDetailFromSources(args: {
     matchedByEpId ??
     matchedByCid ??
     matchedByTitle ??
+    readPlayInfoCandidate(playInfo) ??
     initialState?.epInfo ??
     playerInput ??
     initialState?.videoInfo ??
@@ -112,8 +138,41 @@ export function readFestivalVideoDetailFromSources(args: {
         ? matched.long_title
         : undefined) ||
       activeTitle ||
+      getPlayInfoTitle(playInfo) ||
       initialState?.epInfo?.title ||
       initialState?.epInfo?.long_title ||
       initialState?.videoInfo?.title,
   };
+}
+
+function readPlayInfoCandidate(
+  playInfo: PagePlayInfo | undefined,
+): PageVideoCandidate | null {
+  const episodeInfo = playInfo?.result?.supplement?.ogv_episode_info;
+  const businessEpisodeInfo =
+    playInfo?.result?.supplement?.play_view_business_info?.episode_info;
+  const arc = playInfo?.result?.arc;
+  const epId =
+    episodeInfo?.episode_id ?? episodeInfo?.ep_id ?? businessEpisodeInfo?.ep_id;
+  const cid = arc?.cid ?? businessEpisodeInfo?.cid;
+
+  if (!epId && (!arc?.bvid || cid === undefined)) {
+    return null;
+  }
+
+  return {
+    ep_id: epId,
+    bvid: arc?.bvid,
+    cid,
+  };
+}
+
+function getPlayInfoTitle(
+  playInfo: PagePlayInfo | undefined,
+): string | undefined {
+  const episodeInfo = playInfo?.result?.supplement?.ogv_episode_info;
+  const parts = [episodeInfo?.index_title, episodeInfo?.long_title]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join(" ") : undefined;
 }

--- a/extension/src/content/page-bridge.ts
+++ b/extension/src/content/page-bridge.ts
@@ -1,6 +1,7 @@
 import {
   readFestivalVideoDetailFromSources,
   type PageInitialState,
+  type PagePlayInfo,
   type PlayerInput,
 } from "./page-bridge-detail";
 
@@ -35,6 +36,7 @@ function readFestivalVideoDetail(): {
     const initialState = (
       window as typeof window & {
         __INITIAL_STATE__?: PageInitialState;
+        __playinfo__?: PagePlayInfo;
         player?: {
           __getUserParams?: () => {
             input?: PlayerInput;
@@ -42,6 +44,11 @@ function readFestivalVideoDetail(): {
         };
       }
     ).__INITIAL_STATE__;
+    const playInfo = (
+      window as typeof window & {
+        __playinfo__?: PagePlayInfo;
+      }
+    ).__playinfo__;
 
     const active = document.querySelector<HTMLElement>(
       "li[data-cid].bpx-state-active, [data-cid].bpx-state-active, [data-cid].active, [data-cid].selected, [data-ep-id].active, [data-episode-id].active, [data-epid].active",
@@ -71,6 +78,7 @@ function readFestivalVideoDetail(): {
 
     return readFestivalVideoDetailFromSources({
       initialState,
+      playInfo,
       playerInput,
       activeCid,
       activeEpId,

--- a/extension/test/page-bridge.test.ts
+++ b/extension/test/page-bridge.test.ts
@@ -50,3 +50,40 @@ test("page bridge preserves active cid when matched candidate lacks cid", () => 
     title: "第46话",
   });
 });
+
+test("page bridge resolves current bangumi episode from playinfo when season page has no initial state", () => {
+  const detail = readFestivalVideoDetailFromSources({
+    playInfo: {
+      result: {
+        arc: {
+          bvid: "BV17W411y74a",
+          cid: 55445162,
+        },
+        supplement: {
+          ogv_episode_info: {
+            episode_id: 508404,
+            index_title: "46",
+            long_title: "汤姆与小老鼠 Tom and Cherie",
+          },
+          play_view_business_info: {
+            episode_info: {
+              ep_id: 508404,
+              cid: 55445162,
+            },
+          },
+        },
+      },
+    },
+    playerInput: {
+      cid: undefined,
+    },
+    activeTitle: "第46话 汤姆与小老鼠 Tom and Cherie",
+  });
+
+  assert.deepEqual(detail, {
+    epId: 508404,
+    bvid: "BV17W411y74a",
+    cid: 55445162,
+    title: "第46话 汤姆与小老鼠 Tom and Cherie",
+  });
+});


### PR DESCRIPTION
## Summary
- read current bangumi episode identity from `window.__playinfo__` when `__INITIAL_STATE__` is unavailable
- share canonical `ep...` URLs instead of falling back to season URLs like `/bangumi/play/ss357`
- add regression coverage for season pages resolving to the active episode

## Verification
- `npm run build -w @bili-syncplay/protocol`
- `npm exec -w @bili-syncplay/extension -- tsx --test test/page-bridge.test.ts test/festival-bridge.test.ts test/page-video.test.ts test/share-controller.test.ts`
- `npm run --ignore-scripts test -w @bili-syncplay/extension`
- `npx prettier --check extension/src/content/page-bridge-detail.ts extension/src/content/page-bridge.ts extension/test/page-bridge.test.ts`