### PR TITLE
[codex] fix non-shared video pausing in rooms

### DIFF
--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -90,7 +90,11 @@ export function createNavigationController(args: {
     );
     args.attachPlaybackListeners();
     const video = args.getVideoElement();
-    if (video && !video.paused) {
+    if (
+      video &&
+      !video.paused &&
+      nextNormalizedPageUrl === args.runtimeState.activeSharedUrl
+    ) {
       args.debugLog(
         `Suppressed autoplay immediately after in-room navigation to ${nextPageUrl}`,
       );

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -60,9 +60,24 @@ export function createNavigationController(args: {
       return;
     }
 
-    args.runtimeState.hasReceivedInitialRoomState = false;
-    args.runtimeState.pendingRoomStateHydration = true;
-    args.runtimeState.intendedPlayState = "paused";
+    const activeSharedUrl = args.runtimeState.activeSharedUrl;
+    // We can only positively confirm the navigated page is a *different*
+    // (non-shared) video when the room's shared URL and the navigated page URL
+    // are both present, stable (not a festival / bangumi-season identity), and
+    // different. In every other case the page may still be the shared video:
+    //   - page URL equals the shared URL — it is the shared video;
+    //   - either URL is still an unstable identity (e.g. a paused shared season
+    //     `.../play/ss73077` whose page resolved to `.../play/ep...`, or a
+    //     festival route) — we cannot tell whether it is the shared video;
+    //   - the shared URL is not yet known (just joined/switched room before the
+    //     initial room state arrives) — the page may well be the shared video.
+    const canConfirmDifferentVideo =
+      activeSharedUrl !== null &&
+      !isUnstableSharedVideoUrl(activeSharedUrl) &&
+      nextNormalizedPageUrl !== null &&
+      !isUnstableSharedVideoUrl(nextNormalizedPageUrl) &&
+      nextNormalizedPageUrl !== activeSharedUrl;
+
     // Anchor the previous shared URL so that broadcasts stay suppressed until
     // the page bridge resolves the new page to a different normalized URL or
     // a fresh shared-video room state arrives. This prevents stale
@@ -73,46 +88,46 @@ export function createNavigationController(args: {
     // video URL itself (e.g. coming back to the original episode after a
     // detour) — in that case the page-bridge will correctly resolve to that
     // URL and broadcasts are not at risk of leaking stale data.
-    if (
-      args.runtimeState.activeSharedUrl &&
-      nextNormalizedPageUrl !== args.runtimeState.activeSharedUrl
-    ) {
-      args.runtimeState.postNavigationAnchorSharedUrl =
-        args.runtimeState.activeSharedUrl;
+    if (activeSharedUrl && nextNormalizedPageUrl !== activeSharedUrl) {
+      args.runtimeState.postNavigationAnchorSharedUrl = activeSharedUrl;
       args.runtimeState.postNavigationAnchorSetAt = nowOf();
     } else {
       args.runtimeState.postNavigationAnchorSharedUrl = null;
       args.runtimeState.postNavigationAnchorSetAt = 0;
     }
     resetUserGestureState(args.runtimeState);
+    args.attachPlaybackListeners();
+
+    if (canConfirmDifferentVideo) {
+      // Navigated to a confirmed different, stable, non-shared video. Do not
+      // engage autoplay suppression: leaving `pendingRoomStateHydration`,
+      // `intendedPlayState = "paused"` or a pause hold active would make the
+      // playback-binding guards re-pause this non-shared video once it
+      // autoplays while the page bridge has not yet produced `currentVideo`
+      // (which they treat as an unconfirmed shared context). Still hydrate to
+      // refresh room state — `applyRoomState` ignores room playback on a
+      // non-shared page.
+      args.debugLog(
+        `Detected in-room navigation to non-shared video ${nextPageUrl}, skipping autoplay suppression`,
+      );
+      void args.hydrateRoomState();
+      return;
+    }
+
+    // The navigated page may be the shared video, so suppress autoplay through
+    // the navigation/hydration window until room state confirms playback.
+    // Pause an already-playing video immediately too: waiting for a later
+    // `play` event is not enough because it never fires for a video that is
+    // already playing when navigation completes.
+    args.runtimeState.hasReceivedInitialRoomState = false;
+    args.runtimeState.pendingRoomStateHydration = true;
+    args.runtimeState.intendedPlayState = "paused";
     args.activatePauseHold(args.initialRoomStatePauseHoldMs);
     args.debugLog(
       `Detected in-room navigation to ${nextPageUrl}, waiting for room state`,
     );
-    args.attachPlaybackListeners();
     const video = args.getVideoElement();
-    // Pause an already-playing video immediately unless we can positively
-    // confirm the navigated page is a *different* video. Confirmation requires
-    // the room's shared URL and the navigated page URL to both be present,
-    // stable (not a festival / bangumi-season identity), and different. In
-    // every other case the page may still be the shared video and we must
-    // suppress autoplay through the navigation/hydration window:
-    //   - page URL equals the shared URL — it is the shared video;
-    //   - either URL is still an unstable identity (e.g. a paused shared season
-    //     `.../play/ss73077` whose page resolved to `.../play/ep...`, or a
-    //     festival route) — we cannot tell whether it is the shared video;
-    //   - the shared URL is not yet known (just joined/switched room before the
-    //     initial room state arrives) — the page may well be the shared video.
-    // Waiting for a later `play` event is not enough: it never fires for a
-    // video that is already playing when navigation completes.
-    const activeSharedUrl = args.runtimeState.activeSharedUrl;
-    const canConfirmDifferentVideo =
-      activeSharedUrl !== null &&
-      !isUnstableSharedVideoUrl(activeSharedUrl) &&
-      nextNormalizedPageUrl !== null &&
-      !isUnstableSharedVideoUrl(nextNormalizedPageUrl) &&
-      nextNormalizedPageUrl !== activeSharedUrl;
-    if (video && !video.paused && !canConfirmDifferentVideo) {
+    if (video && !video.paused) {
       args.debugLog(
         `Suppressed autoplay immediately after in-room navigation to ${nextPageUrl}`,
       );

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -91,10 +91,22 @@ export function createNavigationController(args: {
     );
     args.attachPlaybackListeners();
     const video = args.getVideoElement();
+    // Pause an already-playing video immediately when we cannot yet confirm the
+    // navigated page is a *different* video. That is true when the page is the
+    // shared video, or when either side of the comparison is still an unstable
+    // (festival / bangumi season) identity: the navigated page URL itself, or
+    // the room's shared URL. The latter covers a paused shared season (e.g.
+    // `.../play/ss73077`) whose page has already resolved to a concrete
+    // `.../play/ep...` URL — without it `shouldPauseImmediately` would be false
+    // and an autoplaying shared episode could slip through the
+    // navigation/hydration window before any new `play` event fires.
+    const sharedContextUnconfirmed =
+      Boolean(args.runtimeState.activeSharedUrl) &&
+      (isUnstableSharedVideoUrl(nextNormalizedPageUrl) ||
+        isUnstableSharedVideoUrl(args.runtimeState.activeSharedUrl));
     const shouldPauseImmediately =
       nextNormalizedPageUrl === args.runtimeState.activeSharedUrl ||
-      (Boolean(args.runtimeState.activeSharedUrl) &&
-        isUnstableSharedVideoUrl(nextNormalizedPageUrl));
+      sharedContextUnconfirmed;
     if (video && !video.paused && shouldPauseImmediately) {
       args.debugLog(
         `Suppressed autoplay immediately after in-room navigation to ${nextPageUrl}`,

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -2,6 +2,7 @@ import {
   resetUserGestureState,
   type ContentRuntimeState,
 } from "./runtime-state";
+import { isUnstableSharedVideoUrl } from "./video-identity";
 
 export interface NavigationController {
   start(): void;
@@ -90,11 +91,11 @@ export function createNavigationController(args: {
     );
     args.attachPlaybackListeners();
     const video = args.getVideoElement();
-    if (
-      video &&
-      !video.paused &&
-      nextNormalizedPageUrl === args.runtimeState.activeSharedUrl
-    ) {
+    const shouldPauseImmediately =
+      nextNormalizedPageUrl === args.runtimeState.activeSharedUrl ||
+      (Boolean(args.runtimeState.activeSharedUrl) &&
+        isUnstableSharedVideoUrl(nextNormalizedPageUrl));
+    if (video && !video.paused && shouldPauseImmediately) {
       args.debugLog(
         `Suppressed autoplay immediately after in-room navigation to ${nextPageUrl}`,
       );

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -100,13 +100,16 @@ export function createNavigationController(args: {
 
     if (canConfirmDifferentVideo) {
       // Navigated to a confirmed different, stable, non-shared video. Do not
-      // engage autoplay suppression: leaving `pendingRoomStateHydration`,
-      // `intendedPlayState = "paused"` or a pause hold active would make the
-      // playback-binding guards re-pause this non-shared video once it
-      // autoplays while the page bridge has not yet produced `currentVideo`
-      // (which they treat as an unconfirmed shared context). Still hydrate to
-      // refresh room state — `applyRoomState` ignores room playback on a
-      // non-shared page.
+      // engage autoplay suppression, and clear any pause hold inherited from
+      // the previously shared (paused) video. Otherwise, once this non-shared
+      // video autoplays while the page bridge has not yet produced
+      // `currentVideo`, `shouldReapplyPauseHoldForUnconfirmedSharedVideo`
+      // (which treats a null `currentVideo` as an unconfirmed shared context)
+      // would re-pause it on the strength of the still-live `pauseHoldUntil`.
+      // `pendingRoomStateHydration` is left false so the hydration pause guard
+      // also stays inert. Still hydrate to refresh room state — `applyRoomState`
+      // ignores room playback on a non-shared page.
+      args.runtimeState.pauseHoldUntil = 0;
       args.debugLog(
         `Detected in-room navigation to non-shared video ${nextPageUrl}, skipping autoplay suppression`,
       );

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -91,23 +91,28 @@ export function createNavigationController(args: {
     );
     args.attachPlaybackListeners();
     const video = args.getVideoElement();
-    // Pause an already-playing video immediately when we cannot yet confirm the
-    // navigated page is a *different* video. That is true when the page is the
-    // shared video, or when either side of the comparison is still an unstable
-    // (festival / bangumi season) identity: the navigated page URL itself, or
-    // the room's shared URL. The latter covers a paused shared season (e.g.
-    // `.../play/ss73077`) whose page has already resolved to a concrete
-    // `.../play/ep...` URL — without it `shouldPauseImmediately` would be false
-    // and an autoplaying shared episode could slip through the
-    // navigation/hydration window before any new `play` event fires.
-    const sharedContextUnconfirmed =
-      Boolean(args.runtimeState.activeSharedUrl) &&
-      (isUnstableSharedVideoUrl(nextNormalizedPageUrl) ||
-        isUnstableSharedVideoUrl(args.runtimeState.activeSharedUrl));
-    const shouldPauseImmediately =
-      nextNormalizedPageUrl === args.runtimeState.activeSharedUrl ||
-      sharedContextUnconfirmed;
-    if (video && !video.paused && shouldPauseImmediately) {
+    // Pause an already-playing video immediately unless we can positively
+    // confirm the navigated page is a *different* video. Confirmation requires
+    // the room's shared URL and the navigated page URL to both be present,
+    // stable (not a festival / bangumi-season identity), and different. In
+    // every other case the page may still be the shared video and we must
+    // suppress autoplay through the navigation/hydration window:
+    //   - page URL equals the shared URL — it is the shared video;
+    //   - either URL is still an unstable identity (e.g. a paused shared season
+    //     `.../play/ss73077` whose page resolved to `.../play/ep...`, or a
+    //     festival route) — we cannot tell whether it is the shared video;
+    //   - the shared URL is not yet known (just joined/switched room before the
+    //     initial room state arrives) — the page may well be the shared video.
+    // Waiting for a later `play` event is not enough: it never fires for a
+    // video that is already playing when navigation completes.
+    const activeSharedUrl = args.runtimeState.activeSharedUrl;
+    const canConfirmDifferentVideo =
+      activeSharedUrl !== null &&
+      !isUnstableSharedVideoUrl(activeSharedUrl) &&
+      nextNormalizedPageUrl !== null &&
+      !isUnstableSharedVideoUrl(nextNormalizedPageUrl) &&
+      nextNormalizedPageUrl !== activeSharedUrl;
+    if (video && !video.paused && !canConfirmDifferentVideo) {
       args.debugLog(
         `Suppressed autoplay immediately after in-room navigation to ${nextPageUrl}`,
       );

--- a/extension/src/content/playback-apply.ts
+++ b/extension/src/content/playback-apply.ts
@@ -60,9 +60,7 @@ export function decidePlaybackApplication(
     return {
       kind: "ignore-non-shared",
       acceptedHydration: input.pendingRoomStateHydration,
-      shouldPauseNonSharedVideo:
-        input.pendingRoomStateHydration &&
-        input.explicitNonSharedPlaybackUrl !== input.normalizedCurrentUrl,
+      shouldPauseNonSharedVideo: false,
     };
   }
 

--- a/extension/src/content/playback-apply.ts
+++ b/extension/src/content/playback-apply.ts
@@ -3,6 +3,7 @@ import type {
   RoomState,
   SharedVideo,
 } from "@bili-syncplay/protocol";
+import { isConfirmedDifferentSharedVideo } from "./video-identity";
 
 export interface PlaybackApplyDecisionInput {
   roomState: RoomState;
@@ -57,10 +58,21 @@ export function decidePlaybackApplication(
     input.normalizedCurrentUrl !== input.normalizedSharedUrl ||
     input.normalizedPlaybackUrl !== input.normalizedSharedUrl
   ) {
+    const shouldPauseNonSharedVideo =
+      input.pendingRoomStateHydration &&
+      (input.roomState.playback.playState === "paused" ||
+        input.roomState.playback.playState === "buffering") &&
+      !isConfirmedDifferentSharedVideo({
+        currentVideo: input.currentVideo,
+        sharedVideo: input.roomState.sharedVideo,
+        normalizedCurrentUrl: input.normalizedCurrentUrl,
+        normalizedSharedUrl: input.normalizedSharedUrl,
+      });
+
     return {
       kind: "ignore-non-shared",
       acceptedHydration: input.pendingRoomStateHydration,
-      shouldPauseNonSharedVideo: false,
+      shouldPauseNonSharedVideo,
     };
   }
 

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -13,7 +13,10 @@ import type {
   ExplicitUserActionKind,
   LocalPlaybackEventSource,
 } from "./runtime-state";
-import { hasStableSharedVideoIdentity } from "./video-identity";
+import {
+  hasStableSharedVideoIdentity,
+  isUnstableSharedVideoUrl,
+} from "./video-identity";
 
 export interface PlaybackBindingController {
   start(): void;
@@ -183,11 +186,23 @@ export function createPlaybackBindingController(args: {
   }
 
   function isKnownNonSharedVideo(currentVideo: SharedVideo | null): boolean {
+    const activeSharedUrl = args.runtimeState.activeSharedUrl;
     return Boolean(
       currentVideo &&
       hasStableSharedVideoIdentity(currentVideo) &&
-      args.runtimeState.activeSharedUrl &&
+      activeSharedUrl &&
+      !isUnstableSharedVideoUrl(activeSharedUrl) &&
       !isCurrentVideoShared(currentVideo),
+    );
+  }
+
+  function hasUnconfirmedSharedVideoContext(
+    currentVideo: SharedVideo | null,
+  ): boolean {
+    return Boolean(
+      !currentVideo ||
+      !hasStableSharedVideoIdentity(currentVideo) ||
+      isUnstableSharedVideoUrl(args.runtimeState.activeSharedUrl),
     );
   }
 
@@ -261,12 +276,10 @@ export function createPlaybackBindingController(args: {
     return true;
   }
 
-  function shouldReapplyPauseHoldForUnstableVideoIdentity(
+  function shouldReapplyPauseHoldForUnconfirmedSharedVideo(
     currentVideo: SharedVideo | null,
   ): boolean {
     if (
-      !currentVideo ||
-      hasStableSharedVideoIdentity(currentVideo) ||
       !args.runtimeState.activeRoomCode ||
       !args.runtimeState.activeSharedUrl ||
       nowOf() >= args.runtimeState.pauseHoldUntil
@@ -274,10 +287,14 @@ export function createPlaybackBindingController(args: {
       return false;
     }
 
-    return (
-      args.runtimeState.intendedPlayState === "paused" ||
-      args.runtimeState.intendedPlayState === "buffering"
-    );
+    if (
+      args.runtimeState.intendedPlayState !== "paused" &&
+      args.runtimeState.intendedPlayState !== "buffering"
+    ) {
+      return false;
+    }
+
+    return hasUnconfirmedSharedVideoContext(currentVideo);
   }
 
   function forcePauseOnNonSharedPage(video: HTMLVideoElement): boolean {
@@ -285,6 +302,11 @@ export function createPlaybackBindingController(args: {
       !args.runtimeState.activeRoomCode ||
       !args.runtimeState.activeSharedUrl
     ) {
+      return false;
+    }
+    if (isUnstableSharedVideoUrl(args.runtimeState.activeSharedUrl)) {
+      args.runtimeState.explicitNonSharedPlaybackUrl = null;
+      args.runtimeState.lastNonSharedGuardUrl = null;
       return false;
     }
 
@@ -390,9 +412,9 @@ export function createPlaybackBindingController(args: {
         return true;
       }
 
-      if (shouldReapplyPauseHoldForUnstableVideoIdentity(currentVideo)) {
+      if (shouldReapplyPauseHoldForUnconfirmedSharedVideo(currentVideo)) {
         args.debugLog(
-          `Forced pause hold reapplied for unstable video identity intended=${args.runtimeState.intendedPlayState}`,
+          `Forced pause hold reapplied for unconfirmed shared video context intended=${args.runtimeState.intendedPlayState}`,
         );
         args.runtimeState.explicitNonSharedPlaybackUrl = null;
         args.runtimeState.lastNonSharedGuardUrl = null;

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -13,6 +13,7 @@ import type {
   ExplicitUserActionKind,
   LocalPlaybackEventSource,
 } from "./runtime-state";
+import { hasStableSharedVideoIdentity } from "./video-identity";
 
 export interface PlaybackBindingController {
   start(): void;
@@ -184,6 +185,7 @@ export function createPlaybackBindingController(args: {
   function isKnownNonSharedVideo(currentVideo: SharedVideo | null): boolean {
     return Boolean(
       currentVideo &&
+      hasStableSharedVideoIdentity(currentVideo) &&
       args.runtimeState.activeSharedUrl &&
       !isCurrentVideoShared(currentVideo),
     );
@@ -271,6 +273,11 @@ export function createPlaybackBindingController(args: {
     const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
     if (!currentVideo) {
       args.runtimeState.explicitNonSharedPlaybackUrl = null;
+      return false;
+    }
+    if (!hasStableSharedVideoIdentity(currentVideo)) {
+      args.runtimeState.explicitNonSharedPlaybackUrl = null;
+      args.runtimeState.lastNonSharedGuardUrl = null;
       return false;
     }
 

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -224,6 +224,11 @@ export function createPlaybackBindingController(args: {
   function forcePauseWhileWaitingForInitialRoomState(
     video: HTMLVideoElement,
   ): boolean {
+    const currentVideo = args.getSharedVideo();
+    if (currentVideo && !isCurrentVideoShared(currentVideo)) {
+      return false;
+    }
+
     if (
       !shouldForcePauseWhileWaitingForInitialRoomState({
         activeRoomCode: args.runtimeState.activeRoomCode,
@@ -298,19 +303,12 @@ export function createPlaybackBindingController(args: {
 
     args.runtimeState.explicitNonSharedPlaybackUrl =
       decision.nextExplicitNonSharedPlaybackUrl;
-    if (!decision.shouldPause) {
-      return false;
+    if (decision.shouldPause) {
+      args.debugLog(
+        `Ignored non-shared playback guard for ${currentVideo.url}`,
+      );
     }
-
-    args.runtimeState.intendedPlayState = "paused";
-    args.runtimeState.lastForcedPauseAt = nowOf();
-    args.activatePauseHold(args.initialRoomStatePauseHoldMs);
-    window.setTimeout(() => {
-      if (!video.paused) {
-        pauseVideo(video);
-      }
-    }, 0);
-    return true;
+    return decision.shouldPause;
   }
 
   function attachPlaybackListeners(): void {

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -261,6 +261,25 @@ export function createPlaybackBindingController(args: {
     return true;
   }
 
+  function shouldReapplyPauseHoldForUnstableVideoIdentity(
+    currentVideo: SharedVideo | null,
+  ): boolean {
+    if (
+      !currentVideo ||
+      hasStableSharedVideoIdentity(currentVideo) ||
+      !args.runtimeState.activeRoomCode ||
+      !args.runtimeState.activeSharedUrl ||
+      nowOf() >= args.runtimeState.pauseHoldUntil
+    ) {
+      return false;
+    }
+
+    return (
+      args.runtimeState.intendedPlayState === "paused" ||
+      args.runtimeState.intendedPlayState === "buffering"
+    );
+  }
+
   function forcePauseOnNonSharedPage(video: HTMLVideoElement): boolean {
     if (
       !args.runtimeState.activeRoomCode ||
@@ -370,6 +389,20 @@ export function createPlaybackBindingController(args: {
         }, 0);
         return true;
       }
+
+      if (shouldReapplyPauseHoldForUnstableVideoIdentity(currentVideo)) {
+        args.debugLog(
+          `Forced pause hold reapplied for unstable video identity intended=${args.runtimeState.intendedPlayState}`,
+        );
+        args.runtimeState.explicitNonSharedPlaybackUrl = null;
+        args.runtimeState.lastNonSharedGuardUrl = null;
+        args.runtimeState.lastForcedPauseAt = nowOf();
+        window.setTimeout(() => {
+          pauseVideo(video);
+        }, 0);
+        return true;
+      }
+
       if (forcePauseOnNonSharedPage(video)) {
         return true;
       }

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -181,14 +181,21 @@ export function createPlaybackBindingController(args: {
     );
   }
 
+  function isKnownNonSharedVideo(currentVideo: SharedVideo | null): boolean {
+    return Boolean(
+      currentVideo &&
+      args.runtimeState.activeSharedUrl &&
+      !isCurrentVideoShared(currentVideo),
+    );
+  }
+
   function shouldPreRecordNonSharedExplicitPlay(): boolean {
     const currentVideo = args.getSharedVideo();
     if (
       !hasRecentUserGesture() ||
       args.runtimeState.lastUserGestureAt <=
         args.runtimeState.lastForcedPauseAt ||
-      !currentVideo ||
-      isCurrentVideoShared(currentVideo)
+      !isKnownNonSharedVideo(currentVideo)
     ) {
       return false;
     }
@@ -213,7 +220,7 @@ export function createPlaybackBindingController(args: {
   function preAuthorizeExplicitNonSharedPlay(): void {
     const currentVideo = args.getSharedVideo();
     const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
-    if (!normalizedCurrentUrl || isCurrentVideoShared(currentVideo)) {
+    if (!normalizedCurrentUrl || !isKnownNonSharedVideo(currentVideo)) {
       return;
     }
 
@@ -225,7 +232,7 @@ export function createPlaybackBindingController(args: {
     video: HTMLVideoElement,
   ): boolean {
     const currentVideo = args.getSharedVideo();
-    if (currentVideo && !isCurrentVideoShared(currentVideo)) {
+    if (isKnownNonSharedVideo(currentVideo)) {
       return false;
     }
 

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -196,6 +196,30 @@ export function createRoomStateApplyController(args: {
     shareToast: SharedVideoToastPayload | null = null,
     fromDebounce = false,
   ): Promise<void> {
+    const currentVideo = args.getSharedVideo();
+    const normalizedSharedUrl = args.normalizeUrl(state.sharedVideo?.url);
+    const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
+    const normalizedPlaybackUrl = args.normalizeUrl(state.playback?.url);
+    const decision = decidePlaybackApplication({
+      roomState: state,
+      currentVideo,
+      normalizedSharedUrl,
+      normalizedCurrentUrl,
+      normalizedPlaybackUrl,
+      pendingRoomStateHydration: args.runtimeState.pendingRoomStateHydration,
+      explicitNonSharedPlaybackUrl:
+        args.runtimeState.explicitNonSharedPlaybackUrl,
+      now: nowOf(),
+      lastLocalIntentAt: args.runtimeState.lastLocalIntentAt,
+      lastLocalIntentPlayState: args.runtimeState.lastLocalIntentPlayState,
+      localIntentGuardMs: args.localIntentGuardMs,
+      lastAppliedVersion: state.playback
+        ? (args.lastAppliedVersionByActor.get(state.playback.actorId) ?? null)
+        : null,
+      lastLocalPlaybackVersion: args.runtimeState.lastLocalPlaybackVersion,
+      localMemberId: args.runtimeState.localMemberId,
+    });
+
     // Before any other handling, decide whether an existing deferred paused
     // should be dropped because a newer room state has just arrived. We must
     // do this BEFORE deferring a new paused so that paused→paused chains
@@ -274,6 +298,7 @@ export function createRoomStateApplyController(args: {
       remotePauseDebounceMs > 0 &&
       state.playback &&
       state.playback.playState === "paused" &&
+      decision.kind === "apply" &&
       args.runtimeState.localMemberId !== null &&
       state.playback.actorId !== args.runtimeState.localMemberId
     ) {
@@ -347,11 +372,6 @@ export function createRoomStateApplyController(args: {
     args.notifyRoomStateToasts(state);
     args.maybeShowSharedVideoToast(shareToast, state);
 
-    const currentVideo = args.getSharedVideo();
-    const normalizedSharedUrl = args.normalizeUrl(state.sharedVideo?.url);
-    const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
-    const normalizedPlaybackUrl = args.normalizeUrl(state.playback?.url);
-
     // Lift the post-navigation settle anchor as soon as the room reports a
     // shared video that differs from what we recorded before navigation. This
     // covers the cases where the local user (or another member) successfully
@@ -368,26 +388,6 @@ export function createRoomStateApplyController(args: {
       args.runtimeState.postNavigationAnchorSharedUrl = null;
       args.runtimeState.postNavigationAnchorSetAt = 0;
     }
-
-    const decision = decidePlaybackApplication({
-      roomState: state,
-      currentVideo,
-      normalizedSharedUrl,
-      normalizedCurrentUrl,
-      normalizedPlaybackUrl,
-      pendingRoomStateHydration: args.runtimeState.pendingRoomStateHydration,
-      explicitNonSharedPlaybackUrl:
-        args.runtimeState.explicitNonSharedPlaybackUrl,
-      now: nowOf(),
-      lastLocalIntentAt: args.runtimeState.lastLocalIntentAt,
-      lastLocalIntentPlayState: args.runtimeState.lastLocalIntentPlayState,
-      localIntentGuardMs: args.localIntentGuardMs,
-      lastAppliedVersion: state.playback
-        ? (args.lastAppliedVersionByActor.get(state.playback.actorId) ?? null)
-        : null,
-      lastLocalPlaybackVersion: args.runtimeState.lastLocalPlaybackVersion,
-      localMemberId: args.runtimeState.localMemberId,
-    });
 
     if (decision.kind === "empty-room") {
       args.cancelActiveSoftApply(args.getVideoElement(), "room-empty");
@@ -432,14 +432,6 @@ export function createRoomStateApplyController(args: {
       }
       if (decision.acceptedHydration) {
         args.acceptInitialRoomStateHydration();
-        args.runtimeState.intendedPlayState = "paused";
-        args.runtimeState.intendedPlaybackRate = 1;
-        args.activatePauseHold(args.initialRoomStatePauseHoldMs);
-        const video = args.getVideoElement();
-        if (video && !video.paused && decision.shouldPauseNonSharedVideo) {
-          args.runtimeState.lastForcedPauseAt = Date.now();
-          pauseVideo(video);
-        }
       }
       return;
     }
@@ -663,14 +655,41 @@ export function createRoomStateApplyController(args: {
         response.roomState.playback?.playState === "paused" ||
         response.roomState.playback?.playState === "buffering"
       ) {
-        args.runtimeState.intendedPlayState =
-          response.roomState.playback.playState;
-        args.activatePauseHold(args.initialRoomStatePauseHoldMs);
+        const currentVideo = args.getSharedVideo();
+        const normalizedSharedUrl = args.normalizeUrl(
+          response.roomState.sharedVideo?.url,
+        );
+        const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
+        const normalizedPlaybackUrl = args.normalizeUrl(
+          response.roomState.playback.url,
+        );
+        const isCurrentSharedVideo =
+          normalizedSharedUrl !== null &&
+          normalizedCurrentUrl === normalizedSharedUrl &&
+          normalizedPlaybackUrl === normalizedSharedUrl;
+        if (isCurrentSharedVideo) {
+          args.runtimeState.intendedPlayState =
+            response.roomState.playback.playState;
+          args.activatePauseHold(args.initialRoomStatePauseHoldMs);
+        }
       }
       const video = args.getVideoElement();
+      const currentVideo = args.getSharedVideo();
+      const normalizedSharedUrl = args.normalizeUrl(
+        response.roomState.sharedVideo?.url,
+      );
+      const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
+      const normalizedPlaybackUrl = args.normalizeUrl(
+        response.roomState.playback?.url,
+      );
+      const isCurrentSharedVideo =
+        normalizedSharedUrl !== null &&
+        normalizedCurrentUrl === normalizedSharedUrl &&
+        normalizedPlaybackUrl === normalizedSharedUrl;
       if (
         video &&
         !video.paused &&
+        isCurrentSharedVideo &&
         (response.roomState.playback?.playState === "paused" ||
           response.roomState.playback?.playState === "buffering") &&
         nowOf() - args.runtimeState.lastUserGestureAt >= args.userGestureGraceMs

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -424,12 +424,7 @@ export function createRoomStateApplyController(args: {
         const video = args.getVideoElement();
         args.runtimeState.intendedPlayState = state.playback.playState;
         args.activatePauseHold(args.initialRoomStatePauseHoldMs);
-        if (
-          video &&
-          !video.paused &&
-          nowOf() - args.runtimeState.lastUserGestureAt >=
-            args.userGestureGraceMs
-        ) {
+        if (video && !video.paused) {
           args.debugLog(
             `Suppressed autoplay during unstable shared url hydration for ${state.roomCode}`,
           );

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -143,6 +143,48 @@ export function createRoomStateApplyController(args: {
     }
     args.runtimeState.deferredRemotePausedState = null;
   };
+  const isPausedOrBufferingPlayback = (
+    playback: PlaybackState | null,
+  ): playback is PlaybackState =>
+    playback?.playState === "paused" || playback?.playState === "buffering";
+  const shouldPreserveInitialPauseProtection = (input: {
+    currentVideo: SharedVideo | null;
+    playback: PlaybackState | null;
+    normalizedSharedUrl: string | null;
+    normalizedCurrentUrl: string | null;
+    normalizedPlaybackUrl: string | null;
+  }): boolean => {
+    if (
+      !isPausedOrBufferingPlayback(input.playback) ||
+      !input.normalizedSharedUrl ||
+      input.normalizedPlaybackUrl !== input.normalizedSharedUrl
+    ) {
+      return false;
+    }
+
+    return (
+      !input.currentVideo ||
+      !input.normalizedCurrentUrl ||
+      input.normalizedCurrentUrl === input.normalizedSharedUrl
+    );
+  };
+  const activateInitialPauseProtection = (input: {
+    playback: PlaybackState;
+    normalizedSharedUrl: string;
+    roomCode: string;
+    logReason: string;
+  }): void => {
+    args.runtimeState.activeSharedUrl = input.normalizedSharedUrl;
+    args.runtimeState.intendedPlayState = input.playback.playState;
+    args.runtimeState.intendedPlaybackRate = input.playback.playbackRate;
+    args.activatePauseHold(args.initialRoomStatePauseHoldMs);
+    const video = args.getVideoElement();
+    if (video && !video.paused) {
+      args.runtimeState.lastForcedPauseAt = nowOf();
+      args.debugLog(`${input.logReason} for ${input.roomCode}`);
+      pauseVideo(video);
+    }
+  };
 
   /**
    * When hydrating an empty room, suppress autoplay only if the video was not
@@ -403,6 +445,27 @@ export function createRoomStateApplyController(args: {
 
     if (decision.kind === "no-current-video") {
       args.cancelActiveSoftApply(args.getVideoElement(), "no-current-video");
+      if (
+        args.runtimeState.pendingRoomStateHydration &&
+        state.playback &&
+        normalizedSharedUrl &&
+        shouldPreserveInitialPauseProtection({
+          currentVideo,
+          playback: state.playback,
+          normalizedSharedUrl,
+          normalizedCurrentUrl,
+          normalizedPlaybackUrl,
+        })
+      ) {
+        activateInitialPauseProtection({
+          playback: state.playback,
+          normalizedSharedUrl,
+          roomCode: state.roomCode,
+          logReason:
+            "Suppressed autoplay while waiting for page bridge during hydrate",
+        });
+        scheduleHydrationRetry();
+      }
       return;
     }
 
@@ -428,6 +491,7 @@ export function createRoomStateApplyController(args: {
           args.debugLog(
             `Suppressed autoplay during unstable shared url hydration for ${state.roomCode}`,
           );
+          args.runtimeState.lastForcedPauseAt = nowOf();
           pauseVideo(video);
         }
       }
@@ -662,51 +726,36 @@ export function createRoomStateApplyController(args: {
       args.debugLog(
         `Hydrate room state success for ${response.roomState.roomCode}`,
       );
-      if (
-        response.roomState.playback?.playState === "paused" ||
-        response.roomState.playback?.playState === "buffering"
-      ) {
-        const currentVideo = args.getSharedVideo();
-        const normalizedSharedUrl = args.normalizeUrl(
-          response.roomState.sharedVideo?.url,
-        );
-        const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
-        const normalizedPlaybackUrl = args.normalizeUrl(
-          response.roomState.playback.url,
-        );
-        const isCurrentSharedVideo =
-          normalizedSharedUrl !== null &&
-          normalizedCurrentUrl === normalizedSharedUrl &&
-          normalizedPlaybackUrl === normalizedSharedUrl;
-        if (isCurrentSharedVideo) {
-          args.runtimeState.intendedPlayState =
-            response.roomState.playback.playState;
-          args.activatePauseHold(args.initialRoomStatePauseHoldMs);
-        }
-      }
       const video = args.getVideoElement();
       const currentVideo = args.getSharedVideo();
+      const playback = response.roomState.playback ?? null;
       const normalizedSharedUrl = args.normalizeUrl(
         response.roomState.sharedVideo?.url,
       );
       const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
-      const normalizedPlaybackUrl = args.normalizeUrl(
-        response.roomState.playback?.url,
-      );
-      const isCurrentSharedVideo =
-        normalizedSharedUrl !== null &&
-        normalizedCurrentUrl === normalizedSharedUrl &&
-        normalizedPlaybackUrl === normalizedSharedUrl;
+      const normalizedPlaybackUrl = args.normalizeUrl(playback?.url);
+      const shouldPreserveInitialPause = shouldPreserveInitialPauseProtection({
+        currentVideo,
+        playback,
+        normalizedSharedUrl,
+        normalizedCurrentUrl,
+        normalizedPlaybackUrl,
+      });
+      if (playback && normalizedSharedUrl && shouldPreserveInitialPause) {
+        args.runtimeState.activeSharedUrl = normalizedSharedUrl;
+        args.runtimeState.intendedPlayState = playback.playState;
+        args.runtimeState.intendedPlaybackRate = playback.playbackRate;
+        args.activatePauseHold(args.initialRoomStatePauseHoldMs);
+      }
       if (
         video &&
         !video.paused &&
-        isCurrentSharedVideo &&
-        (response.roomState.playback?.playState === "paused" ||
-          response.roomState.playback?.playState === "buffering") &&
+        playback &&
+        shouldPreserveInitialPause &&
         nowOf() - args.runtimeState.lastUserGestureAt >= args.userGestureGraceMs
       ) {
-        args.runtimeState.intendedPlayState =
-          response.roomState.playback.playState;
+        args.runtimeState.intendedPlayState = playback.playState;
+        args.runtimeState.lastForcedPauseAt = nowOf();
         args.debugLog(
           `Suppressed autoplay during hydrate for ${response.roomState.roomCode}`,
         );

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -168,13 +168,43 @@ export function createRoomStateApplyController(args: {
       input.normalizedCurrentUrl === input.normalizedSharedUrl
     );
   };
+  /**
+   * Switch `activeSharedUrl` to a new shared video and clear any playback sync
+   * state stranded by the previous shared video. Mirrors the reset performed on
+   * the main `applyRoomState` apply path so the early pause-protection paths
+   * (page-bridge-not-ready hydration) cannot leave a previous video's
+   * `pendingPlaybackApplication`, soft-apply, or local override active on the
+   * new shared page — which could otherwise be applied after the new video's
+   * `loadedmetadata`. No-op when the shared URL is unchanged.
+   */
+  const switchActiveSharedUrlWithReset = (
+    normalizedSharedUrl: string | null,
+    sharedVideoUrl: string | null | undefined,
+  ): void => {
+    if (args.runtimeState.activeSharedUrl === normalizedSharedUrl) {
+      return;
+    }
+    args.runtimeState.activeSharedUrl = normalizedSharedUrl ?? null;
+    args.resetPlaybackSyncState(
+      `shared url changed to ${sharedVideoUrl ?? "none"}`,
+    );
+    args.runtimeState.intendedPlayState = "paused";
+    args.runtimeState.intendedPlaybackRate = 1;
+    args.debugLog(
+      `Reset local sync state for shared url ${sharedVideoUrl ?? "none"}`,
+    );
+  };
   const activateInitialPauseProtection = (input: {
     playback: PlaybackState;
     normalizedSharedUrl: string;
+    sharedVideoUrl: string | null | undefined;
     roomCode: string;
     logReason: string;
   }): void => {
-    args.runtimeState.activeSharedUrl = input.normalizedSharedUrl;
+    switchActiveSharedUrlWithReset(
+      input.normalizedSharedUrl,
+      input.sharedVideoUrl,
+    );
     args.runtimeState.intendedPlayState = input.playback.playState;
     args.runtimeState.intendedPlaybackRate = input.playback.playbackRate;
     args.activatePauseHold(args.initialRoomStatePauseHoldMs);
@@ -460,6 +490,7 @@ export function createRoomStateApplyController(args: {
         activateInitialPauseProtection({
           playback: state.playback,
           normalizedSharedUrl,
+          sharedVideoUrl: state.sharedVideo?.url,
           roomCode: state.roomCode,
           logReason:
             "Suppressed autoplay while waiting for page bridge during hydrate",
@@ -469,17 +500,7 @@ export function createRoomStateApplyController(args: {
       return;
     }
 
-    if (args.runtimeState.activeSharedUrl !== normalizedSharedUrl) {
-      args.runtimeState.activeSharedUrl = normalizedSharedUrl ?? null;
-      args.resetPlaybackSyncState(
-        `shared url changed to ${state.sharedVideo?.url ?? "none"}`,
-      );
-      args.runtimeState.intendedPlayState = "paused";
-      args.runtimeState.intendedPlaybackRate = 1;
-      args.debugLog(
-        `Reset local sync state for shared url ${state.sharedVideo?.url ?? "none"}`,
-      );
-    }
+    switchActiveSharedUrlWithReset(normalizedSharedUrl, state.sharedVideo?.url);
 
     if (decision.kind === "ignore-non-shared") {
       args.cancelActiveSoftApply(args.getVideoElement(), "non-shared-page");
@@ -742,7 +763,10 @@ export function createRoomStateApplyController(args: {
         normalizedPlaybackUrl,
       });
       if (playback && normalizedSharedUrl && shouldPreserveInitialPause) {
-        args.runtimeState.activeSharedUrl = normalizedSharedUrl;
+        switchActiveSharedUrlWithReset(
+          normalizedSharedUrl,
+          response.roomState.sharedVideo?.url,
+        );
         args.runtimeState.intendedPlayState = playback.playState;
         args.runtimeState.intendedPlaybackRate = playback.playbackRate;
         args.activatePauseHold(args.initialRoomStatePauseHoldMs);

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -420,6 +420,22 @@ export function createRoomStateApplyController(args: {
 
     if (decision.kind === "ignore-non-shared") {
       args.cancelActiveSoftApply(args.getVideoElement(), "non-shared-page");
+      if (decision.shouldPauseNonSharedVideo && state.playback) {
+        const video = args.getVideoElement();
+        args.runtimeState.intendedPlayState = state.playback.playState;
+        args.activatePauseHold(args.initialRoomStatePauseHoldMs);
+        if (
+          video &&
+          !video.paused &&
+          nowOf() - args.runtimeState.lastUserGestureAt >=
+            args.userGestureGraceMs
+        ) {
+          args.debugLog(
+            `Suppressed autoplay during unstable shared url hydration for ${state.roomCode}`,
+          );
+          pauseVideo(video);
+        }
+      }
       if (
         args.shouldLogHeartbeat(
           ignoredRoomStateLogState,

--- a/extension/src/content/room-state-controller.ts
+++ b/extension/src/content/room-state-controller.ts
@@ -82,6 +82,14 @@ export function createRoomStateController(args: {
     }
   }
 
+  function clearRoomScopedSharedVideoState(): void {
+    args.runtimeState.activeSharedUrl = null;
+    args.runtimeState.explicitNonSharedPlaybackUrl = null;
+    args.runtimeState.lastNonSharedGuardUrl = null;
+    args.runtimeState.postNavigationAnchorSharedUrl = null;
+    args.runtimeState.postNavigationAnchorSetAt = 0;
+  }
+
   function handleSyncStatus(payload: {
     roomCode: string | null;
     connected: boolean;
@@ -105,10 +113,12 @@ export function createRoomStateController(args: {
       args.toastState.lastRoomState = null;
       args.runtimeState.hasReceivedInitialRoomState = false;
       args.runtimeState.pendingRoomStateHydration = true;
+      clearRoomScopedSharedVideoState();
     }
 
     if (payload.roomCode && !args.runtimeState.hasReceivedInitialRoomState) {
       args.runtimeState.pendingRoomStateHydration = true;
+      args.runtimeState.hydrationReady = false;
       if (lastWaitingRoomStateLogRoomCode !== payload.roomCode) {
         args.debugLog(`Waiting for initial room state of ${payload.roomCode}`);
         lastWaitingRoomStateLogRoomCode = payload.roomCode;
@@ -120,10 +130,11 @@ export function createRoomStateController(args: {
       if (previousRoomCode) {
         args.resetPlaybackSyncState(`room cleared from ${previousRoomCode}`);
       }
-      args.runtimeState.activeSharedUrl = null;
+      clearRoomScopedSharedVideoState();
       args.toastState.lastRoomState = null;
       args.runtimeState.pendingRoomStateHydration = false;
       args.runtimeState.hasReceivedInitialRoomState = false;
+      args.runtimeState.hydrationReady = false;
       lastWaitingRoomStateLogRoomCode = null;
     }
   }

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -824,14 +824,9 @@ export function createSyncController(args: {
           userGestureGraceMs: args.userGestureGraceMs,
         })
       ) {
-        args.runtimeState.intendedPlayState = "paused";
-        args.runtimeState.lastForcedPauseAt = now;
-        activatePauseHold(args.initialRoomStatePauseHoldMs);
-        window.setTimeout(() => {
-          if (!video.paused) {
-            pauseVideo(video);
-          }
-        }, 0);
+        args.debugLog(
+          `Suppressed non-shared playback broadcast for ${currentVideo.url}`,
+        );
       }
       logBroadcastTrace(
         "non-shared-page",

--- a/extension/src/content/video-identity.ts
+++ b/extension/src/content/video-identity.ts
@@ -1,0 +1,38 @@
+import type { SharedVideo } from "@bili-syncplay/protocol";
+
+export function hasStableSharedVideoIdentity(
+  video: SharedVideo | null,
+): boolean {
+  if (!video) {
+    return false;
+  }
+
+  return !(
+    video.videoId.startsWith("/festival/") || /^ss\d+$/i.test(video.videoId)
+  );
+}
+
+export function isConfirmedDifferentSharedVideo(args: {
+  currentVideo: SharedVideo | null;
+  sharedVideo: SharedVideo | null;
+  normalizedCurrentUrl: string | null;
+  normalizedSharedUrl: string | null;
+}): boolean {
+  if (!args.currentVideo || !args.sharedVideo) {
+    return false;
+  }
+
+  if (args.currentVideo.videoId === args.sharedVideo.videoId) {
+    return false;
+  }
+
+  if (
+    !hasStableSharedVideoIdentity(args.currentVideo) ||
+    !args.normalizedCurrentUrl ||
+    !args.normalizedSharedUrl
+  ) {
+    return false;
+  }
+
+  return args.normalizedCurrentUrl !== args.normalizedSharedUrl;
+}

--- a/extension/src/content/video-identity.ts
+++ b/extension/src/content/video-identity.ts
@@ -8,7 +8,8 @@ export function hasStableSharedVideoIdentity(
   }
 
   return !(
-    video.videoId.startsWith("/festival/") || /^ss\d+$/i.test(video.videoId)
+    video.videoId.startsWith("/festival/") ||
+    /^ss\d+(?::p[1-9]\d*)?$/i.test(video.videoId)
   );
 }
 

--- a/extension/src/content/video-identity.ts
+++ b/extension/src/content/video-identity.ts
@@ -12,6 +12,22 @@ export function hasStableSharedVideoIdentity(
   );
 }
 
+export function isUnstableSharedVideoUrl(url: string | null): boolean {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.pathname.startsWith("/festival/") ||
+      /^\/bangumi\/play\/ss\d+$/i.test(parsed.pathname.replace(/\/+$/, ""))
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function isConfirmedDifferentSharedVideo(args: {
   currentVideo: SharedVideo | null;
   sharedVideo: SharedVideo | null;
@@ -28,6 +44,7 @@ export function isConfirmedDifferentSharedVideo(args: {
 
   if (
     !hasStableSharedVideoIdentity(args.currentVideo) ||
+    !hasStableSharedVideoIdentity(args.sharedVideo) ||
     !args.normalizedCurrentUrl ||
     !args.normalizedSharedUrl
   ) {

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -85,6 +85,7 @@ test("navigation controller hydrates and suppresses autoplay when switching to a
   const runtimeState = createContentRuntimeState();
   runtimeState.activeRoomCode = "ROOM01";
   runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BV1Em421N7uU";
 
   let currentUrl = "https://www.bilibili.com/video/BV1DbiMBwEry";
   let hydrateCalls = 0;
@@ -121,6 +122,55 @@ test("navigation controller hydrates and suppresses autoplay when switching to a
 
     assert.equal(hydrateCalls, 1);
     assert.equal(pauseCalls, 1);
+    assert.equal(runtimeState.pendingRoomStateHydration, true);
+    assert.equal(runtimeState.intendedPlayState, "paused");
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller hydrates without pausing when switching to a non-shared video", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BV1DbiMBwEry";
+
+  let currentUrl = "https://www.bilibili.com/video/BV1DbiMBwEry";
+  let hydrateCalls = 0;
+  let pauseCalls = 0;
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeTestVideoPageUrl,
+    isSupportedVideoPage: (url) => url.includes("/video/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () =>
+      ({
+        paused: false,
+      }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {
+      hydrateCalls += 1;
+    },
+    activatePauseHold: () => {},
+    debugLog: () => {},
+  });
+
+  try {
+    controller.start();
+    currentUrl = "https://www.bilibili.com/video/BV1Em421N7uU";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(hydrateCalls, 1);
+    assert.equal(pauseCalls, 0);
     assert.equal(runtimeState.pendingRoomStateHydration, true);
     assert.equal(runtimeState.intendedPlayState, "paused");
   } finally {

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -129,16 +129,19 @@ test("navigation controller hydrates and suppresses autoplay when switching to a
   }
 });
 
-test("navigation controller hydrates without pausing when switching to a non-shared video", () => {
+test("navigation controller hydrates without pausing or suppressing when switching to a non-shared video", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();
   runtimeState.activeRoomCode = "ROOM01";
   runtimeState.pendingRoomStateHydration = false;
   runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BV1DbiMBwEry";
+  // The user is actively watching this confirmed non-shared video.
+  runtimeState.intendedPlayState = "playing";
 
   let currentUrl = "https://www.bilibili.com/video/BV1DbiMBwEry";
   let hydrateCalls = 0;
   let pauseCalls = 0;
+  let pauseHoldCalls = 0;
 
   const controller = createNavigationController({
     runtimeState,
@@ -160,7 +163,9 @@ test("navigation controller hydrates without pausing when switching to a non-sha
     hydrateRoomState: async () => {
       hydrateCalls += 1;
     },
-    activatePauseHold: () => {},
+    activatePauseHold: () => {
+      pauseHoldCalls += 1;
+    },
     debugLog: () => {},
   });
 
@@ -171,8 +176,67 @@ test("navigation controller hydrates without pausing when switching to a non-sha
 
     assert.equal(hydrateCalls, 1);
     assert.equal(pauseCalls, 0);
-    assert.equal(runtimeState.pendingRoomStateHydration, true);
-    assert.equal(runtimeState.intendedPlayState, "paused");
+    // A confirmed different, stable non-shared video must not engage autoplay
+    // suppression. Otherwise the binding guards would re-pause it once it
+    // autoplays while the page bridge has not yet produced `currentVideo`.
+    assert.equal(pauseHoldCalls, 0);
+    assert.equal(runtimeState.pendingRoomStateHydration, false);
+    assert.equal(runtimeState.intendedPlayState, "playing");
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller does not engage autoplay suppression for a non-shared video that is not playing yet", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BV1DbiMBwEry";
+
+  let currentUrl = "https://www.bilibili.com/video/BV1DbiMBwEry";
+  let hydrateCalls = 0;
+  let pauseCalls = 0;
+  let pauseHoldCalls = 0;
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeTestVideoPageUrl,
+    isSupportedVideoPage: (url) => url.includes("/video/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    // The element has not started playing yet at navigation detection time;
+    // its autoplay fires later. The fix must not leave pending hydration /
+    // pause-hold state that would force-pause that later autoplay.
+    getVideoElement: () =>
+      ({
+        paused: true,
+      }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {
+      hydrateCalls += 1;
+    },
+    activatePauseHold: () => {
+      pauseHoldCalls += 1;
+    },
+    debugLog: () => {},
+  });
+
+  try {
+    controller.start();
+    currentUrl = "https://www.bilibili.com/video/BV1Em421N7uU";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(hydrateCalls, 1);
+    assert.equal(pauseCalls, 0);
+    assert.equal(pauseHoldCalls, 0);
+    assert.equal(runtimeState.pendingRoomStateHydration, false);
   } finally {
     windowHarness.restore();
   }

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -295,6 +295,58 @@ test("navigation controller suppresses autoplay when shared url is an unstable s
   }
 });
 
+test("navigation controller suppresses autoplay when shared url is not yet known", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  // In a room but the initial room state has not populated the shared url yet
+  // (e.g. just joined/switched room before hydration completes). The page may
+  // still be the shared video, so an already-playing video must be paused.
+  runtimeState.activeSharedUrl = null;
+
+  let currentUrl = "https://www.bilibili.com/video/BV1DbiMBwEry";
+  let hydrateCalls = 0;
+  let pauseCalls = 0;
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeTestVideoPageUrl,
+    isSupportedVideoPage: (url) => url.includes("/video/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () =>
+      ({
+        paused: false,
+      }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {
+      hydrateCalls += 1;
+    },
+    activatePauseHold: () => {},
+    debugLog: () => {},
+  });
+
+  try {
+    controller.start();
+    currentUrl = "https://www.bilibili.com/video/BV1Em421N7uU";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(hydrateCalls, 1);
+    assert.equal(pauseCalls, 1);
+    assert.equal(runtimeState.pendingRoomStateHydration, true);
+    assert.equal(runtimeState.intendedPlayState, "paused");
+  } finally {
+    windowHarness.restore();
+  }
+});
+
 test("navigation controller anchors active shared url for post-navigation settle gate", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -300,6 +300,62 @@ test("navigation controller suppresses autoplay when navigating through an unsta
   }
 });
 
+test("navigation controller clears an inherited pause hold when switching to a non-shared video", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BV1DbiMBwEry";
+  // A pause hold is still live from the previously shared (paused) video.
+  runtimeState.intendedPlayState = "paused";
+  runtimeState.pauseHoldUntil = 99_999;
+
+  let currentUrl = "https://www.bilibili.com/video/BV1DbiMBwEry";
+  let pauseCalls = 0;
+  let pauseHoldCalls = 0;
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeTestVideoPageUrl,
+    isSupportedVideoPage: (url) => url.includes("/video/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () =>
+      ({
+        paused: true,
+      }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {
+      pauseHoldCalls += 1;
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    currentUrl = "https://www.bilibili.com/video/BV1Em421N7uU";
+    windowHarness.intervals[0]?.();
+
+    // The inherited pause hold must be cleared so the binding guards do not
+    // re-pause this confirmed non-shared video once it autoplays before the
+    // page bridge produces `currentVideo`.
+    assert.equal(runtimeState.pauseHoldUntil, 0);
+    assert.equal(pauseHoldCalls, 0);
+    assert.equal(pauseCalls, 0);
+    assert.equal(runtimeState.pendingRoomStateHydration, false);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
 test("navigation controller suppresses autoplay when shared url is an unstable season and page resolved to an episode", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -178,6 +178,64 @@ test("navigation controller hydrates without pausing when switching to a non-sha
   }
 });
 
+test("navigation controller suppresses autoplay when navigating through an unstable shared route", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/video/BVfestival?cid=123";
+
+  let currentUrl = "https://www.bilibili.com/video/BV1DbiMBwEry";
+  let hydrateCalls = 0;
+  let pauseCalls = 0;
+
+  function normalizeFestival(url: string): string | null {
+    if (url.includes("/festival/demo")) {
+      return "https://www.bilibili.com/festival/demo";
+    }
+    return normalizeTestVideoPageUrl(url);
+  }
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeFestival,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () =>
+      ({
+        paused: false,
+      }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {
+      hydrateCalls += 1;
+    },
+    activatePauseHold: () => {},
+    debugLog: () => {},
+  });
+
+  try {
+    controller.start();
+    currentUrl = "https://www.bilibili.com/festival/demo";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(hydrateCalls, 1);
+    assert.equal(pauseCalls, 1);
+    assert.equal(runtimeState.pendingRoomStateHydration, true);
+    assert.equal(runtimeState.intendedPlayState, "paused");
+  } finally {
+    windowHarness.restore();
+  }
+});
+
 test("navigation controller anchors active shared url for post-navigation settle gate", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -236,6 +236,65 @@ test("navigation controller suppresses autoplay when navigating through an unsta
   }
 });
 
+test("navigation controller suppresses autoplay when shared url is an unstable season and page resolved to an episode", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  // Room shares an unstable bangumi season url; the page may belong to it even
+  // though it has already resolved to a concrete episode url.
+  runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ss73077";
+
+  let currentUrl = "https://www.bilibili.com/bangumi/play/ss73077";
+  let hydrateCalls = 0;
+  let pauseCalls = 0;
+
+  function normalizeBangumi(url: string): string | null {
+    return (
+      url.match(/https:\/\/www\.bilibili\.com\/bangumi\/play\/[^/?]+/)?.[0] ??
+      null
+    );
+  }
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeBangumi,
+    isSupportedVideoPage: (url) => url.includes("/bangumi/play/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () =>
+      ({
+        paused: false,
+      }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {
+      hydrateCalls += 1;
+    },
+    activatePauseHold: () => {},
+    debugLog: () => {},
+  });
+
+  try {
+    controller.start();
+    currentUrl = "https://www.bilibili.com/bangumi/play/ep1231523";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(hydrateCalls, 1);
+    assert.equal(pauseCalls, 1);
+    assert.equal(runtimeState.pendingRoomStateHydration, true);
+    assert.equal(runtimeState.intendedPlayState, "paused");
+  } finally {
+    windowHarness.restore();
+  }
+});
+
 test("navigation controller anchors active shared url for post-navigation settle gate", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/playback-apply.test.ts
+++ b/extension/test/playback-apply.test.ts
@@ -169,6 +169,55 @@ test("keeps hydration pause guard when room shared identity is unstable", () => 
   );
 });
 
+test("keeps hydration pause guard when room shared identity is a paged season", () => {
+  assert.deepEqual(
+    decidePlaybackApplication({
+      roomState: {
+        roomCode: "ROOM01",
+        sharedVideo: {
+          videoId: "ss73077:p2",
+          url: "https://www.bilibili.com/bangumi/play/ss73077?p=2",
+          title: "Bangumi",
+        },
+        playback: {
+          url: "https://www.bilibili.com/bangumi/play/ss73077?p=2",
+          currentTime: 12,
+          playState: "paused",
+          playbackRate: 1,
+          updatedAt: 1,
+          serverTime: 10,
+          actorId: "remote-member",
+          seq: 2,
+        },
+        members: [],
+      },
+      currentVideo: {
+        videoId: "ep1231523",
+        url: "https://www.bilibili.com/bangumi/play/ep1231523",
+        title: "Bangumi",
+      },
+      normalizedSharedUrl: "https://www.bilibili.com/bangumi/play/ss73077?p=2",
+      normalizedCurrentUrl: "https://www.bilibili.com/bangumi/play/ep1231523",
+      normalizedPlaybackUrl:
+        "https://www.bilibili.com/bangumi/play/ss73077?p=2",
+      pendingRoomStateHydration: true,
+      explicitNonSharedPlaybackUrl: null,
+      now: 1_000,
+      lastLocalIntentAt: 0,
+      lastLocalIntentPlayState: null,
+      localIntentGuardMs: 1_200,
+      lastAppliedVersion: null,
+      lastLocalPlaybackVersion: null,
+      localMemberId: null,
+    }),
+    {
+      kind: "ignore-non-shared",
+      acceptedHydration: true,
+      shouldPauseNonSharedVideo: true,
+    },
+  );
+});
+
 test("ignores conflicting remote resume during local pause guard", () => {
   assert.equal(
     decidePlaybackApplication({

--- a/extension/test/playback-apply.test.ts
+++ b/extension/test/playback-apply.test.ts
@@ -58,7 +58,7 @@ test("accepts empty room state during hydration", () => {
   );
 });
 
-test("protects non-shared page during hydration", () => {
+test("ignores non-shared page during hydration without pausing it", () => {
   assert.deepEqual(
     decidePlaybackApplication({
       roomState: createRoomState("https://www.bilibili.com/video/BVshared?p=1"),
@@ -83,7 +83,7 @@ test("protects non-shared page during hydration", () => {
     {
       kind: "ignore-non-shared",
       acceptedHydration: true,
-      shouldPauseNonSharedVideo: true,
+      shouldPauseNonSharedVideo: false,
     },
   );
 });

--- a/extension/test/playback-apply.test.ts
+++ b/extension/test/playback-apply.test.ts
@@ -121,6 +121,54 @@ test("keeps hydration pause guard for unstable shared url mismatch", () => {
   );
 });
 
+test("keeps hydration pause guard when room shared identity is unstable", () => {
+  assert.deepEqual(
+    decidePlaybackApplication({
+      roomState: {
+        roomCode: "ROOM01",
+        sharedVideo: {
+          videoId: "ss73077",
+          url: "https://www.bilibili.com/bangumi/play/ss73077",
+          title: "Bangumi",
+        },
+        playback: {
+          url: "https://www.bilibili.com/bangumi/play/ss73077",
+          currentTime: 12,
+          playState: "paused",
+          playbackRate: 1,
+          updatedAt: 1,
+          serverTime: 10,
+          actorId: "remote-member",
+          seq: 2,
+        },
+        members: [],
+      },
+      currentVideo: {
+        videoId: "ep1231523",
+        url: "https://www.bilibili.com/bangumi/play/ep1231523",
+        title: "Bangumi",
+      },
+      normalizedSharedUrl: "https://www.bilibili.com/bangumi/play/ss73077",
+      normalizedCurrentUrl: "https://www.bilibili.com/bangumi/play/ep1231523",
+      normalizedPlaybackUrl: "https://www.bilibili.com/bangumi/play/ss73077",
+      pendingRoomStateHydration: true,
+      explicitNonSharedPlaybackUrl: null,
+      now: 1_000,
+      lastLocalIntentAt: 0,
+      lastLocalIntentPlayState: null,
+      localIntentGuardMs: 1_200,
+      lastAppliedVersion: null,
+      lastLocalPlaybackVersion: null,
+      localMemberId: null,
+    }),
+    {
+      kind: "ignore-non-shared",
+      acceptedHydration: true,
+      shouldPauseNonSharedVideo: true,
+    },
+  );
+});
+
 test("ignores conflicting remote resume during local pause guard", () => {
   assert.equal(
     decidePlaybackApplication({

--- a/extension/test/playback-apply.test.ts
+++ b/extension/test/playback-apply.test.ts
@@ -88,6 +88,39 @@ test("ignores non-shared page during hydration without pausing it", () => {
   );
 });
 
+test("keeps hydration pause guard for unstable shared url mismatch", () => {
+  assert.deepEqual(
+    decidePlaybackApplication({
+      roomState: createRoomState(
+        "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123",
+      ),
+      currentVideo: {
+        videoId: "/festival/demo",
+        url: "https://www.bilibili.com/festival/demo",
+        title: "Festival",
+      },
+      normalizedSharedUrl: "https://www.bilibili.com/video/BVfestival?cid=123",
+      normalizedCurrentUrl: "https://www.bilibili.com/festival/demo",
+      normalizedPlaybackUrl:
+        "https://www.bilibili.com/video/BVfestival?cid=123",
+      pendingRoomStateHydration: true,
+      explicitNonSharedPlaybackUrl: null,
+      now: 1_000,
+      lastLocalIntentAt: 0,
+      lastLocalIntentPlayState: null,
+      localIntentGuardMs: 1_200,
+      lastAppliedVersion: null,
+      lastLocalPlaybackVersion: null,
+      localMemberId: null,
+    }),
+    {
+      kind: "ignore-non-shared",
+      acceptedHydration: true,
+      shouldPauseNonSharedVideo: true,
+    },
+  );
+});
+
 test("ignores conflicting remote resume during local pause guard", () => {
   assert.equal(
     decidePlaybackApplication({

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -483,7 +483,7 @@ test("playback binding controller allows explicit play on a non-shared page", as
   }
 });
 
-test("playback binding controller blocks auto-resumed non-shared video after browser seek", async () => {
+test("playback binding controller suppresses auto-resumed non-shared broadcast after browser seek", async () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();
   runtimeState.activeRoomCode = "ROOM42";
@@ -543,9 +543,9 @@ test("playback binding controller blocks auto-resumed non-shared video after bro
 
     await Promise.resolve();
 
-    // The auto-played non-shared video should be force-paused
-    assert.equal(pausedByGuard, 1);
-    // The seeking event is broadcast (non-shared page), but play should be blocked
+    // The auto-played non-shared video should keep playing locally.
+    assert.equal(pausedByGuard, 0);
+    // The seeking event is broadcast (non-shared page), but play should be blocked.
     assert.deepEqual(events, ["seeking"]);
   } finally {
     globalThis.window.setTimeout = originalSetTimeout;
@@ -554,7 +554,7 @@ test("playback binding controller blocks auto-resumed non-shared video after bro
   }
 });
 
-test("playback binding controller allows manual play on non-shared page after auto-resume was blocked", async () => {
+test("playback binding controller allows manual play on non-shared page after auto-resume was suppressed", async () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();
   runtimeState.activeRoomCode = "ROOM42";
@@ -607,15 +607,15 @@ test("playback binding controller allows manual play on non-shared page after au
     controller.attachPlaybackListeners();
     // Browser auto-seeks to resume point after user click
     dom.listeners.get("seeking")?.(new Event("seeking"));
-    // Browser auto-plays after seek — should be force-paused
+    // Browser auto-plays after seek — should be suppressed from sync only.
     now = 1_080;
     dom.video.paused = false;
     dom.listeners.get("play")?.(new Event("play"));
 
     await Promise.resolve();
-    assert.equal(pausedByGuard, 1);
+    assert.equal(pausedByGuard, 0);
 
-    // User manually clicks play after the force-pause
+    // User manually clicks play after the suppressed auto-resume.
     runtimeState.lastUserGestureAt = 1_500;
     now = 1_550;
     dom.video.paused = false;
@@ -623,8 +623,8 @@ test("playback binding controller allows manual play on non-shared page after au
 
     await Promise.resolve();
 
-    // Manual play should NOT be blocked — it's a new gesture after the auto-resume
-    assert.equal(pausedByGuard, 1);
+    // Manual play should NOT be blocked — it's a new gesture after the auto-resume.
+    assert.equal(pausedByGuard, 0);
     assert.ok(events.includes("play"));
     // The first play event should come from the manual click, not the auto-resume
     const playIndex = events.indexOf("play");
@@ -637,7 +637,7 @@ test("playback binding controller allows manual play on non-shared page after au
   }
 });
 
-test("playback binding controller blocks non-shared autoplay replayed after a forced pause from the same gesture", async () => {
+test("playback binding controller suppresses non-shared autoplay replayed after a forced pause from the same gesture", async () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();
   runtimeState.activeRoomCode = "ROOM42";
@@ -696,7 +696,7 @@ test("playback binding controller blocks non-shared autoplay replayed after a fo
     await Promise.resolve();
 
     assert.deepEqual(events, []);
-    assert.equal(pausedByGuard, 1);
+    assert.equal(pausedByGuard, 0);
   } finally {
     globalThis.window.setTimeout = originalSetTimeout;
     dom.video.pause = originalPause;

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -317,6 +317,65 @@ test("playback binding controller re-pauses seek-triggered autoplay when intende
   }
 });
 
+test("playback binding controller keeps hydration pause guard when shared url is unknown", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.pendingRoomStateHydration = true;
+  runtimeState.activeSharedUrl = null;
+  runtimeState.lastUserGestureAt = 1_000;
+  let pausedByGuard = 0;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalPause = dom.video.pause;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    getSharedVideo: () => ({
+      videoId: "BV1xx411c7mD:p1",
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      title: "Video",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 1_100,
+  });
+
+  dom.video.pause = () => {
+    pausedByGuard += 1;
+    dom.video.paused = true;
+    return Promise.resolve();
+  };
+  globalThis.window.setTimeout = ((callback: TimerHandler) => {
+    if (typeof callback === "function") {
+      callback();
+    }
+    return 1;
+  }) as typeof globalThis.window.setTimeout;
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.video.paused = false;
+    dom.listeners.get("play")?.(new Event("play"));
+
+    assert.equal(pausedByGuard, 1);
+    assert.equal(runtimeState.explicitNonSharedPlaybackUrl, null);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.video.pause = originalPause;
+    dom.restore();
+  }
+});
+
 test("playback binding controller clears explicit seek intent after seek-triggered autoplay is blocked", () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -608,6 +608,75 @@ test("playback binding controller reapplies pause hold for unstable identity aft
   }
 });
 
+test("playback binding controller reapplies pause hold for unstable room shared url", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ss73077";
+  runtimeState.intendedPlayState = "paused";
+  runtimeState.pauseHoldUntil = 4_000;
+  runtimeState.lastUserGestureAt = 1_050;
+  runtimeState.explicitNonSharedPlaybackUrl =
+    "https://www.bilibili.com/video/BVold";
+  runtimeState.lastNonSharedGuardUrl = "https://www.bilibili.com/video/BVold";
+  let pausedByGuard = 0;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalPause = dom.video.pause;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    getSharedVideo: () => ({
+      videoId: "ep1231523",
+      url: "https://www.bilibili.com/bangumi/play/ep1231523",
+      title: "Bangumi",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 1_100,
+  });
+
+  dom.video.pause = () => {
+    pausedByGuard += 1;
+    dom.video.paused = true;
+    return Promise.resolve();
+  };
+  globalThis.window.setTimeout = ((callback: TimerHandler) => {
+    if (typeof callback === "function") {
+      callback();
+    }
+    return 1;
+  }) as typeof globalThis.window.setTimeout;
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.video.paused = false;
+    dom.listeners.get("play")?.(new Event("play"));
+
+    assert.equal(pausedByGuard, 1);
+    assert.equal(runtimeState.lastForcedPauseAt, 1_100);
+    assert.equal(runtimeState.explicitNonSharedPlaybackUrl, null);
+    assert.equal(runtimeState.lastNonSharedGuardUrl, null);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.video.pause = originalPause;
+    dom.restore();
+  }
+});
+
 test("playback binding controller clears explicit seek intent after seek-triggered autoplay is blocked", () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -376,6 +376,66 @@ test("playback binding controller keeps hydration pause guard when shared url is
   }
 });
 
+test("playback binding controller keeps hydration pause guard for unstable festival identity", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.pendingRoomStateHydration = true;
+  runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/video/BVfestival?cid=123";
+  runtimeState.lastUserGestureAt = 1_000;
+  let pausedByGuard = 0;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalPause = dom.video.pause;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    getSharedVideo: () => ({
+      videoId: "/festival/demo",
+      url: "https://www.bilibili.com/festival/demo",
+      title: "Festival",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 1_100,
+  });
+
+  dom.video.pause = () => {
+    pausedByGuard += 1;
+    dom.video.paused = true;
+    return Promise.resolve();
+  };
+  globalThis.window.setTimeout = ((callback: TimerHandler) => {
+    if (typeof callback === "function") {
+      callback();
+    }
+    return 1;
+  }) as typeof globalThis.window.setTimeout;
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.video.paused = false;
+    dom.listeners.get("play")?.(new Event("play"));
+
+    assert.equal(pausedByGuard, 1);
+    assert.equal(runtimeState.explicitNonSharedPlaybackUrl, null);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.video.pause = originalPause;
+    dom.restore();
+  }
+});
+
 test("playback binding controller clears explicit seek intent after seek-triggered autoplay is blocked", () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -539,6 +539,75 @@ test("playback binding controller keeps hydration pause guard for unstable festi
   }
 });
 
+test("playback binding controller reapplies pause hold for unstable identity after hydration", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/video/BVfestival?cid=123";
+  runtimeState.intendedPlayState = "paused";
+  runtimeState.pauseHoldUntil = 4_000;
+  runtimeState.lastUserGestureAt = 1_050;
+  runtimeState.explicitNonSharedPlaybackUrl =
+    "https://www.bilibili.com/video/BVold";
+  runtimeState.lastNonSharedGuardUrl = "https://www.bilibili.com/video/BVold";
+  let pausedByGuard = 0;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalPause = dom.video.pause;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    getSharedVideo: () => ({
+      videoId: "/festival/demo",
+      url: "https://www.bilibili.com/festival/demo",
+      title: "Festival",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 1_100,
+  });
+
+  dom.video.pause = () => {
+    pausedByGuard += 1;
+    dom.video.paused = true;
+    return Promise.resolve();
+  };
+  globalThis.window.setTimeout = ((callback: TimerHandler) => {
+    if (typeof callback === "function") {
+      callback();
+    }
+    return 1;
+  }) as typeof globalThis.window.setTimeout;
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.video.paused = false;
+    dom.listeners.get("play")?.(new Event("play"));
+
+    assert.equal(pausedByGuard, 1);
+    assert.equal(runtimeState.lastForcedPauseAt, 1_100);
+    assert.equal(runtimeState.explicitNonSharedPlaybackUrl, null);
+    assert.equal(runtimeState.lastNonSharedGuardUrl, null);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.video.pause = originalPause;
+    dom.restore();
+  }
+});
+
 test("playback binding controller clears explicit seek intent after seek-triggered autoplay is blocked", () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createContentRuntimeState } from "../src/content/runtime-state";
 import { createPlaybackBindingController } from "../src/content/playback-binding-controller";
+import { createRoomStateController } from "../src/content/room-state-controller";
+import { createToastCoordinatorState } from "../src/content/toast";
 
 type ListenerMap = Map<string, EventListener>;
 
@@ -369,6 +371,107 @@ test("playback binding controller keeps hydration pause guard when shared url is
 
     assert.equal(pausedByGuard, 1);
     assert.equal(runtimeState.explicitNonSharedPlaybackUrl, null);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.video.pause = originalPause;
+    dom.restore();
+  }
+});
+
+test("playback binding controller keeps hydration guard after direct room switch clears stale shared url", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  const staleSharedUrl = "https://www.bilibili.com/video/BVold?p=1";
+  const currentUrl = "https://www.bilibili.com/video/BVnew?p=1";
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.activeSharedUrl = staleSharedUrl;
+  runtimeState.explicitNonSharedPlaybackUrl = currentUrl;
+  runtimeState.lastNonSharedGuardUrl = currentUrl;
+  runtimeState.postNavigationAnchorSharedUrl = staleSharedUrl;
+  runtimeState.postNavigationAnchorSetAt = 1_000;
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.hasReceivedInitialRoomState = true;
+  runtimeState.hydrationReady = true;
+  runtimeState.lastUserGestureAt = 1_000;
+  let pausedByGuard = 0;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalPause = dom.video.pause;
+  const hydrationRetries: number[] = [];
+
+  const roomStateController = createRoomStateController({
+    runtimeState,
+    toastState: createToastCoordinatorState(),
+    toastPresenter: {
+      resetMountTarget: () => {},
+      show: () => {},
+    },
+    getSharedVideo: () => null,
+    normalizeUrl: (url) => url ?? null,
+    debugLog: () => {},
+    resetPlaybackSyncState: () => {},
+    scheduleHydrationRetry: (delayMs) => {
+      hydrationRetries.push(delayMs ?? 0);
+    },
+  });
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    getSharedVideo: () => ({
+      videoId: "BVnew:p1",
+      url: currentUrl,
+      title: "New room shared video",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 1_100,
+  });
+
+  dom.video.pause = () => {
+    pausedByGuard += 1;
+    dom.video.paused = true;
+    return Promise.resolve();
+  };
+  globalThis.window.setTimeout = ((callback: TimerHandler) => {
+    if (typeof callback === "function") {
+      callback();
+    }
+    return 1;
+  }) as typeof globalThis.window.setTimeout;
+
+  try {
+    roomStateController.handleSyncStatus({
+      roomCode: "ROOM02",
+      connected: true,
+      memberId: "member-2",
+      rttMs: 20,
+    });
+    controller.attachPlaybackListeners();
+    dom.video.paused = false;
+    dom.listeners.get("play")?.(new Event("play"));
+
+    assert.equal(runtimeState.activeRoomCode, "ROOM02");
+    assert.equal(runtimeState.activeSharedUrl, null);
+    assert.equal(runtimeState.explicitNonSharedPlaybackUrl, null);
+    assert.equal(runtimeState.lastNonSharedGuardUrl, null);
+    assert.equal(runtimeState.postNavigationAnchorSharedUrl, null);
+    assert.equal(runtimeState.postNavigationAnchorSetAt, 0);
+    assert.equal(runtimeState.pendingRoomStateHydration, true);
+    assert.equal(runtimeState.hasReceivedInitialRoomState, false);
+    assert.equal(runtimeState.hydrationReady, false);
+    assert.deepEqual(hydrationRetries, [150]);
+    assert.equal(pausedByGuard, 1);
   } finally {
     globalThis.window.setTimeout = originalSetTimeout;
     dom.video.pause = originalPause;

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -37,6 +37,7 @@ function createController(overrides: {
     playback: import("@bili-syncplay/protocol").PlaybackState,
   ) => void;
   applyPendingPlaybackApplication?: (video: HTMLVideoElement) => void;
+  resetPlaybackSyncState?: (reason: string) => void;
 }) {
   const runtimeState = overrides.runtimeState ?? createContentRuntimeState();
   const video = overrides.video ?? null;
@@ -77,7 +78,7 @@ function createController(overrides: {
     notifyRoomStateToasts: () => {},
     maybeShowSharedVideoToast: () => {},
     cancelActiveSoftApply: () => {},
-    resetPlaybackSyncState: () => {},
+    resetPlaybackSyncState: overrides.resetPlaybackSyncState ?? (() => {}),
     activatePauseHold: () => {
       _pauseHoldActivated = true;
     },
@@ -496,6 +497,58 @@ test("hydrates paused room state while page bridge is not ready", async () => {
     assert.equal(harness.runtimeState.intendedPlayState, "paused");
     assert.equal(win.scheduled.length, 1);
     assert.equal(win.scheduled[0].ms, 350);
+  } finally {
+    win.restore();
+  }
+});
+
+test("clears stale sync state when hydration switches shared video before page bridge is ready", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const roomState = createRoomStateWithPlayback({
+      url: "https://www.bilibili.com/video/BVnew?p=1",
+      currentTime: 42,
+      playState: "paused",
+      actorId: "remote-member",
+      seq: 5,
+    }) as RoomState;
+    const resetReasons: string[] = [];
+    const harness = createController({
+      video,
+      now: 30_000,
+      currentVideo: null,
+      resetPlaybackSyncState: (reason) => resetReasons.push(reason),
+      runtimeSendMessage: async () =>
+        ({
+          ok: true,
+          roomState,
+          memberId: "local-member",
+          roomCode: "ROOM01",
+        }) as never,
+    });
+    // A previous shared video is still recorded; switching to a different
+    // shared video while the page bridge is not ready must not strand its
+    // playback sync state.
+    harness.runtimeState.activeSharedUrl =
+      "https://www.bilibili.com/video/BVold?p=1";
+    harness.runtimeState.pendingRoomStateHydration = true;
+    harness.runtimeState.lastUserGestureAt = 0;
+
+    await harness.controller.hydrateRoomState();
+
+    // Reset runs exactly once for the genuine shared-url change (the second
+    // switch call during applyRoomState no-ops because the url already matches).
+    assert.deepEqual(resetReasons, [
+      "shared url changed to https://www.bilibili.com/video/BVnew?p=1",
+    ]);
+    assert.equal(
+      harness.runtimeState.activeSharedUrl,
+      "https://www.bilibili.com/video/BVnew?p=1",
+    );
+    assert.equal(video.paused, true);
+    assert.equal(harness.runtimeState.intendedPlayState, "paused");
+    assert.equal(harness.runtimeState.pendingRoomStateHydration, true);
   } finally {
     win.restore();
   }

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -445,10 +445,57 @@ test("pauses during hydration when unstable shared url mismatch follows a recent
     await harness.controller.applyRoomState(roomState);
 
     assert.equal(video.paused, true);
+    assert.equal(harness.runtimeState.lastForcedPauseAt, 30_000);
     assert.equal(harness.pauseHoldActivated, true);
     assert.equal(harness.acceptedHydration, true);
     assert.equal(harness.runtimeState.deferredRemotePausedState, null);
     assert.equal(win.scheduled.length, 0);
+  } finally {
+    win.restore();
+  }
+});
+
+test("hydrates paused room state while page bridge is not ready", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const roomState = createRoomStateWithPlayback({
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      currentTime: 42,
+      playState: "paused",
+      actorId: "remote-member",
+      seq: 5,
+    }) as RoomState;
+    const harness = createController({
+      video,
+      now: 30_000,
+      currentVideo: null,
+      runtimeSendMessage: async () =>
+        ({
+          ok: true,
+          roomState,
+          memberId: "local-member",
+          roomCode: "ROOM01",
+        }) as never,
+    });
+    harness.runtimeState.pendingRoomStateHydration = true;
+    harness.runtimeState.lastUserGestureAt = 29_500;
+
+    await harness.controller.hydrateRoomState();
+
+    assert.equal(video.paused, true);
+    assert.equal(harness.runtimeState.lastForcedPauseAt, 30_000);
+    assert.equal(harness.pauseHoldActivated, true);
+    assert.equal(harness.acceptedHydration, false);
+    assert.equal(harness.runtimeState.pendingRoomStateHydration, true);
+    assert.equal(harness.runtimeState.hydrationReady, true);
+    assert.equal(
+      harness.runtimeState.activeSharedUrl,
+      "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    );
+    assert.equal(harness.runtimeState.intendedPlayState, "paused");
+    assert.equal(win.scheduled.length, 1);
+    assert.equal(win.scheduled[0].ms, 350);
   } finally {
     win.restore();
   }

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { RoomState } from "@bili-syncplay/protocol";
+import type { RoomState, SharedVideo } from "@bili-syncplay/protocol";
 import { createContentRuntimeState } from "../src/content/runtime-state";
 import { createRoomStateApplyController } from "../src/content/room-state-apply-controller";
 
@@ -31,6 +31,8 @@ function createController(overrides: {
   userGestureGraceMs?: number;
   remotePauseDebounceMs?: number;
   normalizeUrl?: (url: string | undefined | null) => string | null;
+  currentVideo?: SharedVideo | null;
+  runtimeSendMessage?: <T>(message: unknown) => Promise<T | null>;
   rememberRemotePlaybackForSuppression?: (
     playback: import("@bili-syncplay/protocol").PlaybackState,
   ) => void;
@@ -38,6 +40,11 @@ function createController(overrides: {
 }) {
   const runtimeState = overrides.runtimeState ?? createContentRuntimeState();
   const video = overrides.video ?? null;
+  const defaultCurrentVideo: SharedVideo = {
+    videoId: "BV1xx411c7mD:p1",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
   let _pauseHoldActivated = false;
   let _acceptedHydration = false;
   const logs: string[] = [];
@@ -58,11 +65,14 @@ function createController(overrides: {
     getNow: () => overrides.now ?? 10_000,
     debugLog: (msg) => logs.push(msg),
     shouldLogHeartbeat: () => true,
-    runtimeSendMessage: async () => null,
+    runtimeSendMessage: overrides.runtimeSendMessage ?? (async () => null),
     getHydrateRetryTimer: () => null,
     setHydrateRetryTimer: () => {},
     getVideoElement: () => video,
-    getSharedVideo: () => null,
+    getSharedVideo: () =>
+      overrides.currentVideo === undefined
+        ? defaultCurrentVideo
+        : overrides.currentVideo,
     normalizeUrl: overrides.normalizeUrl ?? ((url) => url ?? null),
     notifyRoomStateToasts: () => {},
     maybeShowSharedVideoToast: () => {},
@@ -317,6 +327,86 @@ function createRoomStateWithPlayback(playback: {
     members: [],
   } as const;
 }
+
+test("ignores non-shared paused room state without debouncing or pausing", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+      currentVideo: {
+        videoId: "BVother:p1",
+        url: "https://www.bilibili.com/video/BVother?p=1",
+        title: "Other Video",
+      },
+    });
+    harness.runtimeState.localMemberId = "local-member";
+    harness.runtimeState.pendingRoomStateHydration = true;
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 5,
+      }) as never,
+    );
+
+    assert.equal(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(win.scheduled.length, 0);
+    assert.equal(video.paused, false);
+    assert.equal(harness.acceptedHydration, true);
+    assert.equal(
+      harness.logs.some((m) => m.includes("Ignored room state")),
+      true,
+    );
+  } finally {
+    win.restore();
+  }
+});
+
+test("does not pre-pause non-shared video during paused room hydration", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const roomState = createRoomStateWithPlayback({
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      currentTime: 42,
+      playState: "paused",
+      actorId: "remote-member",
+      seq: 5,
+    }) as RoomState;
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+      currentVideo: {
+        videoId: "BVother:p1",
+        url: "https://www.bilibili.com/video/BVother?p=1",
+        title: "Other Video",
+      },
+      runtimeSendMessage: async () =>
+        ({
+          ok: true,
+          roomState,
+          memberId: "local-member",
+          roomCode: "ROOM01",
+        }) as never,
+    });
+
+    await harness.controller.hydrateRoomState();
+
+    assert.equal(video.paused, false);
+    assert.equal(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(win.scheduled.length, 0);
+    assert.equal(harness.runtimeState.hydrationReady, true);
+  } finally {
+    win.restore();
+  }
+});
 
 test("defers remote paused room state when remotePauseDebounceMs > 0", async () => {
   const win = installWindowTimerStub();

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -408,7 +408,7 @@ test("does not pre-pause non-shared video during paused room hydration", async (
   }
 });
 
-test("pauses during hydration when shared url mismatch may be unstable", async () => {
+test("pauses during hydration when unstable shared url mismatch follows a recent gesture", async () => {
   const win = installWindowTimerStub();
   try {
     const video = createStubVideo(false);
@@ -440,6 +440,7 @@ test("pauses during hydration when shared url mismatch may be unstable", async (
     });
     harness.runtimeState.localMemberId = "local-member";
     harness.runtimeState.pendingRoomStateHydration = true;
+    harness.runtimeState.lastUserGestureAt = 29_500;
 
     await harness.controller.applyRoomState(roomState);
 

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -408,6 +408,51 @@ test("does not pre-pause non-shared video during paused room hydration", async (
   }
 });
 
+test("pauses during hydration when shared url mismatch may be unstable", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const roomState = createRoomStateWithPlayback({
+      url: "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123",
+      currentTime: 42,
+      playState: "paused",
+      actorId: "remote-member",
+      seq: 5,
+    }) as RoomState;
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+      currentVideo: {
+        videoId: "/festival/demo",
+        url: "https://www.bilibili.com/festival/demo",
+        title: "Festival",
+      },
+      normalizeUrl: (url) => {
+        if (
+          url ===
+          "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123"
+        ) {
+          return "https://www.bilibili.com/video/BVfestival?cid=123";
+        }
+        return url ?? null;
+      },
+    });
+    harness.runtimeState.localMemberId = "local-member";
+    harness.runtimeState.pendingRoomStateHydration = true;
+
+    await harness.controller.applyRoomState(roomState);
+
+    assert.equal(video.paused, true);
+    assert.equal(harness.pauseHoldActivated, true);
+    assert.equal(harness.acceptedHydration, true);
+    assert.equal(harness.runtimeState.deferredRemotePausedState, null);
+    assert.equal(win.scheduled.length, 0);
+  } finally {
+    win.restore();
+  }
+});
+
 test("defers remote paused room state when remotePauseDebounceMs > 0", async () => {
   const win = installWindowTimerStub();
   try {

--- a/extension/test/sync-guards.test.ts
+++ b/extension/test/sync-guards.test.ts
@@ -49,7 +49,7 @@ test("forces pause during initial hydration regardless of user gesture", () => {
   );
 });
 
-test("protects non-shared pages from remote autoplay unless the user explicitly started playback", () => {
+test("flags non-shared playback unless the user explicitly started playback", () => {
   const blocked = evaluateNonSharedPageGuard({
     activeRoomCode: "ROOM01",
     activeSharedUrl: "https://www.bilibili.com/video/BV1shared?p=1",


### PR DESCRIPTION
## Summary
- Ignore paused room-state playback on non-shared Bilibili pages before remote-pause debounce can run.
- Keep local viewing of other videos unpaused while still suppressing non-shared playback from room sync.
- Add regression coverage for hydration, navigation, room-state apply, and non-shared playback guards.

## Root cause
Paused room state was broadcast to all Bilibili video tabs. Non-shared tabs eventually ignored the state, but some pause/debounce/hydration guards ran before the URL check, so other videos could be paused repeatedly while the shared video stayed paused.

## Validation
- npm run format:check && npm run lint && npm run typecheck && npm run build && npm test