### PR TITLE
feat(admin): 房间关键字筛选支持成员名与视频标题/URL

### DIFF
--- a/server/admin-ui/demo-data.js
+++ b/server/admin-ui/demo-data.js
@@ -346,12 +346,25 @@ export function createMockApiRequest() {
       const page = params.get("page") || "1";
       const pageSize = params.get("pageSize") || "20";
 
-      if (keyword) {
-        items = items.filter(
-          (item) =>
-            includesText(item.roomCode, keyword) ||
-            includesText(item.sharedVideo?.title, keyword),
-        );
+      const keywordTokens = keyword
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((token) => token.length > 0);
+      if (keywordTokens.length > 0) {
+        items = items.filter((item) => {
+          const members = demoData.roomMembers[item.roomCode] || [];
+          const haystacks = [
+            item.roomCode,
+            item.ownerDisplayName,
+            item.sharedVideo?.title,
+            item.sharedVideo?.url,
+            item.sharedVideo?.sharedByDisplayName,
+            ...members.map((member) => member.displayName),
+          ];
+          return keywordTokens.every((token) =>
+            haystacks.some((value) => includesText(value, token)),
+          );
+        });
       }
       if (status === "active") {
         items = items.filter((item) => item.isActive);

--- a/server/admin-ui/page-renderers.js
+++ b/server/admin-ui/page-renderers.js
@@ -522,7 +522,10 @@ export function createPageLoaders(options) {
           <div class="section">
             <section class="panel panel-filter">
               <form id="rooms-filter" class="form-grid">
-                ${textField("keyword", "关键字", query.keyword)}
+                ${textField("keyword", "关键字", query.keyword, "text", {
+                  placeholder:
+                    "房间号 / 成员 / 视频标题 / URL，空格分隔多关键字",
+                })}
                 ${selectField("status", "状态", query.status, [
                   ["all", "全部"],
                   ["active", "活跃"],

--- a/server/admin-ui/render-utils.js
+++ b/server/admin-ui/render-utils.js
@@ -805,11 +805,14 @@ export function getRoomOwnerSummary(item) {
   return { primary, secondary };
 }
 
-export function textField(name, label, value, type = "text") {
+export function textField(name, label, value, type = "text", options = {}) {
+  const placeholder = options.placeholder
+    ? ` placeholder="${escapeHtml(options.placeholder)}"`
+    : "";
   return `
     <div class="field">
       <label for="${escapeHtml(name)}">${escapeHtml(label)}</label>
-      <input id="${escapeHtml(name)}" name="${escapeHtml(name)}" type="${escapeHtml(type)}" value="${escapeHtml(value || "")}" />
+      <input id="${escapeHtml(name)}" name="${escapeHtml(name)}" type="${escapeHtml(type)}" value="${escapeHtml(value || "")}"${placeholder} />
     </div>
   `;
 }

--- a/server/src/admin/room-query-service.ts
+++ b/server/src/admin/room-query-service.ts
@@ -42,76 +42,135 @@ function toSummary(
   };
 }
 
+function tokenizeKeyword(raw: string | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+}
+
+function collectHaystacks(room: PersistedRoom, sessions: Session[]): string[] {
+  const values: Array<string | null | undefined> = [
+    room.code,
+    room.ownerDisplayName,
+    room.sharedVideo?.title,
+    room.sharedVideo?.url,
+    room.sharedVideo?.sharedByDisplayName,
+    ...sessions.map((session) => session.displayName),
+  ];
+  return values
+    .filter(
+      (value): value is string => typeof value === "string" && value.length > 0,
+    )
+    .map((value) => value.toLowerCase());
+}
+
+function matchesAllTokens(
+  room: PersistedRoom,
+  sessions: Session[],
+  tokens: string[],
+): boolean {
+  if (tokens.length === 0) {
+    return true;
+  }
+  const haystacks = collectHaystacks(room, sessions);
+  return tokens.every((token) =>
+    haystacks.some((haystack) => haystack.includes(token)),
+  );
+}
+
 export function createAdminRoomQueryService(options: {
   instanceId: string;
   roomStore: RoomStore;
   runtimeStore: RuntimeStore;
   eventStore: GlobalEventStore;
 }) {
-  async function filterByStatus(
-    items: PersistedRoom[],
-    status: RoomListQuery["status"],
-  ): Promise<PersistedRoom[]> {
-    if (status === "all") {
-      return items;
-    }
-
-    const roomsWithState = await Promise.all(
-      items.map(async (room) => ({
+  async function enrichWithSessions(rooms: PersistedRoom[]) {
+    return Promise.all(
+      rooms.map(async (room) => ({
         room,
-        isActive:
-          (await options.runtimeStore.listClusterSessionsByRoom(room.code))
-            .length > 0,
+        sessions: await options.runtimeStore.listClusterSessionsByRoom(
+          room.code,
+        ),
       })),
     );
-
-    return roomsWithState
-      .filter(({ isActive }) => (status === "active" ? isActive : !isActive))
-      .map(({ room }) => room);
   }
 
   return {
     async listRooms(query: RoomListQuery) {
-      const baseRooms =
-        query.status === "all"
-          ? await options.roomStore.listRooms(query)
-          : await filterByStatus(
-              await options.roomStore.listRooms({
-                ...query,
-                page: 1,
-                pageSize: Number.MAX_SAFE_INTEGER,
-              }),
-              query.status,
-            );
+      const tokens = tokenizeKeyword(query.keyword);
+      const needsRuntime = query.status !== "all" || tokens.length > 0;
+      const normalizedQuery: RoomListQuery = {
+        ...query,
+        keyword: tokens.length > 0 ? query.keyword : undefined,
+      };
 
-      const total =
-        query.status === "all"
-          ? await options.roomStore.countRooms(query)
-          : baseRooms.length;
-      const start =
-        query.status === "all" ? 0 : (query.page - 1) * query.pageSize;
-      const selected =
-        query.status === "all"
-          ? baseRooms
-          : baseRooms.slice(start, start + query.pageSize);
+      if (!needsRuntime) {
+        const baseRooms = await options.roomStore.listRooms(normalizedQuery);
+        const total = await options.roomStore.countRooms(normalizedQuery);
+        const roomItems = await Promise.all(
+          baseRooms.map(async (room) => {
+            const activeSessions =
+              await options.runtimeStore.listClusterSessionsByRoom(room.code);
+            const summary = toSummary(room, activeSessions);
+            return {
+              ...summary,
+              instanceId: summary.instanceId ?? options.instanceId,
+            };
+          }),
+        );
+        return {
+          items: roomItems,
+          pagination: {
+            page: normalizedQuery.page,
+            pageSize: normalizedQuery.pageSize,
+            total,
+          },
+        };
+      }
 
-      const roomItems = await Promise.all(
-        selected.map(async (room) => {
-          const activeSessions =
-            await options.runtimeStore.listClusterSessionsByRoom(room.code);
-          const summary = toSummary(room, activeSessions);
-          return {
-            ...summary,
-            instanceId: summary.instanceId ?? options.instanceId,
-          };
-        }),
-      );
+      const allRooms = await options.roomStore.listRooms({
+        ...normalizedQuery,
+        keyword: undefined,
+        page: 1,
+        pageSize: Number.MAX_SAFE_INTEGER,
+      });
+
+      const enriched = await enrichWithSessions(allRooms);
+
+      const filtered = enriched.filter(({ room, sessions }) => {
+        if (!matchesAllTokens(room, sessions, tokens)) {
+          return false;
+        }
+        if (normalizedQuery.status === "active") {
+          return sessions.length > 0;
+        }
+        if (normalizedQuery.status === "idle") {
+          return sessions.length === 0;
+        }
+        return true;
+      });
+
+      const total = filtered.length;
+      const start = (normalizedQuery.page - 1) * normalizedQuery.pageSize;
+      const selected = filtered.slice(start, start + normalizedQuery.pageSize);
+
+      const roomItems = selected.map(({ room, sessions }) => {
+        const summary = toSummary(room, sessions);
+        return {
+          ...summary,
+          instanceId: summary.instanceId ?? options.instanceId,
+        };
+      });
 
       return {
         items: roomItems,
         pagination: {
-          page: query.page,
-          pageSize: query.pageSize,
+          page: normalizedQuery.page,
+          pageSize: normalizedQuery.pageSize,
           total,
         },
       };

--- a/server/test/admin-room-query-keyword.test.ts
+++ b/server/test/admin-room-query-keyword.test.ts
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createAdminRoomQueryService } from "../src/admin/room-query-service.js";
+import type { GlobalEventStore } from "../src/admin/global-event-store.js";
+import { createInMemoryRoomStore } from "../src/room-store.js";
+import { createInMemoryRuntimeStore } from "../src/runtime-store.js";
+import type { Session } from "../src/types.js";
+
+const INSTANCE_ID = "instance-test";
+
+function makeSession(overrides: {
+  id: string;
+  roomCode: string;
+  memberId?: string;
+  displayName: string;
+}): Session {
+  return {
+    id: overrides.id,
+    connectionState: "attached",
+    socket: {
+      readyState: 1,
+      OPEN: 1,
+      send() {},
+      close() {},
+      terminate() {},
+    } as Session["socket"],
+    instanceId: INSTANCE_ID,
+    remoteAddress: "127.0.0.1",
+    origin: "chrome-extension://allowed-extension",
+    roomCode: overrides.roomCode,
+    memberId: overrides.memberId ?? overrides.id,
+    displayName: overrides.displayName,
+    memberToken: `token-${overrides.id}`,
+    protocolVersion: 2,
+    joinedAt: 1_000,
+    invalidMessageCount: 0,
+    rateLimitState: {
+      roomCreate: { windowStart: 0, count: 0 },
+      roomJoin: { windowStart: 0, count: 0 },
+      videoShare: { windowStart: 0, count: 0 },
+      playbackUpdate: { tokens: 0, lastRefillAt: 0 },
+      syncRequest: { windowStart: 0, count: 0 },
+      syncPing: { tokens: 0, lastRefillAt: 0 },
+    },
+  };
+}
+
+const stubEventStore: GlobalEventStore = {
+  async append() {},
+  async query() {
+    return { items: [], pagination: { page: 1, pageSize: 0, total: 0 } };
+  },
+};
+
+async function buildFixture() {
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const runtimeStore = createInMemoryRuntimeStore(() => 1_000);
+
+  await roomStore.createRoom({
+    code: "ROOMAA",
+    joinToken: "join-a",
+    createdAt: 100,
+    ownerMemberId: "owner-alice",
+    ownerDisplayName: "Alice",
+  });
+  await roomStore.saveRoom({
+    code: "ROOMAA",
+    joinToken: "join-a",
+    createdAt: 100,
+    ownerMemberId: "owner-alice",
+    ownerDisplayName: "Alice",
+    sharedVideo: {
+      videoId: "BV1aa",
+      url: "https://www.bilibili.com/video/BV1aa",
+      title: "猫咪的日常 vlog",
+      sharedByDisplayName: "Alice",
+    },
+    playback: null,
+    version: 1,
+    lastActiveAt: 200,
+    expiresAt: null,
+  });
+  runtimeStore.registerSession(
+    makeSession({
+      id: "session-alice",
+      roomCode: "ROOMAA",
+      memberId: "owner-alice",
+      displayName: "Alice",
+    }),
+  );
+  runtimeStore.markSessionJoinedRoom("session-alice", "ROOMAA");
+  runtimeStore.registerSession(
+    makeSession({
+      id: "session-bob",
+      roomCode: "ROOMAA",
+      memberId: "member-bob",
+      displayName: "Bob",
+    }),
+  );
+  runtimeStore.markSessionJoinedRoom("session-bob", "ROOMAA");
+
+  await roomStore.createRoom({
+    code: "ROOMBB",
+    joinToken: "join-b",
+    createdAt: 110,
+    ownerMemberId: "owner-carol",
+    ownerDisplayName: "Carol",
+  });
+  await roomStore.saveRoom({
+    code: "ROOMBB",
+    joinToken: "join-b",
+    createdAt: 110,
+    ownerMemberId: "owner-carol",
+    ownerDisplayName: "Carol",
+    sharedVideo: {
+      videoId: "BV1bb",
+      url: "https://www.bilibili.com/video/BV1bb",
+      title: "深度学习入门教程",
+      sharedByDisplayName: "Carol",
+    },
+    playback: null,
+    version: 1,
+    lastActiveAt: 210,
+    expiresAt: null,
+  });
+  runtimeStore.registerSession(
+    makeSession({
+      id: "session-carol",
+      roomCode: "ROOMBB",
+      memberId: "owner-carol",
+      displayName: "Carol",
+    }),
+  );
+  runtimeStore.markSessionJoinedRoom("session-carol", "ROOMBB");
+
+  await roomStore.createRoom({
+    code: "ROOMCC",
+    joinToken: "join-c",
+    createdAt: 120,
+    ownerMemberId: null,
+    ownerDisplayName: null,
+  });
+  await roomStore.saveRoom({
+    code: "ROOMCC",
+    joinToken: "join-c",
+    createdAt: 120,
+    ownerMemberId: null,
+    ownerDisplayName: null,
+    sharedVideo: null,
+    playback: null,
+    version: 1,
+    lastActiveAt: 220,
+    expiresAt: null,
+  });
+
+  const service = createAdminRoomQueryService({
+    instanceId: INSTANCE_ID,
+    roomStore,
+    runtimeStore,
+    eventStore: stubEventStore,
+  });
+
+  return { service };
+}
+
+const baseQuery = {
+  status: "all" as const,
+  includeExpired: true,
+  page: 1,
+  pageSize: 20,
+  sortBy: "lastActiveAt" as const,
+  sortOrder: "desc" as const,
+};
+
+test("keyword filter matches room code (case-insensitive)", async () => {
+  const { service } = await buildFixture();
+  const result = await service.listRooms({ ...baseQuery, keyword: "roomaa" });
+  assert.equal(result.pagination.total, 1);
+  assert.deepEqual(
+    result.items.map((item) => item.roomCode),
+    ["ROOMAA"],
+  );
+});
+
+test("keyword filter matches active member display name", async () => {
+  const { service } = await buildFixture();
+  const result = await service.listRooms({ ...baseQuery, keyword: "bob" });
+  assert.equal(result.pagination.total, 1);
+  assert.equal(result.items[0]?.roomCode, "ROOMAA");
+});
+
+test("keyword filter matches shared video title", async () => {
+  const { service } = await buildFixture();
+  const result = await service.listRooms({ ...baseQuery, keyword: "深度学习" });
+  assert.equal(result.pagination.total, 1);
+  assert.equal(result.items[0]?.roomCode, "ROOMBB");
+});
+
+test("keyword filter matches shared video URL fragment (BV id)", async () => {
+  const { service } = await buildFixture();
+  const result = await service.listRooms({ ...baseQuery, keyword: "BV1bb" });
+  assert.equal(result.pagination.total, 1);
+  assert.equal(result.items[0]?.roomCode, "ROOMBB");
+});
+
+test("keyword filter requires every space-separated token to match (AND)", async () => {
+  const { service } = await buildFixture();
+  const both = await service.listRooms({
+    ...baseQuery,
+    keyword: "alice 猫咪",
+  });
+  assert.equal(both.pagination.total, 1);
+  assert.equal(both.items[0]?.roomCode, "ROOMAA");
+
+  const conflicting = await service.listRooms({
+    ...baseQuery,
+    keyword: "alice 深度学习",
+  });
+  assert.equal(conflicting.pagination.total, 0);
+});
+
+test("keyword filter composes with status=active", async () => {
+  const { service } = await buildFixture();
+  const idle = await service.listRooms({
+    ...baseQuery,
+    status: "idle",
+    keyword: "room",
+  });
+  assert.deepEqual(
+    idle.items.map((item) => item.roomCode),
+    ["ROOMCC"],
+  );
+
+  const active = await service.listRooms({
+    ...baseQuery,
+    status: "active",
+    keyword: "room",
+  });
+  assert.deepEqual(active.items.map((item) => item.roomCode).sort(), [
+    "ROOMAA",
+    "ROOMBB",
+  ]);
+});
+
+test("blank keyword falls back to the unfiltered fast path", async () => {
+  const { service } = await buildFixture();
+  const result = await service.listRooms({ ...baseQuery, keyword: "   " });
+  assert.equal(result.pagination.total, 3);
+});


### PR DESCRIPTION
## Summary

- 房间管理的关键字筛选不再只匹配房间号，扩展为：房间号 / 房主名 / 当前在线成员名 / 视频标题 / 视频 URL / 视频分享者名
- 支持空格分隔的多关键字（AND 语义），大小写不敏感
- 因成员名需要 runtime 数据，将 keyword 过滤从 `room-store` 上移到 `room-query-service`，复用既有"加载全部→富化 sessions→过滤→分页"模式
- Admin UI 关键字输入框新增 placeholder 提示新作用范围；demo 模式本地过滤同步行为

## Changes

- `server/src/admin/room-query-service.ts`：新增 `tokenizeKeyword` / `matchesAllTokens`，重写 `listRooms` 走 normalized query；空白关键字回落原快路径
- `server/admin-ui/demo-data.js`：mock 过滤逻辑对齐服务端
- `server/admin-ui/render-utils.js`：`textField` 增加可选 `placeholder` 参数
- `server/admin-ui/page-renderers.js`：关键字字段补充 placeholder
- `server/test/admin-room-query-keyword.test.ts`：新增 7 个回归用例（房间号 / 成员名 / 视频标题 / BV 号 / 多 token AND / 与 status 组合 / 空白关键字回落）

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`（256 / 256 通过）
- [ ] 部署后在 Admin 面板手工验证：输入成员显示名、视频标题片段、BV 号、`alice 猫咪` 等多关键字组合，确认结果集与预期一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)