### PR TITLE
feat: Firefox 源码层兼容 (PR-1/3)

### DIFF
--- a/extension/scripts/build.mjs
+++ b/extension/scripts/build.mjs
@@ -39,7 +39,7 @@ await Promise.all([
     },
     bundle: true,
     format: "esm",
-    target: "chrome120",
+    target: ["chrome120", "firefox121"],
     outdir: distDir,
     sourcemap: true,
     define: {

--- a/extension/src/background/socket-controller.ts
+++ b/extension/src/background/socket-controller.ts
@@ -3,6 +3,7 @@ import { isServerMessage, PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import type { DebugLogEntry } from "../shared/messages";
 import type { ConnectionState, RoomSessionState } from "./runtime-state";
 import { getConnectionErrorMessage } from "./connection-error";
+import { getExtensionOrigin } from "../shared/extension-origin";
 import {
   shouldReconnect as shouldScheduleReconnect,
   getReconnectDelayMs,
@@ -90,7 +91,7 @@ export function createSocketController(args: {
       return;
     }
 
-    const extensionOrigin = `chrome-extension://${chrome.runtime.id}`;
+    const extensionOrigin = getExtensionOrigin();
     const connectionCheckUrl = args.buildConnectionCheckUrl(
       serverUrlResult.normalizedUrl,
     );

--- a/extension/src/chrome.d.ts
+++ b/extension/src/chrome.d.ts
@@ -1,2 +1,6 @@
 // Chrome extension types are provided by @types/chrome.
-// This file is intentionally empty.
+//
+// Firefox 同时暴露 `browser` 命名空间（Promise 风格，与 `chrome` 等价）。
+// 源码统一使用 `chrome.*`（Firefox 原生兼容），此处仅作可选兜底声明，
+// 避免在引用 `browser` 做特性探测时报未定义。
+declare const browser: typeof chrome | undefined;

--- a/extension/src/shared/extension-origin.ts
+++ b/extension/src/shared/extension-origin.ts
@@ -1,0 +1,16 @@
+/**
+ * 返回当前扩展运行环境的 origin。
+ *
+ * Chrome/Edge 为 `chrome-extension://<id>`，Firefox 为 `moz-extension://<uuid>`。
+ *
+ * 通过 `chrome.runtime.getURL("/")` 推导，而非手拼 `chrome.runtime.id`，
+ * 可在 Chrome / Edge / Firefox 下都返回正确的 origin。
+ *
+ * 注意：不使用 `new URL(...).origin`——WHATWG URL 解析器对
+ * `chrome-extension:` / `moz-extension:` 这类非特殊 scheme 的 `.origin`
+ * 在部分运行时（如 Node）返回 `"null"`。`getURL("/")` 的返回值恒为
+ * `"<scheme>://<host>/"`，剥掉结尾斜杠即为 origin，跨运行时稳定。
+ */
+export function getExtensionOrigin(): string {
+  return chrome.runtime.getURL("/").replace(/\/$/, "");
+}

--- a/extension/test/extension-origin.test.ts
+++ b/extension/test/extension-origin.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test, { afterEach } from "node:test";
+import { getExtensionOrigin } from "../src/shared/extension-origin";
+
+const originalChrome = globalThis.chrome;
+
+function installChromeRuntime(rootUrl: string): void {
+  globalThis.chrome = {
+    runtime: {
+      // 真实运行时中 chrome.runtime.getURL("/") 恒返回 "<scheme>://<host>/"
+      getURL(path: string): string {
+        return `${rootUrl}${path.replace(/^\//, "")}`;
+      },
+    },
+  } as unknown as typeof chrome;
+}
+
+afterEach(() => {
+  globalThis.chrome = originalChrome;
+});
+
+test("getExtensionOrigin 解析 Chrome/Edge 扩展 origin", () => {
+  installChromeRuntime("chrome-extension://abcdefghijklmnop/");
+  assert.equal(getExtensionOrigin(), "chrome-extension://abcdefghijklmnop");
+});
+
+test("getExtensionOrigin 解析 Firefox moz-extension origin", () => {
+  installChromeRuntime("moz-extension://12345678-90ab-cdef-1234-567890abcdef/");
+  assert.equal(
+    getExtensionOrigin(),
+    "moz-extension://12345678-90ab-cdef-1234-567890abcdef",
+  );
+});
+
+test("getExtensionOrigin 结果不含结尾斜杠", () => {
+  installChromeRuntime("moz-extension://uuid-value/");
+  assert.ok(!getExtensionOrigin().endsWith("/"));
+});

--- a/server/src/config/security-config.ts
+++ b/server/src/config/security-config.ts
@@ -9,6 +9,7 @@ const SUPPORTED_ORIGIN_PROTOCOLS = new Set([
   "http:",
   "https:",
   "chrome-extension:",
+  "moz-extension:",
 ]);
 
 export class SecurityConfigError extends Error {
@@ -42,7 +43,7 @@ export function validateAllowedOriginValues(origins: readonly string[]): void {
 
     if (!SUPPORTED_ORIGIN_PROTOCOLS.has(parsed.protocol)) {
       throw new SecurityConfigError(
-        `ALLOWED_ORIGINS entry "${origin}" uses unsupported scheme "${parsed.protocol.replace(/:$/, "")}"; expected one of http, https, chrome-extension.`,
+        `ALLOWED_ORIGINS entry "${origin}" uses unsupported scheme "${parsed.protocol.replace(/:$/, "")}"; expected one of http, https, chrome-extension, moz-extension.`,
       );
     }
 

--- a/server/test/config-env.test.ts
+++ b/server/test/config-env.test.ts
@@ -142,6 +142,25 @@ test("security config accepts chrome-extension origins", () => {
   ]);
 });
 
+test("security config accepts moz-extension origins (Firefox)", () => {
+  const config = loadSecurityConfig({
+    ALLOWED_ORIGINS: "moz-extension://12345678-90ab-cdef-1234-567890abcdef",
+  });
+  assert.deepEqual(config.allowedOrigins, [
+    "moz-extension://12345678-90ab-cdef-1234-567890abcdef",
+  ]);
+});
+
+test("security config rejects moz-extension origins with a path", () => {
+  assert.throws(
+    () =>
+      loadSecurityConfig({
+        ALLOWED_ORIGINS: "moz-extension://uuid-value/popup.html",
+      }),
+    /must be a bare origin/,
+  );
+});
+
 test("security config rejects origins that include a path", () => {
   assert.throws(
     () => loadSecurityConfig({ ALLOWED_ORIGINS: "https://a.example/app" }),


### PR DESCRIPTION
## 背景

为 Bili-SyncPlay 浏览器扩展适配 Firefox 的第 1 步（共 3 个 PR）。本 PR 只做**源码层兼容**，不改变 Chrome/Edge 现有构建产物形态与行为。

完整规划见 `/home/sky1wu/.claude/plans/jazzy-giggling-parrot.md`（最低支持 Firefox 121，保留 service worker 模型，源码不按浏览器分叉）。

## 改动

### 1. 扩展 origin 跨浏览器推导（`85a37eb`）

`socket-controller` 此前用 `chrome-extension://${chrome.runtime.id}` 手拼扩展 origin，在 Firefox 下应为 `moz-extension://<uuid>`，否则服务端 `ALLOWED_ORIGINS` 校验与连接错误提示信息不正确。

- 新增 `extension/src/shared/extension-origin.ts`：`getExtensionOrigin()`，用 `chrome.runtime.getURL("/")` 剥尾斜杠推导，跨 Chrome/Edge/Firefox 稳定。
  - **不用 `new URL(...).origin`**：WHATWG URL 解析器对 `chrome-extension:` / `moz-extension:` 这类非特殊 scheme 的 `.origin` 在 Node 等运行时返回 `"null"`，既不可单测也偏脆弱；`getURL("/")` 恒返回 `<scheme>://<host>/`，剥尾斜杠即 origin。
- `socket-controller.ts` 改用 `getExtensionOrigin()`。
- `chrome.d.ts` 补 `browser` 命名空间可选兜底声明。
- esbuild `target` → `["chrome120", "firefox121"]`，源码不再按浏览器分叉。
- 新增 `extension-origin.test.ts`：覆盖 chrome / moz 前缀，3 个用例。

### 2. 服务端接受 moz-extension origin（`c1986ab`）

Codex stop-time review 发现的真实阻塞点：服务端 `security-config.ts` 把受支持 scheme 硬限制为 `http/https/chrome-extension`，任何 `moz-extension://<uuid>` 条目会让服务端**启动即抛 `SecurityConfigError`**。这使"让 Firefox 用户手动把 origin 加进 `ALLOWED_ORIGINS`"的文档化方案在代码层根本不可行。

- `SUPPORTED_ORIGIN_PROTOCOLS` 增加 `moz-extension:`，同步更新错误文案。
- `isOriginAllowed` **仍为精确匹配，未引入通配符**，安全语义不变（与既定决策一致：不采纳 `moz-extension://*` 通配符或去 Origin 头方案）。
- 新增回归测试：moz-extension origin 被接受、含路径被拒。

## 验证

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` 全绿：

- Extension：232 测试通过，0 失败
- Server：316 测试，288 通过，0 失败（差额为需 Redis 实例的跳过项），含 2 个新 moz-extension 用例

Chrome/Edge 行为零变化（origin 推导结果与原 `chrome-extension://${chrome.runtime.id}` 等价；服务端仅放宽 scheme 白名单，不影响既有精确匹配）。

## 后续

- PR-2：双产物构建打包（`TARGET_BROWSER`、`browser_specific_settings` 注入、`.zip`/`.xpi`）
- PR-3：CI 矩阵 + README/CONTRIBUTING 文档（含 Firefox 用户须手动把 `moz-extension://<uuid>` 加入 `ALLOWED_ORIGINS` 的说明）
- Firefox 人工冒烟在 PR-2/PR-3 完成后进行

🤖 Generated with [Claude Code](https://claude.com/claude-code)
