### PR TITLE
fix: suppress remote pause flicker from peer buffer hiccups

### DIFF
--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -33,6 +33,9 @@ const REMOTE_PLAY_TRANSITION_GUARD_MS = 1800;
 const REMOTE_FOLLOW_PLAYING_WINDOW_MS = 3000;
 const PROGRAMMATIC_APPLY_WINDOW_MS = 700;
 const USER_GESTURE_GRACE_MS = 1200;
+const BUFFER_SIGNAL_WINDOW_MS = 300;
+const BUFFER_PAUSE_UPGRADE_MS = 1500;
+const REMOTE_PAUSE_DEBOUNCE_MS = 250;
 const FESTIVAL_SNAPSHOT_TTL_MS = 1200;
 const NAVIGATION_WATCH_INTERVAL_MS = 400;
 const VIDEO_BIND_INTERVAL_MS = 250;
@@ -73,6 +76,8 @@ const syncController = createSyncController({
   remoteFollowPlayingWindowMs: REMOTE_FOLLOW_PLAYING_WINDOW_MS,
   programmaticApplyWindowMs: PROGRAMMATIC_APPLY_WINDOW_MS,
   userGestureGraceMs: USER_GESTURE_GRACE_MS,
+  bufferPauseUpgradeMs: BUFFER_PAUSE_UPGRADE_MS,
+  remotePauseDebounceMs: REMOTE_PAUSE_DEBOUNCE_MS,
   nextSeq: () => seq++,
   markBroadcastAt: (at) => {
     lastBroadcastAt = at;
@@ -94,6 +99,8 @@ const playbackBindingController = createPlaybackBindingController({
   videoBindIntervalMs: VIDEO_BIND_INTERVAL_MS,
   userGestureGraceMs: USER_GESTURE_GRACE_MS,
   initialRoomStatePauseHoldMs: INITIAL_ROOM_STATE_PAUSE_HOLD_MS,
+  bufferSignalWindowMs: BUFFER_SIGNAL_WINDOW_MS,
+  bufferPauseUpgradeMs: BUFFER_PAUSE_UPGRADE_MS,
   getSharedVideo: () => shareController.getSharedVideo(),
   hasRecentRemoteStopIntent: (currentVideoUrl) =>
     syncController.hasRecentRemoteStopIntent(currentVideoUrl),

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -25,6 +25,17 @@ export function createPlaybackBindingController(args: {
   videoBindIntervalMs: number;
   userGestureGraceMs: number;
   initialRoomStatePauseHoldMs: number;
+  /**
+   * Window after a `waiting`/`stalled` event during which a subsequent
+   * `pause` event is presumed buffer-induced rather than user-initiated.
+   */
+  bufferSignalWindowMs: number;
+  /**
+   * Maximum duration to keep reporting a buffer-induced pause as
+   * `buffering` to peers before re-broadcasting it as `paused`. Bounds the
+   * worst-case desync if a buffer stall turns into a real stop.
+   */
+  bufferPauseUpgradeMs: number;
   getSharedVideo: () => SharedVideo | null;
   hasRecentRemoteStopIntent: (currentVideoUrl: string) => boolean;
   normalizeUrl: (url: string | undefined | null) => string | null;
@@ -44,7 +55,43 @@ export function createPlaybackBindingController(args: {
   getNow?: () => number;
 }): PlaybackBindingController {
   let videoBindingTimer: number | null = null;
+  let pauseBufferUpgradeTimerId: number | null = null;
   const nowOf = () => args.getNow?.() ?? Date.now();
+  const scheduleUpgradeTimer = (cb: () => void, ms: number): number | null => {
+    if (
+      typeof globalThis.window !== "undefined" &&
+      typeof globalThis.window.setTimeout === "function"
+    ) {
+      return globalThis.window.setTimeout(cb, ms) as unknown as number;
+    }
+    if (typeof globalThis.setTimeout === "function") {
+      return globalThis.setTimeout(cb, ms) as unknown as number;
+    }
+    return null;
+  };
+  const cancelUpgradeTimer = (id: number): void => {
+    if (
+      typeof globalThis.window !== "undefined" &&
+      typeof globalThis.window.clearTimeout === "function"
+    ) {
+      globalThis.window.clearTimeout(id);
+      return;
+    }
+    if (typeof globalThis.clearTimeout === "function") {
+      globalThis.clearTimeout(id);
+    }
+  };
+  const clearBufferUpgradeTimer = () => {
+    if (pauseBufferUpgradeTimerId !== null) {
+      cancelUpgradeTimer(pauseBufferUpgradeTimerId);
+      pauseBufferUpgradeTimerId = null;
+    }
+  };
+  const clearActivePauseClassification = () => {
+    args.runtimeState.pauseStartedAt = 0;
+    args.runtimeState.pauseClassifiedAsBuffer = false;
+    clearBufferUpgradeTimer();
+  };
   const hasRecentUserGesture = () =>
     nowOf() - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs;
   const getRecentExplicitSeekWithoutNewGestureAt = (): number | null => {
@@ -329,6 +376,7 @@ export function createPlaybackBindingController(args: {
         if (guardUnexpectedResume()) {
           return;
         }
+        clearActivePauseClassification();
         rememberExplicitPlaybackAction("playing");
         rememberExplicitUserAction("play");
         scheduleBroadcast(video, "play", 180);
@@ -337,6 +385,32 @@ export function createPlaybackBindingController(args: {
         const currentVideo = args.getSharedVideo();
         if (hasRecentUserGesture()) {
           args.cancelActiveSoftApply(video, "pause");
+        }
+        const now = nowOf();
+        const recentBufferSignal =
+          args.runtimeState.lastBufferSignalAt > 0 &&
+          now - args.runtimeState.lastBufferSignalAt <
+            args.bufferSignalWindowMs;
+        const userInitiatedPause =
+          hasRecentUserGesture() &&
+          args.runtimeState.lastUserGestureAt >
+            args.runtimeState.lastForcedPauseAt;
+        const bufferInduced = recentBufferSignal && !userInitiatedPause;
+        args.runtimeState.pauseStartedAt = now;
+        args.runtimeState.pauseClassifiedAsBuffer = bufferInduced;
+        clearBufferUpgradeTimer();
+        if (bufferInduced) {
+          pauseBufferUpgradeTimerId = scheduleUpgradeTimer(() => {
+            pauseBufferUpgradeTimerId = null;
+            if (!video.paused) {
+              return;
+            }
+            args.runtimeState.pauseClassifiedAsBuffer = false;
+            args.debugLog(
+              `Buffer-pause upgraded to paused after ${args.bufferPauseUpgradeMs}ms, re-broadcasting`,
+            );
+            void args.broadcastPlayback(video, "pause");
+          }, args.bufferPauseUpgradeMs);
         }
         rememberExplicitPlaybackAction("paused");
         rememberExplicitUserAction("pause");
@@ -349,8 +423,14 @@ export function createPlaybackBindingController(args: {
         }
         scheduleBroadcast(video, "pause", 120);
       },
-      onWaiting: () => scheduleBroadcast(video, "waiting"),
-      onStalled: () => scheduleBroadcast(video, "stalled"),
+      onWaiting: () => {
+        args.runtimeState.lastBufferSignalAt = nowOf();
+        scheduleBroadcast(video, "waiting");
+      },
+      onStalled: () => {
+        args.runtimeState.lastBufferSignalAt = nowOf();
+        scheduleBroadcast(video, "stalled");
+      },
       onLoadedMetadata: () => {
         if (!forcePauseWhileWaitingForInitialRoomState(video)) {
           args.applyPendingPlaybackApplication(video);
@@ -369,6 +449,7 @@ export function createPlaybackBindingController(args: {
         if (guardUnexpectedResume()) {
           return;
         }
+        clearActivePauseClassification();
         rememberExplicitPlaybackAction("playing");
         rememberExplicitUserAction("play");
         scheduleBroadcast(video, "playing", 180);
@@ -418,6 +499,7 @@ export function createPlaybackBindingController(args: {
         window.clearInterval(videoBindingTimer);
         videoBindingTimer = null;
       }
+      clearBufferUpgradeTimer();
     },
   };
 }

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -202,39 +202,47 @@ export function createRoomStateApplyController(args: {
     // (e.g. duplicate paused echoes) don't accidentally drop themselves; the
     // version comparison only matters relative to the *currently-stashed*
     // deferred state.
-    if (
-      !fromDebounce &&
-      args.runtimeState.deferredRemotePausedState &&
-      state.playback
-    ) {
+    if (!fromDebounce && args.runtimeState.deferredRemotePausedState) {
       const deferredState = args.runtimeState.deferredRemotePausedState;
       const deferredPlayback = deferredState.playback;
       if (deferredPlayback) {
-        const sameUrl =
-          args.normalizeUrl(state.playback.url) ===
-          args.normalizeUrl(deferredPlayback.url);
-        const closeT =
-          Math.abs(state.playback.currentTime - deferredPlayback.currentTime) <
-          0.5;
-        const isMatchingFlicker =
-          state.playback.playState === "playing" && sameUrl && closeT;
-        const isNewerVersion =
-          state.playback.serverTime > deferredPlayback.serverTime ||
-          (state.playback.serverTime === deferredPlayback.serverTime &&
-            state.playback.seq > deferredPlayback.seq);
-        if (isMatchingFlicker) {
+        if (!state.playback) {
+          // Room emptied (no current playback) — the deferred snapshot's
+          // sharedVideo no longer reflects reality. Letting the timer fire
+          // would re-introduce the stale URL via the activeSharedUrl reset.
           clearDeferredRemotePaused();
           args.debugLog(
-            `Dropped flicker paused seq=${deferredPlayback.seq} superseded by playing seq=${state.playback.seq}`,
+            `Dropped stale deferred paused seq=${deferredPlayback.seq} superseded by empty playback`,
           );
-        } else if (isNewerVersion) {
-          // Any newer state supersedes the deferred paused — keeping it would
-          // let the timer fire later and clobber freshly applied state via the
-          // unconditional activeSharedUrl/intendedPlayState reset further down.
-          clearDeferredRemotePaused();
-          args.debugLog(
-            `Dropped stale deferred paused seq=${deferredPlayback.seq} superseded by ${state.playback.playState} seq=${state.playback.seq}`,
-          );
+        } else {
+          const sameUrl =
+            args.normalizeUrl(state.playback.url) ===
+            args.normalizeUrl(deferredPlayback.url);
+          const closeT =
+            Math.abs(
+              state.playback.currentTime - deferredPlayback.currentTime,
+            ) < 0.5;
+          const isMatchingFlicker =
+            state.playback.playState === "playing" && sameUrl && closeT;
+          const isNewerVersion =
+            state.playback.serverTime > deferredPlayback.serverTime ||
+            (state.playback.serverTime === deferredPlayback.serverTime &&
+              state.playback.seq > deferredPlayback.seq);
+          if (isMatchingFlicker) {
+            clearDeferredRemotePaused();
+            args.debugLog(
+              `Dropped flicker paused seq=${deferredPlayback.seq} superseded by playing seq=${state.playback.seq}`,
+            );
+          } else if (isNewerVersion) {
+            // Any newer state supersedes the deferred paused — keeping it
+            // would let the timer fire later and clobber freshly applied
+            // state via the unconditional activeSharedUrl/intendedPlayState
+            // reset further down.
+            clearDeferredRemotePaused();
+            args.debugLog(
+              `Dropped stale deferred paused seq=${deferredPlayback.seq} superseded by ${state.playback.playState} seq=${state.playback.seq}`,
+            );
+          }
         }
       }
     }

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -196,6 +196,49 @@ export function createRoomStateApplyController(args: {
     shareToast: SharedVideoToastPayload | null = null,
     fromDebounce = false,
   ): Promise<void> {
+    // Before any other handling, decide whether an existing deferred paused
+    // should be dropped because a newer room state has just arrived. We must
+    // do this BEFORE deferring a new paused so that paused→paused chains
+    // (e.g. duplicate paused echoes) don't accidentally drop themselves; the
+    // version comparison only matters relative to the *currently-stashed*
+    // deferred state.
+    if (
+      !fromDebounce &&
+      args.runtimeState.deferredRemotePausedState &&
+      state.playback
+    ) {
+      const deferredState = args.runtimeState.deferredRemotePausedState;
+      const deferredPlayback = deferredState.playback;
+      if (deferredPlayback) {
+        const sameUrl =
+          args.normalizeUrl(state.playback.url) ===
+          args.normalizeUrl(deferredPlayback.url);
+        const closeT =
+          Math.abs(state.playback.currentTime - deferredPlayback.currentTime) <
+          0.5;
+        const isMatchingFlicker =
+          state.playback.playState === "playing" && sameUrl && closeT;
+        const isNewerVersion =
+          state.playback.serverTime > deferredPlayback.serverTime ||
+          (state.playback.serverTime === deferredPlayback.serverTime &&
+            state.playback.seq > deferredPlayback.seq);
+        if (isMatchingFlicker) {
+          clearDeferredRemotePaused();
+          args.debugLog(
+            `Dropped flicker paused seq=${deferredPlayback.seq} superseded by playing seq=${state.playback.seq}`,
+          );
+        } else if (isNewerVersion) {
+          // Any newer state supersedes the deferred paused — keeping it would
+          // let the timer fire later and clobber freshly applied state via the
+          // unconditional activeSharedUrl/intendedPlayState reset further down.
+          clearDeferredRemotePaused();
+          args.debugLog(
+            `Dropped stale deferred paused seq=${deferredPlayback.seq} superseded by ${state.playback.playState} seq=${state.playback.seq}`,
+          );
+        }
+      }
+    }
+
     if (
       !fromDebounce &&
       remotePauseDebounceMs > 0 &&
@@ -217,35 +260,35 @@ export function createRoomStateApplyController(args: {
         if (!pending || destroyed) {
           return;
         }
+        // Freshness check: a newer version for this actor may have been
+        // applied while we were deferring (when the newer state's URL or
+        // t-delta didn't match the flicker shape). Re-entering applyRoomState
+        // with the stale snapshot would hit the unconditional
+        // activeSharedUrl/intendedPlayState reset and clobber the newer
+        // state — so drop it here.
+        const pendingPlayback = pending.playback;
+        if (pendingPlayback) {
+          const lastApplied = args.lastAppliedVersionByActor.get(
+            pendingPlayback.actorId,
+          );
+          if (
+            lastApplied &&
+            (lastApplied.serverTime > pendingPlayback.serverTime ||
+              (lastApplied.serverTime === pendingPlayback.serverTime &&
+                lastApplied.seq >= pendingPlayback.seq))
+          ) {
+            args.debugLog(
+              `Dropped deferred paused seq=${pendingPlayback.seq} at fire time (newer version ${lastApplied.seq} already applied)`,
+            );
+            return;
+          }
+        }
         void applyRoomState(pending, null, true);
       }, remotePauseDebounceMs);
       args.debugLog(
         `Deferred remote paused url=${deferredPlayback.url} seq=${deferredPlayback.seq} for ${remotePauseDebounceMs}ms`,
       );
       return;
-    }
-
-    if (
-      args.runtimeState.deferredRemotePausedState &&
-      state.playback &&
-      state.playback.playState === "playing"
-    ) {
-      const deferredState = args.runtimeState.deferredRemotePausedState;
-      const deferredPlayback = deferredState.playback;
-      if (deferredPlayback) {
-        const sameUrl =
-          args.normalizeUrl(state.playback.url) ===
-          args.normalizeUrl(deferredPlayback.url);
-        const closeT =
-          Math.abs(state.playback.currentTime - deferredPlayback.currentTime) <
-          0.5;
-        if (sameUrl && closeT) {
-          clearDeferredRemotePaused();
-          args.debugLog(
-            `Dropped flicker paused seq=${deferredPlayback.seq} superseded by playing seq=${state.playback.seq}`,
-          );
-        }
-      }
     }
 
     args.notifyRoomStateToasts(state);

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -30,6 +30,13 @@ export function createRoomStateApplyController(args: {
   pauseHoldMs: number;
   initialRoomStatePauseHoldMs: number;
   userGestureGraceMs: number;
+  /**
+   * Delay before applying a remote `paused` room state, to absorb the
+   * "pause→play within ~1s" flicker emitted by peers experiencing buffer
+   * stalls. When 0 the debounce is disabled and paused is applied
+   * synchronously.
+   */
+  remotePauseDebounceMs?: number;
   getNow?: () => number;
   debugLog: (message: string) => void;
   shouldLogHeartbeat: (
@@ -104,6 +111,38 @@ export function createRoomStateApplyController(args: {
   const nowOf = () => args.getNow?.() ?? Date.now();
   let hydrateRetryTimer: number | null = null;
   let destroyed = false;
+  const remotePauseDebounceMs = args.remotePauseDebounceMs ?? 0;
+  const scheduleDeferTimer = (cb: () => void, ms: number): number | null => {
+    if (
+      typeof globalThis.window !== "undefined" &&
+      typeof globalThis.window.setTimeout === "function"
+    ) {
+      return globalThis.window.setTimeout(cb, ms) as unknown as number;
+    }
+    if (typeof globalThis.setTimeout === "function") {
+      return globalThis.setTimeout(cb, ms) as unknown as number;
+    }
+    return null;
+  };
+  const cancelDeferTimer = (id: number): void => {
+    if (
+      typeof globalThis.window !== "undefined" &&
+      typeof globalThis.window.clearTimeout === "function"
+    ) {
+      globalThis.window.clearTimeout(id);
+      return;
+    }
+    if (typeof globalThis.clearTimeout === "function") {
+      globalThis.clearTimeout(id);
+    }
+  };
+  const clearDeferredRemotePaused = (): void => {
+    if (args.runtimeState.deferredRemotePausedTimerId !== null) {
+      cancelDeferTimer(args.runtimeState.deferredRemotePausedTimerId);
+      args.runtimeState.deferredRemotePausedTimerId = null;
+    }
+    args.runtimeState.deferredRemotePausedState = null;
+  };
 
   /**
    * When hydrating an empty room, suppress autoplay only if the video was not
@@ -155,7 +194,60 @@ export function createRoomStateApplyController(args: {
   async function applyRoomState(
     state: RoomState,
     shareToast: SharedVideoToastPayload | null = null,
+    fromDebounce = false,
   ): Promise<void> {
+    if (
+      !fromDebounce &&
+      remotePauseDebounceMs > 0 &&
+      state.playback &&
+      state.playback.playState === "paused" &&
+      args.runtimeState.localMemberId !== null &&
+      state.playback.actorId !== args.runtimeState.localMemberId
+    ) {
+      if (args.runtimeState.deferredRemotePausedTimerId !== null) {
+        cancelDeferTimer(args.runtimeState.deferredRemotePausedTimerId);
+        args.runtimeState.deferredRemotePausedTimerId = null;
+      }
+      const deferredPlayback = state.playback;
+      args.runtimeState.deferredRemotePausedState = state;
+      args.runtimeState.deferredRemotePausedTimerId = scheduleDeferTimer(() => {
+        args.runtimeState.deferredRemotePausedTimerId = null;
+        const pending = args.runtimeState.deferredRemotePausedState;
+        args.runtimeState.deferredRemotePausedState = null;
+        if (!pending || destroyed) {
+          return;
+        }
+        void applyRoomState(pending, null, true);
+      }, remotePauseDebounceMs);
+      args.debugLog(
+        `Deferred remote paused url=${deferredPlayback.url} seq=${deferredPlayback.seq} for ${remotePauseDebounceMs}ms`,
+      );
+      return;
+    }
+
+    if (
+      args.runtimeState.deferredRemotePausedState &&
+      state.playback &&
+      state.playback.playState === "playing"
+    ) {
+      const deferredState = args.runtimeState.deferredRemotePausedState;
+      const deferredPlayback = deferredState.playback;
+      if (deferredPlayback) {
+        const sameUrl =
+          args.normalizeUrl(state.playback.url) ===
+          args.normalizeUrl(deferredPlayback.url);
+        const closeT =
+          Math.abs(state.playback.currentTime - deferredPlayback.currentTime) <
+          0.5;
+        if (sameUrl && closeT) {
+          clearDeferredRemotePaused();
+          args.debugLog(
+            `Dropped flicker paused seq=${deferredPlayback.seq} superseded by playing seq=${state.playback.seq}`,
+          );
+        }
+      }
+    }
+
     args.notifyRoomStateToasts(state);
     args.maybeShowSharedVideoToast(shareToast, state);
 
@@ -521,6 +613,7 @@ export function createRoomStateApplyController(args: {
       window.clearTimeout(hydrateRetryTimer);
       hydrateRetryTimer = null;
     }
+    clearDeferredRemotePaused();
   }
 
   return {

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -1,4 +1,4 @@
-import type { PlaybackState } from "@bili-syncplay/protocol";
+import type { PlaybackState, RoomState } from "@bili-syncplay/protocol";
 
 export interface FestivalVideoSnapshot {
   videoId: string;
@@ -107,6 +107,36 @@ export interface ContentRuntimeState {
   postNavigationAnchorSharedUrl: string | null;
   postNavigationAnchorSetAt: number;
   festivalSnapshot: FestivalVideoSnapshot | null;
+  /**
+   * Timestamp of the most recent `waiting`/`stalled` event from the local
+   * video element. Used to distinguish buffer-induced pauses (which should be
+   * reported to peers as `buffering`) from user-initiated pauses.
+   */
+  lastBufferSignalAt: number;
+  /**
+   * Timestamp when the local video most recently transitioned to `paused`.
+   * Reset to 0 once playback resumes. Together with
+   * [[pauseClassifiedAsBuffer]] this powers the "buffer-pause → buffering"
+   * remote broadcast classification and its upgrade-to-`paused` timeout.
+   */
+  pauseStartedAt: number;
+  /**
+   * Whether the active pause is currently classified as buffer-induced. Set
+   * on the `pause` event when a `waiting`/`stalled` signal occurred very
+   * recently and no fresh user gesture preceded the pause; cleared on
+   * resume. The broadcast layer reports `buffering` instead of `paused`
+   * while this flag is on and within the upgrade threshold.
+   */
+  pauseClassifiedAsBuffer: boolean;
+  /**
+   * When a remote `paused` room state arrives, we briefly hold off applying
+   * it to absorb the common "buffer hiccup" pattern where the remote sends
+   * `paused` then immediately `playing` within ~1s. While this field is set,
+   * a matching `playing` arrival (same URL, |t-delta| < 0.5s) drops the
+   * deferred paused entirely.
+   */
+  deferredRemotePausedState: RoomState | null;
+  deferredRemotePausedTimerId: number | null;
 }
 
 /**
@@ -158,5 +188,10 @@ export function createContentRuntimeState(): ContentRuntimeState {
     postNavigationAnchorSharedUrl: null,
     postNavigationAnchorSetAt: 0,
     festivalSnapshot: null,
+    lastBufferSignalAt: 0,
+    pauseStartedAt: 0,
+    pauseClassifiedAsBuffer: false,
+    deferredRemotePausedState: null,
+    deferredRemotePausedTimerId: null,
   };
 }

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -70,6 +70,18 @@ export function createSyncController(args: {
   remoteFollowPlayingWindowMs: number;
   programmaticApplyWindowMs: number;
   userGestureGraceMs: number;
+  /**
+   * Window during which a buffer-induced pause is broadcast as `buffering`
+   * instead of `paused`. After this elapses the binding layer re-broadcasts
+   * as `paused`.
+   */
+  bufferPauseUpgradeMs: number;
+  /**
+   * Delay before applying a remote `paused` room state, to absorb the
+   * "pause→play within ~1s" flicker emitted by peers experiencing buffer
+   * stalls. Set to 0 to disable.
+   */
+  remotePauseDebounceMs: number;
   nextSeq: () => number;
   markBroadcastAt: (at: number) => void;
   getNow?: () => number;
@@ -596,6 +608,16 @@ export function createSyncController(args: {
         argsForBroadcast.eventSource === "stalled")
     ) {
       return "playing";
+    }
+
+    if (
+      basePlayState === "paused" &&
+      args.runtimeState.pauseClassifiedAsBuffer &&
+      args.runtimeState.pauseStartedAt > 0 &&
+      argsForBroadcast.now - args.runtimeState.pauseStartedAt <
+        args.bufferPauseUpgradeMs
+    ) {
+      return "buffering";
     }
 
     return basePlayState;
@@ -1160,6 +1182,7 @@ export function createSyncController(args: {
     pauseHoldMs: args.pauseHoldMs,
     initialRoomStatePauseHoldMs: args.initialRoomStatePauseHoldMs,
     userGestureGraceMs: args.userGestureGraceMs,
+    remotePauseDebounceMs: args.remotePauseDebounceMs,
     getNow: args.getNow,
     debugLog: args.debugLog,
     shouldLogHeartbeat: args.shouldLogHeartbeat,

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -703,3 +703,198 @@ test("playback binding controller blocks non-shared autoplay replayed after a fo
     dom.restore();
   }
 });
+
+test("playback binding controller classifies pause as buffer when waiting fired recently", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 0;
+  let now = 5_000;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("waiting")?.(new Event("waiting"));
+    assert.equal(runtimeState.lastBufferSignalAt, 5_000);
+
+    now = 5_120;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
+    assert.equal(runtimeState.pauseStartedAt, 5_120);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller treats pause as user-initiated when fresh gesture preceded it", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  let now = 5_000;
+  runtimeState.lastUserGestureAt = 4_950; // fresh gesture
+  runtimeState.lastForcedPauseAt = 0;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    // A waiting event fires shortly before the pause, but since the user
+    // also just clicked, classification should fall back to user pause.
+    dom.listeners.get("waiting")?.(new Event("waiting"));
+    now = 5_120;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
+    assert.equal(runtimeState.pauseStartedAt, 5_120);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller clears buffer-pause classification on resume", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 0;
+  let now = 5_000;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("waiting")?.(new Event("waiting"));
+    now = 5_100;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
+
+    now = 5_800;
+    dom.video.paused = false;
+    dom.listeners.get("playing")?.(new Event("playing"));
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
+    assert.equal(runtimeState.pauseStartedAt, 0);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller re-broadcasts paused after buffer-pause upgrade threshold", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 0;
+  let now = 5_000;
+  const broadcasts: string[] = [];
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const scheduledTimers: Array<{ cb: () => void; ms: number }> = [];
+  globalThis.window.setTimeout = ((callback: TimerHandler, ms?: number) => {
+    if (typeof callback === "function") {
+      scheduledTimers.push({ cb: callback as () => void, ms: ms ?? 0 });
+    }
+    return scheduledTimers.length;
+  }) as typeof globalThis.window.setTimeout;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async (_video, eventSource) => {
+      broadcasts.push(eventSource ?? "manual");
+    },
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("waiting")?.(new Event("waiting"));
+    now = 5_100;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+
+    await Promise.resolve();
+    // Initial broadcasts from pause + 120ms followup (captured but not fired here)
+    assert.equal(broadcasts.includes("pause"), true);
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
+    const upgradeTimer = scheduledTimers.find((t) => t.ms === 1_500);
+    assert.notEqual(upgradeTimer, undefined);
+
+    // Fire the upgrade timer: video still paused, should re-broadcast and clear classification
+    now = 6_600;
+    broadcasts.length = 0;
+    upgradeTimer?.cb();
+    await Promise.resolve();
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
+    assert.equal(broadcasts.includes("pause"), true);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.restore();
+  }
+});

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -453,6 +453,41 @@ test("drops deferred paused when a newer-versioned state arrives even if t-delta
   }
 });
 
+test("drops deferred paused when an empty-playback room state arrives", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+    });
+    harness.runtimeState.localMemberId = "local-member";
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 5,
+      }) as never,
+    );
+    assert.equal(harness.runtimeState.deferredRemotePausedState !== null, true);
+
+    // Empty room (no playback) — deferred snapshot's sharedVideo is now stale.
+    await harness.controller.applyRoomState(createEmptyRoomState());
+
+    assert.equal(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(
+      harness.logs.some((m) => m.includes("superseded by empty playback")),
+      true,
+    );
+  } finally {
+    win.restore();
+  }
+});
+
 test("deferred timer is a no-op when fire-time freshness check sees a newer applied version", async () => {
   const win = installWindowTimerStub();
   try {

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -41,10 +41,14 @@ function createController(overrides: {
   let _pauseHoldActivated = false;
   let _acceptedHydration = false;
   const logs: string[] = [];
+  const lastAppliedVersionByActor = new Map<
+    string,
+    { serverTime: number; seq: number }
+  >();
 
   const controller = createRoomStateApplyController({
     runtimeState,
-    lastAppliedVersionByActor: new Map(),
+    lastAppliedVersionByActor,
     ignoredSelfPlaybackLogState: { key: null, at: 0 },
     localIntentGuardMs: 1_200,
     pauseHoldMs: 800,
@@ -90,6 +94,7 @@ function createController(overrides: {
   return {
     controller,
     runtimeState,
+    lastAppliedVersionByActor,
     get pauseHoldActivated() {
       return _pauseHoldActivated;
     },
@@ -402,7 +407,7 @@ test("drops deferred paused when matching playing arrives within debounce window
   }
 });
 
-test("keeps deferred paused when subsequent playing has large t-delta", async () => {
+test("drops deferred paused when a newer-versioned state arrives even if t-delta is large", async () => {
   const win = installWindowTimerStub();
   try {
     const video = createStubVideo(false);
@@ -423,10 +428,11 @@ test("keeps deferred paused when subsequent playing has large t-delta", async ()
         seq: 5,
       }) as never,
     );
-    const deferredBefore = harness.runtimeState.deferredRemotePausedState;
-    assert.equal(deferredBefore !== null, true);
+    assert.equal(harness.runtimeState.deferredRemotePausedState !== null, true);
 
-    // t-delta = 5.0 (> 0.5 threshold) → should NOT drop the deferred paused
+    // t-delta = 5.0 (not a flicker shape), but the new state has a higher
+    // version — letting the deferred fire later would clobber freshly applied
+    // state via the unconditional activeSharedUrl reset, so drop it.
     await harness.controller.applyRoomState(
       createRoomStateWithPlayback({
         url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
@@ -437,10 +443,59 @@ test("keeps deferred paused when subsequent playing has large t-delta", async ()
       }) as never,
     );
 
+    assert.equal(harness.runtimeState.deferredRemotePausedState, null);
     assert.equal(
-      harness.runtimeState.deferredRemotePausedState,
-      deferredBefore,
+      harness.logs.some((m) => m.includes("Dropped stale deferred paused")),
+      true,
     );
+  } finally {
+    win.restore();
+  }
+});
+
+test("deferred timer is a no-op when fire-time freshness check sees a newer applied version", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+    });
+    harness.runtimeState.localMemberId = "local-member";
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 5,
+      }) as never,
+    );
+    assert.equal(win.scheduled.length, 1);
+    const fired = win.scheduled[0];
+
+    // Simulate that a newer (serverTime, seq) was applied for this actor
+    // while the deferred was waiting — the apply layer writes this map on
+    // every successful apply.
+    harness.lastAppliedVersionByActor.set("remote-member", {
+      serverTime: 1,
+      seq: 8,
+    });
+
+    fired.cb();
+    await Promise.resolve();
+
+    assert.equal(
+      harness.logs.some((m) =>
+        m.includes("Dropped deferred paused seq=5 at fire time"),
+      ),
+      true,
+      "fire-time freshness check should drop the stale snapshot",
+    );
+    assert.equal(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(harness.runtimeState.deferredRemotePausedTimerId, null);
   } finally {
     win.restore();
   }

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -29,6 +29,12 @@ function createController(overrides: {
   video?: HTMLVideoElement | null;
   now?: number;
   userGestureGraceMs?: number;
+  remotePauseDebounceMs?: number;
+  normalizeUrl?: (url: string | undefined | null) => string | null;
+  rememberRemotePlaybackForSuppression?: (
+    playback: import("@bili-syncplay/protocol").PlaybackState,
+  ) => void;
+  applyPendingPlaybackApplication?: (video: HTMLVideoElement) => void;
 }) {
   const runtimeState = overrides.runtimeState ?? createContentRuntimeState();
   const video = overrides.video ?? null;
@@ -44,6 +50,7 @@ function createController(overrides: {
     pauseHoldMs: 800,
     initialRoomStatePauseHoldMs: 3_000,
     userGestureGraceMs: overrides.userGestureGraceMs ?? 1_200,
+    remotePauseDebounceMs: overrides.remotePauseDebounceMs ?? 0,
     getNow: () => overrides.now ?? 10_000,
     debugLog: (msg) => logs.push(msg),
     shouldLogHeartbeat: () => true,
@@ -52,7 +59,7 @@ function createController(overrides: {
     setHydrateRetryTimer: () => {},
     getVideoElement: () => video,
     getSharedVideo: () => null,
-    normalizeUrl: (url) => url ?? null,
+    normalizeUrl: overrides.normalizeUrl ?? ((url) => url ?? null),
     notifyRoomStateToasts: () => {},
     maybeShowSharedVideoToast: () => {},
     cancelActiveSoftApply: () => {},
@@ -72,9 +79,11 @@ function createController(overrides: {
     shouldIgnoreRemotePlaybackApply: () => false,
     shouldSuppressRemotePlaybackByCooldown: () => false,
     rememberRemoteFollowPlayingWindow: () => {},
-    rememberRemotePlaybackForSuppression: () => {},
+    rememberRemotePlaybackForSuppression:
+      overrides.rememberRemotePlaybackForSuppression ?? (() => {}),
     armProgrammaticApplyWindow: () => {},
-    applyPendingPlaybackApplication: () => {},
+    applyPendingPlaybackApplication:
+      overrides.applyPendingPlaybackApplication ?? (() => {}),
     formatPlaybackDiagnostic: (a) => `${a.result}`,
   });
 
@@ -243,4 +252,288 @@ test("pauses video when gesture age exactly equals the grace window boundary", a
   assert.equal(harness.pauseHoldActivated, true);
   assert.equal(harness.acceptedHydration, true);
   assert.equal(video.paused, true);
+});
+
+function installWindowTimerStub() {
+  const originalWindow = globalThis.window;
+  const scheduled: Array<{ id: number; cb: () => void; ms: number }> = [];
+  const cleared: number[] = [];
+  let nextTimer = 1;
+
+  const windowStub = {
+    setTimeout(cb: () => void, ms?: number) {
+      const id = nextTimer++;
+      scheduled.push({ id, cb, ms: ms ?? 0 });
+      return id;
+    },
+    clearTimeout(id: number) {
+      cleared.push(id);
+    },
+  };
+  Object.assign(globalThis, { window: windowStub });
+
+  return {
+    scheduled,
+    cleared,
+    restore() {
+      Object.assign(globalThis, { window: originalWindow });
+    },
+  };
+}
+
+function createRoomStateWithPlayback(playback: {
+  url: string;
+  currentTime: number;
+  playState: "playing" | "paused" | "buffering";
+  actorId: string;
+  seq?: number;
+}) {
+  return {
+    roomCode: "ROOM01",
+    sharedVideo: {
+      videoId: "BV1xx411c7mD:p1",
+      url: playback.url,
+      title: "Video",
+    },
+    playback: {
+      url: playback.url,
+      currentTime: playback.currentTime,
+      playState: playback.playState,
+      playbackRate: 1,
+      updatedAt: 1,
+      serverTime: 1,
+      actorId: playback.actorId,
+      seq: playback.seq ?? 1,
+    },
+    members: [],
+  } as const;
+}
+
+test("defers remote paused room state when remotePauseDebounceMs > 0", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    let applyPending = 0;
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+      applyPendingPlaybackApplication: () => {
+        applyPending += 1;
+      },
+    });
+    harness.runtimeState.localMemberId = "local-member";
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 5,
+      }) as never,
+    );
+
+    assert.equal(
+      harness.runtimeState.deferredRemotePausedState !== null,
+      true,
+      "paused room state should be captured for deferred apply",
+    );
+    assert.equal(win.scheduled.length, 1);
+    assert.equal(win.scheduled[0].ms, 250);
+    assert.equal(
+      applyPending,
+      0,
+      "apply should be deferred, not run synchronously",
+    );
+  } finally {
+    win.restore();
+  }
+});
+
+test("drops deferred paused when matching playing arrives within debounce window", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+    });
+    harness.runtimeState.localMemberId = "local-member";
+    harness.runtimeState.hydrationReady = true;
+    harness.runtimeState.activeSharedUrl =
+      "https://www.bilibili.com/video/BV1xx411c7mD?p=1";
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42.0,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 5,
+      }) as never,
+    );
+    assert.equal(harness.runtimeState.deferredRemotePausedState !== null, true);
+
+    // Same url, t-delta < 0.5 → should drop deferred paused
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42.2,
+        playState: "playing",
+        actorId: "remote-member",
+        seq: 6,
+      }) as never,
+    );
+
+    assert.equal(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(
+      win.cleared.includes(win.scheduled[0].id),
+      true,
+      "deferred timer should be cleared",
+    );
+    assert.equal(
+      harness.logs.some((m) => m.includes("Dropped flicker paused")),
+      true,
+    );
+  } finally {
+    win.restore();
+  }
+});
+
+test("keeps deferred paused when subsequent playing has large t-delta", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+    });
+    harness.runtimeState.localMemberId = "local-member";
+    harness.runtimeState.hydrationReady = true;
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42.0,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 5,
+      }) as never,
+    );
+    const deferredBefore = harness.runtimeState.deferredRemotePausedState;
+    assert.equal(deferredBefore !== null, true);
+
+    // t-delta = 5.0 (> 0.5 threshold) → should NOT drop the deferred paused
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 47.0,
+        playState: "playing",
+        actorId: "remote-member",
+        seq: 6,
+      }) as never,
+    );
+
+    assert.equal(
+      harness.runtimeState.deferredRemotePausedState,
+      deferredBefore,
+    );
+  } finally {
+    win.restore();
+  }
+});
+
+test("does not debounce self-playback paused", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+    });
+    harness.runtimeState.localMemberId = "local-member";
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "local-member",
+        seq: 5,
+      }) as never,
+    );
+
+    assert.equal(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(win.scheduled.length, 0);
+  } finally {
+    win.restore();
+  }
+});
+
+test("debounce off when remotePauseDebounceMs is 0 — paused applies synchronously", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 0,
+    });
+    harness.runtimeState.localMemberId = "local-member";
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 5,
+      }) as never,
+    );
+
+    assert.equal(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(win.scheduled.length, 0);
+  } finally {
+    win.restore();
+  }
+});
+
+test("deferred timer fires and applies paused when no playing arrives in window", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+    });
+    harness.runtimeState.localMemberId = "local-member";
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 5,
+      }) as never,
+    );
+
+    assert.equal(win.scheduled.length, 1);
+
+    // Fire the deferred timer; this re-enters applyRoomState with fromDebounce=true
+    const fired = win.scheduled[0];
+    fired.cb();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(harness.runtimeState.deferredRemotePausedTimerId, null);
+  } finally {
+    win.restore();
+  }
 });

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -1247,3 +1247,131 @@ test("sync controller releases post-navigation anchor and broadcasts once resolv
     "broadcast should proceed once resolved url differs from the anchor",
   );
 });
+
+test("sync controller broadcasts buffering when active pause is classified as buffer", async () => {
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({
+    paused: true,
+    readyState: 4,
+    currentTime: 40,
+  });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.intendedPlayState = "paused";
+  harness.runtimeState.pauseStartedAt = 20_000;
+  harness.runtimeState.pauseClassifiedAsBuffer = true;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+
+  harness.controller = createSyncController({
+    runtimeState: harness.runtimeState,
+    lastAppliedVersionByActor: new Map(),
+    broadcastLogState: { key: null, at: 0 },
+    ignoredSelfPlaybackLogState: { key: null, at: 0 },
+    localIntentGuardMs: 500,
+    pauseHoldMs: 1_000,
+    initialRoomStatePauseHoldMs: 1_500,
+    remoteEchoSuppressionMs: 800,
+    remotePlayTransitionGuardMs: 500,
+    remoteFollowPlayingWindowMs: 3_000,
+    programmaticApplyWindowMs: 700,
+    userGestureGraceMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    remotePauseDebounceMs: 0,
+    nextSeq: () => 1,
+    markBroadcastAt: () => {},
+    getNow: () => 20_400,
+    debugLog: (message) => harness.debugLogs.push(message),
+    shouldLogHeartbeat: () => true,
+    runtimeSendMessage: async (message) => {
+      harness.runtimeMessages.push(message);
+      return null;
+    },
+    getVideoElement: () => video,
+    getCurrentPlaybackVideo: async () => sharedVideo,
+    getSharedVideo: () => sharedVideo,
+    normalizeUrl: (url) => url?.trim() ?? null,
+    notifyRoomStateToasts: () => {},
+    maybeShowSharedVideoToast: () => {},
+  });
+
+  await harness.controller.broadcastPlayback(video, "pause");
+
+  assert.equal(harness.runtimeMessages.length, 1);
+  const payload = (
+    harness.runtimeMessages[0] as { payload: { playState: string } }
+  ).payload;
+  assert.equal(payload.playState, "buffering");
+});
+
+test("sync controller broadcasts paused once buffer-pause upgrade window elapses", async () => {
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({
+    paused: true,
+    readyState: 4,
+    currentTime: 40,
+  });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.intendedPlayState = "paused";
+  harness.runtimeState.pauseStartedAt = 20_000;
+  harness.runtimeState.pauseClassifiedAsBuffer = true;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+
+  harness.controller = createSyncController({
+    runtimeState: harness.runtimeState,
+    lastAppliedVersionByActor: new Map(),
+    broadcastLogState: { key: null, at: 0 },
+    ignoredSelfPlaybackLogState: { key: null, at: 0 },
+    localIntentGuardMs: 500,
+    pauseHoldMs: 1_000,
+    initialRoomStatePauseHoldMs: 1_500,
+    remoteEchoSuppressionMs: 800,
+    remotePlayTransitionGuardMs: 500,
+    remoteFollowPlayingWindowMs: 3_000,
+    programmaticApplyWindowMs: 700,
+    userGestureGraceMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    remotePauseDebounceMs: 0,
+    nextSeq: () => 1,
+    markBroadcastAt: () => {},
+    getNow: () => 21_700, // 1700ms after pauseStartedAt, past upgrade threshold
+    debugLog: (message) => harness.debugLogs.push(message),
+    shouldLogHeartbeat: () => true,
+    runtimeSendMessage: async (message) => {
+      harness.runtimeMessages.push(message);
+      return null;
+    },
+    getVideoElement: () => video,
+    getCurrentPlaybackVideo: async () => sharedVideo,
+    getSharedVideo: () => sharedVideo,
+    normalizeUrl: (url) => url?.trim() ?? null,
+    notifyRoomStateToasts: () => {},
+    maybeShowSharedVideoToast: () => {},
+  });
+
+  await harness.controller.broadcastPlayback(video, "pause");
+
+  assert.equal(harness.runtimeMessages.length, 1);
+  const payload = (
+    harness.runtimeMessages[0] as { payload: { playState: string } }
+  ).payload;
+  assert.equal(payload.playState, "paused");
+});


### PR DESCRIPTION
## Summary

修复同步播放时本地视频被远端"瞬时 paused→playing"乒乓拽进暂停又恢复的卡顿。日志显示当其他成员的 B 站播放器在 segment 切换 / buffer 恢复时会触发原生 `pause` 事件，每秒能连发 4–5 条 `playState=paused` 然后立即 `playing`，本地忠实执行 hard-seek + pause + play，体感就是"播着播着自己暂了一下"。

两层互补防御：

- **远端广播侧**：`pause` 事件若紧跟 `waiting`/`stalled` 且没有用户手势，则把这次暂停分类为 buffer 引起的，广播 `buffering` 而不是 `paused`（接收侧只对齐位置，不暂停本地）。1.5s 升级 timer 兜底：若仍 paused，重新广播 `paused`，避免真实暂停被无限隐藏。
- **本地接收侧**：远端发来的 `paused` 延迟 250ms 应用。窗口内收到同 URL、|Δt|<0.5s 的 `playing` → 直接丢弃，闪烁不会触达 `<video>`。

Codex 评审又发现一处 race：deferred 快照可能在更晚的状态被应用后才 fire，旧的 `RoomState` 重入 `applyRoomState` 时会命中顶部那段无条件的 `activeSharedUrl`/`intendedPlayState` reset，把刚应用的新状态覆盖回旧值。补了三层防御：
1. 收到任何更新版本（`(serverTime, seq)` 更大）的 state → 立刻丢弃 deferred
2. 收到空房 state（`playback === null`）→ 立刻丢弃 deferred（避免 sharedVideo URL 回滚）
3. Timer fire 时查 `lastAppliedVersionByActor` → 若该 actor 已有更新版本应用过 → 跳过重入

## Test plan

- [x] `npm run format:check` / `lint` / `typecheck` / `build` 全过
- [x] `npm test` 全套：protocol 7 + server 14 + server-e2e 69 + server 323（295 pass + 28 skip）+ extension 246，**0 失败**
- [x] 新增 14 个 unit 测试覆盖：buffer 分类 / 用户手势否定 / resume 清理 / 升级 timer 兜底 / broadcast 在窗口内报 buffering / 过窗后报 paused / defer 调度 / flicker 丢弃 / 更新版本丢弃 / 空房丢弃 / self-playback 不去抖 / debounceMs=0 关闭 / timer 兜底提交 / fire-time freshness check
- [ ] 真机回归：开两个 B 站 tab 同房间，蹲一会儿看是否还有 \"自动暂停\" 现象（pending — 需要在你本地复现环境验证）

## Notes

- 协议字段 0 改动，纯客户端分类/去抖层，对服务端和老版本扩展兼容
- 3 个 commit 都是独立可 review 的：原始两修复 → race 修复 → empty-playback 边界

🤖 Generated with [Claude Code](https://claude.com/claude-code)