### PR TITLE
fix: 消除 popup 的 innerHTML 告警（Firefox 校验）

### DIFF
--- a/extension/src/popup/index.ts
+++ b/extension/src/popup/index.ts
@@ -37,7 +37,18 @@ async function init(): Promise<void> {
 
   document.documentElement.lang = getDocumentLanguage();
   document.title = t("popupTitle");
-  app.innerHTML = renderPopupTemplate();
+  // 用 DOMParser 解析静态模板再 adopt 进文档，替代 innerHTML 赋值：
+  // 模板不含任何用户输入，DOMParser 不执行脚本，且 addons-linter 不会
+  // 对其告警（innerHTML 的官方安全替代）。
+  const parsedTemplate = new DOMParser().parseFromString(
+    renderPopupTemplate(),
+    "text/html",
+  );
+  app.replaceChildren(
+    ...Array.from(parsedTemplate.body.childNodes, (node) =>
+      document.importNode(node, true),
+    ),
+  );
 
   refs = collectPopupRefs();
   bindPopupActions({

--- a/extension/src/popup/popup-render.ts
+++ b/extension/src/popup/popup-render.ts
@@ -1,7 +1,6 @@
 import type { RoomMember } from "@bili-syncplay/protocol";
 import type { BackgroundPopupState } from "../shared/messages";
 import { getUiLanguage, t } from "../shared/i18n";
-import { escapeHtml } from "./helpers";
 import {
   getRenderedServerUrlValue,
   type ServerUrlDraftState,
@@ -83,16 +82,11 @@ export function renderPopup(args: {
     args.state.retryAttempt > 0
       ? `(${args.state.retryAttempt}/${args.state.retryAttemptMax})`
       : "";
-  args.refs.clockStatus.innerHTML = `
-    <span class="clock-metric">
-      <span class="clock-metric-label">${escapeHtml(t("metricClockOffset"))}</span>
-      <span class="clock-metric-value">${escapeHtml(formatClockMetricValue(args.state.clockOffsetMs))}</span>
-    </span>
-    <span class="clock-metric">
-      <span class="clock-metric-label">${escapeHtml(t("metricClockRtt"))}</span>
-      <span class="clock-metric-value">${escapeHtml(formatClockMetricValue(args.state.rttMs))}</span>
-    </span>
-  `;
+  renderClockStatus(
+    args.refs.clockStatus,
+    args.state.clockOffsetMs,
+    args.state.rttMs,
+  );
   const visibleMessage = args.localStatusMessage ?? args.state.error;
   args.refs.message.textContent = visibleMessage ?? "";
   args.refs.message.hidden = !visibleMessage;
@@ -194,6 +188,33 @@ function formatClockMetricValue(value: number | null): string {
   return value === null ? "-" : `${value}ms`;
 }
 
+function buildClockMetric(label: string, value: string): HTMLSpanElement {
+  const wrap = document.createElement("span");
+  wrap.className = "clock-metric";
+  const labelEl = document.createElement("span");
+  labelEl.className = "clock-metric-label";
+  labelEl.textContent = label;
+  const valueEl = document.createElement("span");
+  valueEl.className = "clock-metric-value";
+  valueEl.textContent = value;
+  wrap.append(labelEl, valueEl);
+  return wrap;
+}
+
+function renderClockStatus(
+  container: HTMLElement,
+  clockOffsetMs: number | null,
+  rttMs: number | null,
+): void {
+  container.replaceChildren(
+    buildClockMetric(
+      t("metricClockOffset"),
+      formatClockMetricValue(clockOffsetMs),
+    ),
+    buildClockMetric(t("metricClockRtt"), formatClockMetricValue(rttMs)),
+  );
+}
+
 function formatVideoOwner(
   members: RoomMember[],
   actorId: string | null,
@@ -211,18 +232,24 @@ function renderLogs(
   logs: BackgroundPopupState["logs"],
 ): void {
   if (logs.length === 0) {
-    container.innerHTML = `<div class="muted">${escapeHtml(t("stateNoLogs"))}</div>`;
+    const empty = document.createElement("div");
+    empty.className = "muted";
+    empty.textContent = t("stateNoLogs");
+    container.replaceChildren(empty);
     return;
   }
 
-  container.innerHTML = logs
-    .map((entry) => {
+  container.replaceChildren(
+    ...logs.map((entry) => {
       const time = new Date(entry.at).toLocaleTimeString(getUiLanguage(), {
         hour12: false,
       });
-      return `<div class="log-line">[${time}] [${entry.scope}] ${escapeHtml(entry.message)}</div>`;
-    })
-    .join("");
+      const line = document.createElement("div");
+      line.className = "log-line";
+      line.textContent = `[${time}] [${entry.scope}] ${entry.message}`;
+      return line;
+    }),
+  );
 }
 
 function renderMemberList(
@@ -231,17 +258,24 @@ function renderMemberList(
   currentMemberId: string | null,
 ): void {
   if (members.length === 0) {
-    container.innerHTML = `<span class="member-chip">${escapeHtml(t("stateNoMembers"))}</span>`;
+    const chip = document.createElement("span");
+    chip.className = "member-chip";
+    chip.textContent = t("stateNoMembers");
+    container.replaceChildren(chip);
     return;
   }
 
-  container.innerHTML = members
-    .map((member) => {
+  container.replaceChildren(
+    ...members.map((member) => {
       const isCurrentMember = currentMemberId === member.id;
-      const label = isCurrentMember
+      const chip = document.createElement("span");
+      chip.className = isCurrentMember
+        ? "member-chip member-chip-active"
+        : "member-chip";
+      chip.textContent = isCurrentMember
         ? t("memberSelf", { name: member.name })
         : member.name;
-      return `<span class="member-chip${isCurrentMember ? " member-chip-active" : ""}">${escapeHtml(label)}</span>`;
-    })
-    .join("");
+      return chip;
+    }),
+  );
 }

--- a/extension/test/popup-render.test.ts
+++ b/extension/test/popup-render.test.ts
@@ -28,16 +28,45 @@ class FakeClassList {
   }
 }
 
-function createElement() {
-  return {
-    textContent: "",
-    hidden: false,
-    disabled: false,
-    value: "",
-    innerHTML: "",
-    classList: new FakeClassList(),
-  };
+class FakeElement {
+  private ownText = "";
+  hidden = false;
+  disabled = false;
+  value = "";
+  className = "";
+  children: FakeElement[] = [];
+  classList = new FakeClassList();
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children = [];
+  }
+
+  get textContent(): string {
+    if (this.children.length > 0) {
+      return this.children.map((child) => child.textContent).join("");
+    }
+    return this.ownText;
+  }
+
+  append(...nodes: FakeElement[]): void {
+    this.children.push(...nodes);
+  }
+
+  replaceChildren(...nodes: FakeElement[]): void {
+    this.ownText = "";
+    this.children = nodes;
+  }
 }
+
+function createElement() {
+  return new FakeElement();
+}
+
+const fakeDocument = {
+  activeElement: null,
+  createElement: () => new FakeElement(),
+};
 
 function createPopupRefs(): PopupRefs {
   return {
@@ -102,9 +131,7 @@ test("renderPopup updates popup metrics, owner hint, logs, and draft values", as
   const draftValues: string[] = [];
 
   Object.assign(globalThis, {
-    document: {
-      activeElement: null,
-    },
+    document: fakeDocument,
   });
 
   try {
@@ -183,9 +210,9 @@ test("renderPopup updates popup metrics, owner hint, logs, and draft values", as
     assert.equal(refs.sharedVideoMeta.textContent, "BV1xx411c7mD");
     assert.equal(refs.sharedVideoOwner.textContent, "Shared by Bob");
     assert.equal(refs.sharedVideoOwner.hidden, false);
-    assert.equal(refs.logs.innerHTML.includes("Connected"), true);
-    assert.equal(refs.memberList.innerHTML.includes("Bob"), true);
-    assert.equal(refs.memberList.innerHTML.includes("Me (Alice)"), true);
+    assert.equal(refs.logs.textContent.includes("Connected"), true);
+    assert.equal(refs.memberList.textContent.includes("Bob"), true);
+    assert.equal(refs.memberList.textContent.includes("Me (Alice)"), true);
   } finally {
     setLocaleForTests(null);
     Object.assign(globalThis, { document: originalDocument });
@@ -200,9 +227,7 @@ test("renderPopup debug log distinguishes background pending state from local UI
   const popupLogs: string[] = [];
 
   Object.assign(globalThis, {
-    document: {
-      activeElement: null,
-    },
+    document: fakeDocument,
   });
 
   try {
@@ -258,9 +283,7 @@ test("renderPopup only logs once for repeated identical pending renders", async 
   const popupLogs: string[] = [];
 
   Object.assign(globalThis, {
-    document: {
-      activeElement: null,
-    },
+    document: fakeDocument,
   });
 
   const renderArgs = {
@@ -318,9 +341,7 @@ test("renderPopup falls back to sharedByDisplayName when the sharer is no longer
   const refs = createPopupRefs();
 
   Object.assign(globalThis, {
-    document: {
-      activeElement: null,
-    },
+    document: fakeDocument,
   });
 
   try {


### PR DESCRIPTION
## 背景

Firefox `web-ext lint` 对打包产物报 8 个警告：6 个 popup.js 的 `Unsafe assignment to innerHTML`，2 个 manifest 的 `KEY_FIREFOX[_ANDROID]_UNSUPPORTED_BY_MIN_VERSION`。

本 PR 消除前 6 个 `innerHTML` 告警；后 2 个 manifest 软告警是 `build.mjs:33-45` 已写明的预期决策（旧版未知键忽略前向兼容、上调 `strict_min_version` 白丢 121–139 用户且无功能收益；AMO 仅 error 阻断、warning 不阻断），保持现状不动。

## 改动

| 文件 | 改动 |
|---|---|
| `extension/src/popup/popup-render.ts` | clock/logs/members 三处 `innerHTML` → `document.createElement` + `textContent` + `replaceChildren`；移除不再需要的 `escapeHtml` 导入（`textContent` 天然转义，注入面真正消失） |
| `extension/src/popup/index.ts` | `app.innerHTML = renderPopupTemplate()` → `DOMParser.parseFromString` 解析后 `importNode` + `replaceChildren`（静态模板、不执行脚本、addons-linter 不告警） |
| `extension/test/popup-render.test.ts` | `FakeElement` 支持 `replaceChildren/append/children` 与 `textContent` 聚合；断言由 `.innerHTML` 改为 `.textContent` |

## 验证

- `npm run format:check` ✅ · `lint` ✅ · `typecheck` ✅ · `build`（chrome+firefox）✅ · `npm test` 232/232 ✅
- `web-ext lint --source-dir dist-firefox`：**errors 0 / notices 0 / warnings 2**（仅剩 2 个预期 manifest 软告警，6 个 innerHTML 告警全部消除）

## 范围说明

`content/toast.ts:57` 的 `shadowRoot.innerHTML` 属 content script、不在本次报告的 8 个告警内，未一并改动以免越界；如需可另开提交处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)