### PR TITLE
feat(metrics): 按事件类型拆分 room event 回压丢弃计数 (#105)

### DIFF
--- a/server/src/admin/metrics.ts
+++ b/server/src/admin/metrics.ts
@@ -1,5 +1,6 @@
 import type { RuntimeStore } from "../runtime-store.js";
 import type { RoomStore } from "../room-store.js";
+import { ROOM_EVENT_TYPES, type RoomEventType } from "../room-event-bus.js";
 
 const DEFAULT_HISTOGRAM_BUCKETS_SECONDS = [
   0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
@@ -57,6 +58,7 @@ export type MetricsCollector = {
   observeRedisRuntimeStoreFailure: (operation: string) => void;
   observeRedisRoomEventBusPublishDuration: (durationMs: number) => void;
   observeRedisRoomEventBusPublishFailure: () => void;
+  recordRoomEventPublishDropped: (eventType: RoomEventType) => void;
   render: () => Promise<string>;
 };
 
@@ -145,6 +147,10 @@ export function createMetricsCollector(options: {
     help: "Total Redis metric-instrumented operation failures",
     samples: new Map(),
   };
+  const roomEventPublishDroppedCounter: CounterMetric = {
+    help: "Total room event publishes dropped after backpressure timeout, grouped by event type",
+    samples: new Map(),
+  };
   const messageDurationHistogram: HistogramMetric = {
     help: "Duration of monitored message handler paths in seconds",
     buckets: DEFAULT_HISTOGRAM_BUCKETS_SECONDS,
@@ -163,6 +169,15 @@ export function createMetricsCollector(options: {
 
   for (const eventName of CORE_EVENT_NAMES) {
     ensureCounterSample(eventCounter, { event: eventName });
+  }
+
+  // Pre-seed every room event type to 0 so dashboards can distinguish
+  // "no drops" from "metric never emitted" — drops are rare but the
+  // critical room_member_* types must be observable the moment they occur.
+  for (const eventType of ROOM_EVENT_TYPES) {
+    ensureCounterSample(roomEventPublishDroppedCounter, {
+      event_type: eventType,
+    });
   }
 
   function incrementCounter(
@@ -204,6 +219,11 @@ export function createMetricsCollector(options: {
       const right = `${b.labels.component}:${b.labels.operation}`;
       return left.localeCompare(right);
     });
+    const roomEventPublishDroppedSamples = Array.from(
+      roomEventPublishDroppedCounter.samples.values(),
+    ).sort((a, b) =>
+      (a.labels.event_type ?? "").localeCompare(b.labels.event_type ?? ""),
+    );
     const histogramMetrics = [
       {
         name: "bili_syncplay_message_handler_duration_seconds",
@@ -275,6 +295,15 @@ export function createMetricsCollector(options: {
       ...redisFailureSamples.map((sample) =>
         formatMetricLine(
           "bili_syncplay_redis_operation_failures_total",
+          sample.value,
+          sample.labels,
+        ),
+      ),
+      "# HELP bili_syncplay_room_event_publish_dropped_total Total room event publishes dropped after backpressure timeout, grouped by event type",
+      "# TYPE bili_syncplay_room_event_publish_dropped_total counter",
+      ...roomEventPublishDroppedSamples.map((sample) =>
+        formatMetricLine(
+          "bili_syncplay_room_event_publish_dropped_total",
           sample.value,
           sample.labels,
         ),
@@ -354,6 +383,11 @@ export function createMetricsCollector(options: {
       incrementCounter(redisFailureCounter, {
         component: "room_event_bus",
         operation: "publish",
+      });
+    },
+    recordRoomEventPublishDropped(eventType) {
+      incrementCounter(roomEventPublishDroppedCounter, {
+        event_type: eventType,
       });
     },
     render,

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -98,7 +98,10 @@ export function createMessageHandler(options: {
   sendError: SendError;
   publishRoomEvent: (message: RoomEventBusMessage) => Promise<void>;
   instanceId: string;
-  metricsCollector?: Pick<MetricsCollector, "observeMessageHandlerDuration">;
+  metricsCollector?: Pick<
+    MetricsCollector,
+    "observeMessageHandlerDuration" | "recordRoomEventPublishDropped"
+  >;
   maxPendingPublishes?: number;
   backpressureWaitMs?: number;
   publishTimeoutMs?: number;
@@ -241,6 +244,7 @@ export function createMessageHandler(options: {
             maxPending: maxPendingPublishes,
             waitMs: backpressureWaitMs,
           });
+          metricsCollector?.recordRoomEventPublishDropped(type);
           return;
         }
         let waitTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
@@ -267,6 +271,7 @@ export function createMessageHandler(options: {
             maxPending: maxPendingPublishes,
             waitMs: backpressureWaitMs,
           });
+          metricsCollector?.recordRoomEventPublishDropped(type);
           return;
         }
       }

--- a/server/src/room-event-bus.ts
+++ b/server/src/room-event-bus.ts
@@ -34,6 +34,28 @@ export type RoomEventBusMessage =
       emittedAt: number;
     };
 
+export type RoomEventType = RoomEventBusMessage["type"];
+
+// Single source of truth for the set of room event types, used both for
+// runtime iteration (e.g. pre-seeding per-type metrics to 0) and as a
+// type-level exhaustiveness guard. The `satisfies` clause rejects invalid
+// entries; the assertion below fails to compile if a new RoomEventBusMessage
+// variant is added without being listed here.
+export const ROOM_EVENT_TYPES = [
+  "room_state_updated",
+  "room_member_changed",
+  "room_member_joined",
+  "room_member_left",
+  "room_deleted",
+] as const satisfies readonly RoomEventType[];
+
+type _EnsureAllRoomEventTypesCovered =
+  Exclude<RoomEventType, (typeof ROOM_EVENT_TYPES)[number]> extends never
+    ? true
+    : never;
+const _roomEventTypesAreExhaustive: _EnsureAllRoomEventTypesCovered = true;
+void _roomEventTypesAreExhaustive;
+
 export type RoomEventBus = {
   publish: (message: RoomEventBusMessage) => Promise<void>;
   subscribe: (

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -1474,6 +1474,7 @@ test("publish backpressure caps in-flight publishes under concurrent load", asyn
 
 test("publish backpressure drops new events when wait deadline elapses", async () => {
   const dropped: Array<{ event: string; reason: unknown }> = [];
+  const droppedMetricTypes: string[] = [];
   const release: Array<() => void> = [];
 
   const handler = createMessageHandler({
@@ -1499,6 +1500,12 @@ test("publish backpressure drops new events when wait deadline elapses", async (
     maxPendingPublishes: 1,
     // Tight deadline so the test does not sleep 5s.
     backpressureWaitMs: 30,
+    metricsCollector: {
+      observeMessageHandlerDuration() {},
+      recordRoomEventPublishDropped(eventType) {
+        droppedMetricTypes.push(eventType);
+      },
+    },
   });
 
   // Caller 1 occupies the only slot; its publish stays in-flight.
@@ -1521,6 +1528,9 @@ test("publish backpressure drops new events when wait deadline elapses", async (
   // Drop must be recorded with the right reason context.
   assert.equal(dropped.length, 1);
   assert.equal(dropped[0].reason, "profile_update_broadcast_failed");
+  // The drop must also surface on the per-event-type metric so member-affecting
+  // drops can be observed independently of high-frequency state updates.
+  assert.deepEqual(droppedMetricTypes, ["room_state_updated"]);
 
   // Caller 1 should still complete cleanly once we release its publish.
   release[0]();

--- a/server/test/metrics.test.ts
+++ b/server/test/metrics.test.ts
@@ -44,6 +44,8 @@ test("metrics collector renders event counters, histograms, and redis failure co
   metrics.observeRedisRuntimeStoreFailure("register_session");
   metrics.observeRedisRoomEventBusPublishDuration(5);
   metrics.observeRedisRoomEventBusPublishFailure();
+  metrics.recordRoomEventPublishDropped("room_member_changed");
+  metrics.recordRoomEventPublishDropped("room_member_changed");
 
   const rendered = await metrics.render();
 
@@ -81,6 +83,22 @@ test("metrics collector renders event counters, histograms, and redis failure co
   assert.equal(
     rendered.includes(
       'bili_syncplay_redis_operation_failures_total{component="runtime_store",operation="register_session"} 1',
+    ),
+    true,
+  );
+  // Member-affecting drops are counted under their own event_type label so a
+  // critical room_member_changed drop is never hidden behind high-frequency
+  // room_state_updated drops.
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_room_event_publish_dropped_total{event_type="room_member_changed"} 2',
+    ),
+    true,
+  );
+  // Pre-seeded to 0 so "no drops" is distinguishable from "metric absent".
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_room_event_publish_dropped_total{event_type="room_state_updated"} 0',
     ),
     true,
   );


### PR DESCRIPTION
## Summary

Issue #105 跟踪自 PR #97 评审 [#3143561439](https://github.com/sky1wu/Bili-SyncPlay/pull/97#discussion_r3143561439)(P2):回压超时后 `firePublishRoomEvent` 会静默丢弃事件,而高频 `room_state_updated` 与低频关键的 `room_member_changed` 共用同一回压通道,导致成员变更可能被悄悄丢弃且不可区分观测。

本 PR 实现验收清单的第一项(增加 metrics 维度),为后续判断"是否真实波及成员变更"提供数据,**暂不改动丢弃行为本身**:

- 新增 Prometheus 计数器 `bili_syncplay_room_event_publish_dropped_total{event_type="..."}`,按事件类型拆分回压超时丢弃计数。原先所有丢弃都混在 `bili_syncplay_events_total{event="room_event_publish_dropped"}` 一个样本里,无法区分类型。
- 每种 room event 类型预置为 `0`(Prometheus 最佳实践),让"无丢弃"与"指标从未上报"可区分 —— 丢弃罕见,但关键的 `room_member_*` 必须在发生瞬间即可观测。
- `firePublishRoomEvent` 两个丢弃点(deadline 耗尽 / wait 超时)均上报新指标。
- 从 `room-event-bus.ts` 导出 `ROOM_EVENT_TYPES` 作为单一来源,带编译期穷尽性校验:新增 `RoomEventBusMessage` 变体却忘记登记会导致编译失败。

后续(待线上观测 dropped ≥ 0.1% 再决定)的类型分级 / 优先级队列 / 协议补偿等方案不在本 PR 范围。

Fixes #105

## Test plan

- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`(256 通过)
- [x] `metrics.test.ts`:新计数器随 `recordRoomEventPublishDropped` 递增,且未触发类型渲染为 `0`
- [x] `message-handler.test.ts`:回压丢弃路径同时上报 `event_type` 指标