### PR TITLE
fix: queue shares dropped during the socket CLOSING micro-window (#132)

### DIFF
--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -398,6 +398,7 @@ function flushPendingShare(): void {
   executeFlushPendingShare({
     roomSessionState,
     connectionState,
+    shareState,
     sendToServer,
   });
 }

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -158,6 +158,7 @@ const socketController = createSocketController({
   startClockSyncTimer: () => clockController.startClockSyncTimer(),
   clearPendingLocalShare: (reason) =>
     shareController.clearPendingLocalShare(reason),
+  getPendingLocalShareGeneration: () => shareState.pendingLocalShareGeneration,
   sendJoinRequest: (...args) => roomSessionController.sendJoinRequest(...args),
   sendToServer,
   handleServerMessage,

--- a/extension/src/background/message-controller.ts
+++ b/extension/src/background/message-controller.ts
@@ -7,6 +7,7 @@ import type {
 } from "../shared/messages";
 import { t } from "../shared/i18n";
 import { areSharedVideoUrlsEqual } from "../shared/url";
+import { isSocketWritable } from "./socket-manager";
 import type {
   PlaybackState,
   RoomState,
@@ -28,6 +29,7 @@ export function createMessageController(args: {
   connectionState: {
     connected: boolean;
     lastError: string | null;
+    socket: WebSocket | null;
   };
   roomSessionState: {
     roomCode: string | null;
@@ -275,8 +277,16 @@ export function createMessageController(args: {
         // rejects the `video:share` for not-yet-rejoined, or the room has since
         // been advanced by another member. Keep deferring until authoritative
         // room state lands.
+        //
+        // `!isSocketWritable` closes the CLOSING micro-window: the socket has
+        // already moved to CLOSING/CLOSED but its close event has not fired, so
+        // `connected` still reads true. Without this the auto-share would reach
+        // `queueOrSendSharedVideo`, take its offline branch, and queue a
+        // `pendingSharedVideo` that the reconnect `room:joined` flushes before
+        // fresh `room:state` — clobbering whatever the room advanced to.
         if (
           !args.connectionState.connected ||
+          !isSocketWritable(args.connectionState.socket) ||
           args.roomSessionState.awaitingFreshRoomState
         ) {
           args.diagnosticsController.log(
@@ -444,9 +454,11 @@ export function createMessageController(args: {
         // this non-explicit auto-share as a pending share that flushes on the
         // next `room:joined` — before the fresh `room:state` — clobbering whatever
         // the room advanced to while we were disconnected. Defer instead so the
-        // content controller retries against authoritative state.
+        // content controller retries against authoritative state. `!isSocketWritable`
+        // also covers the CLOSING micro-window where `connected` still reads true.
         if (
           !args.connectionState.connected ||
+          !isSocketWritable(args.connectionState.socket) ||
           args.roomSessionState.awaitingFreshRoomState
         ) {
           args.diagnosticsController.log(

--- a/extension/src/background/room-manager.ts
+++ b/extension/src/background/room-manager.ts
@@ -113,7 +113,11 @@ export function executeFlushPendingShare(args: {
     memberToken: string | null;
     roomCode: string | null;
   };
-  connectionState: { connected: boolean };
+  connectionState: { connected: boolean; socketGeneration: number };
+  shareState: {
+    pendingLocalShareUrl: string | null;
+    pendingLocalShareGeneration: number | null;
+  };
   sendToServer: (message: ClientMessage) => void;
 }): void {
   const plan = flushPendingShare({
@@ -137,4 +141,16 @@ export function executeFlushPendingShare(args: {
   });
   args.roomSessionState.pendingSharedVideo = null;
   args.roomSessionState.pendingSharedPlayback = null;
+  // The queued share was set while an earlier (now-superseded) socket was live,
+  // so the pending-local-share confirmation marker is still tagged with that
+  // socket's generation. This re-flush re-sends the share on the CURRENT live
+  // socket, which is the one that will receive the confirming `room:state`, so
+  // transfer marker ownership to it. Without this, the old socket's late close
+  // (generation match) would clear a marker the live socket is still confirming,
+  // while the live socket's own later supersede (nothing left queued) would fail
+  // to clear it. Only re-stamp when a marker is actually pending.
+  if (args.shareState.pendingLocalShareUrl !== null) {
+    args.shareState.pendingLocalShareGeneration =
+      args.connectionState.socketGeneration;
+  }
 }

--- a/extension/src/background/room-manager.ts
+++ b/extension/src/background/room-manager.ts
@@ -5,6 +5,7 @@ import type {
   SharedVideo,
 } from "@bili-syncplay/protocol";
 import type { SharedVideoToastPayload } from "../shared/messages";
+import { isSocketWritable } from "./socket-manager";
 
 export function createPendingShareToast(args: {
   state: RoomState;
@@ -79,6 +80,7 @@ export function flushPendingShare(args: {
   pendingSharedVideo: SharedVideo | null;
   pendingSharedPlayback: PlaybackState | null;
   connected: boolean;
+  socketWritable: boolean;
   roomCode: string | null;
   memberToken: string | null;
 }): {
@@ -89,6 +91,13 @@ export function flushPendingShare(args: {
   if (
     !args.pendingSharedVideo ||
     !args.connected ||
+    // `connected` lags the socket's close/error events, so a flush triggered by
+    // `room:joined` can still see it true while the socket has already moved to
+    // CLOSING/CLOSED. `sendToServer` silently drops a non-OPEN write, so gate on
+    // the live `readyState`: when it is not writable, leave the share queued (and
+    // its marker untouched) so the next reconnect's rejoin re-flushes it instead
+    // of nulling `pendingSharedVideo` against a dropped send.
+    !args.socketWritable ||
     !args.roomCode ||
     !args.memberToken
   ) {
@@ -113,7 +122,11 @@ export function executeFlushPendingShare(args: {
     memberToken: string | null;
     roomCode: string | null;
   };
-  connectionState: { connected: boolean; socketGeneration: number };
+  connectionState: {
+    connected: boolean;
+    socketGeneration: number;
+    socket: WebSocket | null;
+  };
   shareState: {
     pendingLocalShareUrl: string | null;
     pendingLocalShareGeneration: number | null;
@@ -124,6 +137,7 @@ export function executeFlushPendingShare(args: {
     pendingSharedVideo: args.roomSessionState.pendingSharedVideo,
     pendingSharedPlayback: args.roomSessionState.pendingSharedPlayback,
     connected: args.connectionState.connected,
+    socketWritable: isSocketWritable(args.connectionState.socket),
     roomCode: args.roomSessionState.roomCode,
     memberToken: args.roomSessionState.memberToken,
   });

--- a/extension/src/background/room-state.ts
+++ b/extension/src/background/room-state.ts
@@ -125,7 +125,6 @@ export interface TransientShareLifecycleState {
 export interface TransientRoomSessionLifecycleState {
   pendingSharedVideo: unknown;
   pendingSharedPlayback: unknown;
-  shareReflushPending: boolean;
 }
 
 export function resetRoomLifecycleTransientState(
@@ -160,5 +159,4 @@ export function resetRoomLifecycleTransientState(
   args.shareState.pendingShareToast = null;
   args.roomSessionState.pendingSharedVideo = null;
   args.roomSessionState.pendingSharedPlayback = null;
-  args.roomSessionState.shareReflushPending = false;
 }

--- a/extension/src/background/room-state.ts
+++ b/extension/src/background/room-state.ts
@@ -125,6 +125,7 @@ export interface TransientShareLifecycleState {
 export interface TransientRoomSessionLifecycleState {
   pendingSharedVideo: unknown;
   pendingSharedPlayback: unknown;
+  shareReflushPending: boolean;
 }
 
 export function resetRoomLifecycleTransientState(
@@ -159,4 +160,5 @@ export function resetRoomLifecycleTransientState(
   args.shareState.pendingShareToast = null;
   args.roomSessionState.pendingSharedVideo = null;
   args.roomSessionState.pendingSharedPlayback = null;
+  args.roomSessionState.shareReflushPending = false;
 }

--- a/extension/src/background/runtime-state.ts
+++ b/extension/src/background/runtime-state.ts
@@ -32,6 +32,15 @@ export interface ConnectionState {
   connected: boolean;
   lastError: string | null;
   connectProbe: Promise<void> | null;
+  /**
+   * Abort generation for the in-flight connect probe. `openSocketWithProbe`
+   * awaits connection-check/healthcheck fetches before opening the socket; an
+   * authoritative teardown during that window (admin session reset, or an
+   * explicit leave via `disconnectSocket`) bumps this so the resuming probe
+   * aborts instead of opening a room-less ghost connection that clears the
+   * teardown's `lastError`.
+   */
+  connectEpoch: number;
   reconnectTimer: number | null;
   reconnectAttempt: number;
   reconnectDeadlineMs: number | null;
@@ -105,6 +114,7 @@ export function createBackgroundRuntimeState(): BackgroundRuntimeState {
       connected: false,
       lastError: null,
       connectProbe: null,
+      connectEpoch: 0,
       reconnectTimer: null,
       reconnectAttempt: 0,
       reconnectDeadlineMs: null,

--- a/extension/src/background/runtime-state.ts
+++ b/extension/src/background/runtime-state.ts
@@ -33,6 +33,14 @@ export interface ConnectionState {
   lastError: string | null;
   connectProbe: Promise<void> | null;
   /**
+   * Monotonic id incremented every time a new WebSocket is opened. The
+   * pending-local-share marker records the generation that created it
+   * (`ShareState.pendingLocalShareGeneration`) so a superseded socket's late
+   * close only clears a direct-send marker it owns, never one a newer
+   * connection set for a share it is still confirming.
+   */
+  socketGeneration: number;
+  /**
    * Abort generation for the in-flight connect probe. `openSocketWithProbe`
    * awaits connection-check/healthcheck fetches before opening the socket; an
    * authoritative teardown during that window (admin session reset, or an
@@ -89,6 +97,13 @@ export interface ShareState {
   pendingLocalShareUrl: string | null;
   pendingLocalShareExpiresAt: number | null;
   pendingLocalShareTimer: number | null;
+  /**
+   * `ConnectionState.socketGeneration` of the socket that was live when this
+   * marker was set, i.e. which connection owns it. Lets a superseded socket's
+   * late close clear only the direct-send marker it created, not one a newer
+   * connection set for a share still awaiting confirmation. Null when no marker.
+   */
+  pendingLocalShareGeneration: number | null;
   pendingShareToast:
     | (SharedVideoToastPayload & { expiresAt: number; roomCode: string })
     | null;
@@ -126,6 +141,7 @@ export function createBackgroundRuntimeState(): BackgroundRuntimeState {
       connected: false,
       lastError: null,
       connectProbe: null,
+      socketGeneration: 0,
       connectEpoch: 0,
       reconnectTimer: null,
       reconnectAttempt: 0,
@@ -152,6 +168,7 @@ export function createBackgroundRuntimeState(): BackgroundRuntimeState {
       lastOpenedSharedUrl: null,
       openingSharedUrl: null,
       pendingLocalShareUrl: null,
+      pendingLocalShareGeneration: null,
       pendingLocalShareExpiresAt: null,
       pendingLocalShareTimer: null,
       pendingShareToast: null,

--- a/extension/src/background/runtime-state.ts
+++ b/extension/src/background/runtime-state.ts
@@ -76,18 +76,6 @@ export interface RoomSessionState {
   awaitingFreshRoomState: boolean;
   pendingSharedVideo: SharedVideo | null;
   pendingSharedPlayback: PlaybackState | null;
-  /**
-   * Whether the current pending-local-share confirmation marker is backed by a
-   * share that a reconnect will re-flush and the replacement connection will
-   * reconfirm (the CLOSING/offline queue branches of `queueOrSendSharedVideo`),
-   * rather than a plain direct send. `executeFlushPendingShare` nulls
-   * `pendingSharedVideo` once it re-sends, so after a flush `pendingSharedVideo`
-   * alone can no longer tell a re-flush marker (keep across a superseded
-   * socket's late close — the replacement is still confirming it) from a
-   * direct-send marker whose share is lost when its socket dies (clear it so the
-   * post-reconnect `room:state` is not suppressed until the timeout).
-   */
-  shareReflushPending: boolean;
 }
 
 export interface ShareState {
@@ -161,7 +149,6 @@ export function createBackgroundRuntimeState(): BackgroundRuntimeState {
       awaitingFreshRoomState: false,
       pendingSharedVideo: null,
       pendingSharedPlayback: null,
-      shareReflushPending: false,
     },
     share: {
       sharedTabId: null,

--- a/extension/src/background/runtime-state.ts
+++ b/extension/src/background/runtime-state.ts
@@ -68,6 +68,18 @@ export interface RoomSessionState {
   awaitingFreshRoomState: boolean;
   pendingSharedVideo: SharedVideo | null;
   pendingSharedPlayback: PlaybackState | null;
+  /**
+   * Whether the current pending-local-share confirmation marker is backed by a
+   * share that a reconnect will re-flush and the replacement connection will
+   * reconfirm (the CLOSING/offline queue branches of `queueOrSendSharedVideo`),
+   * rather than a plain direct send. `executeFlushPendingShare` nulls
+   * `pendingSharedVideo` once it re-sends, so after a flush `pendingSharedVideo`
+   * alone can no longer tell a re-flush marker (keep across a superseded
+   * socket's late close — the replacement is still confirming it) from a
+   * direct-send marker whose share is lost when its socket dies (clear it so the
+   * post-reconnect `room:state` is not suppressed until the timeout).
+   */
+  shareReflushPending: boolean;
 }
 
 export interface ShareState {
@@ -133,6 +145,7 @@ export function createBackgroundRuntimeState(): BackgroundRuntimeState {
       awaitingFreshRoomState: false,
       pendingSharedVideo: null,
       pendingSharedPlayback: null,
+      shareReflushPending: false,
     },
     share: {
       sharedTabId: null,

--- a/extension/src/background/runtime-sync-controller.ts
+++ b/extension/src/background/runtime-sync-controller.ts
@@ -44,7 +44,6 @@ export function createRuntimeSyncController(args: {
         awaitingFreshRoomState: args.roomSessionState.awaitingFreshRoomState,
         pendingSharedVideo: args.roomSessionState.pendingSharedVideo,
         pendingSharedPlayback: args.roomSessionState.pendingSharedPlayback,
-        shareReflushPending: args.roomSessionState.shareReflushPending,
       },
       share: {
         sharedTabId: args.shareState.sharedTabId,

--- a/extension/src/background/runtime-sync-controller.ts
+++ b/extension/src/background/runtime-sync-controller.ts
@@ -43,6 +43,7 @@ export function createRuntimeSyncController(args: {
         awaitingFreshRoomState: args.roomSessionState.awaitingFreshRoomState,
         pendingSharedVideo: args.roomSessionState.pendingSharedVideo,
         pendingSharedPlayback: args.roomSessionState.pendingSharedPlayback,
+        shareReflushPending: args.roomSessionState.shareReflushPending,
       },
       share: {
         sharedTabId: args.shareState.sharedTabId,

--- a/extension/src/background/runtime-sync-controller.ts
+++ b/extension/src/background/runtime-sync-controller.ts
@@ -24,6 +24,7 @@ export function createRuntimeSyncController(args: {
         connected: args.connectionState.connected,
         lastError: args.connectionState.lastError,
         connectProbe: args.connectionState.connectProbe,
+        connectEpoch: args.connectionState.connectEpoch,
         reconnectTimer: args.connectionState.reconnectTimer,
         reconnectAttempt: args.connectionState.reconnectAttempt,
         reconnectDeadlineMs: args.connectionState.reconnectDeadlineMs,

--- a/extension/src/background/runtime-sync-controller.ts
+++ b/extension/src/background/runtime-sync-controller.ts
@@ -24,6 +24,7 @@ export function createRuntimeSyncController(args: {
         connected: args.connectionState.connected,
         lastError: args.connectionState.lastError,
         connectProbe: args.connectionState.connectProbe,
+        socketGeneration: args.connectionState.socketGeneration,
         connectEpoch: args.connectionState.connectEpoch,
         reconnectTimer: args.connectionState.reconnectTimer,
         reconnectAttempt: args.connectionState.reconnectAttempt,
@@ -50,6 +51,8 @@ export function createRuntimeSyncController(args: {
         lastOpenedSharedUrl: args.shareState.lastOpenedSharedUrl,
         openingSharedUrl: args.shareState.openingSharedUrl,
         pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
+        pendingLocalShareGeneration:
+          args.shareState.pendingLocalShareGeneration,
         pendingLocalShareExpiresAt: args.shareState.pendingLocalShareExpiresAt,
         pendingLocalShareTimer: args.shareState.pendingLocalShareTimer,
         pendingShareToast: args.shareState.pendingShareToast,

--- a/extension/src/background/share-controller.ts
+++ b/extension/src/background/share-controller.ts
@@ -184,17 +184,25 @@ export function createShareController(args: {
       return { ok: true };
     }
 
-    // CLOSING micro-window: the socket can no longer be written but the session
-    // is otherwise valid (`connected` still true, room + member token present).
-    // Queue the share for the reconnect flush and open the replacement
-    // connection WITHOUT tearing down the session — keep the member token so the
-    // rejoin re-attaches as the same member. Dropping it (as the fully-offline
-    // branch below does) makes the server assign a new memberId and can surface
-    // a duplicate member until the old socket leaves. The superseded old socket's
-    // close is ignored by the socket controller, so this marker survives until
-    // the re-flushed share is confirmed.
+    // CLOSING micro-window / reconnect in progress: the socket can no longer be
+    // written but the session is otherwise valid (room + member token present).
+    // This covers both the CLOSING window (`connected` still true, close event
+    // not dispatched) and the window after a previous queued share already
+    // swapped in a CONNECTING replacement socket (which clears `connected`); a
+    // second manual share in that window must NOT fall through to the offline
+    // branch and drop the member token. Queue the share for the reconnect flush
+    // and open/await the replacement WITHOUT tearing down the session — keep the
+    // member token so the rejoin re-attaches as the same member. Dropping it (as
+    // the fully-offline branch below does) makes the server assign a new memberId
+    // and can surface a duplicate member until the old socket leaves. The
+    // superseded old socket's close is ignored by the socket controller, so this
+    // marker survives (flagged as a re-flush) until the re-flushed share is
+    // confirmed.
+    const reconnectInProgress =
+      args.connectionState.socket !== null &&
+      args.connectionState.socket.readyState === WebSocket.CONNECTING;
     if (
-      args.connectionState.connected &&
+      (args.connectionState.connected || reconnectInProgress) &&
       args.roomSessionState.roomCode &&
       args.roomSessionState.memberToken
     ) {
@@ -207,6 +215,7 @@ export function createShareController(args: {
             actorId: args.roomSessionState.memberId ?? payload.playback.actorId,
           }
         : null;
+      args.roomSessionState.shareReflushPending = true;
       await args.connect();
       return { ok: true };
     }
@@ -220,6 +229,9 @@ export function createShareController(args: {
           actorId: args.roomSessionState.memberId ?? payload.playback.actorId,
         }
       : null;
+    // The reconnect rejoin (or room:create) flushes this queued share, so the
+    // marker is re-flush-backed: keep it across a superseded socket's late close.
+    args.roomSessionState.shareReflushPending = true;
 
     if (args.roomSessionState.roomCode) {
       args.roomSessionState.memberToken = null;
@@ -251,6 +263,9 @@ export function createShareController(args: {
   }
 
   function clearPendingLocalShare(reason: string): void {
+    // The marker is being torn down (confirmed, timed out, disconnect, etc.), so
+    // no re-flush is pending against it any more.
+    args.roomSessionState.shareReflushPending = false;
     const cleanup = preparePendingLocalShareCleanup({
       pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
       pendingLocalShareExpiresAt: args.shareState.pendingLocalShareExpiresAt,
@@ -295,6 +310,11 @@ export function createShareController(args: {
 
   function setPendingLocalShare(url: string): void {
     clearPendingLocalShareTimer();
+    // A fresh marker defaults to a plain direct send; the CLOSING/offline queue
+    // branches set `shareReflushPending = true` afterwards when they queue a
+    // re-flush. Reset it here so a direct send that reuses the marker is never
+    // mistaken for a re-flush by a superseded socket's close.
+    args.roomSessionState.shareReflushPending = false;
     args.shareState.pendingLocalShareUrl = url;
     args.shareState.pendingLocalShareExpiresAt = createPendingLocalShareExpiry(
       Date.now(),

--- a/extension/src/background/share-controller.ts
+++ b/extension/src/background/share-controller.ts
@@ -142,7 +142,24 @@ export function createShareController(args: {
   ): Promise<ShareVideoResult> {
     args.rememberSharedSourceTab(tabId ?? undefined, payload.video.url);
 
-    if (args.connectionState.connected && args.roomSessionState.roomCode) {
+    // Treat the live socket's `readyState` as the source of truth for whether we
+    // can actually write a `video:share`. `connectionState.connected` is only
+    // flipped to false by the socket's `close`/`error` events, so during the
+    // micro-window where the socket has already moved to CLOSING/CLOSED but the
+    // close event has not dispatched yet it still reads true. Taking the
+    // connected branch there returns `{ ok: true }` while `sendToServer` (which
+    // requires an OPEN socket) silently drops the message, stranding the room on
+    // the old video with no retry — and auto-share gets no failure to retry on.
+    // Falling through to the offline branch instead queues the share into
+    // `pendingSharedVideo` and reconnects, so it is flushed after the rejoin.
+    const isSocketWritable =
+      args.connectionState.socket?.readyState === WebSocket.OPEN;
+
+    if (
+      args.connectionState.connected &&
+      isSocketWritable &&
+      args.roomSessionState.roomCode
+    ) {
       if (!args.roomSessionState.memberToken) {
         const error = t("popupErrorMemberTokenMissing");
         args.connectionState.lastError = error;

--- a/extension/src/background/share-controller.ts
+++ b/extension/src/background/share-controller.ts
@@ -16,6 +16,7 @@ import type {
   RoomSessionState,
   ShareState,
 } from "./runtime-state";
+import { isSocketWritable } from "./socket-manager";
 
 export interface ActiveVideoPayloadResult {
   ok: boolean;
@@ -152,12 +153,13 @@ export function createShareController(args: {
     // the old video with no retry — and auto-share gets no failure to retry on.
     // Falling through to the offline branch instead queues the share into
     // `pendingSharedVideo` and reconnects, so it is flushed after the rejoin.
-    const isSocketWritable =
-      args.connectionState.socket?.readyState === WebSocket.OPEN;
-
+    // (For the non-explicit auto-share path the message controller defers on the
+    // same writability check *before* reaching here, so it never queues a stale
+    // auto-share that would clobber another member's share on the reconnect
+    // flush — only explicit user shares fall through to the queue.)
     if (
       args.connectionState.connected &&
-      isSocketWritable &&
+      isSocketWritable(args.connectionState.socket) &&
       args.roomSessionState.roomCode
     ) {
       if (!args.roomSessionState.memberToken) {

--- a/extension/src/background/share-controller.ts
+++ b/extension/src/background/share-controller.ts
@@ -147,16 +147,12 @@ export function createShareController(args: {
     // can actually write a `video:share`. `connectionState.connected` is only
     // flipped to false by the socket's `close`/`error` events, so during the
     // micro-window where the socket has already moved to CLOSING/CLOSED but the
-    // close event has not dispatched yet it still reads true. Taking the
-    // connected branch there returns `{ ok: true }` while `sendToServer` (which
-    // requires an OPEN socket) silently drops the message, stranding the room on
-    // the old video with no retry — and auto-share gets no failure to retry on.
-    // Falling through to the offline branch instead queues the share into
-    // `pendingSharedVideo` and reconnects, so it is flushed after the rejoin.
+    // close event has not dispatched yet it still reads true. Sending in that
+    // window returns `{ ok: true }` while `sendToServer` (which requires an OPEN
+    // socket) silently drops the message, stranding the room on the old video.
     // (For the non-explicit auto-share path the message controller defers on the
-    // same writability check *before* reaching here, so it never queues a stale
-    // auto-share that would clobber another member's share on the reconnect
-    // flush — only explicit user shares fall through to the queue.)
+    // same writability check *before* reaching here, so only explicit user
+    // shares reach the CLOSING/offline queue below.)
     if (
       args.connectionState.connected &&
       isSocketWritable(args.connectionState.socket) &&
@@ -185,6 +181,33 @@ export function createShareController(args: {
             : {}),
         },
       });
+      return { ok: true };
+    }
+
+    // CLOSING micro-window: the socket can no longer be written but the session
+    // is otherwise valid (`connected` still true, room + member token present).
+    // Queue the share for the reconnect flush and open the replacement
+    // connection WITHOUT tearing down the session — keep the member token so the
+    // rejoin re-attaches as the same member. Dropping it (as the fully-offline
+    // branch below does) makes the server assign a new memberId and can surface
+    // a duplicate member until the old socket leaves. The superseded old socket's
+    // close is ignored by the socket controller, so this marker survives until
+    // the re-flushed share is confirmed.
+    if (
+      args.connectionState.connected &&
+      args.roomSessionState.roomCode &&
+      args.roomSessionState.memberToken
+    ) {
+      setPendingLocalShare(payload.video.url);
+      args.roomSessionState.pendingSharedVideo = payload.video;
+      args.roomSessionState.pendingSharedPlayback = payload.playback
+        ? {
+            ...payload.playback,
+            serverTime: 0,
+            actorId: args.roomSessionState.memberId ?? payload.playback.actorId,
+          }
+        : null;
+      await args.connect();
       return { ok: true };
     }
 

--- a/extension/src/background/share-controller.ts
+++ b/extension/src/background/share-controller.ts
@@ -181,28 +181,43 @@ export function createShareController(args: {
             : {}),
         },
       });
+      // A prior CLOSING-window share may still be queued for re-flush on a
+      // pending rejoin (replacement socket `open` flips `connected` true and the
+      // socket writable before `room:joined` returns to flush the queue). We just
+      // direct-sent a newer video, so replace the queued payload with it;
+      // otherwise the post-rejoin flush would re-send the stale video and roll
+      // back the share the user just made.
+      if (args.roomSessionState.pendingSharedVideo !== null) {
+        args.roomSessionState.pendingSharedVideo = payload.video;
+        args.roomSessionState.pendingSharedPlayback = payload.playback
+          ? {
+              ...payload.playback,
+              serverTime: 0,
+              actorId:
+                args.roomSessionState.memberId ?? payload.playback.actorId,
+            }
+          : null;
+      }
       return { ok: true };
     }
 
-    // CLOSING micro-window / reconnect in progress: the socket can no longer be
-    // written but the session is otherwise valid (room + member token present).
-    // This covers both the CLOSING window (`connected` still true, close event
-    // not dispatched) and the window after a previous queued share already
-    // swapped in a CONNECTING replacement socket (which clears `connected`); a
-    // second manual share in that window must NOT fall through to the offline
-    // branch and drop the member token. Queue the share for the reconnect flush
-    // and open/await the replacement WITHOUT tearing down the session — keep the
-    // member token so the rejoin re-attaches as the same member. Dropping it (as
-    // the fully-offline branch below does) makes the server assign a new memberId
-    // and can surface a duplicate member until the old socket leaves. The
-    // superseded old socket's close is ignored by the socket controller, so this
-    // marker survives (flagged as a re-flush) until the re-flushed share is
-    // confirmed.
-    const reconnectInProgress =
-      args.connectionState.socket !== null &&
-      args.connectionState.socket.readyState === WebSocket.CONNECTING;
+    // Reconnect window: a live socket reference still exists but it can no longer
+    // be cleanly written, while the session is otherwise valid (room + member
+    // token present). This covers the CLOSING window (`connected` still true,
+    // close event not dispatched), the window after a previous queued share
+    // swapped in a CONNECTING replacement socket (which clears `connected`), and
+    // the error-before-close window (the `error` handler flips `connected` false
+    // but the socket lingers in CLOSING/CLOSED until its `close` event). A manual
+    // share in any of these must NOT fall through to the offline branch and drop
+    // the member token. Queue the share for the reconnect flush and open/await
+    // the replacement WITHOUT tearing down the session — keep the member token so
+    // the rejoin re-attaches as the same member. Dropping it (as the fully-offline
+    // branch below does) makes the server assign a new memberId and can surface a
+    // duplicate member until the old socket leaves. The superseded old socket's
+    // close is ignored by the socket controller, and the queued `pendingSharedVideo`
+    // keeps the marker alive until the re-flushed share is confirmed.
     if (
-      (args.connectionState.connected || reconnectInProgress) &&
+      args.connectionState.socket !== null &&
       args.roomSessionState.roomCode &&
       args.roomSessionState.memberToken
     ) {
@@ -215,7 +230,6 @@ export function createShareController(args: {
             actorId: args.roomSessionState.memberId ?? payload.playback.actorId,
           }
         : null;
-      args.roomSessionState.shareReflushPending = true;
       await args.connect();
       return { ok: true };
     }
@@ -229,10 +243,6 @@ export function createShareController(args: {
           actorId: args.roomSessionState.memberId ?? payload.playback.actorId,
         }
       : null;
-    // The reconnect rejoin (or room:create) flushes this queued share, so the
-    // marker is re-flush-backed: keep it across a superseded socket's late close.
-    args.roomSessionState.shareReflushPending = true;
-
     if (args.roomSessionState.roomCode) {
       args.roomSessionState.memberToken = null;
       await args.connect();
@@ -264,8 +274,7 @@ export function createShareController(args: {
 
   function clearPendingLocalShare(reason: string): void {
     // The marker is being torn down (confirmed, timed out, disconnect, etc.), so
-    // no re-flush is pending against it any more and it no longer has an owner.
-    args.roomSessionState.shareReflushPending = false;
+    // it no longer has an owning connection.
     args.shareState.pendingLocalShareGeneration = null;
     const cleanup = preparePendingLocalShareCleanup({
       pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
@@ -311,11 +320,6 @@ export function createShareController(args: {
 
   function setPendingLocalShare(url: string): void {
     clearPendingLocalShareTimer();
-    // A fresh marker defaults to a plain direct send; the CLOSING/offline queue
-    // branches set `shareReflushPending = true` afterwards when they queue a
-    // re-flush. Reset it here so a direct send that reuses the marker is never
-    // mistaken for a re-flush by a superseded socket's close.
-    args.roomSessionState.shareReflushPending = false;
     // Record which connection owns this marker so a superseded socket's late
     // close only clears the marker it created, not one set by a newer connection.
     args.shareState.pendingLocalShareGeneration =

--- a/extension/src/background/share-controller.ts
+++ b/extension/src/background/share-controller.ts
@@ -264,8 +264,9 @@ export function createShareController(args: {
 
   function clearPendingLocalShare(reason: string): void {
     // The marker is being torn down (confirmed, timed out, disconnect, etc.), so
-    // no re-flush is pending against it any more.
+    // no re-flush is pending against it any more and it no longer has an owner.
     args.roomSessionState.shareReflushPending = false;
+    args.shareState.pendingLocalShareGeneration = null;
     const cleanup = preparePendingLocalShareCleanup({
       pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
       pendingLocalShareExpiresAt: args.shareState.pendingLocalShareExpiresAt,
@@ -315,6 +316,10 @@ export function createShareController(args: {
     // re-flush. Reset it here so a direct send that reuses the marker is never
     // mistaken for a re-flush by a superseded socket's close.
     args.roomSessionState.shareReflushPending = false;
+    // Record which connection owns this marker so a superseded socket's late
+    // close only clears the marker it created, not one set by a newer connection.
+    args.shareState.pendingLocalShareGeneration =
+      args.connectionState.socketGeneration;
     args.shareState.pendingLocalShareUrl = url;
     args.shareState.pendingLocalShareExpiresAt = createPendingLocalShareExpiry(
       Date.now(),

--- a/extension/src/background/socket-controller.ts
+++ b/extension/src/background/socket-controller.ts
@@ -70,13 +70,19 @@ export function createSocketController(args: {
 
     clearReconnectTimer();
     args.log("background", `Connecting to ${serverUrlResult.normalizedUrl}`);
-    args.connectionState.connectProbe = openSocketWithProbe(
-      serverUrlResult.normalizedUrl,
-    );
+    const probe = openSocketWithProbe(serverUrlResult.normalizedUrl);
+    args.connectionState.connectProbe = probe;
     try {
-      await args.connectionState.connectProbe;
+      await probe;
     } finally {
-      args.connectionState.connectProbe = null;
+      // Only clear if this is still the active probe. An authoritative teardown
+      // (admin reset / leave) can abort this probe AND null `connectProbe` so a
+      // subsequent `connect()` starts fresh instead of awaiting this doomed
+      // promise; an unconditional clear here would then wipe that newer probe's
+      // reference when this aborted one finally settles.
+      if (args.connectionState.connectProbe === probe) {
+        args.connectionState.connectProbe = null;
+      }
     }
   }
 
@@ -298,8 +304,12 @@ export function createSocketController(args: {
         // a CLOSING-window reconnect was still awaiting connection-check /
         // healthcheck (the replacement socket is not created yet, so closing
         // `liveSocket` cannot reach it), the resuming probe would otherwise open
-        // a room-less ghost connection and clear this reset's `lastError`.
+        // a room-less ghost connection and clear this reset's `lastError`. Also
+        // null `connectProbe`: the aborted probe will short-circuit, but leaving
+        // its promise in place would make a later create/join reuse it (and
+        // never open a connection).
         args.connectionState.connectEpoch += 1;
+        args.connectionState.connectProbe = null;
         if (liveSocket && liveSocket !== socket) {
           liveSocket.close();
         }
@@ -310,12 +320,21 @@ export function createSocketController(args: {
       }
 
       // A superseded socket's close belongs to a connection the replacement has
-      // already taken over. Acting here would clear a share-confirmation marker
-      // the new connection is still confirming (`flushPendingShare` nulls
-      // `pendingSharedVideo` right after rejoin, so the queued-share check below
-      // can no longer tell a re-flushed share from a lost one), flip `connected`
-      // false on the live socket, and schedule a redundant reconnect.
+      // already taken over, so it must not flip `connected` false on the live
+      // socket or schedule a redundant reconnect. It must still tidy the marker
+      // though: a share sent directly on THIS now-dead socket (not queued for
+      // re-flush) will never be reconfirmed by the replacement, so its marker
+      // would suppress the post-reconnect `room:state` until the 10s timeout.
+      // `shareReflushPending` distinguishes that from a re-flush marker the
+      // replacement is still confirming (`flushPendingShare` nulls
+      // `pendingSharedVideo` right after rejoin, so `pendingSharedVideo` alone
+      // can no longer tell the two apart). Clear only the direct-send marker.
       if (isSuperseded()) {
+        if (!args.roomSessionState.shareReflushPending) {
+          args.clearPendingLocalShare(
+            "superseded socket closed before share confirmation",
+          );
+        }
         return;
       }
 

--- a/extension/src/background/socket-controller.ts
+++ b/extension/src/background/socket-controller.ts
@@ -327,19 +327,25 @@ export function createSocketController(args: {
       // A superseded socket's close belongs to a connection the replacement has
       // already taken over, so it must not flip `connected` false on the live
       // socket or schedule a redundant reconnect. It must still tidy the marker
-      // though: a share sent directly on THIS now-dead socket (not queued for
-      // re-flush) will never be reconfirmed by the replacement, so its marker
-      // would suppress the post-reconnect `room:state` until the 10s timeout.
-      // `shareReflushPending` distinguishes that from a re-flush marker the
-      // replacement is still confirming (`flushPendingShare` nulls
-      // `pendingSharedVideo` right after rejoin, so `pendingSharedVideo` alone
-      // can no longer tell the two apart). The generation check ensures we only
-      // clear a marker THIS socket created: after it was superseded the user may
-      // have sent a fresh direct share on the new connection (also
-      // `shareReflushPending === false`), and that newer marker must survive.
+      // though, gated on two checks:
+      //   1. `pendingSharedVideo` is null — nothing is still queued for the
+      //      replacement's rejoin to re-flush. While a share is queued the marker
+      //      is preserved (the rejoin re-sends it and reconfirms).
+      //   2. The marker's generation matches THIS socket — it owns the last send
+      //      the marker is tracking. A direct send stamps the marker with the
+      //      live socket's generation; a re-flush (`flushPendingShare`) transfers
+      //      ownership to the socket it re-sends on. So once a queued share has
+      //      been re-flushed on the replacement, the marker belongs to the
+      //      replacement and THIS old socket's late close no longer matches it
+      //      (leaving it for the replacement to confirm). Conversely a fresh
+      //      direct share the user sent on the new connection after this socket
+      //      was superseded carries the newer generation and is also left intact.
+      // When both hold the marker can only be reconfirmed by a `video:share` this
+      // dead socket may have dropped on close, so it would suppress the
+      // post-reconnect `room:state` until the 10s timeout; clear it.
       if (isSuperseded()) {
         if (
-          !args.roomSessionState.shareReflushPending &&
+          args.roomSessionState.pendingSharedVideo === null &&
           args.getPendingLocalShareGeneration() === socketGeneration
         ) {
           args.clearPendingLocalShare(

--- a/extension/src/background/socket-controller.ts
+++ b/extension/src/background/socket-controller.ts
@@ -91,6 +91,15 @@ export function createSocketController(args: {
       return;
     }
 
+    // Capture the abort generation before the first await. An authoritative
+    // teardown (admin session reset / explicit leave) that lands while this
+    // probe is awaiting connection-check/healthcheck bumps `connectEpoch`, so a
+    // resuming probe must abort rather than open a room-less ghost connection
+    // (which would also clear the teardown's `lastError`).
+    const probeEpoch = args.connectionState.connectEpoch;
+    const isProbeAborted = () =>
+      args.connectionState.connectEpoch !== probeEpoch;
+
     const extensionOrigin = getExtensionOrigin();
     const connectionCheckUrl = args.buildConnectionCheckUrl(
       serverUrlResult.normalizedUrl,
@@ -115,6 +124,9 @@ export function createSocketController(args: {
 
           const payload = (await response.json()) as ConnectionCheckResponse;
           healthcheckReachable = true;
+          if (isProbeAborted()) {
+            return;
+          }
           if (payload.data?.websocketAllowed === false) {
             args.connectionState.lastError = getConnectionErrorMessage({
               healthcheckReachable: true,
@@ -148,6 +160,9 @@ export function createSocketController(args: {
         });
         healthcheckReachable = true;
       } catch {
+        if (isProbeAborted()) {
+          return;
+        }
         args.connectionState.lastError = getConnectionErrorMessage({
           healthcheckReachable: false,
           extensionOrigin,
@@ -165,7 +180,20 @@ export function createSocketController(args: {
       }
     }
 
+    if (isProbeAborted()) {
+      return;
+    }
+
     const socket = new WebSocket(serverUrlResult.normalizedUrl);
+    // A reconnect opened in the CLOSING micro-window replaces a socket whose
+    // `connected` is still the stale `true` of the dying connection, but this
+    // new socket is only CONNECTING until its `open` fires. Reflect that now:
+    // callers that gate on `connected` right after `await connect()`
+    // (requestCreateRoom / requestJoinRoom) would otherwise hand
+    // `room:create` / `room:join` to a non-OPEN socket (silently dropped by
+    // `sendToServer`) and mark the request as already sent, so the `open`
+    // handler never re-issues it.
+    args.connectionState.connected = false;
     args.connectionState.socket = socket;
 
     // True once a newer connection has replaced this socket (e.g. a reconnect
@@ -266,6 +294,12 @@ export function createSocketController(args: {
         const liveSocket = args.connectionState.socket;
         args.connectionState.socket = null;
         args.connectionState.connected = false;
+        // Abort any in-flight connect probe: when this admin close arrived while
+        // a CLOSING-window reconnect was still awaiting connection-check /
+        // healthcheck (the replacement socket is not created yet, so closing
+        // `liveSocket` cannot reach it), the resuming probe would otherwise open
+        // a room-less ghost connection and clear this reset's `lastError`.
+        args.connectionState.connectEpoch += 1;
         if (liveSocket && liveSocket !== socket) {
           liveSocket.close();
         }

--- a/extension/src/background/socket-controller.ts
+++ b/extension/src/background/socket-controller.ts
@@ -255,9 +255,19 @@ export function createSocketController(args: {
       // for a superseded socket so a kicked / disconnected / closed-room session
       // is torn down rather than silently rejoined by the replacement.
       if (event.reason && ADMIN_SESSION_RESET_REASONS.has(event.reason)) {
-        if (!isSuperseded()) {
-          args.connectionState.connected = false;
-          args.stopClockSyncTimer();
+        args.stopClockSyncTimer();
+        // Tear down the *live* connection. When this admin close arrived on a
+        // socket that a CLOSING-window reconnect had already replaced, the
+        // replacement is the live socket and may have rejoined; closing it stops
+        // the kicked session from lingering as a ghost connection. Null the ref
+        // before closing so the replacement's own close event is treated as
+        // superseded and cannot schedule a reconnect (`onAdminSessionReset` then
+        // clears the room context, which also resets the reconnect state).
+        const liveSocket = args.connectionState.socket;
+        args.connectionState.socket = null;
+        args.connectionState.connected = false;
+        if (liveSocket && liveSocket !== socket) {
+          liveSocket.close();
         }
         args.onAdminSessionReset(
           args.formatAdminSessionResetReason(event.reason),

--- a/extension/src/background/socket-controller.ts
+++ b/extension/src/background/socket-controller.ts
@@ -165,9 +165,19 @@ export function createSocketController(args: {
       }
     }
 
-    args.connectionState.socket = new WebSocket(serverUrlResult.normalizedUrl);
+    const socket = new WebSocket(serverUrlResult.normalizedUrl);
+    args.connectionState.socket = socket;
 
-    args.connectionState.socket.addEventListener("open", () => {
+    // True once a newer connection has replaced this socket (e.g. a reconnect
+    // opened while this one was still CLOSING — an explicit share queued in the
+    // CLOSING micro-window opens the replacement). A superseded socket's events
+    // must not mutate the live connection state, which the replacement now owns.
+    const isSuperseded = () => args.connectionState.socket !== socket;
+
+    socket.addEventListener("open", () => {
+      if (isSuperseded()) {
+        return;
+      }
       args.connectionState.connected = true;
       args.connectionState.lastError = null;
       args.connectionState.reconnectAttempt = 0;
@@ -214,7 +224,10 @@ export function createSocketController(args: {
       args.notifyAll();
     });
 
-    args.connectionState.socket.addEventListener("message", (event) => {
+    socket.addEventListener("message", (event) => {
+      if (isSuperseded()) {
+        return;
+      }
       let parsed: unknown;
       try {
         parsed = JSON.parse(event.data);
@@ -229,21 +242,7 @@ export function createSocketController(args: {
       void args.handleServerMessage(parsed);
     });
 
-    args.connectionState.socket.addEventListener("close", (event) => {
-      args.connectionState.connected = false;
-      args.stopClockSyncTimer();
-      // Keep the pending local-share confirmation marker when the share is
-      // queued for re-flush on reconnect (the offline/CLOSING branch of
-      // `queueOrSendSharedVideo` set `pendingSharedVideo` before opening the
-      // replacement connection). The reconnect `room:joined` re-sends it, and
-      // the surviving marker keeps the interim stale `room:state` (the previous
-      // video) from pulling the sharer back until the re-shared video is
-      // confirmed. With nothing queued the in-flight share is genuinely lost, so
-      // clear the marker and let fresh room state apply instead of stranding the
-      // client on a never-confirmed local share.
-      if (args.roomSessionState.pendingSharedVideo === null) {
-        args.clearPendingLocalShare("socket closed before share confirmation");
-      }
+    socket.addEventListener("close", (event) => {
       const closeReason = event.reason
         ? ` reason=${JSON.stringify(event.reason)}`
         : "";
@@ -251,17 +250,51 @@ export function createSocketController(args: {
         "background",
         `Socket closed code=${event.code} clean=${event.wasClean}${closeReason}`,
       );
+
+      // Admin session resets are authoritative server actions: honour them even
+      // for a superseded socket so a kicked / disconnected / closed-room session
+      // is torn down rather than silently rejoined by the replacement.
       if (event.reason && ADMIN_SESSION_RESET_REASONS.has(event.reason)) {
+        if (!isSuperseded()) {
+          args.connectionState.connected = false;
+          args.stopClockSyncTimer();
+        }
         args.onAdminSessionReset(
           args.formatAdminSessionResetReason(event.reason),
         );
         return;
       }
+
+      // A superseded socket's close belongs to a connection the replacement has
+      // already taken over. Acting here would clear a share-confirmation marker
+      // the new connection is still confirming (`flushPendingShare` nulls
+      // `pendingSharedVideo` right after rejoin, so the queued-share check below
+      // can no longer tell a re-flushed share from a lost one), flip `connected`
+      // false on the live socket, and schedule a redundant reconnect.
+      if (isSuperseded()) {
+        return;
+      }
+
+      args.connectionState.connected = false;
+      args.stopClockSyncTimer();
+      // Keep the pending local-share confirmation marker while a share is queued
+      // for re-flush on reconnect (the CLOSING/offline branch of
+      // `queueOrSendSharedVideo` set `pendingSharedVideo`): the reconnect
+      // `room:joined` re-sends it and the surviving marker suppresses the
+      // interim stale `room:state` until the re-shared video is confirmed. With
+      // nothing queued the in-flight share is lost, so clear the marker and let
+      // fresh room state apply instead of stranding the client on it.
+      if (args.roomSessionState.pendingSharedVideo === null) {
+        args.clearPendingLocalShare("socket closed before share confirmation");
+      }
       scheduleReconnect();
       args.notifyAll();
     });
 
-    args.connectionState.socket.addEventListener("error", () => {
+    socket.addEventListener("error", () => {
+      if (isSuperseded()) {
+        return;
+      }
       args.connectionState.lastError = getConnectionErrorMessage({
         healthcheckReachable,
         extensionOrigin,
@@ -277,7 +310,7 @@ export function createSocketController(args: {
         stage: "websocket",
         serverUrl: serverUrlResult.normalizedUrl,
         extensionOrigin,
-        readyState: args.connectionState.socket?.readyState ?? -1,
+        readyState: socket.readyState,
       });
       args.notifyAll();
     });

--- a/extension/src/background/socket-controller.ts
+++ b/extension/src/background/socket-controller.ts
@@ -36,6 +36,7 @@ export function createSocketController(args: {
   syncClock: () => void;
   startClockSyncTimer: () => void;
   clearPendingLocalShare: (reason: string) => void;
+  getPendingLocalShareGeneration: () => number | null;
   sendJoinRequest: (targetRoomCode: string, targetJoinToken: string) => void;
   sendToServer: (message: ClientMessage) => void;
   handleServerMessage: (message: ServerMessage) => Promise<void>;
@@ -191,6 +192,10 @@ export function createSocketController(args: {
     }
 
     const socket = new WebSocket(serverUrlResult.normalizedUrl);
+    // Tag this socket with a fresh generation so its handlers can tell a marker
+    // it owns from one a newer connection set (see the superseded close below).
+    args.connectionState.socketGeneration += 1;
+    const socketGeneration = args.connectionState.socketGeneration;
     // A reconnect opened in the CLOSING micro-window replaces a socket whose
     // `connected` is still the stale `true` of the dying connection, but this
     // new socket is only CONNECTING until its `open` fires. Reflect that now:
@@ -328,9 +333,15 @@ export function createSocketController(args: {
       // `shareReflushPending` distinguishes that from a re-flush marker the
       // replacement is still confirming (`flushPendingShare` nulls
       // `pendingSharedVideo` right after rejoin, so `pendingSharedVideo` alone
-      // can no longer tell the two apart). Clear only the direct-send marker.
+      // can no longer tell the two apart). The generation check ensures we only
+      // clear a marker THIS socket created: after it was superseded the user may
+      // have sent a fresh direct share on the new connection (also
+      // `shareReflushPending === false`), and that newer marker must survive.
       if (isSuperseded()) {
-        if (!args.roomSessionState.shareReflushPending) {
+        if (
+          !args.roomSessionState.shareReflushPending &&
+          args.getPendingLocalShareGeneration() === socketGeneration
+        ) {
           args.clearPendingLocalShare(
             "superseded socket closed before share confirmation",
           );

--- a/extension/src/background/socket-controller.ts
+++ b/extension/src/background/socket-controller.ts
@@ -165,22 +165,9 @@ export function createSocketController(args: {
       }
     }
 
-    // Capture this socket instance so each handler can ignore events from a
-    // connection that has since been superseded. A replacement socket can be
-    // opened before this one's events drain — e.g. an explicit share queued
-    // during the CLOSING micro-window takes the offline branch and calls
-    // `connect()`, which opens a new socket while this one is still CLOSING.
-    // When this stale socket's `close` later fires, running the normal handler
-    // would `clearPendingLocalShare` and flip `connected`, dropping the share
-    // confirmation marker that keeps the post-rejoin stale `room:state` from
-    // pulling the sharer back to the previous video.
-    const socket = new WebSocket(serverUrlResult.normalizedUrl);
-    args.connectionState.socket = socket;
+    args.connectionState.socket = new WebSocket(serverUrlResult.normalizedUrl);
 
-    socket.addEventListener("open", () => {
-      if (args.connectionState.socket !== socket) {
-        return;
-      }
+    args.connectionState.socket.addEventListener("open", () => {
       args.connectionState.connected = true;
       args.connectionState.lastError = null;
       args.connectionState.reconnectAttempt = 0;
@@ -227,10 +214,7 @@ export function createSocketController(args: {
       args.notifyAll();
     });
 
-    socket.addEventListener("message", (event) => {
-      if (args.connectionState.socket !== socket) {
-        return;
-      }
+    args.connectionState.socket.addEventListener("message", (event) => {
       let parsed: unknown;
       try {
         parsed = JSON.parse(event.data);
@@ -245,13 +229,21 @@ export function createSocketController(args: {
       void args.handleServerMessage(parsed);
     });
 
-    socket.addEventListener("close", (event) => {
-      if (args.connectionState.socket !== socket) {
-        return;
-      }
+    args.connectionState.socket.addEventListener("close", (event) => {
       args.connectionState.connected = false;
       args.stopClockSyncTimer();
-      args.clearPendingLocalShare("socket closed before share confirmation");
+      // Keep the pending local-share confirmation marker when the share is
+      // queued for re-flush on reconnect (the offline/CLOSING branch of
+      // `queueOrSendSharedVideo` set `pendingSharedVideo` before opening the
+      // replacement connection). The reconnect `room:joined` re-sends it, and
+      // the surviving marker keeps the interim stale `room:state` (the previous
+      // video) from pulling the sharer back until the re-shared video is
+      // confirmed. With nothing queued the in-flight share is genuinely lost, so
+      // clear the marker and let fresh room state apply instead of stranding the
+      // client on a never-confirmed local share.
+      if (args.roomSessionState.pendingSharedVideo === null) {
+        args.clearPendingLocalShare("socket closed before share confirmation");
+      }
       const closeReason = event.reason
         ? ` reason=${JSON.stringify(event.reason)}`
         : "";
@@ -269,22 +261,23 @@ export function createSocketController(args: {
       args.notifyAll();
     });
 
-    socket.addEventListener("error", () => {
-      if (args.connectionState.socket !== socket) {
-        return;
-      }
+    args.connectionState.socket.addEventListener("error", () => {
       args.connectionState.lastError = getConnectionErrorMessage({
         healthcheckReachable,
         extensionOrigin,
       });
       args.connectionState.connected = false;
       args.stopClockSyncTimer();
-      args.clearPendingLocalShare("socket error before share confirmation");
+      // See the close handler: preserve the marker only while a queued share is
+      // still pending re-flush, otherwise clear it.
+      if (args.roomSessionState.pendingSharedVideo === null) {
+        args.clearPendingLocalShare("socket error before share confirmation");
+      }
       args.logConnectionProbeFailure({
         stage: "websocket",
         serverUrl: serverUrlResult.normalizedUrl,
         extensionOrigin,
-        readyState: socket.readyState,
+        readyState: args.connectionState.socket?.readyState ?? -1,
       });
       args.notifyAll();
     });

--- a/extension/src/background/socket-controller.ts
+++ b/extension/src/background/socket-controller.ts
@@ -165,9 +165,22 @@ export function createSocketController(args: {
       }
     }
 
-    args.connectionState.socket = new WebSocket(serverUrlResult.normalizedUrl);
+    // Capture this socket instance so each handler can ignore events from a
+    // connection that has since been superseded. A replacement socket can be
+    // opened before this one's events drain — e.g. an explicit share queued
+    // during the CLOSING micro-window takes the offline branch and calls
+    // `connect()`, which opens a new socket while this one is still CLOSING.
+    // When this stale socket's `close` later fires, running the normal handler
+    // would `clearPendingLocalShare` and flip `connected`, dropping the share
+    // confirmation marker that keeps the post-rejoin stale `room:state` from
+    // pulling the sharer back to the previous video.
+    const socket = new WebSocket(serverUrlResult.normalizedUrl);
+    args.connectionState.socket = socket;
 
-    args.connectionState.socket.addEventListener("open", () => {
+    socket.addEventListener("open", () => {
+      if (args.connectionState.socket !== socket) {
+        return;
+      }
       args.connectionState.connected = true;
       args.connectionState.lastError = null;
       args.connectionState.reconnectAttempt = 0;
@@ -214,7 +227,10 @@ export function createSocketController(args: {
       args.notifyAll();
     });
 
-    args.connectionState.socket.addEventListener("message", (event) => {
+    socket.addEventListener("message", (event) => {
+      if (args.connectionState.socket !== socket) {
+        return;
+      }
       let parsed: unknown;
       try {
         parsed = JSON.parse(event.data);
@@ -229,7 +245,10 @@ export function createSocketController(args: {
       void args.handleServerMessage(parsed);
     });
 
-    args.connectionState.socket.addEventListener("close", (event) => {
+    socket.addEventListener("close", (event) => {
+      if (args.connectionState.socket !== socket) {
+        return;
+      }
       args.connectionState.connected = false;
       args.stopClockSyncTimer();
       args.clearPendingLocalShare("socket closed before share confirmation");
@@ -250,7 +269,10 @@ export function createSocketController(args: {
       args.notifyAll();
     });
 
-    args.connectionState.socket.addEventListener("error", () => {
+    socket.addEventListener("error", () => {
+      if (args.connectionState.socket !== socket) {
+        return;
+      }
       args.connectionState.lastError = getConnectionErrorMessage({
         healthcheckReachable,
         extensionOrigin,
@@ -262,7 +284,7 @@ export function createSocketController(args: {
         stage: "websocket",
         serverUrl: serverUrlResult.normalizedUrl,
         extensionOrigin,
-        readyState: args.connectionState.socket?.readyState ?? -1,
+        readyState: socket.readyState,
       });
       args.notifyAll();
     });

--- a/extension/src/background/socket-lifecycle.ts
+++ b/extension/src/background/socket-lifecycle.ts
@@ -3,6 +3,7 @@ export function disconnectSocket(args: {
     socket: WebSocket | null;
     connected: boolean;
     connectEpoch: number;
+    connectProbe: Promise<void> | null;
   };
   memberTokenState: { memberToken: string | null };
   resetReconnectState: () => void;
@@ -17,7 +18,10 @@ export function disconnectSocket(args: {
   // reconnect cannot open a room-less ghost connection after we tear down here.
   // Bump before the early return: a probe that has not created its socket yet
   // leaves `connectionState.socket` null, so the null check alone would miss it.
+  // Null `connectProbe` too so an immediate re-create/join starts a fresh
+  // connection instead of awaiting this now-doomed probe.
   args.connectionState.connectEpoch += 1;
+  args.connectionState.connectProbe = null;
 
   if (!args.connectionState.socket) {
     args.connectionState.connected = false;

--- a/extension/src/background/socket-lifecycle.ts
+++ b/extension/src/background/socket-lifecycle.ts
@@ -2,6 +2,7 @@ export function disconnectSocket(args: {
   connectionState: {
     socket: WebSocket | null;
     connected: boolean;
+    connectEpoch: number;
   };
   memberTokenState: { memberToken: string | null };
   resetReconnectState: () => void;
@@ -12,6 +13,11 @@ export function disconnectSocket(args: {
   args.stopClockSyncTimer();
   args.clearPendingLocalShare("socket disconnected");
   args.memberTokenState.memberToken = null;
+  // Abort any in-flight connect probe so a leave that races an awaiting
+  // reconnect cannot open a room-less ghost connection after we tear down here.
+  // Bump before the early return: a probe that has not created its socket yet
+  // leaves `connectionState.socket` null, so the null check alone would miss it.
+  args.connectionState.connectEpoch += 1;
 
   if (!args.connectionState.socket) {
     args.connectionState.connected = false;

--- a/extension/src/background/socket-manager.ts
+++ b/extension/src/background/socket-manager.ts
@@ -18,3 +18,16 @@ export function shouldReconnect(args: {
 export function getReconnectDelayMs(reconnectAttempt: number): number {
   return Math.min(1000 * 2 ** Math.max(0, reconnectAttempt - 1), 10000);
 }
+
+/**
+ * Whether a `ClientMessage` can actually be written to the socket right now.
+ *
+ * `connectionState.connected` is only flipped to false by the socket's
+ * `close`/`error` events, so during the micro-window where the socket has
+ * already moved to CLOSING/CLOSED but the close event has not dispatched yet it
+ * still reads true. The live `readyState` is the source of truth for
+ * writability: `sendToServer` drops anything sent while it is not OPEN.
+ */
+export function isSocketWritable(socket: WebSocket | null): boolean {
+  return socket !== null && socket.readyState === WebSocket.OPEN;
+}

--- a/extension/test/background-share-controller.test.ts
+++ b/extension/test/background-share-controller.test.ts
@@ -20,8 +20,19 @@ function installSelfStub() {
   };
 }
 
+function setSocketReadyState(
+  runtimeState: ReturnType<typeof createBackgroundRuntimeState>,
+  readyState: number,
+): void {
+  runtimeState.connection.socket = { readyState } as WebSocket;
+}
+
 function createControllerHarness() {
   const runtimeState = createBackgroundRuntimeState();
+  // Default the connected-path tests to a writable socket. Production now gates
+  // the "send now" branch on the live socket being OPEN, not just
+  // `connection.connected`, so an online harness must expose an OPEN socket.
+  setSocketReadyState(runtimeState, WebSocket.OPEN);
   const sendToServerCalls: Array<unknown> = [];
   const rememberedSharedTabs: Array<{
     tabId?: number;
@@ -102,6 +113,48 @@ test("background share controller forwards a share without playback when content
       },
     ]);
     assert.equal(harness.notifyAllCalls, 0);
+  } finally {
+    selfHarness.restore();
+  }
+});
+
+test("background share controller queues the share for reconnect when the socket is closing", async () => {
+  const selfHarness = installSelfStub();
+  const harness = createControllerHarness();
+  // `connected` lags the socket: the close event has not dispatched yet, so the
+  // background still believes it is online while the socket can no longer write.
+  harness.runtimeState.connection.connected = true;
+  setSocketReadyState(harness.runtimeState, WebSocket.CLOSING);
+  harness.runtimeState.room.roomCode = "ROOM01";
+  harness.runtimeState.room.memberToken = "member-token-1";
+  harness.runtimeState.room.memberId = "member-1";
+
+  try {
+    const result = await harness.controller.queueOrSendSharedVideo(
+      {
+        video: {
+          videoId: "BV199W9zEEcH",
+          url: "https://www.bilibili.com/video/BV199W9zEEcH",
+          title: "New Video",
+        },
+        playback: null,
+      },
+      123,
+    );
+
+    assert.deepEqual(result, { ok: true });
+    // The share must NOT be sent over the dying socket (it would be dropped
+    // silently). It is queued instead and the member token is cleared to force a
+    // fresh rejoin, after which `flushPendingShare` re-sends it.
+    assert.deepEqual(harness.sendToServerCalls, []);
+    assert.deepEqual(harness.runtimeState.room.pendingSharedVideo, {
+      videoId: "BV199W9zEEcH",
+      url: "https://www.bilibili.com/video/BV199W9zEEcH",
+      title: "New Video",
+    });
+    assert.equal(harness.runtimeState.room.memberToken, null);
+    // The offline branch reconnects (the harness `connect` stub flips this true).
+    assert.equal(harness.runtimeState.connection.connected, true);
   } finally {
     selfHarness.restore();
   }

--- a/extension/test/background-share-controller.test.ts
+++ b/extension/test/background-share-controller.test.ts
@@ -174,6 +174,53 @@ test("background share controller queues the share for reconnect when the socket
   }
 });
 
+test("background share controller keeps the member token for a second share during the reconnect window", async () => {
+  const selfHarness = installSelfStub();
+  const harness = createControllerHarness();
+  // A previous CLOSING-window share already swapped in a CONNECTING replacement
+  // socket, which clears `connected`. The session is still valid.
+  harness.runtimeState.connection.connected = false;
+  setSocketReadyState(harness.runtimeState, WebSocket.CONNECTING);
+  harness.runtimeState.room.roomCode = "ROOM01";
+  harness.runtimeState.room.memberToken = "member-token-1";
+  harness.runtimeState.room.memberId = "member-1";
+  harness.runtimeState.room.pendingSharedVideo = {
+    videoId: "BVfirst",
+    url: "https://www.bilibili.com/video/BVfirst",
+    title: "First Video",
+  };
+
+  try {
+    const result = await harness.controller.queueOrSendSharedVideo(
+      {
+        video: {
+          videoId: "BV199W9zEEcH",
+          url: "https://www.bilibili.com/video/BV199W9zEEcH",
+          title: "New Video",
+        },
+        playback: null,
+      },
+      123,
+    );
+
+    assert.deepEqual(result, { ok: true });
+    // Not sent over the not-yet-OPEN socket; queued for the reconnect flush.
+    assert.deepEqual(harness.sendToServerCalls, []);
+    // The queued video is replaced with the latest share.
+    assert.deepEqual(harness.runtimeState.room.pendingSharedVideo, {
+      videoId: "BV199W9zEEcH",
+      url: "https://www.bilibili.com/video/BV199W9zEEcH",
+      title: "New Video",
+    });
+    // The member token MUST survive (do not fall through to the offline branch
+    // that nulls it, which would spawn a duplicate member on rejoin).
+    assert.equal(harness.runtimeState.room.memberToken, "member-token-1");
+    assert.equal(harness.runtimeState.room.shareReflushPending, true);
+  } finally {
+    selfHarness.restore();
+  }
+});
+
 test("background share controller sends create request with protocolVersion when sharing outside a room", async () => {
   const selfHarness = installSelfStub();
   const harness = createControllerHarness();

--- a/extension/test/background-share-controller.test.ts
+++ b/extension/test/background-share-controller.test.ts
@@ -4,6 +4,18 @@ import { PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import { createBackgroundRuntimeState } from "../src/background/runtime-state";
 import { createShareController } from "../src/background/share-controller";
 
+// Node < 22 has no global WebSocket; production `isSocketWritable` reads
+// `WebSocket.OPEN`. Provide the readyState statics so these unit tests run on
+// any Node (CI pins Node 22 via .nvmrc, where it is already present).
+if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === "undefined") {
+  (globalThis as { WebSocket?: unknown }).WebSocket = {
+    CONNECTING: 0,
+    OPEN: 1,
+    CLOSING: 2,
+    CLOSED: 3,
+  };
+}
+
 function installSelfStub() {
   const originalSelf = globalThis.self;
   Object.assign(globalThis, {
@@ -144,16 +156,18 @@ test("background share controller queues the share for reconnect when the socket
 
     assert.deepEqual(result, { ok: true });
     // The share must NOT be sent over the dying socket (it would be dropped
-    // silently). It is queued instead and the member token is cleared to force a
-    // fresh rejoin, after which `flushPendingShare` re-sends it.
+    // silently). It is queued for the reconnect flush instead.
     assert.deepEqual(harness.sendToServerCalls, []);
     assert.deepEqual(harness.runtimeState.room.pendingSharedVideo, {
       videoId: "BV199W9zEEcH",
       url: "https://www.bilibili.com/video/BV199W9zEEcH",
       title: "New Video",
     });
-    assert.equal(harness.runtimeState.room.memberToken, null);
-    // The offline branch reconnects (the harness `connect` stub flips this true).
+    // The session is still valid: the member token is KEPT so the rejoin
+    // re-attaches as the same member (clearing it would spawn a new memberId /
+    // duplicate member). The reconnect flush re-sends the queued share.
+    assert.equal(harness.runtimeState.room.memberToken, "member-token-1");
+    // The CLOSING branch reconnects (the harness `connect` stub flips this true).
     assert.equal(harness.runtimeState.connection.connected, true);
   } finally {
     selfHarness.restore();

--- a/extension/test/background-share-controller.test.ts
+++ b/extension/test/background-share-controller.test.ts
@@ -215,7 +215,106 @@ test("background share controller keeps the member token for a second share duri
     // The member token MUST survive (do not fall through to the offline branch
     // that nulls it, which would spawn a duplicate member on rejoin).
     assert.equal(harness.runtimeState.room.memberToken, "member-token-1");
-    assert.equal(harness.runtimeState.room.shareReflushPending, true);
+  } finally {
+    selfHarness.restore();
+  }
+});
+
+test("background share controller replaces a still-queued share when direct-sending a newer one", async () => {
+  const selfHarness = installSelfStub();
+  const harness = createControllerHarness();
+  // The replacement socket opened (connected + writable) but `room:joined` has
+  // not returned yet, so a prior CLOSING-window share is still queued for the
+  // pending rejoin flush.
+  harness.runtimeState.connection.connected = true;
+  setSocketReadyState(harness.runtimeState, WebSocket.OPEN);
+  harness.runtimeState.room.roomCode = "ROOM01";
+  harness.runtimeState.room.memberToken = "member-token-1";
+  harness.runtimeState.room.memberId = "member-1";
+  harness.runtimeState.room.pendingSharedVideo = {
+    videoId: "BVfirst",
+    url: "https://www.bilibili.com/video/BVfirst",
+    title: "First Video",
+  };
+
+  try {
+    const result = await harness.controller.queueOrSendSharedVideo(
+      {
+        video: {
+          videoId: "BV199W9zEEcH",
+          url: "https://www.bilibili.com/video/BV199W9zEEcH",
+          title: "New Video",
+        },
+        playback: null,
+      },
+      123,
+    );
+
+    assert.deepEqual(result, { ok: true });
+    // The newer video is sent directly over the OPEN socket.
+    assert.deepEqual(harness.sendToServerCalls, [
+      {
+        type: "video:share",
+        payload: {
+          memberToken: "member-token-1",
+          video: {
+            videoId: "BV199W9zEEcH",
+            url: "https://www.bilibili.com/video/BV199W9zEEcH",
+            title: "New Video",
+          },
+        },
+      },
+    ]);
+    // The stale queued share MUST be replaced with the latest one; otherwise the
+    // post-rejoin flush would re-send the old video and roll back this share.
+    assert.deepEqual(harness.runtimeState.room.pendingSharedVideo, {
+      videoId: "BV199W9zEEcH",
+      url: "https://www.bilibili.com/video/BV199W9zEEcH",
+      title: "New Video",
+    });
+  } finally {
+    selfHarness.restore();
+  }
+});
+
+test("background share controller keeps the member token in the error-before-close window", async () => {
+  const selfHarness = installSelfStub();
+  const harness = createControllerHarness();
+  // The socket `error` handler flipped `connected` false, but the socket lingers
+  // in CLOSING until its `close` event dispatches. A manual share here must keep
+  // the member token instead of falling through to the offline branch.
+  harness.runtimeState.connection.connected = false;
+  setSocketReadyState(harness.runtimeState, WebSocket.CLOSING);
+  harness.runtimeState.room.roomCode = "ROOM01";
+  harness.runtimeState.room.memberToken = "member-token-1";
+  harness.runtimeState.room.memberId = "member-1";
+
+  try {
+    const result = await harness.controller.queueOrSendSharedVideo(
+      {
+        video: {
+          videoId: "BV199W9zEEcH",
+          url: "https://www.bilibili.com/video/BV199W9zEEcH",
+          title: "New Video",
+        },
+        playback: null,
+      },
+      123,
+    );
+
+    assert.deepEqual(result, { ok: true });
+    // Not written over the dying socket; queued for the reconnect flush.
+    assert.deepEqual(harness.sendToServerCalls, []);
+    assert.deepEqual(harness.runtimeState.room.pendingSharedVideo, {
+      videoId: "BV199W9zEEcH",
+      url: "https://www.bilibili.com/video/BV199W9zEEcH",
+      title: "New Video",
+    });
+    // The member token MUST survive so the rejoin re-attaches as the same member
+    // (clearing it would surface a duplicate member with a new memberId).
+    assert.equal(harness.runtimeState.room.memberToken, "member-token-1");
+    // The reconnect was triggered (the harness `connect` stub flips this true).
+    assert.equal(harness.runtimeState.connection.connected, true);
   } finally {
     selfHarness.restore();
   }

--- a/extension/test/message-controller.test.ts
+++ b/extension/test/message-controller.test.ts
@@ -3,6 +3,18 @@ import test from "node:test";
 import { createMessageController } from "../src/background/message-controller";
 import type { RoomState } from "@bili-syncplay/protocol";
 
+// Node < 22 has no global WebSocket; production `isSocketWritable` reads
+// `WebSocket.OPEN`. Provide the readyState statics so these unit tests run on
+// any Node (CI pins Node 22 via .nvmrc, where it is already present).
+if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === "undefined") {
+  (globalThis as { WebSocket?: unknown }).WebSocket = {
+    CONNECTING: 0,
+    OPEN: 1,
+    CLOSING: 2,
+    CLOSED: 3,
+  };
+}
+
 function createControllerHarness(
   overrides: {
     connectionState?: {

--- a/extension/test/message-controller.test.ts
+++ b/extension/test/message-controller.test.ts
@@ -5,7 +5,11 @@ import type { RoomState } from "@bili-syncplay/protocol";
 
 function createControllerHarness(
   overrides: {
-    connectionState?: { connected: boolean; lastError: string | null };
+    connectionState?: {
+      connected: boolean;
+      lastError: string | null;
+      socket?: WebSocket | null;
+    };
     roomSessionState?: {
       roomCode: string | null;
       memberToken: string | null;
@@ -63,9 +67,24 @@ function createControllerHarness(
     updateServerUrl: [] as string[],
     reclaimSharedSourceTab: [] as Array<number | undefined>,
   };
-  const connectionState = overrides.connectionState ?? {
+  const connectionStateInput = overrides.connectionState ?? {
     connected: true,
     lastError: null,
+  };
+  // The message controller now gates auto-share defers on the live socket being
+  // writable, not just `connected`. Default an undeclared socket from
+  // `connected` (OPEN when online, none when offline) so existing tests keep
+  // their intent; tests exercising the CLOSING micro-window pass an explicit
+  // socket with a non-OPEN `readyState`.
+  const connectionState = {
+    connected: connectionStateInput.connected,
+    lastError: connectionStateInput.lastError,
+    socket:
+      connectionStateInput.socket !== undefined
+        ? connectionStateInput.socket
+        : connectionStateInput.connected
+          ? ({ readyState: WebSocket.OPEN } as WebSocket)
+          : null,
   };
   const roomSessionState = {
     awaitingFreshRoomState: false,
@@ -910,6 +929,60 @@ test("message controller defers auto-share when the socket drops while validatin
 
   // queueOrSendSharedVideo would take its offline branch and store a pending
   // share that flushes on reconnect before fresh room state. Defer instead.
+  assert.deepEqual(harness.calls.queueOrSendSharedVideo, []);
+  assert.deepEqual(response, { ok: false, deferred: true });
+});
+
+test("message controller defers auto-share during the socket CLOSING micro-window", async () => {
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD",
+    title: "Old Video",
+    sharedByMemberId: "member-1",
+  };
+  const harness = createControllerHarness({
+    // `connected` still reads true because the socket's close event has not
+    // dispatched yet, but the socket is already CLOSING and cannot be written.
+    connectionState: {
+      connected: true,
+      lastError: null,
+      socket: { readyState: WebSocket.CLOSING } as WebSocket,
+    },
+    isRememberedSharedSourceTab: true,
+    roomSessionState: {
+      roomCode: "ROOM01",
+      memberToken: "member-token-1",
+      memberId: "member-1",
+      displayName: "Alice",
+      roomState: {
+        roomCode: "ROOM01",
+        sharedVideo,
+        playback: null,
+        members: [{ id: "member-1", name: "Alice" }],
+      },
+    },
+  });
+  let response: unknown;
+
+  await harness.controller.handleRuntimeMessage(
+    {
+      type: "content:auto-share-next-video",
+      payload: {
+        previousSharedUrl: "https://www.bilibili.com/video/BV1xx411c7mD",
+        targetNormalizedUrl: "https://www.bilibili.com/video/BV199W9zEEcH",
+      },
+    },
+    { tab: { id: 456, url: "https://www.bilibili.com/video/BV199W9zEEcH" } },
+    (nextResponse) => {
+      response = nextResponse;
+    },
+  );
+
+  // The auto-share must defer (retryable) rather than fall through to the
+  // offline queue, which would flush before fresh room state on reconnect and
+  // clobber whatever another member shared during the disconnect. The tab is
+  // never even read since the first guard defers up front.
+  assert.deepEqual(harness.calls.getVideoPayloadFromTab, []);
   assert.deepEqual(harness.calls.queueOrSendSharedVideo, []);
   assert.deepEqual(response, { ok: false, deferred: true });
 });

--- a/extension/test/room-manager-flush.test.ts
+++ b/extension/test/room-manager-flush.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ClientMessage, SharedVideo } from "@bili-syncplay/protocol";
+import { executeFlushPendingShare } from "../src/background/room-manager";
+
+const sampleVideo: SharedVideo = {
+  videoId: "BV199W9zEEcH",
+  url: "https://www.bilibili.com/video/BV199W9zEEcH",
+  title: "Queued Video",
+};
+
+function createHarness(overrides?: {
+  pendingSharedVideo?: SharedVideo | null;
+  pendingLocalShareUrl?: string | null;
+  pendingLocalShareGeneration?: number | null;
+  socketGeneration?: number;
+  connected?: boolean;
+}) {
+  const sent: ClientMessage[] = [];
+  const roomSessionState = {
+    pendingSharedVideo:
+      overrides?.pendingSharedVideo === undefined
+        ? sampleVideo
+        : overrides.pendingSharedVideo,
+    pendingSharedPlayback: null,
+    memberToken: "member-token-1",
+    roomCode: "ROOM01",
+  };
+  const connectionState = {
+    connected: overrides?.connected ?? true,
+    socketGeneration: overrides?.socketGeneration ?? 2,
+  };
+  const shareState = {
+    pendingLocalShareUrl:
+      overrides?.pendingLocalShareUrl === undefined
+        ? sampleVideo.url
+        : overrides.pendingLocalShareUrl,
+    pendingLocalShareGeneration:
+      overrides?.pendingLocalShareGeneration === undefined
+        ? 1
+        : overrides.pendingLocalShareGeneration,
+  };
+  return { sent, roomSessionState, connectionState, shareState };
+}
+
+test("executeFlushPendingShare transfers marker ownership to the live socket", () => {
+  const harness = createHarness();
+
+  executeFlushPendingShare({
+    roomSessionState: harness.roomSessionState,
+    connectionState: harness.connectionState,
+    shareState: harness.shareState,
+    sendToServer: (message) => harness.sent.push(message),
+  });
+
+  // The queued share is re-sent and the queue cleared.
+  assert.equal(harness.sent.length, 1);
+  assert.equal(harness.roomSessionState.pendingSharedVideo, null);
+  // The marker was created on the old socket (generation 1); the re-flush re-sent
+  // it on the live socket (generation 2), so ownership moves to generation 2.
+  // This stops the old socket's late close from clearing a marker the live socket
+  // is still confirming.
+  assert.equal(harness.shareState.pendingLocalShareGeneration, 2);
+});
+
+test("executeFlushPendingShare leaves the generation untouched when no marker is pending", () => {
+  const harness = createHarness({
+    pendingLocalShareUrl: null,
+    pendingLocalShareGeneration: null,
+  });
+
+  executeFlushPendingShare({
+    roomSessionState: harness.roomSessionState,
+    connectionState: harness.connectionState,
+    shareState: harness.shareState,
+    sendToServer: (message) => harness.sent.push(message),
+  });
+
+  assert.equal(harness.sent.length, 1);
+  assert.equal(harness.shareState.pendingLocalShareGeneration, null);
+});
+
+test("executeFlushPendingShare does not re-stamp when nothing is queued to flush", () => {
+  const harness = createHarness({ pendingSharedVideo: null });
+
+  executeFlushPendingShare({
+    roomSessionState: harness.roomSessionState,
+    connectionState: harness.connectionState,
+    shareState: harness.shareState,
+    sendToServer: (message) => harness.sent.push(message),
+  });
+
+  // No flush, so no re-send and the marker generation stays as it was.
+  assert.equal(harness.sent.length, 0);
+  assert.equal(harness.shareState.pendingLocalShareGeneration, 1);
+});

--- a/extension/test/room-manager-flush.test.ts
+++ b/extension/test/room-manager-flush.test.ts
@@ -3,6 +3,16 @@ import test from "node:test";
 import type { ClientMessage, SharedVideo } from "@bili-syncplay/protocol";
 import { executeFlushPendingShare } from "../src/background/room-manager";
 
+// Node < 22 has no global WebSocket; `isSocketWritable` reads `WebSocket.OPEN`.
+if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === "undefined") {
+  (globalThis as { WebSocket?: unknown }).WebSocket = {
+    CONNECTING: 0,
+    OPEN: 1,
+    CLOSING: 2,
+    CLOSED: 3,
+  };
+}
+
 const sampleVideo: SharedVideo = {
   videoId: "BV199W9zEEcH",
   url: "https://www.bilibili.com/video/BV199W9zEEcH",
@@ -15,6 +25,7 @@ function createHarness(overrides?: {
   pendingLocalShareGeneration?: number | null;
   socketGeneration?: number;
   connected?: boolean;
+  socketReadyState?: number;
 }) {
   const sent: ClientMessage[] = [];
   const roomSessionState = {
@@ -29,6 +40,9 @@ function createHarness(overrides?: {
   const connectionState = {
     connected: overrides?.connected ?? true,
     socketGeneration: overrides?.socketGeneration ?? 2,
+    socket: {
+      readyState: overrides?.socketReadyState ?? WebSocket.OPEN,
+    } as WebSocket,
   };
   const shareState = {
     pendingLocalShareUrl:
@@ -92,5 +106,28 @@ test("executeFlushPendingShare does not re-stamp when nothing is queued to flush
 
   // No flush, so no re-send and the marker generation stays as it was.
   assert.equal(harness.sent.length, 0);
+  assert.equal(harness.shareState.pendingLocalShareGeneration, 1);
+});
+
+test("executeFlushPendingShare keeps the share queued when the socket is not writable", () => {
+  // `connected` still lags as true while the socket has moved to CLOSING (the
+  // close event has not dispatched yet). The send would be dropped, so the flush
+  // must NOT fire and must leave the queue + marker intact for the next rejoin.
+  const harness = createHarness({
+    connected: true,
+    socketReadyState: WebSocket.CLOSING,
+  });
+
+  executeFlushPendingShare({
+    roomSessionState: harness.roomSessionState,
+    connectionState: harness.connectionState,
+    shareState: harness.shareState,
+    sendToServer: (message) => harness.sent.push(message),
+  });
+
+  assert.equal(harness.sent.length, 0);
+  // The queued share survives so the next reconnect's rejoin re-flushes it.
+  assert.deepEqual(harness.roomSessionState.pendingSharedVideo, sampleVideo);
+  // Ownership is untouched (no re-send happened).
   assert.equal(harness.shareState.pendingLocalShareGeneration, 1);
 });

--- a/extension/test/socket-controller.test.ts
+++ b/extension/test/socket-controller.test.ts
@@ -37,17 +37,38 @@ class FakeWebSocket {
 
 let createdSockets: FakeWebSocket[] = [];
 
+// Controls the stubbed global `fetch` used by the connection-check probe. When
+// `blockFetch` is true the probe's fetch hangs until `releaseFetch()` is called,
+// letting a test interleave an admin close while the probe is mid-await.
+let blockFetch = false;
+let releaseFetch: (() => void) | null = null;
+
 function installGlobals(): { restore: () => void } {
   const original = {
     WebSocket: (globalThis as Record<string, unknown>).WebSocket,
     chrome: (globalThis as Record<string, unknown>).chrome,
     self: (globalThis as Record<string, unknown>).self,
+    fetch: (globalThis as Record<string, unknown>).fetch,
   };
   createdSockets = [];
+  blockFetch = false;
+  releaseFetch = null;
   Object.assign(globalThis, {
     WebSocket: FakeWebSocket,
     chrome: { runtime: { getURL: () => "chrome-extension://test/" } },
     self: { setTimeout, clearTimeout },
+    fetch: () => {
+      const result = {
+        ok: true,
+        json: async () => ({ data: { websocketAllowed: true } }),
+      };
+      if (blockFetch) {
+        return new Promise((resolve) => {
+          releaseFetch = () => resolve(result);
+        });
+      }
+      return Promise.resolve(result);
+    },
   });
   return {
     restore() {
@@ -56,7 +77,7 @@ function installGlobals(): { restore: () => void } {
   };
 }
 
-function createHarness() {
+function createHarness(options: { withProbeFetch?: boolean } = {}) {
   const runtimeState = createBackgroundRuntimeState();
   runtimeState.connection.serverUrl = "ws://localhost:9999";
   runtimeState.room.roomCode = "ROOM01";
@@ -81,8 +102,12 @@ function createHarness() {
     sendToServer: () => {},
     handleServerMessage: async () => {},
     // Returning null skips the connection-check / healthcheck fetches so the
-    // probe goes straight to opening the (faked) socket.
-    buildConnectionCheckUrl: () => null,
+    // probe goes straight to opening the (faked) socket. Opt into the
+    // connection-check fetch to exercise the in-flight probe-abort window.
+    buildConnectionCheckUrl: () =>
+      options.withProbeFetch
+        ? "https://localhost:9999/api/connection-check"
+        : null,
     buildHealthcheckUrl: () => null,
     onOpen: () => {},
     onAdminSessionReset: (reason) => {
@@ -240,6 +265,74 @@ test("socket controller still applies an admin reset from a superseded socket", 
     assert.equal(secondSocket.closeCalls, 1);
     assert.equal(firstSocket.closeCalls, 0);
     assert.equal(harness.runtimeState.connection.socket, null);
+  } finally {
+    harness?.controller.clearReconnectTimer();
+    globals.restore();
+  }
+});
+
+test("a CLOSING-window reconnect clears the stale connected flag for the CONNECTING replacement", async () => {
+  const globals = installGlobals();
+  let harness: ReturnType<typeof createHarness> | undefined;
+  try {
+    harness = createHarness();
+
+    await harness.controller.connect();
+    const firstSocket = createdSockets[0];
+    // The old connection was online; its socket is now CLOSING but the close
+    // event has not dispatched, so `connected` still reads the stale true.
+    harness.runtimeState.connection.connected = true;
+    firstSocket.readyState = FakeWebSocket.CLOSING;
+
+    await harness.controller.connect();
+    const secondSocket = createdSockets[1];
+
+    assert.notEqual(secondSocket, firstSocket);
+    assert.equal(harness.runtimeState.connection.socket, secondSocket);
+    // The replacement is only CONNECTING; until its `open` fires the connection
+    // is not writable. `connected` must be cleared so requestCreateRoom /
+    // requestJoinRoom (which gate on `connected` after `await connect()`) do not
+    // hand room:create / room:join to a non-OPEN socket that drops them.
+    assert.equal(secondSocket.readyState, FakeWebSocket.CONNECTING);
+    assert.equal(harness.runtimeState.connection.connected, false);
+  } finally {
+    harness?.controller.clearReconnectTimer();
+    globals.restore();
+  }
+});
+
+test("an admin reset aborts an in-flight reconnect probe instead of opening a ghost socket", async () => {
+  const globals = installGlobals();
+  let harness: ReturnType<typeof createHarness> | undefined;
+  try {
+    harness = createHarness({ withProbeFetch: true });
+
+    // First connect: the connection-check fetch resolves immediately and opens
+    // the live socket.
+    await harness.controller.connect();
+    const firstSocket = createdSockets[0];
+    harness.runtimeState.connection.connected = true;
+    firstSocket.readyState = FakeWebSocket.CLOSING;
+
+    // A CLOSING-window reconnect starts but its connection-check fetch now hangs,
+    // so the probe is parked before it can create the replacement socket.
+    blockFetch = true;
+    const probe = harness.controller.connect();
+
+    // The admin kick lands on the old socket while the probe is still awaiting.
+    firstSocket.emit("close", closeEvent("Admin kicked member"));
+
+    // Releasing the fetch lets the probe resume; it must detect the abort and
+    // bail out rather than open a room-less ghost connection.
+    releaseFetch?.();
+    await probe;
+
+    assert.deepEqual(harness.adminResets, ["Admin kicked member"]);
+    // No replacement socket was created, and the live ref stays torn down so the
+    // admin reason is not cleared by a stray `open`.
+    assert.equal(createdSockets.length, 1);
+    assert.equal(harness.runtimeState.connection.socket, null);
+    assert.equal(harness.runtimeState.connection.connected, false);
   } finally {
     harness?.controller.clearReconnectTimer();
     globals.restore();

--- a/extension/test/socket-controller.test.ts
+++ b/extension/test/socket-controller.test.ts
@@ -98,6 +98,8 @@ function createHarness(options: { withProbeFetch?: boolean } = {}) {
     clearPendingLocalShare: (reason) => {
       clearPendingLocalShareReasons.push(reason);
     },
+    getPendingLocalShareGeneration: () =>
+      runtimeState.share.pendingLocalShareGeneration,
     sendJoinRequest: () => {},
     sendToServer: () => {},
     handleServerMessage: async () => {},
@@ -257,11 +259,12 @@ test("a superseded socket close clears a direct-send marker that will not be re-
     assert.equal(harness.runtimeState.connection.socket, secondSocket);
 
     harness.runtimeState.connection.connected = true;
-    // A share was sent directly on the now-dead old socket (not queued for
-    // re-flush): nothing will reconfirm it, so its marker must be cleared rather
-    // than suppress the post-reconnect room state until the 10s timeout.
+    // A share was sent directly on the now-dead old socket (generation 1, not
+    // queued for re-flush): nothing will reconfirm it, so its marker must be
+    // cleared rather than suppress the post-reconnect room state until timeout.
     harness.runtimeState.room.pendingSharedVideo = null;
     harness.runtimeState.room.shareReflushPending = false;
+    harness.runtimeState.share.pendingLocalShareGeneration = 1;
 
     firstSocket.emit("close", closeEvent());
 
@@ -270,6 +273,37 @@ test("a superseded socket close clears a direct-send marker that will not be re-
     ]);
     // The live replacement connection is untouched.
     assert.equal(harness.runtimeState.connection.connected, true);
+    assert.equal(harness.runtimeState.connection.socket, secondSocket);
+  } finally {
+    harness?.controller.clearReconnectTimer();
+    globals.restore();
+  }
+});
+
+test("a superseded socket close keeps a direct-send marker owned by a newer connection", async () => {
+  const globals = installGlobals();
+  let harness: ReturnType<typeof createHarness> | undefined;
+  try {
+    harness = createHarness();
+
+    await harness.controller.connect();
+    const firstSocket = createdSockets[0];
+    firstSocket.readyState = FakeWebSocket.CLOSING;
+    await harness.controller.connect();
+    const secondSocket = createdSockets[1];
+    assert.equal(harness.runtimeState.connection.socket, secondSocket);
+
+    harness.runtimeState.connection.connected = true;
+    // The user sent a fresh direct share on the NEW connection (generation 2)
+    // after the old socket was superseded. The old socket's late close must NOT
+    // clear that newer marker, even though it is a direct send (not a re-flush).
+    harness.runtimeState.room.pendingSharedVideo = null;
+    harness.runtimeState.room.shareReflushPending = false;
+    harness.runtimeState.share.pendingLocalShareGeneration = 2;
+
+    firstSocket.emit("close", closeEvent());
+
+    assert.deepEqual(harness.clearPendingLocalShareReasons, []);
     assert.equal(harness.runtimeState.connection.socket, secondSocket);
   } finally {
     harness?.controller.clearReconnectTimer();

--- a/extension/test/socket-controller.test.ts
+++ b/extension/test/socket-controller.test.ts
@@ -12,6 +12,7 @@ class FakeWebSocket {
 
   readyState = FakeWebSocket.CONNECTING;
   url: string;
+  closeCalls = 0;
   private readonly listeners = new Map<string, (event: unknown) => void>();
 
   constructor(url: string) {
@@ -28,7 +29,10 @@ class FakeWebSocket {
   }
 
   send(): void {}
-  close(): void {}
+  close(): void {
+    this.closeCalls += 1;
+    this.readyState = FakeWebSocket.CLOSING;
+  }
 }
 
 let createdSockets: FakeWebSocket[] = [];
@@ -170,6 +174,10 @@ test("socket close still applies an admin session reset even with a queued share
     // The admin reset must take effect regardless of the queued share / marker
     // handling, so the client honours the kick instead of silently rejoining.
     assert.deepEqual(harness.adminResets, ["Admin kicked member"]);
+    // The live socket reference is torn down (it is the closing socket itself,
+    // so no extra close() is needed).
+    assert.equal(harness.runtimeState.connection.socket, null);
+    assert.equal(socket.closeCalls, 0);
   } finally {
     harness?.controller.clearReconnectTimer();
     globals.restore();
@@ -219,12 +227,19 @@ test("socket controller still applies an admin reset from a superseded socket", 
     const firstSocket = createdSockets[0];
     firstSocket.readyState = FakeWebSocket.CLOSING;
     await harness.controller.connect();
+    const secondSocket = createdSockets[1];
 
     // An admin kick on the old connection must still tear down the session even
     // though the socket has been superseded, so the kicked user cannot rejoin.
-    firstSocket.emit("close", closeEvent("Admin kicked member"));
+    firstSocket.emit("close", closeEvent("Admin disconnected session"));
 
-    assert.deepEqual(harness.adminResets, ["Admin kicked member"]);
+    assert.deepEqual(harness.adminResets, ["Admin disconnected session"]);
+    // The live replacement socket must be closed (otherwise it lingers as a
+    // ghost connection that already rejoined), and the ref nulled so its own
+    // close is treated as superseded and never reconnects.
+    assert.equal(secondSocket.closeCalls, 1);
+    assert.equal(firstSocket.closeCalls, 0);
+    assert.equal(harness.runtimeState.connection.socket, null);
   } finally {
     harness?.controller.clearReconnectTimer();
     globals.restore();

--- a/extension/test/socket-controller.test.ts
+++ b/extension/test/socket-controller.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { SharedVideo } from "@bili-syncplay/protocol";
 import { createBackgroundRuntimeState } from "../src/background/runtime-state";
 import { createSocketController } from "../src/background/socket-controller";
 
@@ -56,6 +57,7 @@ function createHarness() {
   runtimeState.connection.serverUrl = "ws://localhost:9999";
   runtimeState.room.roomCode = "ROOM01";
   const clearPendingLocalShareReasons: string[] = [];
+  const adminResets: string[] = [];
 
   const controller = createSocketController({
     connectionState: runtimeState.connection,
@@ -79,63 +81,97 @@ function createHarness() {
     buildConnectionCheckUrl: () => null,
     buildHealthcheckUrl: () => null,
     onOpen: () => {},
-    onAdminSessionReset: () => {},
+    onAdminSessionReset: (reason) => {
+      adminResets.push(reason);
+    },
     formatAdminSessionResetReason: (reason) => reason,
     reconnectFailedMessage: () => "reconnect failed",
   });
 
-  return { runtimeState, controller, clearPendingLocalShareReasons };
+  return {
+    runtimeState,
+    controller,
+    clearPendingLocalShareReasons,
+    adminResets,
+  };
 }
 
-const closeEvent = { code: 1006, reason: "", wasClean: false };
+const sampleVideo: SharedVideo = {
+  videoId: "BV199W9zEEcH",
+  url: "https://www.bilibili.com/video/BV199W9zEEcH",
+  title: "New Video",
+};
 
-test("socket controller ignores the close event of a superseded socket", async () => {
+function closeEvent(reason = "") {
+  return { code: 1006, reason, wasClean: false };
+}
+
+test("socket close keeps the pending local share marker while a share is queued for re-flush", async () => {
   const globals = installGlobals();
+  let harness: ReturnType<typeof createHarness> | undefined;
   try {
-    const harness = createHarness();
-
-    await harness.controller.connect();
-    const firstSocket = createdSockets[0];
-    assert.equal(harness.runtimeState.connection.socket, firstSocket);
-
-    // The first socket is dying (CLOSING) but its close event has not fired yet.
-    // A replacement connection is opened (mirrors the explicit-share-during-
-    // CLOSING offline branch calling `connect()`).
-    firstSocket.readyState = FakeWebSocket.CLOSING;
-    await harness.controller.connect();
-    const secondSocket = createdSockets[1];
-    assert.notEqual(secondSocket, firstSocket);
-    assert.equal(harness.runtimeState.connection.socket, secondSocket);
-
-    harness.runtimeState.connection.connected = true;
-
-    // The stale first socket finally emits close. It must be ignored: clearing
-    // the pending local share here would drop the share-confirmation marker.
-    firstSocket.emit("close", closeEvent);
-
-    assert.deepEqual(harness.clearPendingLocalShareReasons, []);
-    assert.equal(harness.runtimeState.connection.connected, true);
-  } finally {
-    globals.restore();
-  }
-});
-
-test("socket controller processes the close event of the current socket", async () => {
-  const globals = installGlobals();
-  try {
-    const harness = createHarness();
+    harness = createHarness();
 
     await harness.controller.connect();
     const socket = createdSockets[0];
     harness.runtimeState.connection.connected = true;
+    // The share was queued (offline/CLOSING branch) and will be re-flushed on
+    // reconnect, so the confirmation marker must survive this close.
+    harness.runtimeState.room.pendingSharedVideo = sampleVideo;
 
-    socket.emit("close", closeEvent);
+    socket.emit("close", closeEvent());
+
+    assert.deepEqual(harness.clearPendingLocalShareReasons, []);
+    assert.equal(harness.runtimeState.connection.connected, false);
+  } finally {
+    harness?.controller.clearReconnectTimer();
+    globals.restore();
+  }
+});
+
+test("socket close clears the pending local share marker when no share is queued", async () => {
+  const globals = installGlobals();
+  let harness: ReturnType<typeof createHarness> | undefined;
+  try {
+    harness = createHarness();
+
+    await harness.controller.connect();
+    const socket = createdSockets[0];
+    harness.runtimeState.connection.connected = true;
+    // Nothing queued to re-flush: the in-flight share is lost, so the marker
+    // must be cleared to let fresh room state apply.
+    harness.runtimeState.room.pendingSharedVideo = null;
+
+    socket.emit("close", closeEvent());
 
     assert.deepEqual(harness.clearPendingLocalShareReasons, [
       "socket closed before share confirmation",
     ]);
     assert.equal(harness.runtimeState.connection.connected, false);
   } finally {
+    harness?.controller.clearReconnectTimer();
+    globals.restore();
+  }
+});
+
+test("socket close still applies an admin session reset even with a queued share", async () => {
+  const globals = installGlobals();
+  let harness: ReturnType<typeof createHarness> | undefined;
+  try {
+    harness = createHarness();
+
+    await harness.controller.connect();
+    const socket = createdSockets[0];
+    harness.runtimeState.connection.connected = true;
+    harness.runtimeState.room.pendingSharedVideo = sampleVideo;
+
+    socket.emit("close", closeEvent("Admin kicked member"));
+
+    // The admin reset must take effect regardless of the queued share / marker
+    // handling, so the client honours the kick instead of silently rejoining.
+    assert.deepEqual(harness.adminResets, ["Admin kicked member"]);
+  } finally {
+    harness?.controller.clearReconnectTimer();
     globals.restore();
   }
 });

--- a/extension/test/socket-controller.test.ts
+++ b/extension/test/socket-controller.test.ts
@@ -175,3 +175,58 @@ test("socket close still applies an admin session reset even with a queued share
     globals.restore();
   }
 });
+
+test("socket controller ignores the close of a superseded socket", async () => {
+  const globals = installGlobals();
+  let harness: ReturnType<typeof createHarness> | undefined;
+  try {
+    harness = createHarness();
+
+    await harness.controller.connect();
+    const firstSocket = createdSockets[0];
+    // The first socket is dying; a replacement connection is opened (mirrors the
+    // CLOSING-window share / clock-sync calling `connect()`).
+    firstSocket.readyState = FakeWebSocket.CLOSING;
+    await harness.controller.connect();
+    const secondSocket = createdSockets[1];
+    assert.notEqual(secondSocket, firstSocket);
+    assert.equal(harness.runtimeState.connection.socket, secondSocket);
+
+    harness.runtimeState.connection.connected = true;
+    // Even with nothing queued (which on the current socket would clear the
+    // marker), the superseded socket's close must not touch the live state:
+    // after `flushPendingShare` nulls `pendingSharedVideo`, a late old close
+    // would otherwise drop the marker the new connection is still confirming.
+    harness.runtimeState.room.pendingSharedVideo = null;
+
+    firstSocket.emit("close", closeEvent());
+
+    assert.deepEqual(harness.clearPendingLocalShareReasons, []);
+    assert.equal(harness.runtimeState.connection.connected, true);
+  } finally {
+    harness?.controller.clearReconnectTimer();
+    globals.restore();
+  }
+});
+
+test("socket controller still applies an admin reset from a superseded socket", async () => {
+  const globals = installGlobals();
+  let harness: ReturnType<typeof createHarness> | undefined;
+  try {
+    harness = createHarness();
+
+    await harness.controller.connect();
+    const firstSocket = createdSockets[0];
+    firstSocket.readyState = FakeWebSocket.CLOSING;
+    await harness.controller.connect();
+
+    // An admin kick on the old connection must still tear down the session even
+    // though the socket has been superseded, so the kicked user cannot rejoin.
+    firstSocket.emit("close", closeEvent("Admin kicked member"));
+
+    assert.deepEqual(harness.adminResets, ["Admin kicked member"]);
+  } finally {
+    harness?.controller.clearReconnectTimer();
+    globals.restore();
+  }
+});

--- a/extension/test/socket-controller.test.ts
+++ b/extension/test/socket-controller.test.ts
@@ -228,12 +228,10 @@ test("socket controller ignores the close of a superseded socket", async () => {
     assert.equal(harness.runtimeState.connection.socket, secondSocket);
 
     harness.runtimeState.connection.connected = true;
-    // A re-flush marker: `flushPendingShare` already nulled `pendingSharedVideo`
-    // after rejoin but the replacement is still confirming the re-sent share, so
-    // `shareReflushPending` stays true. A late close on the old socket must not
-    // touch the live state nor drop the marker the new connection is confirming.
-    harness.runtimeState.room.pendingSharedVideo = null;
-    harness.runtimeState.room.shareReflushPending = true;
+    // A share is still queued for re-flush on the replacement's rejoin
+    // (`pendingSharedVideo` non-null). A late close on the old socket must not
+    // touch the live state nor drop the marker the new connection will reconfirm.
+    harness.runtimeState.room.pendingSharedVideo = sampleVideo;
 
     firstSocket.emit("close", closeEvent());
 
@@ -245,7 +243,7 @@ test("socket controller ignores the close of a superseded socket", async () => {
   }
 });
 
-test("a superseded socket close clears a direct-send marker that will not be re-flushed", async () => {
+test("a superseded socket close clears a marker with nothing left to re-flush", async () => {
   const globals = installGlobals();
   let harness: ReturnType<typeof createHarness> | undefined;
   try {
@@ -259,11 +257,12 @@ test("a superseded socket close clears a direct-send marker that will not be re-
     assert.equal(harness.runtimeState.connection.socket, secondSocket);
 
     harness.runtimeState.connection.connected = true;
-    // A share was sent directly on the now-dead old socket (generation 1, not
-    // queued for re-flush): nothing will reconfirm it, so its marker must be
-    // cleared rather than suppress the post-reconnect room state until timeout.
+    // The marker this socket (generation 1) created has nothing left to
+    // re-flush: either it was a direct send, or the queued share was already
+    // flushed on this socket (`pendingSharedVideo` nulled) before it was
+    // superseded. Nothing will reconfirm it, so it must be cleared rather than
+    // suppress the post-reconnect room state until timeout.
     harness.runtimeState.room.pendingSharedVideo = null;
-    harness.runtimeState.room.shareReflushPending = false;
     harness.runtimeState.share.pendingLocalShareGeneration = 1;
 
     firstSocket.emit("close", closeEvent());
@@ -296,9 +295,8 @@ test("a superseded socket close keeps a direct-send marker owned by a newer conn
     harness.runtimeState.connection.connected = true;
     // The user sent a fresh direct share on the NEW connection (generation 2)
     // after the old socket was superseded. The old socket's late close must NOT
-    // clear that newer marker, even though it is a direct send (not a re-flush).
+    // clear that newer marker even though nothing is queued to re-flush.
     harness.runtimeState.room.pendingSharedVideo = null;
-    harness.runtimeState.room.shareReflushPending = false;
     harness.runtimeState.share.pendingLocalShareGeneration = 2;
 
     firstSocket.emit("close", closeEvent());

--- a/extension/test/socket-controller.test.ts
+++ b/extension/test/socket-controller.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createBackgroundRuntimeState } from "../src/background/runtime-state";
+import { createSocketController } from "../src/background/socket-controller";
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readyState = FakeWebSocket.CONNECTING;
+  url: string;
+  private readonly listeners = new Map<string, (event: unknown) => void>();
+
+  constructor(url: string) {
+    this.url = url;
+    createdSockets.push(this);
+  }
+
+  addEventListener(type: string, handler: (event: unknown) => void): void {
+    this.listeners.set(type, handler);
+  }
+
+  emit(type: string, event: unknown): void {
+    this.listeners.get(type)?.(event);
+  }
+
+  send(): void {}
+  close(): void {}
+}
+
+let createdSockets: FakeWebSocket[] = [];
+
+function installGlobals(): { restore: () => void } {
+  const original = {
+    WebSocket: (globalThis as Record<string, unknown>).WebSocket,
+    chrome: (globalThis as Record<string, unknown>).chrome,
+    self: (globalThis as Record<string, unknown>).self,
+  };
+  createdSockets = [];
+  Object.assign(globalThis, {
+    WebSocket: FakeWebSocket,
+    chrome: { runtime: { getURL: () => "chrome-extension://test/" } },
+    self: { setTimeout, clearTimeout },
+  });
+  return {
+    restore() {
+      Object.assign(globalThis, original);
+    },
+  };
+}
+
+function createHarness() {
+  const runtimeState = createBackgroundRuntimeState();
+  runtimeState.connection.serverUrl = "ws://localhost:9999";
+  runtimeState.room.roomCode = "ROOM01";
+  const clearPendingLocalShareReasons: string[] = [];
+
+  const controller = createSocketController({
+    connectionState: runtimeState.connection,
+    roomSessionState: runtimeState.room,
+    maxReconnectAttempts: 5,
+    log: () => {},
+    logInvalidServerUrl: () => {},
+    logConnectionProbeFailure: () => {},
+    notifyAll: () => {},
+    stopClockSyncTimer: () => {},
+    syncClock: () => {},
+    startClockSyncTimer: () => {},
+    clearPendingLocalShare: (reason) => {
+      clearPendingLocalShareReasons.push(reason);
+    },
+    sendJoinRequest: () => {},
+    sendToServer: () => {},
+    handleServerMessage: async () => {},
+    // Returning null skips the connection-check / healthcheck fetches so the
+    // probe goes straight to opening the (faked) socket.
+    buildConnectionCheckUrl: () => null,
+    buildHealthcheckUrl: () => null,
+    onOpen: () => {},
+    onAdminSessionReset: () => {},
+    formatAdminSessionResetReason: (reason) => reason,
+    reconnectFailedMessage: () => "reconnect failed",
+  });
+
+  return { runtimeState, controller, clearPendingLocalShareReasons };
+}
+
+const closeEvent = { code: 1006, reason: "", wasClean: false };
+
+test("socket controller ignores the close event of a superseded socket", async () => {
+  const globals = installGlobals();
+  try {
+    const harness = createHarness();
+
+    await harness.controller.connect();
+    const firstSocket = createdSockets[0];
+    assert.equal(harness.runtimeState.connection.socket, firstSocket);
+
+    // The first socket is dying (CLOSING) but its close event has not fired yet.
+    // A replacement connection is opened (mirrors the explicit-share-during-
+    // CLOSING offline branch calling `connect()`).
+    firstSocket.readyState = FakeWebSocket.CLOSING;
+    await harness.controller.connect();
+    const secondSocket = createdSockets[1];
+    assert.notEqual(secondSocket, firstSocket);
+    assert.equal(harness.runtimeState.connection.socket, secondSocket);
+
+    harness.runtimeState.connection.connected = true;
+
+    // The stale first socket finally emits close. It must be ignored: clearing
+    // the pending local share here would drop the share-confirmation marker.
+    firstSocket.emit("close", closeEvent);
+
+    assert.deepEqual(harness.clearPendingLocalShareReasons, []);
+    assert.equal(harness.runtimeState.connection.connected, true);
+  } finally {
+    globals.restore();
+  }
+});
+
+test("socket controller processes the close event of the current socket", async () => {
+  const globals = installGlobals();
+  try {
+    const harness = createHarness();
+
+    await harness.controller.connect();
+    const socket = createdSockets[0];
+    harness.runtimeState.connection.connected = true;
+
+    socket.emit("close", closeEvent);
+
+    assert.deepEqual(harness.clearPendingLocalShareReasons, [
+      "socket closed before share confirmation",
+    ]);
+    assert.equal(harness.runtimeState.connection.connected, false);
+  } finally {
+    globals.restore();
+  }
+});

--- a/extension/test/socket-controller.test.ts
+++ b/extension/test/socket-controller.test.ts
@@ -226,16 +226,89 @@ test("socket controller ignores the close of a superseded socket", async () => {
     assert.equal(harness.runtimeState.connection.socket, secondSocket);
 
     harness.runtimeState.connection.connected = true;
-    // Even with nothing queued (which on the current socket would clear the
-    // marker), the superseded socket's close must not touch the live state:
-    // after `flushPendingShare` nulls `pendingSharedVideo`, a late old close
-    // would otherwise drop the marker the new connection is still confirming.
+    // A re-flush marker: `flushPendingShare` already nulled `pendingSharedVideo`
+    // after rejoin but the replacement is still confirming the re-sent share, so
+    // `shareReflushPending` stays true. A late close on the old socket must not
+    // touch the live state nor drop the marker the new connection is confirming.
     harness.runtimeState.room.pendingSharedVideo = null;
+    harness.runtimeState.room.shareReflushPending = true;
 
     firstSocket.emit("close", closeEvent());
 
     assert.deepEqual(harness.clearPendingLocalShareReasons, []);
     assert.equal(harness.runtimeState.connection.connected, true);
+  } finally {
+    harness?.controller.clearReconnectTimer();
+    globals.restore();
+  }
+});
+
+test("a superseded socket close clears a direct-send marker that will not be re-flushed", async () => {
+  const globals = installGlobals();
+  let harness: ReturnType<typeof createHarness> | undefined;
+  try {
+    harness = createHarness();
+
+    await harness.controller.connect();
+    const firstSocket = createdSockets[0];
+    firstSocket.readyState = FakeWebSocket.CLOSING;
+    await harness.controller.connect();
+    const secondSocket = createdSockets[1];
+    assert.equal(harness.runtimeState.connection.socket, secondSocket);
+
+    harness.runtimeState.connection.connected = true;
+    // A share was sent directly on the now-dead old socket (not queued for
+    // re-flush): nothing will reconfirm it, so its marker must be cleared rather
+    // than suppress the post-reconnect room state until the 10s timeout.
+    harness.runtimeState.room.pendingSharedVideo = null;
+    harness.runtimeState.room.shareReflushPending = false;
+
+    firstSocket.emit("close", closeEvent());
+
+    assert.deepEqual(harness.clearPendingLocalShareReasons, [
+      "superseded socket closed before share confirmation",
+    ]);
+    // The live replacement connection is untouched.
+    assert.equal(harness.runtimeState.connection.connected, true);
+    assert.equal(harness.runtimeState.connection.socket, secondSocket);
+  } finally {
+    harness?.controller.clearReconnectTimer();
+    globals.restore();
+  }
+});
+
+test("an aborted in-flight probe is not reused by a later connect", async () => {
+  const globals = installGlobals();
+  let harness: ReturnType<typeof createHarness> | undefined;
+  try {
+    harness = createHarness({ withProbeFetch: true });
+
+    await harness.controller.connect();
+    const firstSocket = createdSockets[0];
+    harness.runtimeState.connection.connected = true;
+    firstSocket.readyState = FakeWebSocket.CLOSING;
+
+    // A CLOSING-window reconnect parks on its hanging connection-check fetch.
+    blockFetch = true;
+    const doomed = harness.controller.connect();
+    const parkedRelease = releaseFetch;
+
+    // An admin kick aborts that probe and must also null `connectProbe` so it is
+    // not reused.
+    firstSocket.emit("close", closeEvent("Admin kicked member"));
+    assert.equal(harness.runtimeState.connection.connectProbe, null);
+
+    // A fresh connect must open a new socket instead of awaiting the doomed
+    // probe (which would never open a connection).
+    blockFetch = false;
+    await harness.controller.connect();
+    assert.equal(createdSockets.length, 2);
+    assert.equal(harness.runtimeState.connection.socket, createdSockets[1]);
+
+    // Releasing the doomed probe must not clobber the fresh probe's bookkeeping.
+    parkedRelease?.();
+    await doomed;
+    assert.equal(harness.runtimeState.connection.socket, createdSockets[1]);
   } finally {
     harness?.controller.clearReconnectTimer();
     globals.restore();

--- a/extension/test/socket-lifecycle.test.ts
+++ b/extension/test/socket-lifecycle.test.ts
@@ -97,3 +97,14 @@ test("disconnectSocket bumps connectEpoch even when no socket has been created y
   assert.equal(harness.runtimeState.connection.connectEpoch, epochBefore + 1);
   assert.equal(harness.runtimeState.connection.connected, false);
 });
+
+test("disconnectSocket nulls connectProbe so a later connect does not reuse it", () => {
+  const harness = createHarness();
+  // Simulate an in-flight probe parked on its connection-check fetch.
+  harness.runtimeState.connection.connectProbe = Promise.resolve();
+
+  harness.run();
+
+  // The doomed probe must not be reused by a subsequent create/join `connect()`.
+  assert.equal(harness.runtimeState.connection.connectProbe, null);
+});

--- a/extension/test/socket-lifecycle.test.ts
+++ b/extension/test/socket-lifecycle.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createBackgroundRuntimeState } from "../src/background/runtime-state";
+import { disconnectSocket } from "../src/background/socket-lifecycle";
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readyState = FakeWebSocket.OPEN;
+  closeCalls = 0;
+
+  close(): void {
+    this.closeCalls += 1;
+    this.readyState = FakeWebSocket.CLOSING;
+  }
+}
+
+function createHarness() {
+  const runtimeState = createBackgroundRuntimeState();
+  const reasons: string[] = [];
+  let resetReconnectCalls = 0;
+  let stopClockCalls = 0;
+
+  function run(): void {
+    disconnectSocket({
+      connectionState: runtimeState.connection,
+      memberTokenState: runtimeState.room,
+      resetReconnectState: () => {
+        resetReconnectCalls += 1;
+      },
+      stopClockSyncTimer: () => {
+        stopClockCalls += 1;
+      },
+      clearPendingLocalShare: (reason) => {
+        reasons.push(reason);
+      },
+    });
+  }
+
+  return {
+    runtimeState,
+    run,
+    reasons,
+    get resetReconnectCalls() {
+      return resetReconnectCalls;
+    },
+    get stopClockCalls() {
+      return stopClockCalls;
+    },
+  };
+}
+
+test("disconnectSocket tears down the live socket and clears session state", () => {
+  const harness = createHarness();
+  const socket = new FakeWebSocket();
+  harness.runtimeState.connection.socket = socket as unknown as WebSocket;
+  harness.runtimeState.connection.connected = true;
+  harness.runtimeState.room.memberToken = "member-token-1";
+
+  harness.run();
+
+  assert.equal(socket.closeCalls, 1);
+  assert.equal(harness.runtimeState.connection.socket, null);
+  assert.equal(harness.runtimeState.connection.connected, false);
+  assert.equal(harness.runtimeState.room.memberToken, null);
+  assert.deepEqual(harness.reasons, ["socket disconnected"]);
+  assert.equal(harness.resetReconnectCalls, 1);
+  assert.equal(harness.stopClockCalls, 1);
+});
+
+test("disconnectSocket bumps connectEpoch so an in-flight probe aborts", () => {
+  const harness = createHarness();
+  const socket = new FakeWebSocket();
+  harness.runtimeState.connection.socket = socket as unknown as WebSocket;
+  const epochBefore = harness.runtimeState.connection.connectEpoch;
+
+  harness.run();
+
+  // The probe captures `connectEpoch` before its awaits and bails when it
+  // changes; the leave must bump it so a parked reconnect cannot open a
+  // room-less ghost connection after this teardown.
+  assert.equal(harness.runtimeState.connection.connectEpoch, epochBefore + 1);
+});
+
+test("disconnectSocket bumps connectEpoch even when no socket has been created yet", () => {
+  const harness = createHarness();
+  // A probe that is still awaiting connection-check has not assigned a socket
+  // yet, so the null-socket early return must still abort it.
+  assert.equal(harness.runtimeState.connection.socket, null);
+  const epochBefore = harness.runtimeState.connection.connectEpoch;
+
+  harness.run();
+
+  assert.equal(harness.runtimeState.connection.connectEpoch, epochBefore + 1);
+  assert.equal(harness.runtimeState.connection.connected, false);
+});


### PR DESCRIPTION
## Summary

Issue #132 第 2 部分（收尾深层断线竞态：socket CLOSING 微窗口）。三部分将分三个 PR 提交，此 PR 仅处理 socket CLOSING 微窗口，不关闭整个 issue。

- `queueOrSendSharedVideo` 的「立即发送」分支此前只看 `connectionState.connected`，而该标志仅由 socket 的 `close`/`error` 事件置 false。在 socket 已进入 `CLOSING`/`CLOSED` 但 close 事件尚未派发的微窗口里，它仍返回 `{ ok: true }`，而底层 `sendToServer`（要求 socket 为 `OPEN`）会静默丢弃 `video:share`，使房间滞留在旧视频且无重试。
- 改为以实际 `socket.readyState === WebSocket.OPEN` 作为可写判据；微窗口下 fall through 到离线分支，把分享入队 `pendingSharedVideo` 并触发重连，重连 rejoin 后由 `flushPendingShare` 补发。手动分享与 auto-share 走同一路径，统一受益。

## Test plan

- [x] 新增 `background-share-controller.test.ts` 回归：socket 处于 CLOSING 时不发送、入队 `pendingSharedVideo`、清空 memberToken 触发 rejoin、返回 `{ ok: true }`。
- [x] 更新 harness 默认提供 OPEN socket（在线路径测试需要）。
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`（363 passed）

Refs #132