### PR TITLE
[codex] mark stale admin playback snapshots

### DIFF
--- a/server/admin-ui/page-renderers.js
+++ b/server/admin-ui/page-renderers.js
@@ -4,8 +4,8 @@ import {
   formatDuration,
   formatJson,
   formatPlaybackPosition,
+  getPlaybackSyncedAt,
   formatRelativeDuration,
-  getPlaybackState,
   getRoomPlaybackSummary,
   getRoomOwnerSummary,
   getRoomVideoSummary,
@@ -637,6 +637,7 @@ export function createPageLoaders(options) {
     async renderRoomDetailPage(roomCode) {
       try {
         const detail = await api.getRoomDetail(roomCode);
+        const playbackSummary = getRoomPlaybackSummary(detail.room);
         return {
           meta: {
             title: `房间 ${detail.room.roomCode}`,
@@ -699,16 +700,17 @@ export function createPageLoaders(options) {
                     <div class="media-summary-title">${escapeHtml(detail.room.sharedVideo?.title || "未共享视频")}</div>
                     <div class="media-summary-meta">
                       ${detail.room.sharedVideo?.videoId ? `<span class="pill subtle">ID ${escapeHtml(detail.room.sharedVideo.videoId)}</span>` : renderEmptyValue("无视频 ID")}
-                      ${detail.room.playback ? renderResultBadge(getPlaybackState(detail.room.playback)) : renderEmptyValue("未同步")}
+                      ${detail.room.playback ? renderStatus(playbackSummary.tone, playbackSummary.primary) : renderEmptyValue("未同步")}
                     </div>
                   </div>
                   <dl class="kv">
                     <dt>标题</dt><dd>${escapeHtml(detail.room.sharedVideo?.title || "未共享")}</dd>
                     <dt>视频 ID</dt><dd>${detail.room.sharedVideo?.videoId ? `<span class="code">${escapeHtml(detail.room.sharedVideo.videoId)}</span>` : renderEmptyValue()}</dd>
                     <dt>URL</dt><dd>${detail.room.sharedVideo?.url ? `<a href="${escapeHtml(detail.room.sharedVideo.url)}" target="_blank" rel="noreferrer">${escapeHtml(detail.room.sharedVideo.url)}</a>` : renderEmptyValue()}</dd>
-                    <dt>播放状态</dt><dd>${detail.room.playback ? renderResultBadge(getPlaybackState(detail.room.playback)) : renderEmptyValue("未同步")}</dd>
+                    <dt>播放状态</dt><dd>${detail.room.playback ? renderStatus(playbackSummary.tone, playbackSummary.primary) : renderEmptyValue("未同步")}</dd>
                     <dt>当前时间</dt><dd>${detail.room.playback ? formatPlaybackPosition(detail.room.playback.currentTime) : renderEmptyValue()}</dd>
                     <dt>播放速度</dt><dd>${detail.room.playback ? `x${Number(detail.room.playback.playbackRate || 1).toFixed(2)}` : renderEmptyValue()}</dd>
+                    <dt>上次同步</dt><dd>${formatDateTime(getPlaybackSyncedAt(detail.room))}</dd>
                   </dl>
                 </section>
               </div>

--- a/server/admin-ui/render-utils.js
+++ b/server/admin-ui/render-utils.js
@@ -1,5 +1,7 @@
 import { escapeHtml } from "./templates.js";
 
+const PLAYBACK_STALE_AFTER_MS = 30_000;
+
 export function formatDateTime(value) {
   if (value === null || value === undefined || value === "") {
     return "—";
@@ -182,6 +184,42 @@ export function formatRelativeDuration(ms) {
   return `${Math.floor(hours / 24)} 天后`;
 }
 
+export function formatElapsedDuration(ms) {
+  if (!Number.isFinite(ms) || ms < 0) {
+    return "—";
+  }
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) {
+    return "不足 1 分钟前";
+  }
+  if (minutes < 60) {
+    return `${minutes} 分钟前`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours} 小时前`;
+  }
+  return `${Math.floor(hours / 24)} 天前`;
+}
+
+export function getPlaybackSyncedAt(item) {
+  if (!item?.playback) {
+    return null;
+  }
+  if (Number.isFinite(item.playback.serverTime)) {
+    return item.playback.serverTime;
+  }
+  if (Number.isFinite(item.playback.updatedAt)) {
+    return item.playback.updatedAt;
+  }
+  return Number.isFinite(item.lastActiveAt) ? item.lastActiveAt : null;
+}
+
+export function isRoomPlaybackStale(item, currentTime = Date.now()) {
+  const syncedAt = getPlaybackSyncedAt(item);
+  return syncedAt !== null && currentTime - syncedAt > PLAYBACK_STALE_AFTER_MS;
+}
+
 export function getRoomVideoSummary(item) {
   if (!item.sharedVideo) {
     return {
@@ -208,15 +246,22 @@ export function getRoomPlaybackSummary(item) {
   }
 
   const state = getPlaybackState(item.playback);
+  const syncedAt = getPlaybackSyncedAt(item);
+  const stale = isRoomPlaybackStale(item);
   return {
-    tone:
-      state === "playing"
+    tone: stale
+      ? "warning"
+      : state === "playing"
         ? "success"
         : state === "buffering"
           ? "warning"
           : "neutral",
-    primary: getPlaybackStateLabel(state),
-    secondary: `${formatPlaybackPosition(item.playback.currentTime)} · x${Number(item.playback.playbackRate || 1).toFixed(2)}`,
+    primary: stale
+      ? `${getPlaybackStateLabel(state)}（已陈旧）`
+      : getPlaybackStateLabel(state),
+    secondary: stale
+      ? `${formatPlaybackPosition(item.playback.currentTime)} · 上次同步 ${formatElapsedDuration(Date.now() - syncedAt)}`
+      : `${formatPlaybackPosition(item.playback.currentTime)} · x${Number(item.playback.playbackRate || 1).toFixed(2)}`,
   };
 }
 

--- a/server/test/admin-ui-page-renderers.test.ts
+++ b/server/test/admin-ui-page-renderers.test.ts
@@ -198,6 +198,7 @@ test("rooms and events pages render direct admin ui tables", async () => {
                 playState: "playing",
                 currentTime: 12.3,
                 playbackRate: 1,
+                serverTime: Date.now(),
               },
               lastActiveAt: Date.now(),
               expiresAt: Date.now() + 60_000,
@@ -297,6 +298,7 @@ test("room detail renders playback position as media timestamp", async () => {
               playState: "playing",
               currentTime: 3723.4,
               playbackRate: 1,
+              serverTime: Date.now(),
             },
           },
           members: [],
@@ -339,6 +341,96 @@ test("room detail renders playback position as media timestamp", async () => {
   assert.equal(page.html.includes("3723.4s"), false);
   assert.equal(page.html.includes("Alice 加入了房间"), true);
   assert.equal(page.html.includes("Alice 加入了房间 · 房间 ROOM8A"), false);
+});
+
+test("room pages mark stale playback snapshots instead of presenting them as live", async () => {
+  const staleServerTime = Date.now() - 3 * 60 * 60 * 1000;
+  const pageLoaders = createPageLoaders({
+    document: createDocumentStub(),
+    location: { search: "" },
+    history: { replaceState() {} },
+    state: {
+      overviewAutoRefresh: true,
+      lastOverviewData: { instanceId: "instance-1" },
+    },
+    api: {
+      async listRooms() {
+        return {
+          items: [
+            {
+              roomCode: "ROOM8A",
+              isActive: true,
+              ownerDisplayName: "Alice",
+              ownerMemberId: "member-alice",
+              memberCount: 1,
+              sharedVideo: { title: "测试视频" },
+              playback: {
+                playState: "playing",
+                currentTime: 12.3,
+                playbackRate: 1,
+                serverTime: staleServerTime,
+              },
+              lastActiveAt: staleServerTime,
+              expiresAt: Date.now() + 60_000,
+            },
+          ],
+          pagination: { total: 1 },
+        };
+      },
+      async getRoomDetail() {
+        return {
+          instanceId: "instance-1",
+          room: {
+            roomCode: "ROOM8A",
+            isActive: true,
+            memberCount: 1,
+            instanceId: "instance-1",
+            createdAt: staleServerTime,
+            lastActiveAt: staleServerTime,
+            expiresAt: Date.now() + 60_000,
+            sharedVideo: {
+              title: "测试视频",
+              videoId: "BV1TEST",
+              url: "https://www.bilibili.com/video/BV1TEST",
+            },
+            playback: {
+              playState: "playing",
+              currentTime: 12.3,
+              playbackRate: 1,
+              serverTime: staleServerTime,
+            },
+          },
+          members: [],
+          recentEvents: [],
+        };
+      },
+    },
+    routeHref(path: string) {
+      return `/admin${path}`;
+    },
+    withDemoQuery(url: string) {
+      return url;
+    },
+    serializeQuery() {
+      return "";
+    },
+    navigate() {},
+    navigateToUrl() {},
+    rerender() {},
+    canManage() {
+      return true;
+    },
+    confirmAction() {},
+    openReasonDialog() {},
+  });
+
+  const roomsPage = await pageLoaders.renderRoomsPage();
+  const detailPage = await pageLoaders.renderRoomDetailPage("ROOM8A");
+
+  assert.equal(roomsPage.html.includes("播放中（已陈旧）"), true);
+  assert.equal(roomsPage.html.includes("上次同步 3 小时前"), true);
+  assert.equal(detailPage.html.includes("播放中（已陈旧）"), true);
+  assert.equal(detailPage.html.includes("<dt>上次同步</dt>"), true);
 });
 
 test("danger room actions require confirmed config before execution", async () => {


### PR DESCRIPTION
## What changed
- mark admin room playback snapshots as stale when they have not synced recently
- show the last sync time in room detail
- add regression coverage for stale playback rendering

## Why
The admin panel was presenting the last persisted playback snapshot as if it were live state. Stable playback `timeupdate` ticks are intentionally omitted from recent events to avoid flooding the event store, so a room could show `playing` for hours while also showing no recent events.

## Impact
Operators can now distinguish live playback from old persisted snapshots instead of interpreting stale `playing` states as active progress.

## Validation
- `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`
