### PR TITLE
chore: release 1.1.0

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.0.1"
+    "@bili-syncplay/protocol": "1.1.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.1.40",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "workspaces": [
         "packages/*",
         "server",
@@ -24,9 +24,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.0.1"
+        "@bili-syncplay/protocol": "1.1.0"
       },
       "devDependencies": {
         "@types/chrome": "^0.1.40",
@@ -2740,16 +2740,16 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "devDependencies": {
         "typescript": "^5.9.3"
       }
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.0.1",
+        "@bili-syncplay/protocol": "1.1.0",
         "ioredis": "^5.10.0",
         "ws": "^8.18.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.0.1",
+    "@bili-syncplay/protocol": "1.1.0",
     "ioredis": "^5.10.0",
     "ws": "^8.18.3"
   },


### PR DESCRIPTION
## Summary
- bump workspace, server, protocol, extension, and manifest versions to 1.1.0
- update workspace lockfile for the 1.1.0 release

## Verification
- `npm run build:release`
- `npx prettier --check package.json package-lock.json packages/protocol/package.json server/package.json extension/package.json extension/public/manifest.json`
- `npm run lint`
- `npm run build`
- `npm test`

## Notes
- Local full `npm run format:check` is blocked by pre-existing untracked `docs/archive/` files.
- Local `npm run typecheck` is blocked by existing extension Chrome global type resolution errors, while `npm run build` passes.