### PR TITLE
fix: stop stale page-bridge state from leaking after bangumi SPA navigation

### DIFF
--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -23,7 +23,9 @@ export function createNavigationController(args: {
   hydrateRoomState: () => Promise<void>;
   activatePauseHold: (durationMs?: number) => void;
   debugLog: (message: string) => void;
+  getNow?: () => number;
 }): NavigationController {
+  const nowOf = () => args.getNow?.() ?? Date.now();
   let navigationWatchTimer: number | null = null;
   let lastObservedPageUrl = args.getCurrentPageUrl();
   let lastObservedNormalizedPageUrl =
@@ -76,8 +78,10 @@ export function createNavigationController(args: {
     ) {
       args.runtimeState.postNavigationAnchorSharedUrl =
         args.runtimeState.activeSharedUrl;
+      args.runtimeState.postNavigationAnchorSetAt = nowOf();
     } else {
       args.runtimeState.postNavigationAnchorSharedUrl = null;
+      args.runtimeState.postNavigationAnchorSetAt = 0;
     }
     resetUserGestureState(args.runtimeState);
     args.activatePauseHold(args.initialRoomStatePauseHoldMs);

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -60,6 +60,25 @@ export function createNavigationController(args: {
     args.runtimeState.hasReceivedInitialRoomState = false;
     args.runtimeState.pendingRoomStateHydration = true;
     args.runtimeState.intendedPlayState = "paused";
+    // Anchor the previous shared URL so that broadcasts stay suppressed until
+    // the page bridge resolves the new page to a different normalized URL or
+    // a fresh shared-video room state arrives. This prevents stale
+    // `__INITIAL_STATE__` data captured mid-SPA from being broadcast as
+    // updates to the still-shared previous video.
+    //
+    // Skip the anchor when the user is navigating directly to the shared
+    // video URL itself (e.g. coming back to the original episode after a
+    // detour) — in that case the page-bridge will correctly resolve to that
+    // URL and broadcasts are not at risk of leaking stale data.
+    if (
+      args.runtimeState.activeSharedUrl &&
+      nextNormalizedPageUrl !== args.runtimeState.activeSharedUrl
+    ) {
+      args.runtimeState.postNavigationAnchorSharedUrl =
+        args.runtimeState.activeSharedUrl;
+    } else {
+      args.runtimeState.postNavigationAnchorSharedUrl = null;
+    }
     resetUserGestureState(args.runtimeState);
     args.activatePauseHold(args.initialRoomStatePauseHoldMs);
     args.debugLog(

--- a/extension/src/content/page-bridge-detail.ts
+++ b/extension/src/content/page-bridge-detail.ts
@@ -98,11 +98,32 @@ export function readFestivalVideoDetailFromSources(args: {
         )
       : null;
 
+  const playInfoCandidate = readPlayInfoCandidate(playInfo);
+  const playInfoEpId = playInfoCandidate
+    ? (playInfoCandidate.ep_id ??
+      playInfoCandidate.epId ??
+      playInfoCandidate.id)
+    : undefined;
+
+  // Prefer __playinfo__ over DOM-derived / __INITIAL_STATE__ candidates.
+  //
+  // During SPA navigation between bangumi (e.g. from /bangumi/play/epXXX to
+  // /bangumi/play/ssYYY), Bilibili refreshes `__playinfo__` together with the
+  // newly loaded video, but `__INITIAL_STATE__.epInfo / epList / sectionEpisodes`
+  // can stay populated with the previous bangumi's data for several hundred
+  // milliseconds — long enough for the content script to broadcast playback
+  // events derived from the stale ep_id. When the DOM-matched candidates
+  // (which read from those stale episode arrays) disagree with `__playinfo__`,
+  // trusting `__playinfo__` is the safer choice because the player only
+  // populates it once it has actually loaded the new episode.
   const matched: PageVideoCandidate | null =
+    (playInfoCandidate && playInfoEpId !== undefined
+      ? playInfoCandidate
+      : null) ??
     matchedByEpId ??
     matchedByCid ??
     matchedByTitle ??
-    readPlayInfoCandidate(playInfo) ??
+    playInfoCandidate ??
     initialState?.epInfo ??
     playerInput ??
     initialState?.videoInfo ??

--- a/extension/src/content/page-bridge-detail.ts
+++ b/extension/src/content/page-bridge-detail.ts
@@ -99,27 +99,34 @@ export function readFestivalVideoDetailFromSources(args: {
       : null;
 
   const playInfoCandidate = readPlayInfoCandidate(playInfo);
-  const playInfoEpId = playInfoCandidate
-    ? (playInfoCandidate.ep_id ??
-      playInfoCandidate.epId ??
-      playInfoCandidate.id)
-    : undefined;
+  const activeBackingCandidate = activeCid
+    ? [matchedByEpId, matchedByCid, playInfoCandidate, playerInput]
+        .filter((candidate): candidate is PageVideoCandidate =>
+          Boolean(candidate),
+        )
+        .find(
+          (candidate) =>
+            candidate.cid === undefined || String(candidate.cid) === activeCid,
+        )
+    : (matchedByEpId ?? playInfoCandidate ?? playerInput ?? null);
+  const activeCandidate: PageVideoCandidate | null = activeEpId
+    ? {
+        ep_id: activeEpId,
+        bvid: activeBackingCandidate?.bvid,
+        cid: activeBackingCandidate?.cid ?? activeCid ?? undefined,
+        title: activeTitle ?? undefined,
+      }
+    : null;
 
-  // Prefer __playinfo__ over DOM-derived / __INITIAL_STATE__ candidates.
+  // Prefer explicit active DOM episode identity over stale page globals.
   //
   // During SPA navigation between bangumi (e.g. from /bangumi/play/epXXX to
-  // /bangumi/play/ssYYY), Bilibili refreshes `__playinfo__` together with the
-  // newly loaded video, but `__INITIAL_STATE__.epInfo / epList / sectionEpisodes`
-  // can stay populated with the previous bangumi's data for several hundred
-  // milliseconds — long enough for the content script to broadcast playback
-  // events derived from the stale ep_id. When the DOM-matched candidates
-  // (which read from those stale episode arrays) disagree with `__playinfo__`,
-  // trusting `__playinfo__` is the safer choice because the player only
-  // populates it once it has actually loaded the new episode.
+  // /bangumi/play/ssYYY), Bilibili can update the active player episode list
+  // before refreshing `__playinfo__`. In that window, trusting stale
+  // `__playinfo__` leaks the previous ep_id into playback broadcasts and share
+  // payloads.
   const matched: PageVideoCandidate | null =
-    (playInfoCandidate && playInfoEpId !== undefined
-      ? playInfoCandidate
-      : null) ??
+    activeCandidate ??
     matchedByEpId ??
     matchedByCid ??
     matchedByTitle ??

--- a/extension/src/content/page-bridge.ts
+++ b/extension/src/content/page-bridge.ts
@@ -51,12 +51,13 @@ function readFestivalVideoDetail(): {
     ).__playinfo__;
 
     const active = document.querySelector<HTMLElement>(
-      "li[data-cid].bpx-state-active, [data-cid].bpx-state-active, [data-cid].active, [data-cid].selected, [data-ep-id].active, [data-episode-id].active, [data-epid].active",
+      "li[data-cid].bpx-state-active, [data-cid].bpx-state-active, [data-cid].active, [data-cid].selected, [data-ep-id].active, [data-episode-id].active, [data-episodeid].active, [data-epid].active",
     );
     const activeCid = active?.getAttribute("data-cid") ?? null;
     const activeEpId =
       active?.getAttribute("data-ep-id") ??
       active?.getAttribute("data-episode-id") ??
+      active?.getAttribute("data-episodeid") ??
       active?.getAttribute("data-epid") ??
       null;
     const activeTitle =

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -178,6 +178,7 @@ export function createRoomStateApplyController(args: {
         `Cleared post-navigation settle anchor (was ${args.runtimeState.postNavigationAnchorSharedUrl}, room shared changed to ${normalizedSharedUrl ?? "none"})`,
       );
       args.runtimeState.postNavigationAnchorSharedUrl = null;
+      args.runtimeState.postNavigationAnchorSetAt = 0;
     }
 
     const decision = decidePlaybackApplication({

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -164,6 +164,22 @@ export function createRoomStateApplyController(args: {
     const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
     const normalizedPlaybackUrl = args.normalizeUrl(state.playback?.url);
 
+    // Lift the post-navigation settle anchor as soon as the room reports a
+    // shared video that differs from what we recorded before navigation. This
+    // covers the cases where the local user (or another member) successfully
+    // re-shares to a new URL after SPA navigation, or where the room becomes
+    // empty — in both situations the broadcast suppression is no longer
+    // protecting against stale page-bridge data.
+    if (
+      args.runtimeState.postNavigationAnchorSharedUrl &&
+      args.runtimeState.postNavigationAnchorSharedUrl !== normalizedSharedUrl
+    ) {
+      args.debugLog(
+        `Cleared post-navigation settle anchor (was ${args.runtimeState.postNavigationAnchorSharedUrl}, room shared changed to ${normalizedSharedUrl ?? "none"})`,
+      );
+      args.runtimeState.postNavigationAnchorSharedUrl = null;
+    }
+
     const decision = decidePlaybackApplication({
       roomState: state,
       currentVideo,

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -95,6 +95,16 @@ export interface ContentRuntimeState {
   recentRemotePlayingIntent: RecentRemotePlayingIntent | null;
   lastExplicitUserAction: ExplicitUserAction | null;
   lastNonSharedGuardUrl: string | null;
+  /**
+   * Captures `activeSharedUrl` at the moment in-room SPA navigation is
+   * detected. Used as a "settle anchor": until the page bridge resolves the
+   * new page to a normalized URL different from this anchor (or the room's
+   * shared video changes), playback broadcasts are suppressed so that stale
+   * page-bridge data captured during the SPA transition (typically from old
+   * `__INITIAL_STATE__.epInfo` that has not yet been refreshed) cannot leak
+   * out as bogus updates against the previously shared video.
+   */
+  postNavigationAnchorSharedUrl: string | null;
   festivalSnapshot: FestivalVideoSnapshot | null;
 }
 
@@ -144,6 +154,7 @@ export function createContentRuntimeState(): ContentRuntimeState {
     recentRemotePlayingIntent: null,
     lastExplicitUserAction: null,
     lastNonSharedGuardUrl: null,
+    postNavigationAnchorSharedUrl: null,
     festivalSnapshot: null,
   };
 }

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -105,6 +105,7 @@ export interface ContentRuntimeState {
    * out as bogus updates against the previously shared video.
    */
   postNavigationAnchorSharedUrl: string | null;
+  postNavigationAnchorSetAt: number;
   festivalSnapshot: FestivalVideoSnapshot | null;
 }
 
@@ -155,6 +156,7 @@ export function createContentRuntimeState(): ContentRuntimeState {
     lastExplicitUserAction: null,
     lastNonSharedGuardUrl: null,
     postNavigationAnchorSharedUrl: null,
+    postNavigationAnchorSetAt: 0,
     festivalSnapshot: null,
   };
 }

--- a/extension/src/content/share-controller.ts
+++ b/extension/src/content/share-controller.ts
@@ -131,12 +131,14 @@ export function createShareController(args: {
         "[data-cid].selected",
         "[data-ep-id].active",
         "[data-episode-id].active",
+        "[data-episodeid].active",
         "[data-epid].active",
       ].join(", "),
     );
     const rawEpId =
       active?.getAttribute("data-ep-id") ??
       active?.getAttribute("data-episode-id") ??
+      active?.getAttribute("data-episodeid") ??
       active?.getAttribute("data-epid") ??
       null;
     const title = active?.textContent?.trim() || null;

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -236,6 +236,7 @@ export function createSyncController(args: {
     args.runtimeState.lastExplicitPlaybackAction = null;
     args.runtimeState.explicitNonSharedPlaybackUrl = null;
     args.runtimeState.postNavigationAnchorSharedUrl = null;
+    args.runtimeState.postNavigationAnchorSetAt = 0;
     args.debugLog(`Reset playback sync state: ${reason}`);
   }
 
@@ -714,11 +715,23 @@ export function createSyncController(args: {
     // stale URL would silently overwrite the existing shared video's state
     // for other clients. Hold off on broadcasts until the page bridge resolves
     // to a URL different from the pre-navigation anchor (or the room's shared
-    // video changes via `applyRoomState`, which clears the anchor there).
+    // video changes via `applyRoomState`, which clears the anchor there). The
+    // gate is also bounded by the initial hydration hold so equivalent
+    // bangumi /ep and /ss route transitions cannot block broadcasts forever.
     const postNavigationAnchor =
       args.runtimeState.postNavigationAnchorSharedUrl;
     if (postNavigationAnchor) {
-      if (
+      const anchorAge =
+        args.runtimeState.postNavigationAnchorSetAt > 0
+          ? now - args.runtimeState.postNavigationAnchorSetAt
+          : 0;
+      if (anchorAge >= args.initialRoomStatePauseHoldMs) {
+        args.runtimeState.postNavigationAnchorSharedUrl = null;
+        args.runtimeState.postNavigationAnchorSetAt = 0;
+        args.debugLog(
+          `Cleared post-navigation settle anchor after timeout (was ${postNavigationAnchor}, age=${anchorAge})`,
+        );
+      } else if (
         normalizedCurrentVideoUrl === null ||
         normalizedCurrentVideoUrl === postNavigationAnchor
       ) {
@@ -754,10 +767,13 @@ export function createSyncController(args: {
         );
         return;
       }
-      args.runtimeState.postNavigationAnchorSharedUrl = null;
-      args.debugLog(
-        `Cleared post-navigation settle anchor (was ${postNavigationAnchor}, now broadcasting ${normalizedCurrentVideoUrl})`,
-      );
+      if (args.runtimeState.postNavigationAnchorSharedUrl) {
+        args.runtimeState.postNavigationAnchorSharedUrl = null;
+        args.runtimeState.postNavigationAnchorSetAt = 0;
+        args.debugLog(
+          `Cleared post-navigation settle anchor (was ${postNavigationAnchor}, now broadcasting ${normalizedCurrentVideoUrl})`,
+        );
+      }
     }
     if (
       args.runtimeState.activeRoomCode &&

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -235,6 +235,7 @@ export function createSyncController(args: {
     args.runtimeState.lastNonSharedGuardUrl = null;
     args.runtimeState.lastExplicitPlaybackAction = null;
     args.runtimeState.explicitNonSharedPlaybackUrl = null;
+    args.runtimeState.postNavigationAnchorSharedUrl = null;
     args.debugLog(`Reset playback sync state: ${reason}`);
   }
 
@@ -705,6 +706,59 @@ export function createSyncController(args: {
       normalizedCurrentVideoUrl,
       now,
     );
+    // Post-navigation settle gate.
+    //
+    // After in-room SPA navigation, the page bridge can briefly return the
+    // previous bangumi's ep_id (because `__INITIAL_STATE__` and friends have
+    // not yet refreshed). Broadcasting playback events derived from that
+    // stale URL would silently overwrite the existing shared video's state
+    // for other clients. Hold off on broadcasts until the page bridge resolves
+    // to a URL different from the pre-navigation anchor (or the room's shared
+    // video changes via `applyRoomState`, which clears the anchor there).
+    const postNavigationAnchor =
+      args.runtimeState.postNavigationAnchorSharedUrl;
+    if (postNavigationAnchor) {
+      if (
+        normalizedCurrentVideoUrl === null ||
+        normalizedCurrentVideoUrl === postNavigationAnchor
+      ) {
+        if (shouldLogSuppressedBroadcastDetail(eventSource)) {
+          args.debugLog(
+            `Skip broadcast ${formatPlaybackDiagnostic({
+              actor: args.runtimeState.localMemberId,
+              playState: getPlayState(
+                video,
+                args.runtimeState.intendedPlayState,
+              ),
+              url: currentVideo.url,
+              localTime: video.currentTime,
+              targetTime: video.currentTime,
+              result: "post-navigation-stale-url",
+              extra: `anchor=${postNavigationAnchor}`,
+            })}`,
+          );
+        }
+        logBroadcastTrace(
+          "post-navigation-stale-url",
+          eventSource,
+          formatBroadcastTrace({
+            eventSource,
+            currentVideoUrl: currentVideo.url,
+            normalizedCurrentVideoUrl,
+            playState: getPlayState(video, args.runtimeState.intendedPlayState),
+            currentTime: video.currentTime,
+            playbackRate: video.playbackRate,
+          }),
+          normalizedCurrentVideoUrl,
+          now,
+        );
+        return;
+      }
+      args.runtimeState.postNavigationAnchorSharedUrl = null;
+      args.debugLog(
+        `Cleared post-navigation settle anchor (was ${postNavigationAnchor}, now broadcasting ${normalizedCurrentVideoUrl})`,
+      );
+    }
     if (
       args.runtimeState.activeRoomCode &&
       args.runtimeState.activeSharedUrl &&

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -128,6 +128,149 @@ test("navigation controller hydrates and suppresses autoplay when switching to a
   }
 });
 
+test("navigation controller anchors active shared url for post-navigation settle gate", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep1231523";
+
+  let currentUrl = "https://www.bilibili.com/bangumi/play/ep1231523";
+
+  function normalizeBangumi(url: string): string | null {
+    return (
+      url.match(/https:\/\/www\.bilibili\.com\/bangumi\/play\/[^/?]+/)?.[0] ??
+      null
+    );
+  }
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeBangumi,
+    isSupportedVideoPage: (url) => url.includes("/bangumi/play/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () =>
+      ({
+        paused: true,
+      }) as HTMLVideoElement,
+    pauseVideo: () => {},
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+  });
+
+  try {
+    controller.start();
+    currentUrl =
+      "https://www.bilibili.com/bangumi/play/ss73077?from_spmid=666.25.recommend.0";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(
+      runtimeState.postNavigationAnchorSharedUrl,
+      "https://www.bilibili.com/bangumi/play/ep1231523",
+    );
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller clears any anchor when user navigates back to the shared video url", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep1231523";
+  runtimeState.postNavigationAnchorSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep1231523";
+
+  let currentUrl =
+    "https://www.bilibili.com/bangumi/play/ss73077?from_spmid=666.25.recommend.0";
+
+  function normalizeBangumi(url: string): string | null {
+    return (
+      url.match(/https:\/\/www\.bilibili\.com\/bangumi\/play\/[^/?]+/)?.[0] ??
+      null
+    );
+  }
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeBangumi,
+    isSupportedVideoPage: (url) => url.includes("/bangumi/play/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () =>
+      ({
+        paused: true,
+      }) as HTMLVideoElement,
+    pauseVideo: () => {},
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+  });
+
+  try {
+    controller.start();
+    currentUrl = "https://www.bilibili.com/bangumi/play/ep1231523";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(runtimeState.postNavigationAnchorSharedUrl, null);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller does not anchor when no shared video was active", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = null;
+
+  let currentUrl = "https://www.bilibili.com/video/BV1DbiMBwEry";
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeTestVideoPageUrl,
+    isSupportedVideoPage: (url) => url.includes("/video/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () =>
+      ({
+        paused: true,
+      }) as HTMLVideoElement,
+    pauseVideo: () => {},
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+  });
+
+  try {
+    controller.start();
+    currentUrl = "https://www.bilibili.com/video/BV1Em421N7uU";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(runtimeState.postNavigationAnchorSharedUrl, null);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
 test("navigation controller clears stale gesture state on in-room navigation", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -137,6 +137,7 @@ test("navigation controller anchors active shared url for post-navigation settle
     "https://www.bilibili.com/bangumi/play/ep1231523";
 
   let currentUrl = "https://www.bilibili.com/bangumi/play/ep1231523";
+  const now = 40_000;
 
   function normalizeBangumi(url: string): string | null {
     return (
@@ -163,6 +164,7 @@ test("navigation controller anchors active shared url for post-navigation settle
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
+    getNow: () => now,
   });
 
   try {
@@ -175,6 +177,7 @@ test("navigation controller anchors active shared url for post-navigation settle
       runtimeState.postNavigationAnchorSharedUrl,
       "https://www.bilibili.com/bangumi/play/ep1231523",
     );
+    assert.equal(runtimeState.postNavigationAnchorSetAt, now);
   } finally {
     windowHarness.restore();
   }

--- a/extension/test/page-bridge.test.ts
+++ b/extension/test/page-bridge.test.ts
@@ -51,6 +51,65 @@ test("page bridge preserves active cid when matched candidate lacks cid", () => 
   });
 });
 
+test("page bridge prefers playinfo over stale initialState during cross-bangumi SPA navigation", () => {
+  // Reproduces the situation from the cross-bangumi navigation bug:
+  // - `__INITIAL_STATE__.epInfo` and `epList` still hold the previous bangumi's
+  //   data (ep_id 1231523 with title "秘密。（Sub rosa.）") because Bilibili's
+  //   SPA has not yet refreshed those globals.
+  // - `__playinfo__` is already populated with the freshly loaded episode
+  //   (ep_id 1231525 with the new title "羽丘的不可思议女孩").
+  // The page bridge must resolve to the fresh ep_id so that downstream
+  // broadcasts and shares carry the correct shared video URL.
+  const detail = readFestivalVideoDetailFromSources({
+    initialState: {
+      epInfo: {
+        ep_id: 1231523,
+        bvid: "BVoldsubrosa",
+        cid: 1100000001,
+        title: "第1话 秘密。（Sub rosa.）",
+      },
+      epList: [
+        {
+          id: 1231523,
+          ep_id: 1231523,
+          bvid: "BVoldsubrosa",
+          cid: 1100000001,
+          title: "第1话 秘密。（Sub rosa.）",
+        },
+      ],
+    },
+    playInfo: {
+      result: {
+        arc: {
+          bvid: "BVnewseason",
+          cid: 1200000099,
+        },
+        supplement: {
+          ogv_episode_info: {
+            episode_id: 1231525,
+            index_title: "1",
+            long_title: "羽丘的不可思议女孩",
+          },
+          play_view_business_info: {
+            episode_info: {
+              ep_id: 1231525,
+              cid: 1200000099,
+            },
+          },
+        },
+      },
+    },
+    activeTitle: "第1话 羽丘的不可思议女孩",
+  });
+
+  assert.deepEqual(detail, {
+    epId: 1231525,
+    bvid: "BVnewseason",
+    cid: 1200000099,
+    title: "第1话 羽丘的不可思议女孩",
+  });
+});
+
 test("page bridge resolves current bangumi episode from playinfo when season page has no initial state", () => {
   const detail = readFestivalVideoDetailFromSources({
     playInfo: {

--- a/extension/test/page-bridge.test.ts
+++ b/extension/test/page-bridge.test.ts
@@ -51,7 +51,7 @@ test("page bridge preserves active cid when matched candidate lacks cid", () => 
   });
 });
 
-test("page bridge prefers playinfo over stale initialState during cross-bangumi SPA navigation", () => {
+test("page bridge uses playinfo fallback when active DOM has not exposed episode identity", () => {
   // Reproduces the situation from the cross-bangumi navigation bug:
   // - `__INITIAL_STATE__.epInfo` and `epList` still hold the previous bangumi's
   //   data (ep_id 1231523 with title "秘密。（Sub rosa.）") because Bilibili's
@@ -106,6 +106,45 @@ test("page bridge prefers playinfo over stale initialState during cross-bangumi 
     epId: 1231525,
     bvid: "BVnewseason",
     cid: 1200000099,
+    title: "第1话 羽丘的不可思议女孩",
+  });
+});
+
+test("page bridge prefers active DOM episode over stale playinfo during cross-bangumi SPA navigation", () => {
+  const detail = readFestivalVideoDetailFromSources({
+    playInfo: {
+      result: {
+        arc: {
+          bvid: "BVoldsubrosa",
+          cid: 27730904912,
+        },
+        supplement: {
+          ogv_episode_info: {
+            episode_id: 1231523,
+            index_title: "1",
+            long_title: "秘密。（Sub rosa.）",
+          },
+          play_view_business_info: {
+            episode_info: {
+              ep_id: 1231523,
+              cid: 27730904912,
+            },
+          },
+        },
+      },
+    },
+    playerInput: {
+      cid: undefined,
+    },
+    activeEpId: "1183102",
+    activeCid: "27730052544",
+    activeTitle: "第1话 羽丘的不可思议女孩",
+  });
+
+  assert.deepEqual(detail, {
+    epId: "1183102",
+    bvid: undefined,
+    cid: "27730052544",
     title: "第1话 羽丘的不可思议女孩",
   });
 });

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -162,6 +162,69 @@ test("skips pauseVideo when a recent user gesture is within the grace window", a
   assert.equal(video.paused, false);
 });
 
+test("clears post-navigation anchor when room shared video changes to a different url", async () => {
+  const video = createStubVideo(true);
+  const harness = createController({ video, now: 10_000 });
+
+  harness.runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep1231523";
+  harness.runtimeState.postNavigationAnchorSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep1231523";
+
+  await harness.controller.applyRoomState({
+    roomCode: "ROOM01",
+    sharedVideo: {
+      videoId: "ep1231525",
+      url: "https://www.bilibili.com/bangumi/play/ep1231525",
+      title: "新番剧第1话",
+    },
+    playback: null,
+    members: [],
+  });
+
+  assert.equal(harness.runtimeState.postNavigationAnchorSharedUrl, null);
+});
+
+test("keeps post-navigation anchor when room shared video remains on the anchor url", async () => {
+  const video = createStubVideo(true);
+  const harness = createController({ video, now: 10_000 });
+
+  harness.runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep1231523";
+  harness.runtimeState.postNavigationAnchorSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep1231523";
+
+  await harness.controller.applyRoomState({
+    roomCode: "ROOM01",
+    sharedVideo: {
+      videoId: "ep1231523",
+      url: "https://www.bilibili.com/bangumi/play/ep1231523",
+      title: "原番剧第1话",
+    },
+    playback: null,
+    members: [],
+  });
+
+  assert.equal(
+    harness.runtimeState.postNavigationAnchorSharedUrl,
+    "https://www.bilibili.com/bangumi/play/ep1231523",
+  );
+});
+
+test("clears post-navigation anchor when room becomes empty", async () => {
+  const video = createStubVideo(true);
+  const harness = createController({ video, now: 10_000 });
+
+  harness.runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep1231523";
+  harness.runtimeState.postNavigationAnchorSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep1231523";
+
+  await harness.controller.applyRoomState(createEmptyRoomState());
+
+  assert.equal(harness.runtimeState.postNavigationAnchorSharedUrl, null);
+});
+
 test("pauses video when gesture age exactly equals the grace window boundary", async () => {
   const video = createStubVideo(false);
   const harness = createController({

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -1143,3 +1143,72 @@ test("sync controller avoids repeated correction loops after a short 2x buffer",
     windowHarness.restore();
   }
 });
+
+test("sync controller blocks broadcast while post-navigation anchor still matches resolved url", async () => {
+  const harness = createControllerHarness();
+  const anchorUrl = "https://www.bilibili.com/bangumi/play/ep1231523";
+  const sharedVideo: SharedVideo = {
+    videoId: "ep1231523",
+    url: anchorUrl,
+    title: "Episode 1",
+  };
+  const video = createVideo({ paused: true, currentTime: 0.22 });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.activeRoomCode = "ROOM01";
+  harness.runtimeState.activeSharedUrl = anchorUrl;
+  harness.runtimeState.postNavigationAnchorSharedUrl = anchorUrl;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+
+  await harness.controller.broadcastPlayback(video, "play");
+
+  assert.equal(harness.runtimeMessages.length, 0);
+  assert.equal(
+    harness.runtimeState.postNavigationAnchorSharedUrl,
+    anchorUrl,
+    "anchor must remain set while resolved url matches it",
+  );
+  assert.equal(
+    harness.debugLogs.some(
+      (message) =>
+        message.includes("post-navigation-stale-url") ||
+        message.includes("result=post-navigation-stale-url"),
+    ),
+    true,
+  );
+});
+
+test("sync controller releases post-navigation anchor and broadcasts once resolved url moves off it", async () => {
+  const harness = createControllerHarness();
+  const anchorUrl = "https://www.bilibili.com/bangumi/play/ep1231523";
+  const newUrl = "https://www.bilibili.com/bangumi/play/ep1231525";
+  const newSharedVideo: SharedVideo = {
+    videoId: "ep1231525",
+    url: newUrl,
+    title: "Episode 1 - 新番剧",
+  };
+  const video = createVideo({ paused: false, currentTime: 5 });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.activeRoomCode = "ROOM01";
+  harness.runtimeState.activeSharedUrl = newUrl;
+  harness.runtimeState.postNavigationAnchorSharedUrl = anchorUrl;
+  harness.setSharedVideo(newSharedVideo);
+  harness.setCurrentPlaybackVideo(newSharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+
+  await harness.controller.broadcastPlayback(video, "play");
+
+  assert.equal(harness.runtimeState.postNavigationAnchorSharedUrl, null);
+  assert.equal(
+    harness.runtimeMessages.length >= 1,
+    true,
+    "broadcast should proceed once resolved url differs from the anchor",
+  );
+});

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -1159,6 +1159,7 @@ test("sync controller blocks broadcast while post-navigation anchor still matche
   harness.runtimeState.activeRoomCode = "ROOM01";
   harness.runtimeState.activeSharedUrl = anchorUrl;
   harness.runtimeState.postNavigationAnchorSharedUrl = anchorUrl;
+  harness.runtimeState.postNavigationAnchorSetAt = 19_000;
   harness.setSharedVideo(sharedVideo);
   harness.setCurrentPlaybackVideo(sharedVideo);
   harness.setVideoElement(video);
@@ -1182,6 +1183,39 @@ test("sync controller blocks broadcast while post-navigation anchor still matche
   );
 });
 
+test("sync controller releases post-navigation anchor after settle timeout for equivalent route", async () => {
+  const harness = createControllerHarness();
+  const anchorUrl = "https://www.bilibili.com/bangumi/play/ep1231523";
+  const sharedVideo: SharedVideo = {
+    videoId: "ep1231523",
+    url: anchorUrl,
+    title: "Episode 1",
+  };
+  const video = createVideo({ paused: false, currentTime: 8 });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.activeRoomCode = "ROOM01";
+  harness.runtimeState.activeSharedUrl = anchorUrl;
+  harness.runtimeState.postNavigationAnchorSharedUrl = anchorUrl;
+  harness.runtimeState.postNavigationAnchorSetAt = 18_500;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+
+  await harness.controller.broadcastPlayback(video, "play");
+
+  assert.equal(harness.runtimeState.postNavigationAnchorSharedUrl, null);
+  assert.equal(harness.runtimeMessages.length >= 1, true);
+  assert.equal(
+    harness.debugLogs.some((message) =>
+      message.includes("Cleared post-navigation settle anchor after timeout"),
+    ),
+    true,
+  );
+});
+
 test("sync controller releases post-navigation anchor and broadcasts once resolved url moves off it", async () => {
   const harness = createControllerHarness();
   const anchorUrl = "https://www.bilibili.com/bangumi/play/ep1231523";
@@ -1198,6 +1232,7 @@ test("sync controller releases post-navigation anchor and broadcasts once resolv
   harness.runtimeState.activeRoomCode = "ROOM01";
   harness.runtimeState.activeSharedUrl = newUrl;
   harness.runtimeState.postNavigationAnchorSharedUrl = anchorUrl;
+  harness.runtimeState.postNavigationAnchorSetAt = 20_000;
   harness.setSharedVideo(newSharedVideo);
   harness.setCurrentPlaybackVideo(newSharedVideo);
   harness.setVideoElement(video);


### PR DESCRIPTION
## Summary
- 复现：A、B 两个客户端同步播放 `ep1231523`，A 在该页面点开推荐里的另一番剧（`ss73077`），未点同步；B 的播放器被 A 错乱的 `paused t=0.22` / `play t=6.20` 状态反复 hard-seek，A 之后手动点同步也不能让 B 切换到新番剧。
- 根因属于 PR #110 同一家族：SPA 跨番剧切换时 `__INITIAL_STATE__.epInfo / epList` 残留旧番剧数据，但 page-bridge 的候选优先级让这些 stale 字段比 `__playinfo__` 更高；同时 `applyRoomState` 在 `ignore-non-shared` 路径会立刻清掉 `pendingRoomStateHydration`，于是 `broadcastPlayback` 拿着 stale 的 `ep_id` 发出播放事件。两端的 `activeSharedUrl` 又恰好都还是这个 `ep_id`，B 端把这些当成共享视频的状态接收。
- 修复同时落两处：
  - **page-bridge 优先级**：`__playinfo__` 给出 `episode_id` 时优先于 DOM-matched / `initialState.epInfo`，让新番剧的真实 `ep_id` 立刻顶出来。
  - **导航 settle 门**：站内导航时把"导航前的 `activeSharedUrl`"锚定为 `postNavigationAnchorSharedUrl`；只要 page-bridge 仍然把当前页解析为锚定 URL，就跳过广播（写 `result=post-navigation-stale-url` 日志）。`applyRoomState` 看到房间共享 URL 与锚定不同（含空房间）就清掉 anchor；用户回到共享 URL 本身时不再设 anchor，避免误伤往返导航。
- 加的回归测试：page-bridge 跨番剧 stale 场景、navigation 设/清 anchor 的 4 个分支、`broadcastPlayback` 被门挡住与解锚后放行、`applyRoomState` 在共享视频变化/空房间时清 anchor。

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`（227 用例全过）
- [ ] 手动验证：A 共享 `ep1231523` → 跨番剧 SPA 跳到 `ss73077` → 不点同步时 B 不再被 A 的 stale 广播打乱；A 点同步后，新番剧的 `ep_id` 经 `__playinfo__` 解析正确，B 切换到新视频。

🤖 Generated with [Claude Code](https://claude.com/claude-code)