### PR TITLE
feat: signal user-initiated pause to bypass remote-pause flicker debounce

### DIFF
--- a/extension/src/content/playback-broadcast.ts
+++ b/extension/src/content/playback-broadcast.ts
@@ -56,12 +56,13 @@ export function createPlaybackBroadcastPayload(args: {
   currentTime: number;
   playState: PlaybackState["playState"];
   syncIntent?: PlaybackState["syncIntent"];
+  userInitiated?: boolean;
   playbackRate: number;
   actorId: string;
   seq: number;
   now: number;
 }): PlaybackState {
-  return {
+  const payload: PlaybackState = {
     url: args.currentVideo.url,
     currentTime: args.currentTime,
     playState: args.playState,
@@ -72,6 +73,57 @@ export function createPlaybackBroadcastPayload(args: {
     actorId: args.actorId,
     seq: args.seq,
   };
+  // Omit the field entirely (instead of serializing `false`) when not set, so
+  // we stay byte-identical to legacy senders on the wire for non-user pauses.
+  if (args.userInitiated) {
+    payload.userInitiated = true;
+  }
+  return payload;
+}
+
+/**
+ * Returns `true` when this broadcast represents a true user-driven pause
+ * (e.g. the user clicked pause on the player). False/undefined otherwise.
+ *
+ * The signal is consumed by peers to skip the remote-pause flicker debounce,
+ * so it must be conservative: any pause that *could* be buffer-induced,
+ * programmatic-apply-induced, or post-forced-pause must NOT be marked.
+ */
+export function deriveUserInitiatedPause(args: {
+  eventSource: LocalPlaybackEventSource;
+  playState: PlaybackState["playState"];
+  lastExplicitUserAction: {
+    kind: "play" | "pause" | "seek" | "ratechange";
+    at: number;
+  } | null;
+  lastForcedPauseAt: number;
+  programmaticApplyUntil: number;
+  programmaticApplyPlayState: PlaybackState["playState"] | null;
+  now: number;
+  userGestureGraceMs: number;
+}): boolean {
+  if (args.eventSource !== "pause" || args.playState !== "paused") {
+    return false;
+  }
+  if (
+    !args.lastExplicitUserAction ||
+    args.lastExplicitUserAction.kind !== "pause" ||
+    args.lastExplicitUserAction.at <= args.lastForcedPauseAt ||
+    args.now - args.lastExplicitUserAction.at >= args.userGestureGraceMs
+  ) {
+    return false;
+  }
+  // A programmatic remote-paused apply also fires a `pause` DOM event. Even
+  // though we usually suppress that broadcast via the programmatic guard,
+  // belt-and-braces: never tag the broadcast as user-initiated while a
+  // matching paused-apply window is still open.
+  if (
+    args.programmaticApplyPlayState === "paused" &&
+    args.now < args.programmaticApplyUntil
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export function derivePlaybackSyncIntent(args: {

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -247,8 +247,26 @@ export function createRoomStateApplyController(args: {
       }
     }
 
+    // A peer-marked user-initiated pause bypasses the flicker debounce: by
+    // convention the sender only sets the flag for explicit gestures (never
+    // for buffer-induced pauses or remote-state echoes), so we can apply
+    // immediately and avoid the visible 250ms lag that the debounce otherwise
+    // adds to legitimate user pauses. Any deferred paused already in flight
+    // is dropped so the immediate apply isn't undone by a stale timer.
+    const userInitiatedRemotePause =
+      !fromDebounce &&
+      state.playback &&
+      state.playback.playState === "paused" &&
+      state.playback.userInitiated === true &&
+      args.runtimeState.localMemberId !== null &&
+      state.playback.actorId !== args.runtimeState.localMemberId;
+    if (userInitiatedRemotePause) {
+      clearDeferredRemotePaused();
+    }
+
     if (
       !fromDebounce &&
+      !userInitiatedRemotePause &&
       remotePauseDebounceMs > 0 &&
       state.playback &&
       state.playback.playState === "paused" &&

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -277,6 +277,29 @@ export function createRoomStateApplyController(args: {
       args.runtimeState.localMemberId !== null &&
       state.playback.actorId !== args.runtimeState.localMemberId
     ) {
+      // Mirror the upstream version-comparison block: if a deferred snapshot
+      // is still present after that block ran, the incoming state was deemed
+      // older (or otherwise non-superseding). Overwriting the deferred slot
+      // here would invert the version ordering — the older state would fire
+      // 250ms later and clobber the newer one. Drop the incoming instead.
+      // This is especially important now that incoming paused can carry
+      // userInitiated:true: a delayed hydrate response landing after a newer
+      // realtime push must not get a "skip the debounce" express ticket via
+      // an overwrite-then-fire path.
+      const existingDeferred = args.runtimeState.deferredRemotePausedState;
+      const existingDeferredPlayback = existingDeferred?.playback;
+      if (existingDeferredPlayback) {
+        const incomingIsOlder =
+          state.playback.serverTime < existingDeferredPlayback.serverTime ||
+          (state.playback.serverTime === existingDeferredPlayback.serverTime &&
+            state.playback.seq < existingDeferredPlayback.seq);
+        if (incomingIsOlder) {
+          args.debugLog(
+            `Dropped incoming paused seq=${state.playback.seq} (older than deferred seq=${existingDeferredPlayback.seq})`,
+          );
+          return;
+        }
+      }
       if (args.runtimeState.deferredRemotePausedTimerId !== null) {
         cancelDeferTimer(args.runtimeState.deferredRemotePausedTimerId);
         args.runtimeState.deferredRemotePausedTimerId = null;

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -251,18 +251,22 @@ export function createRoomStateApplyController(args: {
     // convention the sender only sets the flag for explicit gestures (never
     // for buffer-induced pauses or remote-state echoes), so we can apply
     // immediately and avoid the visible 250ms lag that the debounce otherwise
-    // adds to legitimate user pauses. Any deferred paused already in flight
-    // is dropped so the immediate apply isn't undone by a stale timer.
+    // adds to legitimate user pauses.
+    //
+    // The short-circuit is gated on the deferred slot already being clear —
+    // the upstream version-comparison block above clears it when the incoming
+    // state genuinely supersedes the deferred snapshot. If a deferred is
+    // still present here, the incoming state did NOT supersede it (older
+    // serverTime/seq, not a matching flicker), so taking the short-circuit
+    // would invert the version ordering. Yield to the normal path instead.
     const userInitiatedRemotePause =
       !fromDebounce &&
       state.playback &&
       state.playback.playState === "paused" &&
       state.playback.userInitiated === true &&
       args.runtimeState.localMemberId !== null &&
-      state.playback.actorId !== args.runtimeState.localMemberId;
-    if (userInitiatedRemotePause) {
-      clearDeferredRemotePaused();
-    }
+      state.playback.actorId !== args.runtimeState.localMemberId &&
+      args.runtimeState.deferredRemotePausedState === null;
 
     if (
       !fromDebounce &&

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -7,6 +7,7 @@ import type { SharedVideoToastPayload } from "../shared/messages";
 import {
   createPlaybackBroadcastPayload,
   derivePlaybackSyncIntent,
+  deriveUserInitiatedPause,
   shouldPauseForNonSharedBroadcast,
   shouldSkipBroadcastWhileHydrating,
 } from "./playback-broadcast";
@@ -1116,6 +1117,17 @@ export function createSyncController(args: {
         eventSource,
         lastExplicitUserAction: args.runtimeState.lastExplicitUserAction,
         lastForcedPauseAt: args.runtimeState.lastForcedPauseAt,
+        now,
+        userGestureGraceMs: args.userGestureGraceMs,
+      }),
+      userInitiated: deriveUserInitiatedPause({
+        eventSource,
+        playState,
+        lastExplicitUserAction: args.runtimeState.lastExplicitUserAction,
+        lastForcedPauseAt: args.runtimeState.lastForcedPauseAt,
+        programmaticApplyUntil: args.runtimeState.programmaticApplyUntil,
+        programmaticApplyPlayState:
+          args.runtimeState.programmaticApplySignature?.playState ?? null,
         now,
         userGestureGraceMs: args.userGestureGraceMs,
       }),

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -710,7 +710,7 @@ test("userInitiated remote paused cancels any already-deferred paused snapshot",
   }
 });
 
-test("userInitiated remote paused does NOT short-circuit when the incoming state is older than an in-flight deferred", async () => {
+test("older userInitiated remote paused neither short-circuits nor overwrites the newer in-flight deferred", async () => {
   const win = installWindowTimerStub();
   try {
     const video = createStubVideo(false);
@@ -735,14 +735,22 @@ test("userInitiated remote paused does NOT short-circuit when the incoming state
         seq: 10,
       }) as never,
     );
-    assert.notEqual(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(
+      (
+        harness.runtimeState.deferredRemotePausedState as never as {
+          playback: { seq: number };
+        }
+      )?.playback.seq,
+      10,
+    );
     assert.equal(win.scheduled.length, 1);
+    const newerDeferredRef = harness.runtimeState.deferredRemotePausedState;
 
     // Second arrival: SAME actor but OLDER seq, with userInitiated=true.
-    // This models e.g. a delayed hydrate response landing after a newer
-    // realtime push. The upstream version-comparison block must preserve
-    // the in-flight deferred, and the short-circuit must NOT fire — taking
-    // it would lose the newer deferred snapshot via immediate apply.
+    // Models a delayed hydrate response landing after a newer realtime push.
+    // The short-circuit must NOT fire (would lose the deferred via immediate
+    // apply), AND the defer block must NOT overwrite the newer deferred
+    // (would invert ordering and let the older state fire 250ms later).
     await harness.controller.applyRoomState(
       createRoomStateWithPlayback({
         url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
@@ -754,12 +762,68 @@ test("userInitiated remote paused does NOT short-circuit when the incoming state
       }) as never,
     );
 
-    // The short-circuit didn't run: no immediate apply, no new debounce
-    // timer fires before the existing one. The deferred slot is still
-    // populated (either by the original deferred, or by the defer block's
-    // overwrite — that pre-existing PR #120 behaviour is out of scope here;
-    // what we verify is that this PR did NOT bypass debounce on the older).
     assert.equal(applyPending, 0);
+    // Deferred slot must still point to the newer snapshot — same reference,
+    // same seq.
+    assert.equal(
+      harness.runtimeState.deferredRemotePausedState,
+      newerDeferredRef,
+    );
+    assert.equal(
+      (
+        harness.runtimeState.deferredRemotePausedState as never as {
+          playback: { seq: number };
+        }
+      )?.playback.seq,
+      10,
+    );
+    // No additional debounce timer was scheduled by the older arrival.
+    assert.equal(win.scheduled.length, 1);
+  } finally {
+    win.restore();
+  }
+});
+
+test("older non-userInitiated remote paused does not overwrite the newer in-flight deferred", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+    });
+    harness.runtimeState.localMemberId = "local-member";
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 10,
+      }) as never,
+    );
+    const newerDeferredRef = harness.runtimeState.deferredRemotePausedState;
+    assert.equal(win.scheduled.length, 1);
+
+    // Older paused without userInitiated must also be dropped, not be
+    // allowed to silently replace the newer deferred snapshot.
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 8,
+      }) as never,
+    );
+
+    assert.equal(
+      harness.runtimeState.deferredRemotePausedState,
+      newerDeferredRef,
+    );
+    assert.equal(win.scheduled.length, 1);
   } finally {
     win.restore();
   }

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -292,6 +292,7 @@ function createRoomStateWithPlayback(playback: {
   playState: "playing" | "paused" | "buffering";
   actorId: string;
   seq?: number;
+  userInitiated?: boolean;
 }) {
   return {
     roomCode: "ROOM01",
@@ -304,6 +305,9 @@ function createRoomStateWithPlayback(playback: {
       url: playback.url,
       currentTime: playback.currentTime,
       playState: playback.playState,
+      ...(playback.userInitiated !== undefined
+        ? { userInitiated: playback.userInitiated }
+        : {}),
       playbackRate: 1,
       updatedAt: 1,
       serverTime: 1,
@@ -623,6 +627,112 @@ test("deferred timer fires and applies paused when no playing arrives in window"
 
     assert.equal(harness.runtimeState.deferredRemotePausedState, null);
     assert.equal(harness.runtimeState.deferredRemotePausedTimerId, null);
+  } finally {
+    win.restore();
+  }
+});
+
+test("applies remote paused immediately when peer marks it userInitiated, bypassing debounce", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+    });
+    harness.runtimeState.localMemberId = "local-member";
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 5,
+        userInitiated: true,
+      }) as never,
+    );
+
+    // No defer timer is scheduled; the paused state is applied synchronously
+    // (the immediate apply path runs through to pendingPlaybackApplication).
+    assert.equal(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(win.scheduled.length, 0);
+  } finally {
+    win.restore();
+  }
+});
+
+test("userInitiated remote paused cancels any already-deferred paused snapshot", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+    });
+    harness.runtimeState.localMemberId = "local-member";
+
+    // First arrival: legacy peer (no userInitiated flag) → gets deferred.
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 5,
+      }) as never,
+    );
+    assert.notEqual(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(win.scheduled.length, 1);
+
+    // Second arrival: same actor, now marked userInitiated → must wipe the
+    // deferred snapshot and apply immediately so a stale timer can't fire
+    // later and overwrite the freshly-applied state.
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 6,
+        userInitiated: true,
+      }) as never,
+    );
+
+    assert.equal(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(harness.runtimeState.deferredRemotePausedTimerId, null);
+  } finally {
+    win.restore();
+  }
+});
+
+test("legacy remote paused (no userInitiated field) still goes through the debounce", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+    });
+    harness.runtimeState.localMemberId = "local-member";
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 5,
+      }) as never,
+    );
+
+    // Legacy senders omit the field → backward-compatible behavior preserved.
+    assert.notEqual(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(win.scheduled.length, 1);
+    assert.equal(win.scheduled[0].ms, 250);
   } finally {
     win.restore();
   }

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -687,9 +687,11 @@ test("userInitiated remote paused cancels any already-deferred paused snapshot",
     assert.notEqual(harness.runtimeState.deferredRemotePausedState, null);
     assert.equal(win.scheduled.length, 1);
 
-    // Second arrival: same actor, now marked userInitiated → must wipe the
-    // deferred snapshot and apply immediately so a stale timer can't fire
-    // later and overwrite the freshly-applied state.
+    // Second arrival: same actor with a strictly newer seq, now marked
+    // userInitiated. The upstream version-comparison block clears the
+    // older deferred snapshot, and the short-circuit then applies the
+    // newer state immediately so a stale timer can't fire later and
+    // overwrite the freshly-applied state.
     await harness.controller.applyRoomState(
       createRoomStateWithPlayback({
         url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
@@ -703,6 +705,61 @@ test("userInitiated remote paused cancels any already-deferred paused snapshot",
 
     assert.equal(harness.runtimeState.deferredRemotePausedState, null);
     assert.equal(harness.runtimeState.deferredRemotePausedTimerId, null);
+  } finally {
+    win.restore();
+  }
+});
+
+test("userInitiated remote paused does NOT short-circuit when the incoming state is older than an in-flight deferred", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    let applyPending = 0;
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+      applyPendingPlaybackApplication: () => {
+        applyPending += 1;
+      },
+    });
+    harness.runtimeState.localMemberId = "local-member";
+
+    // First arrival: newer seq, no userInitiated → enters debounce.
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 10,
+      }) as never,
+    );
+    assert.notEqual(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(win.scheduled.length, 1);
+
+    // Second arrival: SAME actor but OLDER seq, with userInitiated=true.
+    // This models e.g. a delayed hydrate response landing after a newer
+    // realtime push. The upstream version-comparison block must preserve
+    // the in-flight deferred, and the short-circuit must NOT fire — taking
+    // it would lose the newer deferred snapshot via immediate apply.
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 8,
+        userInitiated: true,
+      }) as never,
+    );
+
+    // The short-circuit didn't run: no immediate apply, no new debounce
+    // timer fires before the existing one. The deferred slot is still
+    // populated (either by the original deferred, or by the defer block's
+    // overwrite — that pre-existing PR #120 behaviour is out of scope here;
+    // what we verify is that this PR did NOT bypass debounce on the older).
+    assert.equal(applyPending, 0);
   } finally {
     win.restore();
   }

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -1375,3 +1375,221 @@ test("sync controller broadcasts paused once buffer-pause upgrade window elapses
   ).payload;
   assert.equal(payload.playState, "paused");
 });
+
+test("sync controller tags broadcast with userInitiated:true on a fresh user pause", async () => {
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({
+    paused: true,
+    readyState: 4,
+    currentTime: 40,
+  });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.intendedPlayState = "paused";
+  // Fresh user pause gesture: postdates lastForcedPauseAt and well within
+  // the gesture grace window.
+  harness.runtimeState.lastUserGestureAt = 20_350;
+  harness.runtimeState.lastForcedPauseAt = 0;
+  harness.runtimeState.lastExplicitUserAction = {
+    kind: "pause",
+    at: 20_350,
+  };
+  harness.runtimeState.pauseStartedAt = 20_350;
+  harness.runtimeState.pauseClassifiedAsBuffer = false;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+
+  harness.controller = createSyncController({
+    runtimeState: harness.runtimeState,
+    lastAppliedVersionByActor: new Map(),
+    broadcastLogState: { key: null, at: 0 },
+    ignoredSelfPlaybackLogState: { key: null, at: 0 },
+    localIntentGuardMs: 500,
+    pauseHoldMs: 1_000,
+    initialRoomStatePauseHoldMs: 1_500,
+    remoteEchoSuppressionMs: 800,
+    remotePlayTransitionGuardMs: 500,
+    remoteFollowPlayingWindowMs: 3_000,
+    programmaticApplyWindowMs: 700,
+    userGestureGraceMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    remotePauseDebounceMs: 0,
+    nextSeq: () => 1,
+    markBroadcastAt: () => {},
+    getNow: () => 20_400,
+    debugLog: (message) => harness.debugLogs.push(message),
+    shouldLogHeartbeat: () => true,
+    runtimeSendMessage: async (message) => {
+      harness.runtimeMessages.push(message);
+      return null;
+    },
+    getVideoElement: () => video,
+    getCurrentPlaybackVideo: async () => sharedVideo,
+    getSharedVideo: () => sharedVideo,
+    normalizeUrl: (url) => url?.trim() ?? null,
+    notifyRoomStateToasts: () => {},
+    maybeShowSharedVideoToast: () => {},
+  });
+
+  await harness.controller.broadcastPlayback(video, "pause");
+
+  assert.equal(harness.runtimeMessages.length, 1);
+  const payload = (
+    harness.runtimeMessages[0] as {
+      payload: { playState: string; userInitiated?: boolean };
+    }
+  ).payload;
+  assert.equal(payload.playState, "paused");
+  assert.equal(payload.userInitiated, true);
+});
+
+test("sync controller omits userInitiated when a pause is buffer-induced", async () => {
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({
+    paused: true,
+    readyState: 4,
+    currentTime: 40,
+  });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.intendedPlayState = "paused";
+  harness.runtimeState.pauseStartedAt = 20_000;
+  // Mark this pause as buffer-induced: there's no recent user gesture and
+  // pauseClassifiedAsBuffer is true → getBroadcastPlayState yields buffering.
+  harness.runtimeState.pauseClassifiedAsBuffer = true;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+
+  harness.controller = createSyncController({
+    runtimeState: harness.runtimeState,
+    lastAppliedVersionByActor: new Map(),
+    broadcastLogState: { key: null, at: 0 },
+    ignoredSelfPlaybackLogState: { key: null, at: 0 },
+    localIntentGuardMs: 500,
+    pauseHoldMs: 1_000,
+    initialRoomStatePauseHoldMs: 1_500,
+    remoteEchoSuppressionMs: 800,
+    remotePlayTransitionGuardMs: 500,
+    remoteFollowPlayingWindowMs: 3_000,
+    programmaticApplyWindowMs: 700,
+    userGestureGraceMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    remotePauseDebounceMs: 0,
+    nextSeq: () => 1,
+    markBroadcastAt: () => {},
+    getNow: () => 20_400,
+    debugLog: (message) => harness.debugLogs.push(message),
+    shouldLogHeartbeat: () => true,
+    runtimeSendMessage: async (message) => {
+      harness.runtimeMessages.push(message);
+      return null;
+    },
+    getVideoElement: () => video,
+    getCurrentPlaybackVideo: async () => sharedVideo,
+    getSharedVideo: () => sharedVideo,
+    normalizeUrl: (url) => url?.trim() ?? null,
+    notifyRoomStateToasts: () => {},
+    maybeShowSharedVideoToast: () => {},
+  });
+
+  await harness.controller.broadcastPlayback(video, "pause");
+
+  assert.equal(harness.runtimeMessages.length, 1);
+  const payload = (
+    harness.runtimeMessages[0] as {
+      payload: { playState: string; userInitiated?: boolean };
+    }
+  ).payload;
+  assert.equal(payload.playState, "buffering");
+  assert.equal(payload.userInitiated, undefined);
+});
+
+test("sync controller omits userInitiated on buffer-pause upgrade re-broadcast", async () => {
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({
+    paused: true,
+    readyState: 4,
+    currentTime: 40,
+  });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.intendedPlayState = "paused";
+  harness.runtimeState.pauseStartedAt = 20_000;
+  harness.runtimeState.pauseClassifiedAsBuffer = false; // already upgraded
+  // Original gesture, if any, is way past the gesture grace window — the
+  // re-broadcast must not be mistaken for a fresh user pause.
+  harness.runtimeState.lastExplicitUserAction = {
+    kind: "pause",
+    at: 19_900,
+  };
+  harness.runtimeState.lastUserGestureAt = 19_900;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+
+  harness.controller = createSyncController({
+    runtimeState: harness.runtimeState,
+    lastAppliedVersionByActor: new Map(),
+    broadcastLogState: { key: null, at: 0 },
+    ignoredSelfPlaybackLogState: { key: null, at: 0 },
+    localIntentGuardMs: 500,
+    pauseHoldMs: 1_000,
+    initialRoomStatePauseHoldMs: 1_500,
+    remoteEchoSuppressionMs: 800,
+    remotePlayTransitionGuardMs: 500,
+    remoteFollowPlayingWindowMs: 3_000,
+    programmaticApplyWindowMs: 700,
+    userGestureGraceMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    remotePauseDebounceMs: 0,
+    nextSeq: () => 1,
+    markBroadcastAt: () => {},
+    getNow: () => 21_700,
+    debugLog: (message) => harness.debugLogs.push(message),
+    shouldLogHeartbeat: () => true,
+    runtimeSendMessage: async (message) => {
+      harness.runtimeMessages.push(message);
+      return null;
+    },
+    getVideoElement: () => video,
+    getCurrentPlaybackVideo: async () => sharedVideo,
+    getSharedVideo: () => sharedVideo,
+    normalizeUrl: (url) => url?.trim() ?? null,
+    notifyRoomStateToasts: () => {},
+    maybeShowSharedVideoToast: () => {},
+  });
+
+  await harness.controller.broadcastPlayback(video, "pause");
+
+  assert.equal(harness.runtimeMessages.length, 1);
+  const payload = (
+    harness.runtimeMessages[0] as {
+      payload: { playState: string; userInitiated?: boolean };
+    }
+  ).payload;
+  assert.equal(payload.playState, "paused");
+  assert.equal(payload.userInitiated, undefined);
+});

--- a/packages/protocol/src/guards/client-message.ts
+++ b/packages/protocol/src/guards/client-message.ts
@@ -73,6 +73,8 @@ export function isPlaybackState(value: unknown): value is PlaybackState {
     isPlaybackPlayState(value.playState) &&
     (value.syncIntent === undefined ||
       isPlaybackSyncIntent(value.syncIntent)) &&
+    (value.userInitiated === undefined ||
+      typeof value.userInitiated === "boolean") &&
     isFiniteNumber(value.playbackRate) &&
     isFiniteNumber(value.updatedAt) &&
     isFiniteNumber(value.serverTime) &&

--- a/packages/protocol/src/guards/server-message.ts
+++ b/packages/protocol/src/guards/server-message.ts
@@ -61,6 +61,8 @@ function isPlaybackState(value: unknown): value is PlaybackState {
     isPlaybackPlayState(value.playState) &&
     (value.syncIntent === undefined ||
       isPlaybackSyncIntent(value.syncIntent)) &&
+    (value.userInitiated === undefined ||
+      typeof value.userInitiated === "boolean") &&
     isFiniteNumber(value.playbackRate) &&
     isFiniteNumber(value.updatedAt) &&
     isFiniteNumber(value.serverTime) &&

--- a/packages/protocol/src/types/domain.ts
+++ b/packages/protocol/src/types/domain.ts
@@ -35,6 +35,14 @@ export interface PlaybackState {
   currentTime: number;
   playState: PlaybackPlayState;
   syncIntent?: PlaybackSyncIntent;
+  /**
+   * Hint that this state transition was driven by an explicit user gesture
+   * (e.g. clicking pause) rather than a buffer stall, hydration, or
+   * remote-state application. Receivers may use this to skip flicker-defence
+   * debounces and apply the transition without delay. Optional for
+   * backward-compatibility: legacy senders omit it; legacy receivers ignore it.
+   */
+  userInitiated?: boolean;
   playbackRate: number;
   updatedAt: number;
   serverTime: number;

--- a/packages/protocol/test/client-message.test.ts
+++ b/packages/protocol/test/client-message.test.ts
@@ -576,6 +576,52 @@ test("rejects playback:update with an invalid sync intent", () => {
   );
 });
 
+test("accepts playback:update carrying userInitiated:true", () => {
+  assert.equal(
+    isClientMessage({
+      type: "playback:update",
+      payload: {
+        memberToken: VALID_TOKEN,
+        playback: {
+          url: "https://www.bilibili.com/video/BV1xx411c7mD",
+          currentTime: 12,
+          playState: "paused",
+          userInitiated: true,
+          playbackRate: 1,
+          updatedAt: 1,
+          serverTime: 1,
+          actorId: "member-1",
+          seq: 1,
+        },
+      },
+    }),
+    true,
+  );
+});
+
+test("rejects playback:update with non-boolean userInitiated", () => {
+  assert.equal(
+    isClientMessage({
+      type: "playback:update",
+      payload: {
+        memberToken: VALID_TOKEN,
+        playback: {
+          url: "https://www.bilibili.com/video/BV1xx411c7mD",
+          currentTime: 12,
+          playState: "paused",
+          userInitiated: 1,
+          playbackRate: 1,
+          updatedAt: 1,
+          serverTime: 1,
+          actorId: "member-1",
+          seq: 1,
+        },
+      },
+    }),
+    false,
+  );
+});
+
 test("accepts a valid room:join message", () => {
   assert.equal(
     isClientMessage({

--- a/packages/protocol/test/server-message.test.ts
+++ b/packages/protocol/test/server-message.test.ts
@@ -186,6 +186,64 @@ test("rejects room:created when memberId format is invalid", () => {
   );
 });
 
+test("accepts room:state when playback carries userInitiated:true", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:state",
+      payload: {
+        roomCode: "ABC123",
+        sharedVideo: {
+          videoId: "BV1xx411c7mD",
+          url: "https://www.bilibili.com/video/BV1xx411c7mD?p=2",
+          title: "Video",
+        },
+        playback: {
+          url: "https://www.bilibili.com/video/BV1xx411c7mD?p=2",
+          currentTime: 12,
+          playState: "paused",
+          userInitiated: true,
+          playbackRate: 1,
+          updatedAt: 1,
+          serverTime: 1,
+          actorId: "member-1",
+          seq: 1,
+        },
+        members: [{ id: "member-1", name: "Alice" }],
+      },
+    }),
+    true,
+  );
+});
+
+test("rejects room:state when playback userInitiated is non-boolean", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:state",
+      payload: {
+        roomCode: "ABC123",
+        sharedVideo: {
+          videoId: "BV1xx411c7mD",
+          url: "https://www.bilibili.com/video/BV1xx411c7mD?p=2",
+          title: "Video",
+        },
+        playback: {
+          url: "https://www.bilibili.com/video/BV1xx411c7mD?p=2",
+          currentTime: 12,
+          playState: "paused",
+          userInitiated: "yes",
+          playbackRate: 1,
+          updatedAt: 1,
+          serverTime: 1,
+          actorId: "member-1",
+          seq: 1,
+        },
+        members: [{ id: "member-1", name: "Alice" }],
+      },
+    }),
+    false,
+  );
+});
+
 test("rejects room:state when playback sync intent is invalid", () => {
   assert.equal(
     isServerMessage({


### PR DESCRIPTION
## Summary

PR #120 在接收端给远端 paused 加了 250ms 防抖，用来兜底广播端 buffer 分类漏判的 flicker。代价是所有合法的用户暂停在对端都晚了 250ms 才生效，体感很明显。

本 PR 在协议层加一个**可选字段** `PlaybackState.userInitiated?: boolean`，让"真实用户手势触发的暂停"能跳过这个防抖：

- 发送端 `deriveUserInitiatedPause` 只在以下条件全部满足时设 `true`：
  - `eventSource === "pause"` 且经过 buffer-pause 降级后仍是 `paused`
  - `lastExplicitUserAction.kind === "pause"`，在 `userGestureGraceMs` 内，且 postdate `lastForcedPauseAt`
  - 不处于 programmatic-paused apply 窗口（避免远端 paused 应用产生的合成 pause 事件被误标）
- 接收端 `applyRoomState` 的 deferred-paused 分支检测到该 flag 时短路 debounce，并清掉任何已经在 flight 的 deferred 快照。

## 兼容性（已与 v1.1.1 逐项核对）

| 组合 | 行为 |
|---|---|
| v1.1.1 ↔ v1.1.1 | 完全不变 |
| 新发 → v1.1.1 收 | 老守卫不校验未知字段，消息照收；老代码不读字段 → 走原 250ms 防抖 |
| v1.1.1 发 → 新收 | 字段不存在 → 新代码降级为今天行为，走 250ms 防抖 |
| 新发 → 新收 | 用户暂停立即生效，buffer flicker 仍走防抖兜底 |

- `git diff v1.1.1 HEAD -- packages/protocol/src/` 在动手前为空 → v1.1.1 与 main 的守卫行为一致，本 PR 的可选字段 + 可选 boolean 校验向后兼容。
- 服务端 `room-service.ts` 用 `{...playback, actorId, serverTime}` 透传 + Redis `JSON.stringify`/`JSON.parse` 端到端保留未知字段。
- 安全面：恶意客户端伪造 `userInitiated:true` 也最多让对端早 250ms 暂停，未引入新攻击面。

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` 全绿（252/252）
- [x] 协议守卫测试：接受 boolean、拒绝非 boolean（client-message + server-message 各两条）
- [x] 发送端测试：用户手势触发 broadcast 带 `userInitiated:true`；buffer-induced 广播 `buffering` 不带；buffer-pause-upgrade 重广播 `paused` 不带
- [x] 接收端测试：带 flag 跳过防抖；带 flag 取消已在 flight 的 deferred 快照；老消息（无字段）仍走 250ms
- [ ] 双端联调：A 端按下暂停 → B 端立即暂停（< 100ms 量级，无可感延迟）；A 端发生短缓冲 flicker → B 端不会被瞬间打断

## Related

- PR #120 — 引入 250ms 防抖，本 PR 是其副作用的针对性优化
- PR #121 — 处理另一条 PR #120 的副作用（remote pause→resume 延迟），逻辑独立、互不依赖

🤖 Generated with [Claude Code](https://claude.com/claude-code)