### PR TITLE
feat: Firefox 双浏览器构建/打包管道 (PR-2/3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-firefox/
 build/
 coverage/
 *.log

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+dist-firefox
 release
 .tmp
 coverage

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ const sourceFiles = ["**/*.{ts,js,mjs,cjs}"];
 const ignores = [
   "**/node_modules/**",
   "**/dist/**",
+  "**/dist-firefox/**",
   "**/release/**",
   "**/.tmp/**",
   "**/coverage/**",

--- a/extension/package.json
+++ b/extension/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "prebuild": "npm --prefix ../packages/protocol run build",
-    "build": "node scripts/build.mjs",
+    "build": "node scripts/build.mjs --target=chrome",
     "pretypecheck": "npm --prefix ../packages/protocol run build",
     "typecheck": "tsc -p tsconfig.json",
     "pretest": "npm --prefix ../packages/protocol run build",

--- a/extension/scripts/build.mjs
+++ b/extension/scripts/build.mjs
@@ -33,6 +33,16 @@ if (targetBrowser === "firefox") {
       strict_min_version: "121.0",
     },
   };
+  // Firefox 不支持 MV3 background.service_worker（Bugzilla 1573659），
+  // 必须用 background.scripts（event page）。Firefox 121+ 才会在
+  // service_worker 存在时启动 background page，且支持 type:"module"
+  // ES module 后台脚本——与上面的 strict_min_version 对齐。
+  // 这是专用 Firefox 产物，去掉 Chrome 专属的 service_worker 键，
+  // 避免 web-ext lint 对不支持字段告警。
+  manifest.background = {
+    scripts: ["background.js"],
+    type: "module",
+  };
 } else {
   const extensionKey = normalizeExtensionKey(
     process.env.BILI_SYNCPLAY_EXTENSION_KEY,

--- a/extension/scripts/build.mjs
+++ b/extension/scripts/build.mjs
@@ -2,11 +2,16 @@ import { build } from "esbuild";
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  distDirName,
+  resolveTargetBrowser,
+} from "../../scripts/target-browser.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
 const workspaceRootDir = path.resolve(rootDir, "..");
-const distDir = path.join(rootDir, "dist");
+const targetBrowser = resolveTargetBrowser();
+const distDir = path.join(rootDir, distDirName(targetBrowser));
 const packageJsonPath = path.join(workspaceRootDir, "package.json");
 const manifestPath = path.join(rootDir, "public", "manifest.json");
 const defaultServerUrl = resolveDefaultServerUrl(
@@ -19,14 +24,25 @@ await mkdir(distDir, { recursive: true });
 const rootPackage = JSON.parse(await readFile(packageJsonPath, "utf8"));
 const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
 manifest.version = rootPackage.version;
-const extensionKey = normalizeExtensionKey(
-  process.env.BILI_SYNCPLAY_EXTENSION_KEY,
-);
-
-if (extensionKey) {
-  manifest.key = extensionKey;
-} else {
+if (targetBrowser === "firefox") {
+  // Firefox 必需 add-on ID；manifest.key 是 Chrome 专属，对 Firefox 无意义。
   delete manifest.key;
+  manifest.browser_specific_settings = {
+    gecko: {
+      id: "bili-syncplay@bilibili-tools.local",
+      strict_min_version: "121.0",
+    },
+  };
+} else {
+  const extensionKey = normalizeExtensionKey(
+    process.env.BILI_SYNCPLAY_EXTENSION_KEY,
+  );
+
+  if (extensionKey) {
+    manifest.key = extensionKey;
+  } else {
+    delete manifest.key;
+  }
 }
 
 await Promise.all([

--- a/extension/scripts/build.mjs
+++ b/extension/scripts/build.mjs
@@ -31,6 +31,21 @@ if (targetBrowser === "firefox") {
     gecko: {
       id: "bili-syncplay@bilibili-tools.local",
       strict_min_version: "121.0",
+      // Firefox 新规：新扩展须声明数据收集/传输（与目的地无关，发往
+      // 用户自建服务端也算）。本扩展把同步的 B 站视频 URL
+      // （browsingActivity）与播放操作交互（websiteActivity）发往用户
+      // 配置的 WebSocket 服务端；房间码/token 为临时会话标识，昵称为
+      // 用户自填的临时假名句柄（按扩展设计意图不属 PII），故不声明
+      // personallyIdentifyingInfo；无遥测故无 technicalAndInteraction。
+      //
+      // 该键 Firefox 140（桌面）/142（Android）才识别，本扩展 min
+      // 版本为 121——旧版按"未知键忽略"处理（前向兼容、不破坏，121–139
+      // 仍正常运行，仅无数据同意 UI），140+ 强制并展示。故 web-ext lint
+      // 的 KEY_FIREFOX[_ANDROID]_UNSUPPORTED_BY_MIN_VERSION 为预期软告警，
+      // 不上调 strict_min_version（否则白丢 121–139 用户且无功能收益）。
+      data_collection_permissions: {
+        required: ["browsingActivity", "websiteActivity"],
+      },
     },
   };
   // Firefox 不支持 MV3 background.service_worker（Bugzilla 1573659），

--- a/extension/scripts/build.mjs
+++ b/extension/scripts/build.mjs
@@ -43,6 +43,14 @@ if (targetBrowser === "firefox") {
     scripts: ["background.js"],
     type: "module",
   };
+  // MV3 默认 CSP 隐含 upgrade-insecure-requests，Firefox 会据此把扩展
+  // 自身发起的 ws:// 升级为 wss://（无 Chrome 那种 localhost 豁免），
+  // 导致连不上明文 WebSocket 服务端。本扩展显式支持用户配置 ws:// 服务端，
+  // 故按 Mozilla 文档显式覆盖 extension_pages CSP，去掉该升级指令；
+  // 其余沿用 MV3 默认（script-src/object-src 'self'）。
+  manifest.content_security_policy = {
+    extension_pages: "script-src 'self'; object-src 'self'",
+  };
 } else {
   const extensionKey = normalizeExtensionKey(
     process.env.BILI_SYNCPLAY_EXTENSION_KEY,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "typecheck": "npm run typecheck -w @bili-syncplay/protocol && npm run typecheck -w @bili-syncplay/server && npm run typecheck -w @bili-syncplay/extension",
     "build": "npm run build -w @bili-syncplay/protocol && npm run build -w @bili-syncplay/server && npm run build -w @bili-syncplay/extension",
     "pretest": "npm run build -w @bili-syncplay/protocol",
-    "test": "npm run test:audit-gate && npm run --ignore-scripts test -w @bili-syncplay/protocol && npm run --ignore-scripts test -w @bili-syncplay/server && npm run --ignore-scripts test -w @bili-syncplay/extension",
+    "test": "npm run test:audit-gate && npm run test:scripts && npm run --ignore-scripts test -w @bili-syncplay/protocol && npm run --ignore-scripts test -w @bili-syncplay/server && npm run --ignore-scripts test -w @bili-syncplay/extension",
+    "test:scripts": "node --test scripts/target-browser.test.mjs",
     "coverage": "npm run --ignore-scripts coverage -w @bili-syncplay/protocol && npm run --ignore-scripts coverage -w @bili-syncplay/server && npm run --ignore-scripts coverage -w @bili-syncplay/extension",
     "audit": "node scripts/audit-gate.mjs",
     "test:audit-gate": "node --test scripts/audit-gate.test.mjs",
@@ -32,7 +33,10 @@
     "test:server:redis": "npm run --ignore-scripts test:redis -w @bili-syncplay/server",
     "dev:server": "npm run dev -w @bili-syncplay/server",
     "build:extension": "npm run build -w @bili-syncplay/extension",
-    "build:release": "npm run build:extension && node scripts/package-release.mjs",
+    "build:extension:firefox": "npm run build -w @bili-syncplay/extension -- --target=firefox",
+    "build:release:chrome": "npm run build:extension && node scripts/package-release.mjs",
+    "build:release:firefox": "npm run build:extension:firefox && node scripts/package-release.mjs --target=firefox",
+    "build:release": "npm run build:release:chrome && npm run build:release:firefox",
     "release:version": "node scripts/release-version.mjs"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dev:server": "npm run dev -w @bili-syncplay/server",
     "build:extension": "npm run build -w @bili-syncplay/extension",
     "build:extension:firefox": "npm run build -w @bili-syncplay/extension -- --target=firefox",
-    "build:release:chrome": "npm run build:extension && node scripts/package-release.mjs",
+    "build:release:chrome": "npm run build:extension && node scripts/package-release.mjs --target=chrome",
     "build:release:firefox": "npm run build:extension:firefox && node scripts/package-release.mjs --target=firefox",
     "build:release": "npm run build:release:chrome && npm run build:release:firefox",
     "release:version": "node scripts/release-version.mjs"

--- a/scripts/package-release.mjs
+++ b/scripts/package-release.mjs
@@ -1,13 +1,15 @@
-import { access, mkdir, readFile, rm } from "node:fs/promises";
+import { access, copyFile, mkdir, readFile, rm } from "node:fs/promises";
 import { constants } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
+import { distDirName, resolveTargetBrowser } from "./target-browser.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");
 const extensionDir = path.join(rootDir, "extension");
-const distDir = path.join(extensionDir, "dist");
+const targetBrowser = resolveTargetBrowser();
+const distDir = path.join(extensionDir, distDirName(targetBrowser));
 const releaseDir = path.join(rootDir, "release");
 
 const extensionPackageRaw = await readFile(
@@ -16,12 +18,20 @@ const extensionPackageRaw = await readFile(
 );
 const extensionPackage = JSON.parse(extensionPackageRaw);
 const version = extensionPackage.version;
-const zipName = `bili-syncplay-extension-v${version}.zip`;
+const zipName = `bili-syncplay-extension-v${version}-${targetBrowser}.zip`;
 const zipPath = path.join(releaseDir, zipName);
+// Firefox 用户可直接拖入 .xpi 安装；与 zip 同字节流，复制即可。
+const xpiPath =
+  targetBrowser === "firefox"
+    ? path.join(releaseDir, `bili-syncplay-extension-v${version}-firefox.xpi`)
+    : null;
 
 await access(distDir, constants.F_OK);
 await mkdir(releaseDir, { recursive: true });
 await rm(zipPath, { force: true });
+if (xpiPath) {
+  await rm(xpiPath, { force: true });
+}
 
 if (process.platform === "win32") {
   await run(
@@ -40,6 +50,11 @@ if (process.platform === "win32") {
 }
 
 console.log(`Release package created: ${zipPath}`);
+
+if (xpiPath) {
+  await copyFile(zipPath, xpiPath);
+  console.log(`Release package created: ${xpiPath}`);
+}
 
 function run(command, args, cwd) {
   return new Promise((resolve, reject) => {

--- a/scripts/target-browser.mjs
+++ b/scripts/target-browser.mjs
@@ -14,15 +14,27 @@ export function resolveTargetBrowser(
   argv = process.argv.slice(2),
   env = process.env,
 ) {
+  const expected = `expected one of: ${[...SUPPORTED_TARGETS].join(", ")}`;
   let fromArg = null;
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--target") {
-      fromArg = argv[index + 1] ?? fromArg;
+      // 裸 `--target`（末尾无值）或其后紧跟另一个选项，多为笔误；
+      // 静默回退会在发布流程里悄悄产出错误浏览器的包，必须直接报错。
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith("-")) {
+        throw new Error(`Missing value for "--target"; ${expected}.`);
+      }
+      fromArg = value;
+      index += 1; // 消费值，避免被后续迭代误解析
       continue;
     }
     if (arg.startsWith("--target=")) {
-      fromArg = arg.slice("--target=".length);
+      const value = arg.slice("--target=".length);
+      if (value === "") {
+        throw new Error(`Missing value for "--target="; ${expected}.`);
+      }
+      fromArg = value;
       continue;
     }
   }

--- a/scripts/target-browser.mjs
+++ b/scripts/target-browser.mjs
@@ -1,0 +1,38 @@
+// 解析构建/打包脚本的目标浏览器。
+//
+// 优先级：CLI `--target=<v>` / `--target <v>` > 环境变量 TARGET_BROWSER > 默认 chrome。
+// 用 CLI 参数而非 cross-env，可跨平台（含 Windows）且不引入额外依赖；
+// 同时保留 TARGET_BROWSER 环境变量入口，便于 CI 矩阵注入。
+
+const SUPPORTED_TARGETS = new Set(["chrome", "firefox"]);
+
+export function resolveTargetBrowser(
+  argv = process.argv.slice(2),
+  env = process.env,
+) {
+  let fromArg = null;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--target") {
+      fromArg = argv[index + 1] ?? null;
+      break;
+    }
+    if (arg.startsWith("--target=")) {
+      fromArg = arg.slice("--target=".length);
+      break;
+    }
+  }
+
+  const raw = (fromArg ?? env.TARGET_BROWSER ?? "chrome").trim().toLowerCase();
+  if (!SUPPORTED_TARGETS.has(raw)) {
+    throw new Error(
+      `Unsupported target browser "${raw}"; expected one of: ${[...SUPPORTED_TARGETS].join(", ")}.`,
+    );
+  }
+  return raw;
+}
+
+// 各 target 对应的 dist 目录名，build 与 package 脚本共用，避免不一致。
+export function distDirName(targetBrowser) {
+  return targetBrowser === "firefox" ? "dist-firefox" : "dist";
+}

--- a/scripts/target-browser.mjs
+++ b/scripts/target-browser.mjs
@@ -1,8 +1,12 @@
 // 解析构建/打包脚本的目标浏览器。
 //
-// 优先级：CLI `--target=<v>` / `--target <v>` > 环境变量 TARGET_BROWSER > 默认 chrome。
-// 用 CLI 参数而非 cross-env，可跨平台（含 Windows）且不引入额外依赖；
-// 同时保留 TARGET_BROWSER 环境变量入口，便于 CI 矩阵注入。
+// 优先级：CLI `--target` > 环境变量 TARGET_BROWSER > 默认 chrome。
+// 用 CLI 参数而非 cross-env，可跨平台（含 Windows）且不引入额外依赖。
+//
+// 多个 `--target` 时取**最后一个**：npm 脚本分层时（基础脚本固定一个
+// 默认 target，调用方再追加 `-- --target=<other>` 覆盖），后者生效。
+// 这也保证只要脚本显式带了 `--target`，结果就完全确定，不会被环境里
+// 残留的 TARGET_BROWSER（如 CI 矩阵或开发者 shell 导出）悄悄劫持。
 
 const SUPPORTED_TARGETS = new Set(["chrome", "firefox"]);
 
@@ -14,12 +18,12 @@ export function resolveTargetBrowser(
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--target") {
-      fromArg = argv[index + 1] ?? null;
-      break;
+      fromArg = argv[index + 1] ?? fromArg;
+      continue;
     }
     if (arg.startsWith("--target=")) {
       fromArg = arg.slice("--target=".length);
-      break;
+      continue;
     }
   }
 

--- a/scripts/target-browser.test.mjs
+++ b/scripts/target-browser.test.mjs
@@ -63,6 +63,34 @@ test("不支持的目标抛错", () => {
   );
 });
 
+test("裸 --target（末尾无值）立即抛错而非静默回退", () => {
+  assert.throws(
+    () => resolveTargetBrowser(["--target"], { TARGET_BROWSER: "firefox" }),
+    /Missing value for "--target"/,
+  );
+});
+
+test("--target 后紧跟另一个选项时抛错", () => {
+  assert.throws(
+    () => resolveTargetBrowser(["--target", "--verbose"], {}),
+    /Missing value for "--target"/,
+  );
+});
+
+test("--target= 空值抛错", () => {
+  assert.throws(
+    () => resolveTargetBrowser(["--target="], {}),
+    /Missing value for "--target="/,
+  );
+});
+
+test("前有有效值、后跟裸 --target 仍抛错（笔误不被吞）", () => {
+  assert.throws(
+    () => resolveTargetBrowser(["--target=firefox", "--target"], {}),
+    /Missing value for "--target"/,
+  );
+});
+
 test("distDirName 映射", () => {
   assert.equal(distDirName("chrome"), "dist");
   assert.equal(distDirName("firefox"), "dist-firefox");

--- a/scripts/target-browser.test.mjs
+++ b/scripts/target-browser.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { distDirName, resolveTargetBrowser } from "./target-browser.mjs";
+
+test("默认目标为 chrome", () => {
+  assert.equal(resolveTargetBrowser([], {}), "chrome");
+});
+
+test("环境变量 TARGET_BROWSER 生效", () => {
+  assert.equal(
+    resolveTargetBrowser([], { TARGET_BROWSER: "firefox" }),
+    "firefox",
+  );
+});
+
+test("CLI --target=value 形式", () => {
+  assert.equal(resolveTargetBrowser(["--target=firefox"], {}), "firefox");
+});
+
+test("CLI --target value 形式", () => {
+  assert.equal(resolveTargetBrowser(["--target", "firefox"], {}), "firefox");
+});
+
+test("CLI 参数优先于环境变量", () => {
+  assert.equal(
+    resolveTargetBrowser(["--target=chrome"], { TARGET_BROWSER: "firefox" }),
+    "chrome",
+  );
+});
+
+test("大小写与空白被归一", () => {
+  assert.equal(
+    resolveTargetBrowser([], { TARGET_BROWSER: " FireFox " }),
+    "firefox",
+  );
+});
+
+test("不支持的目标抛错", () => {
+  assert.throws(
+    () => resolveTargetBrowser(["--target=safari"], {}),
+    /Unsupported target browser "safari"/,
+  );
+});
+
+test("distDirName 映射", () => {
+  assert.equal(distDirName("chrome"), "dist");
+  assert.equal(distDirName("firefox"), "dist-firefox");
+});

--- a/scripts/target-browser.test.mjs
+++ b/scripts/target-browser.test.mjs
@@ -28,6 +28,27 @@ test("CLI 参数优先于环境变量", () => {
   );
 });
 
+test("多个 --target 时后者覆盖（npm 脚本分层）", () => {
+  // 基础脚本固定 --target=chrome，调用方追加 --target=firefox 覆盖
+  assert.equal(
+    resolveTargetBrowser(["--target=chrome", "--target=firefox"], {}),
+    "firefox",
+  );
+  assert.equal(
+    resolveTargetBrowser(["--target", "chrome", "--target", "firefox"], {}),
+    "firefox",
+  );
+});
+
+test("显式 --target 不被环境变量劫持（后者覆盖时仍然 CLI 优先）", () => {
+  assert.equal(
+    resolveTargetBrowser(["--target=chrome", "--target=firefox"], {
+      TARGET_BROWSER: "chrome",
+    }),
+    "firefox",
+  );
+});
+
 test("大小写与空白被归一", () => {
   assert.equal(
     resolveTargetBrowser([], { TARGET_BROWSER: " FireFox " }),


### PR DESCRIPTION
## 背景

Firefox 适配第 2 步（共 3 个 PR）。本 PR 引入**双浏览器构建/打包管道**，本地 `npm run build:release` 一次性产出 Chrome 与 Firefox 两套产物。Chrome 行为与产物形态**零变化**。

> 基于 PR #114（`feat/firefox-source-compat`）。本 PR base 指向该分支，diff 仅含 PR-2 改动。

完整规划见 `/home/sky1wu/.claude/plans/jazzy-giggling-parrot.md`。

## 改动

### `feat`: 双浏览器构建/打包管道（`7178b97`）

- **`scripts/target-browser.mjs`（新）**：共享 target 解析，优先级 `CLI --target` > 环境变量 `TARGET_BROWSER` > 默认 `chrome`；build 与 package 脚本共用，杜绝目录/命名不一致。
- **`extension/scripts/build.mjs`**：firefox 输出到 `dist-firefox/`，注入 `browser_specific_settings.gecko = { id: "bili-syncplay@bilibili-tools.local", strict_min_version: "121.0" }`，强制删除 Chrome 专属 `manifest.key`；**chrome 分支逻辑不变**。
- **`scripts/package-release.mjs`**：按 target 选源目录与产物名 `bili-syncplay-extension-v{ver}-{chrome|firefox}.zip`；firefox 额外同字节流复制 `.xpi`。
- **`package.json`**：新增 `build:extension:firefox` / `build:release:chrome` / `build:release:firefox`；`build:release` 顺序产出双包。
- **`scripts/target-browser.test.mjs` + `test:scripts`（新）**：8 个用例覆盖参数优先级、归一化、非法目标抛错、dist 目录映射，接入 `npm test`。

### `chore`: ignore 配置排除 dist-firefox（`782f716`）

`.gitignore` / `.prettierignore` / `eslint.config.mjs` 同步排除 `dist-firefox/`，与现有 `dist/` 一致。

## 对计划的有意偏差（更优做法）

1. **不引入 `cross-env`**：计划原写用 `cross-env` 设环境变量。改用 CLI `--target=firefox` 参数透传 —— 跨平台（含 Windows）、零新依赖、不动 lockfile（符合 AGENTS.md 对 lockfile 的谨慎要求）。`TARGET_BROWSER` 环境变量入口仍保留，便于 PR-3 的 CI 矩阵。
2. **不在 `extension/package.json` 加 `build:firefox`**：改为根 `build:extension:firefox` 复用现有 `build` 脚本 + `--target` 透传，保留 protocol `prebuild` 钩子，更 DRY、改动面更小。

## 验证

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` 全绿：

- Extension：232 通过 / 0 失败
- `test:scripts`（target-browser）：8 通过 / 0 失败
- Server：288 通过 / 0 失败（PR-1 引入，未回归）

**Firefox manifest 注入实测**（`npm run build:extension:firefox`）：

```json
// extension/dist-firefox/manifest.json
{ "version": "1.1.1", "manifest_version": 3,
  "browser_specific_settings": { "gecko": {
    "id": "bili-syncplay@bilibili-tools.local", "strict_min_version": "121.0" } } }
// 无 key
```

Chrome `dist/manifest.json` 实测：无 `key`、无 `browser_specific_settings`（未受影响）。`dist` 与 `dist-firefox` 并存。

## 已知未验证项 → 已端到端验证 ✅

PR 创建时本沙箱无 `zip` 二进制，打包步骤未能本地运行。`zip` 安装后已补做完整端到端验证：

```
$ rm -rf release && npm run build:release
Release package created: release/bili-syncplay-extension-v1.1.1-chrome.zip
Release package created: release/bili-syncplay-extension-v1.1.1-firefox.zip
Release package created: release/bili-syncplay-extension-v1.1.1-firefox.xpi
```

- **xpi == firefox.zip 字节完全一致**：`cmp` 确认 IDENTICAL
- **chrome.zip/manifest.json**：无 `key`、无 `browser_specific_settings`（Chrome 未受影响）
- **firefox.zip/manifest.json**：`browser_specific_settings.gecko={id, strict_min_version:"121.0"}`、无 `key`
- **firefox.zip 内容完整**：background/content/page-bridge/popup/manifest/_locales/icons 齐全（源自 `dist-firefox/`）

CI（PR-3）将在 ubuntu-latest 上再次执行同一路径。

## Codex 复审修复：Firefox background.service_worker 不受支持（`023bbd5`）

复审命中：Firefox **完全不支持** MV3 `background.service_worker`（[Bugzilla 1573659](https://bugzil.la/1573659)），MV3 必须用 `background.scripts`（event page）。此前 Firefox 构建只注入 `browser_specific_settings`，`manifest.background` 仍只有 `service_worker` → **Firefox 上后台脚本根本不启动，扩展完全不可用**。

修复：Firefox 分支重写 `manifest.background = { scripts:["background.js"], type:"module" }`，去掉 Chrome 专属 `service_worker`（专用产物无需保留，且避免 PR-3 `web-ext lint` 告警）。`strict_min_version 121.0` 与之对齐：Firefox 121+ 才会在该场景启动 background page 并支持 `type:"module"`。Chrome 分支不变。

实测：`firefox.zip/manifest.json` background = `{scripts:[background.js],type:module}`；`chrome.zip` 仍 `{service_worker:background.js,type:module}`；format/lint/typecheck/test 全绿（232 过），双产物 + xpi 正常。

## 本地验证发现并修复：Firefox 把 ws:// 升级为 wss://（`b5675e1`）

本地用 Firefox 实测连接失败：服务端**无任何** `ws_connection_rejected` 日志（Chrome 失败时有），客户端报 `Firefox 无法建立到 wss://localhost:8787/ 的连接`——但服务端是明文 `http://localhost:8787`。

定性（已排除代码侧，`validateServerUrl` 原样透传）：**MV3 默认 CSP 隐含 `upgrade-insecure-requests`**，Firefox 据此把扩展自身发起的 `ws://` 升级为 `wss://`（无 Chrome 的 localhost 豁免）→ TLS 握手对明文服务端失败 → 请求不到达服务端。Chrome 用 `ws://localhost` 可达（再被 Origin 拒，故有日志）。

修复（Mozilla 官方文档解法，用户已确认采用）：Firefox 构建显式覆盖 `content_security_policy.extension_pages = "script-src 'self'; object-src 'self'"`，去掉 `upgrade-insecure-requests`，其余沿用 MV3 默认。**仅 Firefox 产物注入；Chrome 构建与产物字节不变**（Chrome 经 localhost 豁免本就可用）。

实测：`firefox.zip/manifest.json` 含该 CSP（无 upgrade 指令）；`chrome.zip` 无该键；`web-ext lint` 仍 0 error；format/lint/typecheck/test 全绿（232 过）。端到端 `ws://` 连通待 Firefox 121+ 本机复测。

## Codex 检视修复 P1：发布 target 防环境劫持（`7b61826`）

`build:release:chrome` 原未显式传 `--target=chrome`，依赖 `resolveTargetBrowser` 回退；环境若有 `TARGET_BROWSER=firefox`（CI 矩阵/开发者 shell），"chrome" 脚本会打出 Firefox 包，`build:release` 连出两份 Firefox、缺 Chrome。

根因修复 + 同类点审计：`resolveTargetBrowser` 多个 `--target` 改为**后者覆盖**（支持 npm 脚本分层）；`extension` workspace `build` 固定 `--target=chrome`（关闭 root build/test 同类 env 泄漏）；`build:release:chrome` 打包步显式 `--target=chrome`；加回归测试。复现验证：`TARGET_BROWSER=firefox npm run build:release` 仍正确产出 chrome+firefox 各一份。已在 Codex 线程回复。

## 后续

- PR-3：CI 矩阵（chrome/firefox）+ `web-ext lint` + README/CONTRIBUTING 文档（含 Firefox 用户须把 `moz-extension://<uuid>` 加入 `ALLOWED_ORIGINS`，PR-1 已让服务端支持该 scheme）

🤖 Generated with [Claude Code](https://claude.com/claude-code)




