### PR TITLE
[codex] fix remote buffering forced pause

### DIFF
--- a/extension/src/content/sync-guards.ts
+++ b/extension/src/content/sync-guards.ts
@@ -460,10 +460,7 @@ export function hasRecentRemoteStopIntent(
     return false;
   }
 
-  if (
-    input.intendedPlayState === "paused" ||
-    input.intendedPlayState === "buffering"
-  ) {
+  if (input.intendedPlayState === "paused") {
     return true;
   }
 
@@ -474,10 +471,7 @@ export function hasRecentRemoteStopIntent(
     return false;
   }
 
-  return (
-    input.suppressedRemotePlayback.playState === "paused" ||
-    input.suppressedRemotePlayback.playState === "buffering"
-  );
+  return input.suppressedRemotePlayback.playState === "paused";
 }
 
 export function shouldSuppressRemotePlayTransition(

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -58,6 +58,8 @@ function createControllerHarness() {
     remoteFollowPlayingWindowMs: 3_000,
     programmaticApplyWindowMs: 700,
     userGestureGraceMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    remotePauseDebounceMs: 0,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
     getNow: () => now,
@@ -531,6 +533,57 @@ test("sync controller keeps the remote follow window through buffering and suppr
 
   assert.equal(harness.runtimeMessages.length, 0);
   assert.equal(harness.runtimeState.remoteFollowPlayingUntil > 20_900, true);
+});
+
+test("sync controller does not force-pause local playback after remote buffering", async () => {
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  let pauseCalls = 0;
+  const video = createVideo({
+    paused: false,
+    readyState: 4,
+    currentTime: 24.04,
+    pause() {
+      pauseCalls += 1;
+    },
+  });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.hasReceivedInitialRoomState = true;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.activeRoomCode = "ROOM01";
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+
+  await harness.controller.applyRoomState(
+    createRoomState({
+      actorId: "remote-member",
+      seq: 8,
+      serverTime: 19_900,
+      currentTime: 24,
+      playState: "buffering",
+    }),
+  );
+
+  assert.equal(pauseCalls, 0);
+  assert.equal(harness.runtimeState.intendedPlayState, "buffering");
+
+  harness.setNow(20_050);
+  await harness.controller.broadcastPlayback(video, "timeupdate");
+
+  assert.equal(pauseCalls, 0);
+  assert.notEqual(harness.runtimeState.intendedPlayState, "paused");
+  assert.equal(
+    harness.debugLogs.some((message) => message.includes("remote-stop-hold")),
+    false,
+  );
 });
 
 test("sync controller allows explicit user seek inside the silence window", async () => {

--- a/extension/test/sync-guards.test.ts
+++ b/extension/test/sync-guards.test.ts
@@ -397,6 +397,31 @@ test("reapplies remote stop intent when an unexpected resume happens shortly aft
   );
 });
 
+test("does not treat remote buffering as a stop intent", () => {
+  const memory = rememberRemotePlaybackForSuppression({
+    playback: createPlayback({
+      playState: "buffering",
+      currentTime: 30,
+    }),
+    normalizedUrl: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    now: 20_000,
+    remoteEchoSuppressionMs: 700,
+    remotePlayTransitionGuardMs: 1_800,
+  });
+
+  assert.equal(
+    hasRecentRemoteStopIntent({
+      now: 20_300,
+      pauseHoldUntil: 21_000,
+      normalizedCurrentUrl: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      activeSharedUrl: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      intendedPlayState: "buffering",
+      suppressedRemotePlayback: memory.suppressedRemotePlayback,
+    }),
+    false,
+  );
+});
+
 test("suppresses pause echo right after a remote playing intent unless it was user initiated", () => {
   const memory = rememberRemotePlaybackForSuppression({
     playback: createPlayback({


### PR DESCRIPTION
## 变更内容

修复内容脚本中把远端 `buffering` 当作“远端停止意图”的问题。现在只有真正的 `paused` 会触发 `remote-stop-hold` 强制暂停逻辑，`buffering` 仍保留正常的播放状态同步和回声抑制语义。

## 根因

触发端收到其它成员的 `buffering` 后，会把 `intendedPlayState=buffering` 视为 remote stop intent。随后本地视频仍在播放时进入 `remote-stop-hold` 分支并调用 `pauseVideo()`，这个程序化暂停又触发本地 DOM `pause` 事件，最终以触发端用户身份广播成 `paused`，导致其它用户看到“该用户暂停了视频”。

## 影响

- 网络/播放器瞬时缓冲不再把本地强制暂停，也不会被扩散成用户暂停。
- 真正的远端 `paused` 仍然会同步暂停。
- `buffering` 仍会参与时间点/倍速同步、local echo 抑制和相关缓冲态广播。

## 验证

已运行：

```bash
npm run format:check && npm run lint && npm run typecheck && npm run build && npm test
```

另外新增回归测试覆盖：

- `hasRecentRemoteStopIntent` 不再把 `buffering` 视为 stop intent。
- sync controller 收到远端 `buffering` 后不会调用本地 `pause()`，也不会进入 `remote-stop-hold`。