### PR TITLE
chore: release v1.1.1

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.1.0"
+    "@bili-syncplay/protocol": "1.1.1"
   },
   "devDependencies": {
     "@types/chrome": "^0.1.40",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "workspaces": [
         "packages/*",
         "server",
@@ -24,9 +24,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.1.0"
+        "@bili-syncplay/protocol": "1.1.1"
       },
       "devDependencies": {
         "@types/chrome": "^0.1.40",
@@ -2740,16 +2740,16 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "devDependencies": {
         "typescript": "^5.9.3"
       }
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.1.0",
+        "@bili-syncplay/protocol": "1.1.1",
         "ioredis": "^5.10.0",
         "ws": "^8.18.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.1.0",
+    "@bili-syncplay/protocol": "1.1.1",
     "ioredis": "^5.10.0",
     "ws": "^8.18.3"
   },


### PR DESCRIPTION
## Summary
- bump workspace, protocol, server, extension, and manifest versions to 1.1.1
- refresh package-lock metadata for the release
- publish tag v1.1.1 and verify the GitHub Release workflow completed successfully

## Validation
- npm run format:check && npm run lint && npm run typecheck && npm run build && npm test
- npm run build:release
- GitHub Actions Release Extension run 25566967175 completed successfully

## Release
- https://github.com/sky1wu/Bili-SyncPlay/releases/tag/v1.1.1