### PR TITLE
fix: skip buffer-pause classification during programmatic paused apply

### DIFF
--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -395,7 +395,28 @@ export function createPlaybackBindingController(args: {
           hasRecentUserGesture() &&
           args.runtimeState.lastUserGestureAt >
             args.runtimeState.lastForcedPauseAt;
-        const bufferInduced = recentBufferSignal && !userInitiatedPause;
+        // When applying a remote `paused`, we hard-seek then call `video.pause()`.
+        // The seek trips a `waiting` event milliseconds before the `pause`, so the
+        // buffer-signal window will look "fresh" even though no real stall occurred.
+        // Classifying this as buffer-induced would (a) escape the programmatic
+        // suppression (signature=paused vs broadcast=buffering) and leak the
+        // applied state back out, and (b) record lastLocalIntent=buffering,
+        // which blocks the peer's next `playing` via local-intent-guard for up
+        // to LOCAL_INTENT_GUARD_MS — the visible "resume takes a few seconds"
+        // symptom after a remote pause→play.
+        const programmaticSignature =
+          args.runtimeState.programmaticApplySignature;
+        const normalizedSharedUrl = args.normalizeUrl(currentVideo?.url);
+        const insideProgrammaticPausedWindow =
+          programmaticSignature !== null &&
+          programmaticSignature.playState === "paused" &&
+          now < args.runtimeState.programmaticApplyUntil &&
+          normalizedSharedUrl !== null &&
+          normalizedSharedUrl === programmaticSignature.url;
+        const bufferInduced =
+          !insideProgrammaticPausedWindow &&
+          recentBufferSignal &&
+          !userInitiatedPause;
         args.runtimeState.pauseStartedAt = now;
         args.runtimeState.pauseClassifiedAsBuffer = bufferInduced;
         clearBufferUpgradeTimer();

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -834,6 +834,128 @@ test("playback binding controller clears buffer-pause classification on resume",
   }
 });
 
+test("playback binding controller does not classify pause as buffer-induced inside a programmatic paused-apply window", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 0;
+  // Programmatic paused-apply is in flight: matches signature path used by
+  // room-state-apply-controller when applying a remote `paused`. Without the
+  // guard, the synthetic `waiting` event from the hard-seek would tag the
+  // following `pause` as buffer-induced and let it broadcast as `buffering`,
+  // which then blocks the peer's next `playing` via local-intent-guard.
+  runtimeState.programmaticApplyUntil = 5_500;
+  runtimeState.programmaticApplySignature = {
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    playState: "paused",
+    currentTime: 11.12,
+    playbackRate: 1,
+  };
+  let now = 5_000;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const scheduledTimers: Array<{ cb: () => void; ms: number }> = [];
+  globalThis.window.setTimeout = ((callback: TimerHandler, ms?: number) => {
+    if (typeof callback === "function") {
+      scheduledTimers.push({ cb: callback as () => void, ms: ms ?? 0 });
+    }
+    return scheduledTimers.length;
+  }) as typeof globalThis.window.setTimeout;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    getSharedVideo: () => ({
+      videoId: "BV1xx411c7mD:p1",
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      title: "Video",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    // Synthetic waiting from hard-seek, then synthetic pause from video.pause().
+    dom.listeners.get("waiting")?.(new Event("waiting"));
+    assert.equal(runtimeState.lastBufferSignalAt, 5_000);
+    now = 5_120;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
+    assert.equal(runtimeState.pauseStartedAt, 5_120);
+    // No buffer-pause upgrade timer should have been armed.
+    assert.equal(
+      scheduledTimers.some((t) => t.ms === 1_500),
+      false,
+    );
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.restore();
+  }
+});
+
+test("playback binding controller still classifies pause as buffer-induced when programmatic apply window has expired", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 0;
+  runtimeState.programmaticApplyUntil = 4_500; // already expired vs now=5_000
+  runtimeState.programmaticApplySignature = {
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    playState: "paused",
+    currentTime: 11.12,
+    playbackRate: 1,
+  };
+  let now = 5_000;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    getSharedVideo: () => ({
+      videoId: "BV1xx411c7mD:p1",
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      title: "Video",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("waiting")?.(new Event("waiting"));
+    now = 5_120;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
+  } finally {
+    dom.restore();
+  }
+});
+
 test("playback binding controller re-broadcasts paused after buffer-pause upgrade threshold", async () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();


### PR DESCRIPTION
## Summary

PR #120 之后出现的回归：远端暂停再恢复播放，本端要过几秒才开始播。

根因：远端 `paused` 经 deferred 路径 apply 时做 `hard-seek` + `video.pause()`，连续触发本地 `waiting` → `pause` 两个事件。`onPause` 看到刚有 `waiting` 信号且无近期用户手势，把这次 pause 误判为 `bufferInduced=true`，导致：

1. `getBroadcastPlayState` 把 paused 改写成 `buffering`；
2. programmatic 抑制器签名是 `paused`，和 `buffering` 不兼容，广播逃逸；
3. 这次广播把 `lastLocalIntent` 写成 `buffering`/`paused`；
4. 远端发来的 `playing` 在 `LOCAL_INTENT_GUARD_MS`（1.2s）+ buffer-pause-upgrade 续 1.5s 的 `paused` 重广播窗口内被 `local-intent-guard` 一直拦截；
5. 直到 guard 过期、远端以 `explicit-seek` 重 hard-seek 才生效，宏观上"延迟几秒才开始播放"。

修复：`onPause` 中如果当前处于 programmatic apply 窗口、签名是 `paused`、URL 匹配，则不把这次 pause 标为 buffer-induced。这样广播保持 `paused`，programmatic 抑制器正常匹配并抑制，`lastLocalIntent` 不被污染，远端 `playing` 能立刻应用。

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`（248/248 通过）
- [x] 新增 2 条回归测试 `extension/test/playback-binding-controller.test.ts`
  - 窗口内 + 同 URL + 签名为 paused：`pauseClassifiedAsBuffer` 保持 false，未调度 1500ms 升级定时器
  - 窗口过期：仍按 buffer-induced 处理，保留原行为兜底
- [ ] 双端联调：A 端暂停 → 恢复播放，确认 B 端立即响应（< 200ms 量级），不再有 1–2s 等待

🤖 Generated with [Claude Code](https://claude.com/claude-code)