### PR TITLE
fix: keep chained autoplay in sync when it outruns room confirmation (#132)

### DIFF
--- a/extension/src/background/message-controller.ts
+++ b/extension/src/background/message-controller.ts
@@ -74,8 +74,10 @@ export function createMessageController(args: {
     queueOrSendSharedVideo(
       payload: { video: SharedVideo; playback: PlaybackState | null },
       tabId: number | null,
+      isAutoShare?: boolean,
     ): Promise<QueueSharedVideoResult>;
     hasActivePendingLocalShare(): boolean;
+    hasActivePendingManualShare(): boolean;
     getActivePendingLocalShareUrl(): string | null;
   };
   tabController: {
@@ -522,8 +524,11 @@ export function createMessageController(args: {
         // An explicit share the user just made only sets a pending local share;
         // `roomState.sharedVideo` still holds the previous video until the server
         // confirms, so the room re-check above can still pass. Sending now would
-        // overwrite that unconfirmed manual share — skip and let it stand.
-        if (args.shareController.hasActivePendingLocalShare()) {
+        // overwrite that unconfirmed manual share — skip and let it stand. Only a
+        // *manual* pending share blocks here: our own previous in-flight
+        // auto-share is the chain we are advancing, so skipping on it would strand
+        // the room one step behind when chained autoplay outruns confirmation.
+        if (args.shareController.hasActivePendingManualShare()) {
           args.diagnosticsController.log(
             "content",
             "Auto-share next video skipped: a manual share is awaiting confirmation",
@@ -535,6 +540,7 @@ export function createMessageController(args: {
         const shareResult = await args.shareController.queueOrSendSharedVideo(
           response.payload,
           response.tabId,
+          true,
         );
         if (shareResult.ok === false) {
           args.diagnosticsController.log(

--- a/extension/src/background/message-controller.ts
+++ b/extension/src/background/message-controller.ts
@@ -76,6 +76,7 @@ export function createMessageController(args: {
       tabId: number | null,
     ): Promise<QueueSharedVideoResult>;
     hasActivePendingLocalShare(): boolean;
+    getActivePendingLocalShareUrl(): string | null;
   };
   tabController: {
     openSharedVideoFromPopup(): Promise<void>;
@@ -308,10 +309,27 @@ export function createMessageController(args: {
         // share a different video or fresh room state could arrive; without
         // re-checking, the stale timer would overwrite the room back to the
         // previous video's next episode.
-        const isRoomStillOnScheduledVideo = (): boolean => {
+        // Classify the room against the video this auto-share was scheduled from
+        // (`previousSharedUrl`):
+        //   - "on-scheduled": the room is parked on it and we still own the
+        //     share → safe to advance to the next video.
+        //   - "share-in-flight": the room has not reached it yet because our OWN
+        //     share of it is still awaiting confirmation — chained autoplay
+        //     (A→B→C) outran the room round-trip, so when C arrives the room is
+        //     still on A while `previousSharedUrl` is B, the video we just shared
+        //     but whose `room:state` has not returned. Retry without consuming
+        //     the page-bridge attempt budget; once B confirms, the retry sees
+        //     "on-scheduled" and advances to C.
+        //   - "moved-on": the room is on a different video for any other reason
+        //     (another member shared, the room genuinely advanced past it, …) →
+        //     skip so this stale autoplay does not override it.
+        const classifyRoomSchedule = ():
+          | "on-scheduled"
+          | "share-in-flight"
+          | "moved-on" => {
           const sharedVideo = args.roomSessionState.roomState?.sharedVideo;
           const sharedVideoUrl = sharedVideo?.url ?? null;
-          return (
+          if (
             sharedVideoUrl !== null &&
             areSharedVideoUrlsEqual(
               sharedVideoUrl,
@@ -323,10 +341,36 @@ export function createMessageController(args: {
             // not override the new sharer's freshly acquired control.
             args.roomSessionState.memberId !== null &&
             sharedVideo?.sharedByMemberId === args.roomSessionState.memberId
-          );
+          ) {
+            return "on-scheduled";
+          }
+          const inFlightOwnShareUrl =
+            args.shareController.getActivePendingLocalShareUrl();
+          if (
+            inFlightOwnShareUrl !== null &&
+            areSharedVideoUrlsEqual(
+              inFlightOwnShareUrl,
+              message.payload.previousSharedUrl,
+            )
+          ) {
+            return "share-in-flight";
+          }
+          return "moved-on";
         };
 
-        if (!isRoomStillOnScheduledVideo()) {
+        const scheduleState = classifyRoomSchedule();
+        if (scheduleState === "share-in-flight") {
+          args.diagnosticsController.log(
+            "content",
+            "Auto-share next video deferred: room has not confirmed the previous share yet",
+          );
+          sendResponse({
+            ok: false,
+            deferred: true,
+          } satisfies ShareCurrentVideoResponse);
+          return;
+        }
+        if (scheduleState === "moved-on") {
           args.diagnosticsController.log(
             "content",
             "Auto-share next video skipped: room moved past the scheduled shared video",
@@ -411,8 +455,11 @@ export function createMessageController(args: {
         // `getVideoPayloadFromTab` yielded the event loop, so re-confirm the room
         // is still on `previousSharedUrl` before overwriting it. A manual share
         // or fresh room state received in that window means the room has moved
-        // on and this stale auto-share must not clobber it.
-        if (!isRoomStillOnScheduledVideo()) {
+        // on and this stale auto-share must not clobber it. (Only "on-scheduled"
+        // may proceed here: having already passed the check above the room was on
+        // `previousSharedUrl`, so a non-on-scheduled recheck means it advanced —
+        // treat any such state as moved-on and skip rather than send.)
+        if (classifyRoomSchedule() !== "on-scheduled") {
           args.diagnosticsController.log(
             "content",
             "Auto-share next video skipped: room moved past the scheduled shared video while reading the tab",

--- a/extension/src/background/runtime-state.ts
+++ b/extension/src/background/runtime-state.ts
@@ -92,6 +92,15 @@ export interface ShareState {
    * connection set for a share still awaiting confirmation. Null when no marker.
    */
   pendingLocalShareGeneration: number | null;
+  /**
+   * Whether the current pending local-share marker was set by an auto-share
+   * (chained autoplay) rather than an explicit manual share. The auto-share
+   * handler skips when a *manual* share is still awaiting confirmation (so it
+   * does not clobber the user's deliberate share), but it must NOT skip on its
+   * own previous in-flight auto-share — that is the chain it is advancing, and
+   * skipping would strand the room one step behind. False when no marker.
+   */
+  pendingLocalShareIsAutoShare: boolean;
   pendingShareToast:
     | (SharedVideoToastPayload & { expiresAt: number; roomCode: string })
     | null;
@@ -156,6 +165,7 @@ export function createBackgroundRuntimeState(): BackgroundRuntimeState {
       openingSharedUrl: null,
       pendingLocalShareUrl: null,
       pendingLocalShareGeneration: null,
+      pendingLocalShareIsAutoShare: false,
       pendingLocalShareExpiresAt: null,
       pendingLocalShareTimer: null,
       pendingShareToast: null,

--- a/extension/src/background/runtime-sync-controller.ts
+++ b/extension/src/background/runtime-sync-controller.ts
@@ -52,6 +52,8 @@ export function createRuntimeSyncController(args: {
         pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
         pendingLocalShareGeneration:
           args.shareState.pendingLocalShareGeneration,
+        pendingLocalShareIsAutoShare:
+          args.shareState.pendingLocalShareIsAutoShare,
         pendingLocalShareExpiresAt: args.shareState.pendingLocalShareExpiresAt,
         pendingLocalShareTimer: args.shareState.pendingLocalShareTimer,
         pendingShareToast: args.shareState.pendingShareToast,

--- a/extension/src/background/share-controller.ts
+++ b/extension/src/background/share-controller.ts
@@ -35,10 +35,11 @@ export interface ShareController {
   queueOrSendSharedVideo(
     payload: { video: SharedVideo; playback: PlaybackState | null },
     tabId: number | null,
+    isAutoShare?: boolean,
   ): Promise<ShareVideoResult>;
   clearPendingLocalShare(reason: string): void;
   expirePendingLocalShareIfNeeded(): void;
-  setPendingLocalShare(url: string): void;
+  setPendingLocalShare(url: string, isAutoShare?: boolean): void;
   /**
    * Whether an explicit local share is still awaiting server confirmation. Used
    * to stop a stale auto-share from overwriting a manual share the user just
@@ -46,6 +47,13 @@ export interface ShareController {
    * holds the previous video until the server confirms).
    */
   hasActivePendingLocalShare(): boolean;
+  /**
+   * Whether a *manual* (non-auto-share) local share is still awaiting server
+   * confirmation. The auto-share handler skips on this so it does not clobber a
+   * deliberate user share, but it must keep advancing past its own in-flight
+   * auto-share (which this returns false for).
+   */
+  hasActivePendingManualShare(): boolean;
   /**
    * The URL of the share still awaiting server confirmation (the pending
    * local-share marker), or null. This is the video this client last shared but
@@ -149,6 +157,7 @@ export function createShareController(args: {
   async function queueOrSendSharedVideo(
     payload: { video: SharedVideo; playback: PlaybackState | null },
     tabId: number | null,
+    isAutoShare = false,
   ): Promise<ShareVideoResult> {
     args.rememberSharedSourceTab(tabId ?? undefined, payload.video.url);
 
@@ -172,7 +181,7 @@ export function createShareController(args: {
         args.connectionState.lastError = error;
         return { ok: false, error };
       }
-      setPendingLocalShare(payload.video.url);
+      setPendingLocalShare(payload.video.url, isAutoShare);
       args.sendToServer({
         type: "video:share",
         payload: {
@@ -230,7 +239,7 @@ export function createShareController(args: {
       args.roomSessionState.roomCode &&
       args.roomSessionState.memberToken
     ) {
-      setPendingLocalShare(payload.video.url);
+      setPendingLocalShare(payload.video.url, isAutoShare);
       args.roomSessionState.pendingSharedVideo = payload.video;
       args.roomSessionState.pendingSharedPlayback = payload.playback
         ? {
@@ -243,7 +252,7 @@ export function createShareController(args: {
       return { ok: true };
     }
 
-    setPendingLocalShare(payload.video.url);
+    setPendingLocalShare(payload.video.url, isAutoShare);
     args.roomSessionState.pendingSharedVideo = payload.video;
     args.roomSessionState.pendingSharedPlayback = payload.playback
       ? {
@@ -283,8 +292,9 @@ export function createShareController(args: {
 
   function clearPendingLocalShare(reason: string): void {
     // The marker is being torn down (confirmed, timed out, disconnect, etc.), so
-    // it no longer has an owning connection.
+    // it no longer has an owning connection and is no longer an auto-share.
     args.shareState.pendingLocalShareGeneration = null;
+    args.shareState.pendingLocalShareIsAutoShare = false;
     const cleanup = preparePendingLocalShareCleanup({
       pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
       pendingLocalShareExpiresAt: args.shareState.pendingLocalShareExpiresAt,
@@ -316,6 +326,13 @@ export function createShareController(args: {
     return readActivePendingLocalShareUrl() !== null;
   }
 
+  function hasActivePendingManualShare(): boolean {
+    return (
+      readActivePendingLocalShareUrl() !== null &&
+      !args.shareState.pendingLocalShareIsAutoShare
+    );
+  }
+
   function expirePendingLocalShareIfNeeded(): void {
     const activePendingShare = getActivePendingLocalShareUrl({
       pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
@@ -329,12 +346,16 @@ export function createShareController(args: {
     }
   }
 
-  function setPendingLocalShare(url: string): void {
+  function setPendingLocalShare(url: string, isAutoShare = false): void {
     clearPendingLocalShareTimer();
     // Record which connection owns this marker so a superseded socket's late
     // close only clears the marker it created, not one set by a newer connection.
     args.shareState.pendingLocalShareGeneration =
       args.connectionState.socketGeneration;
+    // Remember whether this marker is a chained auto-share so the auto-share
+    // handler can advance past its own in-flight share without skipping (only a
+    // manual share's marker should block the next auto-share).
+    args.shareState.pendingLocalShareIsAutoShare = isAutoShare;
     args.shareState.pendingLocalShareUrl = url;
     args.shareState.pendingLocalShareExpiresAt = createPendingLocalShareExpiry(
       Date.now(),
@@ -357,6 +378,7 @@ export function createShareController(args: {
     expirePendingLocalShareIfNeeded,
     setPendingLocalShare,
     hasActivePendingLocalShare,
+    hasActivePendingManualShare,
     getActivePendingLocalShareUrl: readActivePendingLocalShareUrl,
   };
 }

--- a/extension/src/background/share-controller.ts
+++ b/extension/src/background/share-controller.ts
@@ -46,6 +46,15 @@ export interface ShareController {
    * holds the previous video until the server confirms).
    */
   hasActivePendingLocalShare(): boolean;
+  /**
+   * The URL of the share still awaiting server confirmation (the pending
+   * local-share marker), or null. This is the video this client last shared but
+   * whose authoritative `room:state` has not arrived yet — i.e. our own share
+   * still in flight. Used to tell a chained auto-share that the room simply has
+   * not caught up to the previous share yet (retry) from one where the room has
+   * genuinely moved on (skip).
+   */
+  getActivePendingLocalShareUrl(): string | null;
 }
 
 export function createShareController(args: {
@@ -295,14 +304,16 @@ export function createShareController(args: {
     } = cleanup.nextState);
   }
 
+  function readActivePendingLocalShareUrl(): string | null {
+    return getActivePendingLocalShareUrl({
+      pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
+      pendingLocalShareExpiresAt: args.shareState.pendingLocalShareExpiresAt,
+      now: Date.now(),
+    });
+  }
+
   function hasActivePendingLocalShare(): boolean {
-    return (
-      getActivePendingLocalShareUrl({
-        pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
-        pendingLocalShareExpiresAt: args.shareState.pendingLocalShareExpiresAt,
-        now: Date.now(),
-      }) !== null
-    );
+    return readActivePendingLocalShareUrl() !== null;
   }
 
   function expirePendingLocalShareIfNeeded(): void {
@@ -346,5 +357,6 @@ export function createShareController(args: {
     expirePendingLocalShareIfNeeded,
     setPendingLocalShare,
     hasActivePendingLocalShare,
+    getActivePendingLocalShareUrl: readActivePendingLocalShareUrl,
   };
 }

--- a/extension/src/content/auto-share-next-controller.ts
+++ b/extension/src/content/auto-share-next-controller.ts
@@ -22,13 +22,6 @@ export interface AutoShareNextController {
 interface PendingAutoShare {
   previousSharedUrl: string;
   targetNormalizedUrl: string;
-  /**
-   * Our own previous chain step's target (the in-flight auto-share this
-   * navigation advanced FROM), or `null` for a non-chained step. The only video
-   * `previousSharedUrl` may be re-anchored to at send time if the room confirms
-   * it during the settle window — see {@link requestAutoShare}.
-   */
-  previousAutoShareTargetUrl: string | null;
   attempt: number;
   /**
    * Identifies the navigation that produced this request. A later navigation —
@@ -72,6 +65,12 @@ export function createAutoShareNextController(args: {
   let pendingNormalizedUrl: string | null = null;
   let pendingPreviousSharedUrl: string | null = null;
   let scheduleGeneration = 0;
+  // Targets this controller has actually *sent* in the current uninterrupted
+  // chain. The room's confirmed shared video, when it is ours, is always one of
+  // these — so a request whose scheduled anchor went stale may safely re-anchor
+  // to the live shared video iff it is in this set. Reset when a fresh
+  // (non-chained) auto-share starts; see {@link scheduleForNavigation}.
+  const sentChainTargets = new Set<string>();
 
   function clearPendingTimer(): void {
     if (pendingTimer !== null) {
@@ -108,25 +107,32 @@ export function createAutoShareNextController(args: {
     }
 
     // Re-anchor to the room's *currently* confirmed shared video when — and only
-    // when — it is our own previous chain step that has just confirmed. A chained
-    // autoplay (A→B→C) schedules B→C while B is still unconfirmed, so the anchor
-    // is A; but B's `room:state` can confirm during this settle window, moving the
-    // room to B. Sending the stale anchor A would make the background see room=B ≠
-    // A, classify it as "moved-on", and skip C with `ok:true` (no retry) —
-    // stranding the room on B. Re-anchoring to B keeps the background
+    // when — it is a video THIS chain has already sent that just confirmed. A
+    // chained autoplay (A→B→C) schedules B→C while B is still unconfirmed, so the
+    // anchor is A; but B's `room:state` can confirm during this settle window,
+    // moving the room to B. Sending the stale anchor A would make the background
+    // see room=B ≠ A, classify it as "moved-on", and skip C with `ok:true` (no
+    // retry) — stranding the room on B. Re-anchoring to B keeps the background
     // "on-scheduled" so it advances to C.
     //
-    // The re-anchor is restricted to `previousAutoShareTargetUrl` (our own prior
-    // step). If the room moved during the window to some *other* video — e.g. the
-    // same member manually shared X from another tab and it confirmed — the live
-    // anchor is X, not our prior step, so we keep the scheduled anchor and let the
-    // background skip this stale auto-share as moved-on rather than clobber X.
+    // Restricting the re-anchor to our own sent targets handles deeper lag too:
+    // if B→C→D rapidly superseded down to D while only B was actually sent, B
+    // (not the immediately-prior page C) is what confirms, and B ∈ sentChainTargets
+    // so D still re-anchors to it. Conversely, if the room moved during the window
+    // to a video we never sent — e.g. the same member manually shared X from
+    // another tab and it confirmed — X ∉ sentChainTargets, so we keep the
+    // scheduled anchor and let the background skip this stale auto-share as
+    // moved-on rather than clobber X.
     const liveAnchor = args.getActiveSharedUrl?.() ?? null;
     const previousSharedUrl =
-      pending.previousAutoShareTargetUrl !== null &&
-      liveAnchor === pending.previousAutoShareTargetUrl
-        ? pending.previousAutoShareTargetUrl
+      liveAnchor !== null && sentChainTargets.has(liveAnchor)
+        ? liveAnchor
         : pending.previousSharedUrl;
+
+    // Record the target before sending: once dispatched, the room may confirm it,
+    // and a later chain step whose anchor goes stale must be able to re-anchor to
+    // it here.
+    sentChainTargets.add(pending.targetNormalizedUrl);
 
     const message: ContentToBackgroundMessage = {
       type: "content:auto-share-next-video",
@@ -182,10 +188,22 @@ export function createAutoShareNextController(args: {
   function scheduleForNavigation(input: {
     previousSharedUrl: string;
     nextNormalizedPageUrl: string;
+    /**
+     * The sharer's own in-flight auto-share target this navigation advanced FROM,
+     * or `null`/absent when this is not a chained step (it came straight from the
+     * room's confirmed shared video). A `null`/absent value marks a fresh chain,
+     * so the sent-target lineage from any previous chain is reset.
+     */
     previousAutoShareTargetUrl?: string | null;
   }): void {
     if (input.previousSharedUrl === input.nextNormalizedPageUrl) {
       return;
+    }
+    // A fresh (non-chained) auto-share starts a new lineage: the room cannot be
+    // on a target an earlier, now-abandoned chain sent, so clear the set to keep
+    // the re-anchor (in `requestAutoShare`) from adopting a stale prior target.
+    if (input.previousAutoShareTargetUrl == null) {
+      sentChainTargets.clear();
     }
     // Coalesce only with a still-pending timer for the exact same transition —
     // same target *and* same source shared video — so rapid duplicate
@@ -208,7 +226,6 @@ export function createAutoShareNextController(args: {
       {
         previousSharedUrl: input.previousSharedUrl,
         targetNormalizedUrl: input.nextNormalizedPageUrl,
-        previousAutoShareTargetUrl: input.previousAutoShareTargetUrl ?? null,
         attempt: 1,
         generation: scheduleGeneration,
       },

--- a/extension/src/content/auto-share-next-controller.ts
+++ b/extension/src/content/auto-share-next-controller.ts
@@ -7,6 +7,7 @@ export interface AutoShareNextController {
   scheduleForNavigation(args: {
     previousSharedUrl: string;
     nextNormalizedPageUrl: string;
+    previousAutoShareTargetUrl?: string | null;
   }): void;
   /**
    * Invalidate any pending/in-flight auto-share. Called when a fresh navigation
@@ -21,6 +22,13 @@ export interface AutoShareNextController {
 interface PendingAutoShare {
   previousSharedUrl: string;
   targetNormalizedUrl: string;
+  /**
+   * Our own previous chain step's target (the in-flight auto-share this
+   * navigation advanced FROM), or `null` for a non-chained step. The only video
+   * `previousSharedUrl` may be re-anchored to at send time if the room confirms
+   * it during the settle window — see {@link requestAutoShare}.
+   */
+  previousAutoShareTargetUrl: string | null;
   attempt: number;
   /**
    * Identifies the navigation that produced this request. A later navigation —
@@ -46,6 +54,14 @@ export function createAutoShareNextController(args: {
   retryDelayMs?: number;
   getCurrentPageUrl: () => string;
   normalizeVideoPageUrl: (url: string) => string | null;
+  /**
+   * The room's *currently* confirmed shared video, read fresh when a request is
+   * about to be sent. Used to re-anchor `previousSharedUrl` so a chained autoplay
+   * that confirms an intermediate step during the settle window is not sent with
+   * a now-stale anchor. Optional: when absent, the value captured at schedule
+   * time is used unchanged.
+   */
+  getActiveSharedUrl?: () => string | null;
   runtimeSendMessage: <T>(message: unknown) => Promise<T | null>;
   debugLog: (message: string) => void;
 }): AutoShareNextController {
@@ -91,10 +107,31 @@ export function createAutoShareNextController(args: {
       return;
     }
 
+    // Re-anchor to the room's *currently* confirmed shared video when — and only
+    // when — it is our own previous chain step that has just confirmed. A chained
+    // autoplay (A→B→C) schedules B→C while B is still unconfirmed, so the anchor
+    // is A; but B's `room:state` can confirm during this settle window, moving the
+    // room to B. Sending the stale anchor A would make the background see room=B ≠
+    // A, classify it as "moved-on", and skip C with `ok:true` (no retry) —
+    // stranding the room on B. Re-anchoring to B keeps the background
+    // "on-scheduled" so it advances to C.
+    //
+    // The re-anchor is restricted to `previousAutoShareTargetUrl` (our own prior
+    // step). If the room moved during the window to some *other* video — e.g. the
+    // same member manually shared X from another tab and it confirmed — the live
+    // anchor is X, not our prior step, so we keep the scheduled anchor and let the
+    // background skip this stale auto-share as moved-on rather than clobber X.
+    const liveAnchor = args.getActiveSharedUrl?.() ?? null;
+    const previousSharedUrl =
+      pending.previousAutoShareTargetUrl !== null &&
+      liveAnchor === pending.previousAutoShareTargetUrl
+        ? pending.previousAutoShareTargetUrl
+        : pending.previousSharedUrl;
+
     const message: ContentToBackgroundMessage = {
       type: "content:auto-share-next-video",
       payload: {
-        previousSharedUrl: pending.previousSharedUrl,
+        previousSharedUrl,
         targetNormalizedUrl: pending.targetNormalizedUrl,
       },
     };
@@ -145,6 +182,7 @@ export function createAutoShareNextController(args: {
   function scheduleForNavigation(input: {
     previousSharedUrl: string;
     nextNormalizedPageUrl: string;
+    previousAutoShareTargetUrl?: string | null;
   }): void {
     if (input.previousSharedUrl === input.nextNormalizedPageUrl) {
       return;
@@ -170,6 +208,7 @@ export function createAutoShareNextController(args: {
       {
         previousSharedUrl: input.previousSharedUrl,
         targetNormalizedUrl: input.nextNormalizedPageUrl,
+        previousAutoShareTargetUrl: input.previousAutoShareTargetUrl ?? null,
         attempt: 1,
         generation: scheduleGeneration,
       },

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -62,6 +62,7 @@ const autoShareNextController = createAutoShareNextController({
   settleDelayMs: AUTO_SHARE_NEXT_SETTLE_DELAY_MS,
   getCurrentPageUrl: () => window.location.href.split("#")[0],
   normalizeVideoPageUrl: (url) => normalizeSharedVideoUrl(url),
+  getActiveSharedUrl: () => runtimeState.activeSharedUrl,
   runtimeSendMessage,
   debugLog,
 });

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -176,13 +176,19 @@ export function createNavigationController(args: {
 
       if (shouldTreatAsAutoplay && isLocalSharedSource) {
         args.runtimeState.explicitNonSharedPlaybackUrl = nextNormalizedPageUrl;
-        // Advance FROM the page we navigated from, not `activeSharedUrl`: in a
-        // chained autoplay these differ (prev=B, `activeSharedUrl` still A) and
-        // the room is catching up to B, so B is the correct `previousSharedUrl`.
-        // In the normal single-step case `navigatedFromSharedVideo` guarantees
+        // Advance FROM the room's confirmed shared video (`activeSharedUrl`), not
+        // the page we navigated from. A multi-part / chained autoplay that outruns
+        // room confirmation (A→B→C→D before any `room:state` returns) can't replay
+        // the intermediate videos — once the tab moves past B/C the background's
+        // tab-resolution check rejects them — so the room must jump straight to the
+        // latest video the sharer is actually on. The auto-share controller already
+        // collapses rapid navigations to the latest target via supersede; pairing
+        // that target with the room's confirmed video as `previousSharedUrl` lets
+        // the background advance the room directly to it (room A → latest). In the
+        // normal single-step case `navigatedFromSharedVideo` guarantees
         // `previousNormalizedPageUrl === activeSharedUrl`, so this is unchanged.
         args.scheduleAutoShareNextVideo?.({
-          previousSharedUrl: previousNormalizedPageUrl,
+          previousSharedUrl: activeSharedUrl,
           nextNormalizedPageUrl,
         });
         // Remember this target so the next chained autoplay (next → next+1) is

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -61,11 +61,19 @@ export function createNavigationController(args: {
     // intent can be transferred across a detour that auto-advances.
     const previousExplicitNonSharedPlaybackUrl =
       args.runtimeState.explicitNonSharedPlaybackUrl;
+    // The next video the local sharer auto-shared but the room has not yet
+    // confirmed (`activeSharedUrl` still lags it). Captured before the reset so a
+    // chained autoplay whose previous page is this in-flight target is still
+    // recognised as a sharer autoplay below. Re-armed only when this navigation
+    // is itself a sharer autoplay-next.
+    const previousPendingAutoShareTargetUrl =
+      args.runtimeState.pendingAutoShareTargetUrl;
     lastObservedPageUrl = nextPageUrl;
     lastObservedNormalizedPageUrl = nextNormalizedPageUrl;
     args.clearFestivalSnapshot();
     args.runtimeState.pendingPlaybackApplication = null;
     args.runtimeState.explicitNonSharedPlaybackUrl = null;
+    args.runtimeState.pendingAutoShareTargetUrl = null;
     // Any genuine navigation invalidates an auto-share scheduled by an earlier
     // autoplay. A manual detour — even one that returns to the same target — must
     // not let a stale settle timer fire and auto-share without the manual
@@ -133,9 +141,18 @@ export function createNavigationController(args: {
       // shared A, then X auto-advanced to Y), this is not the room advancing:
       // auto-sharing Y with `previousSharedUrl=A` or pausing a non-sharer's own
       // detour would both be wrong.
+      //
+      // Also accept the previous page being the sharer's own in-flight auto-share
+      // target: during chained autoplay (A→B→C) the player can advance B→C before
+      // B's `room:state` returns, so `activeSharedUrl` is still A while the page
+      // came from B. Without this the B→C step would look like a local detour and
+      // C would never be shared, stranding the room behind the sharer. (The
+      // background still defers/skips if the room is not actually behind our
+      // share, so a stale target cannot force an out-of-turn share.)
       const navigatedFromSharedVideo =
         previousNormalizedPageUrl !== null &&
-        previousNormalizedPageUrl === activeSharedUrl;
+        (previousNormalizedPageUrl === activeSharedUrl ||
+          previousNormalizedPageUrl === previousPendingAutoShareTargetUrl);
       const shouldTreatAsAutoplay =
         !hadRecentUserGesture &&
         navigatedFromSharedVideo &&
@@ -159,10 +176,18 @@ export function createNavigationController(args: {
 
       if (shouldTreatAsAutoplay && isLocalSharedSource) {
         args.runtimeState.explicitNonSharedPlaybackUrl = nextNormalizedPageUrl;
+        // Advance FROM the page we navigated from, not `activeSharedUrl`: in a
+        // chained autoplay these differ (prev=B, `activeSharedUrl` still A) and
+        // the room is catching up to B, so B is the correct `previousSharedUrl`.
+        // In the normal single-step case `navigatedFromSharedVideo` guarantees
+        // `previousNormalizedPageUrl === activeSharedUrl`, so this is unchanged.
         args.scheduleAutoShareNextVideo?.({
-          previousSharedUrl: activeSharedUrl,
+          previousSharedUrl: previousNormalizedPageUrl,
           nextNormalizedPageUrl,
         });
+        // Remember this target so the next chained autoplay (next → next+1) is
+        // recognised as a sharer autoplay even before the room confirms it.
+        args.runtimeState.pendingAutoShareTargetUrl = nextNormalizedPageUrl;
       } else if (shouldPauseNonSharerAutoplay) {
         args.runtimeState.intendedPlayState = "paused";
         // Mark this as a non-sharer autoplay page so the playback binding will

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -26,6 +26,14 @@ export function createNavigationController(args: {
   scheduleAutoShareNextVideo?: (input: {
     previousSharedUrl: string;
     nextNormalizedPageUrl: string;
+    /**
+     * The sharer's own in-flight auto-share target this navigation advanced FROM
+     * (the previous chain step), or `null` when this is not a chained step. The
+     * auto-share controller may re-anchor `previousSharedUrl` to the live shared
+     * video only when it matches this — i.e. our own previous step confirmed —
+     * never to an unrelated video (e.g. a manual share) the room moved to.
+     */
+    previousAutoShareTargetUrl: string | null;
   }) => void;
   cancelAutoShareNextVideo?: () => void;
   debugLog: (message: string) => void;
@@ -187,9 +195,18 @@ export function createNavigationController(args: {
         // the background advance the room directly to it (room A → latest). In the
         // normal single-step case `navigatedFromSharedVideo` guarantees
         // `previousNormalizedPageUrl === activeSharedUrl`, so this is unchanged.
+        //
+        // `activeSharedUrl` is the anchor as of *now*. If our own previous step
+        // (`previousPendingAutoShareTargetUrl`) confirms during the settle window,
+        // the room moves to it while this anchor goes stale; the auto-share
+        // controller re-anchors to the live shared video, but only when it equals
+        // that previous step — so an unrelated video the room moved to (e.g. a
+        // manual share confirmed in the same window) is never adopted as the
+        // anchor and the stale auto-share is correctly skipped as moved-on.
         args.scheduleAutoShareNextVideo?.({
           previousSharedUrl: activeSharedUrl,
           nextNormalizedPageUrl,
+          previousAutoShareTargetUrl: previousPendingAutoShareTargetUrl,
         });
         // Remember this target so the next chained autoplay (next → next+1) is
         // recognised as a sharer autoplay even before the room confirms it.

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -28,10 +28,10 @@ export function createNavigationController(args: {
     nextNormalizedPageUrl: string;
     /**
      * The sharer's own in-flight auto-share target this navigation advanced FROM
-     * (the previous chain step), or `null` when this is not a chained step. The
-     * auto-share controller may re-anchor `previousSharedUrl` to the live shared
-     * video only when it matches this — i.e. our own previous step confirmed —
-     * never to an unrelated video (e.g. a manual share) the room moved to.
+     * (the previous chain step), or `null` when this is not a chained step (it
+     * came straight from the room's confirmed shared video). A `null` value marks
+     * a fresh chain so the auto-share controller resets its sent-target lineage;
+     * a non-null value continues the current chain.
      */
     previousAutoShareTargetUrl: string | null;
   }) => void;
@@ -196,13 +196,15 @@ export function createNavigationController(args: {
         // normal single-step case `navigatedFromSharedVideo` guarantees
         // `previousNormalizedPageUrl === activeSharedUrl`, so this is unchanged.
         //
-        // `activeSharedUrl` is the anchor as of *now*. If our own previous step
-        // (`previousPendingAutoShareTargetUrl`) confirms during the settle window,
-        // the room moves to it while this anchor goes stale; the auto-share
-        // controller re-anchors to the live shared video, but only when it equals
-        // that previous step — so an unrelated video the room moved to (e.g. a
-        // manual share confirmed in the same window) is never adopted as the
-        // anchor and the stale auto-share is correctly skipped as moved-on.
+        // `activeSharedUrl` is the anchor as of *now*. If a step our own chain
+        // already sent confirms during the settle window, the room moves to it
+        // while this anchor goes stale; the auto-share controller re-anchors to the
+        // live shared video, but only when it is one of its own sent targets — so
+        // an unrelated video the room moved to (e.g. a manual share confirmed in
+        // the same window) is never adopted and the stale auto-share is correctly
+        // skipped as moved-on. `previousPendingAutoShareTargetUrl` tells the
+        // controller whether this is a chained step (continue the lineage) or a
+        // fresh start (reset it).
         args.scheduleAutoShareNextVideo?.({
           previousSharedUrl: activeSharedUrl,
           nextNormalizedPageUrl,

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -183,6 +183,18 @@ export function createRoomStateApplyController(args: {
     sharedByMemberId: string | null | undefined,
   ): void => {
     args.runtimeState.activeSharedByMemberId = sharedByMemberId ?? null;
+    // Clear the chained auto-share target once the room confirms it, or once
+    // another member takes over the share: the in-flight chain marker that lets a
+    // sharer schedule the next autoplay before `room:state` catches up is no
+    // longer pending. Leaving it set could later make an unrelated autoplay look
+    // like a chain continuation.
+    if (
+      args.runtimeState.pendingAutoShareTargetUrl !== null &&
+      (normalizedSharedUrl === args.runtimeState.pendingAutoShareTargetUrl ||
+        (sharedByMemberId ?? null) !== args.runtimeState.localMemberId)
+    ) {
+      args.runtimeState.pendingAutoShareTargetUrl = null;
+    }
     if (args.runtimeState.activeSharedUrl === normalizedSharedUrl) {
       return;
     }
@@ -469,6 +481,7 @@ export function createRoomStateApplyController(args: {
       args.cancelActiveSoftApply(args.getVideoElement(), "room-empty");
       args.runtimeState.activeSharedUrl = null;
       args.runtimeState.activeSharedByMemberId = null;
+      args.runtimeState.pendingAutoShareTargetUrl = null;
       args.runtimeState.suppressedLocalEndPauseUrl = null;
       args.runtimeState.suppressedLocalEndPauseUntil = 0;
       args.runtimeState.nonSharerAutoplayHoldUrl = null;

--- a/extension/src/content/room-state-controller.ts
+++ b/extension/src/content/room-state-controller.ts
@@ -85,6 +85,7 @@ export function createRoomStateController(args: {
   function clearRoomScopedSharedVideoState(): void {
     args.runtimeState.activeSharedUrl = null;
     args.runtimeState.activeSharedByMemberId = null;
+    args.runtimeState.pendingAutoShareTargetUrl = null;
     args.runtimeState.explicitNonSharedPlaybackUrl = null;
     args.runtimeState.suppressedLocalEndPauseUrl = null;
     args.runtimeState.suppressedLocalEndPauseUntil = 0;

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -94,6 +94,17 @@ export interface ContentRuntimeState {
    * hence no marker) is left playable for the user.
    */
   nonSharerAutoplayHoldUrl: string | null;
+  /**
+   * Normalized URL the local sharer auto-shared as the next video but whose
+   * authoritative `room:state` has not arrived yet (`activeSharedUrl` still lags
+   * behind it). Lets chained autoplay (A→B→C) keep scheduling: when the player
+   * advances B→C before B's `room:state` returns, `activeSharedUrl` is still A,
+   * so the navigation guard would otherwise treat B→C as a local detour and not
+   * auto-share C. Treating a navigation whose previous page equals this in-flight
+   * target as a sharer autoplay re-arms the chain. Cleared once `room:state`
+   * confirms it (or another member takes over the share) and on room teardown.
+   */
+  pendingAutoShareTargetUrl: string | null;
   lastForcedPauseAt: number;
   pauseHoldUntil: number;
   pendingPlaybackApplication: PlaybackState | null;
@@ -191,6 +202,7 @@ export function createContentRuntimeState(): ContentRuntimeState {
     suppressedLocalEndPauseUrl: null,
     suppressedLocalEndPauseUntil: 0,
     nonSharerAutoplayHoldUrl: null,
+    pendingAutoShareTargetUrl: null,
     lastForcedPauseAt: 0,
     pauseHoldUntil: 0,
     pendingPlaybackApplication: null,

--- a/extension/test/auto-share-next-controller.test.ts
+++ b/extension/test/auto-share-next-controller.test.ts
@@ -85,6 +85,102 @@ test("auto-share next controller sends a request after the navigation settles", 
   }
 });
 
+test("auto-share next controller re-anchors to its own confirmed previous step before sending", async () => {
+  // A→B→C chained autoplay: B→C was scheduled while the room was still on A, with
+  // B recorded as our own previous chain step. B's room state confirmed during
+  // the settle window so the live shared video is now B. The sent request must
+  // re-anchor to B (the live video), not the stale A, so the background stays
+  // "on-scheduled" and advances to C.
+  const windowHarness = installWindowStub();
+  const sentMessages: unknown[] = [];
+  let activeSharedUrl: string | null =
+    "https://www.bilibili.com/video/BV1AVideo";
+  const controller = createAutoShareNextController({
+    settleDelayMs: 900,
+    getCurrentPageUrl: () => "https://www.bilibili.com/video/BV1CVideo",
+    normalizeVideoPageUrl: normalizeTestVideoPageUrl,
+    getActiveSharedUrl: () => activeSharedUrl,
+    runtimeSendMessage: async (message) => {
+      sentMessages.push(message);
+      return { ok: true };
+    },
+    debugLog: () => {},
+  });
+
+  try {
+    controller.scheduleForNavigation({
+      previousSharedUrl: "https://www.bilibili.com/video/BV1AVideo",
+      nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1CVideo",
+      previousAutoShareTargetUrl: "https://www.bilibili.com/video/BV1BVideo",
+    });
+    // Our own previous step B confirms during the settle window.
+    activeSharedUrl = "https://www.bilibili.com/video/BV1BVideo";
+    windowHarness.runTimers();
+    await Promise.resolve();
+
+    assert.deepEqual(sentMessages, [
+      {
+        type: "content:auto-share-next-video",
+        payload: {
+          previousSharedUrl: "https://www.bilibili.com/video/BV1BVideo",
+          targetNormalizedUrl: "https://www.bilibili.com/video/BV1CVideo",
+        },
+      },
+    ]);
+  } finally {
+    controller.destroy();
+    windowHarness.restore();
+  }
+});
+
+test("auto-share next controller does not re-anchor to an unrelated video the room moved to", async () => {
+  // A→B auto-share queued (no prior chain step). During the settle window the
+  // same member manually shares X from another tab and it confirms, so the live
+  // shared video is now X. X is NOT our own previous chain step, so the request
+  // must keep the scheduled anchor A — letting the background skip this stale
+  // auto-share as moved-on rather than clobber the manual X with B.
+  const windowHarness = installWindowStub();
+  const sentMessages: unknown[] = [];
+  let activeSharedUrl: string | null =
+    "https://www.bilibili.com/video/BV1AVideo";
+  const controller = createAutoShareNextController({
+    settleDelayMs: 900,
+    getCurrentPageUrl: () => "https://www.bilibili.com/video/BV1BVideo",
+    normalizeVideoPageUrl: normalizeTestVideoPageUrl,
+    getActiveSharedUrl: () => activeSharedUrl,
+    runtimeSendMessage: async (message) => {
+      sentMessages.push(message);
+      return { ok: true };
+    },
+    debugLog: () => {},
+  });
+
+  try {
+    controller.scheduleForNavigation({
+      previousSharedUrl: "https://www.bilibili.com/video/BV1AVideo",
+      nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1BVideo",
+      previousAutoShareTargetUrl: null,
+    });
+    // A manual share X confirms during the settle window.
+    activeSharedUrl = "https://www.bilibili.com/video/BV1XVideo";
+    windowHarness.runTimers();
+    await Promise.resolve();
+
+    assert.deepEqual(sentMessages, [
+      {
+        type: "content:auto-share-next-video",
+        payload: {
+          previousSharedUrl: "https://www.bilibili.com/video/BV1AVideo",
+          targetNormalizedUrl: "https://www.bilibili.com/video/BV1BVideo",
+        },
+      },
+    ]);
+  } finally {
+    controller.destroy();
+    windowHarness.restore();
+  }
+});
+
 test("auto-share next controller skips a settled request when the page moved again", async () => {
   const windowHarness = installWindowStub();
   let currentUrl = "https://www.bilibili.com/video/BV1NextVideo";

--- a/extension/test/auto-share-next-controller.test.ts
+++ b/extension/test/auto-share-next-controller.test.ts
@@ -86,18 +86,18 @@ test("auto-share next controller sends a request after the navigation settles", 
 });
 
 test("auto-share next controller re-anchors to its own confirmed previous step before sending", async () => {
-  // A→B→C chained autoplay: B→C was scheduled while the room was still on A, with
-  // B recorded as our own previous chain step. B's room state confirmed during
-  // the settle window so the live shared video is now B. The sent request must
-  // re-anchor to B (the live video), not the stale A, so the background stays
-  // "on-scheduled" and advances to C.
+  // A→B→C chained autoplay. B is sent first (room still on A), then B→C is
+  // scheduled. B's room state confirms during C's settle window, so the live
+  // shared video is now B. C must re-anchor to B (a video this chain already
+  // sent), not the stale A, so the background stays "on-scheduled" and advances.
   const windowHarness = installWindowStub();
   const sentMessages: unknown[] = [];
+  let currentUrl = "https://www.bilibili.com/video/BV1BVideo";
   let activeSharedUrl: string | null =
     "https://www.bilibili.com/video/BV1AVideo";
   const controller = createAutoShareNextController({
     settleDelayMs: 900,
-    getCurrentPageUrl: () => "https://www.bilibili.com/video/BV1CVideo",
+    getCurrentPageUrl: () => currentUrl,
     normalizeVideoPageUrl: normalizeTestVideoPageUrl,
     getActiveSharedUrl: () => activeSharedUrl,
     runtimeSendMessage: async (message) => {
@@ -108,17 +108,35 @@ test("auto-share next controller re-anchors to its own confirmed previous step b
   });
 
   try {
+    // A→B: fresh chain start, sent while the room is still on A.
+    controller.scheduleForNavigation({
+      previousSharedUrl: "https://www.bilibili.com/video/BV1AVideo",
+      nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1BVideo",
+      previousAutoShareTargetUrl: null,
+    });
+    windowHarness.runTimers();
+    await Promise.resolve();
+
+    // B→C: chained step, still anchored to A because B has not confirmed yet.
+    currentUrl = "https://www.bilibili.com/video/BV1CVideo";
     controller.scheduleForNavigation({
       previousSharedUrl: "https://www.bilibili.com/video/BV1AVideo",
       nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1CVideo",
       previousAutoShareTargetUrl: "https://www.bilibili.com/video/BV1BVideo",
     });
-    // Our own previous step B confirms during the settle window.
+    // B confirms during C's settle window.
     activeSharedUrl = "https://www.bilibili.com/video/BV1BVideo";
     windowHarness.runTimers();
     await Promise.resolve();
 
     assert.deepEqual(sentMessages, [
+      {
+        type: "content:auto-share-next-video",
+        payload: {
+          previousSharedUrl: "https://www.bilibili.com/video/BV1AVideo",
+          targetNormalizedUrl: "https://www.bilibili.com/video/BV1BVideo",
+        },
+      },
       {
         type: "content:auto-share-next-video",
         payload: {
@@ -128,6 +146,7 @@ test("auto-share next controller re-anchors to its own confirmed previous step b
       },
     ]);
   } finally {
+    currentUrl = "";
     controller.destroy();
     windowHarness.restore();
   }
@@ -176,6 +195,81 @@ test("auto-share next controller does not re-anchor to an unrelated video the ro
       },
     ]);
   } finally {
+    controller.destroy();
+    windowHarness.restore();
+  }
+});
+
+test("auto-share next controller re-anchors to an earlier sent step that confirms across deeper lag", async () => {
+  // A→B sent (room still on A). The page then rapidly advances B→C→D before B
+  // confirms, so C is superseded and only D is ultimately sent. B (not the
+  // immediately-prior page C) is the in-flight share that confirms during D's
+  // settle window. Because B was actually sent by this chain, D must still
+  // re-anchor to B — the immediately-prior target C would miss it.
+  const windowHarness = installWindowStub();
+  const sentMessages: unknown[] = [];
+  let currentUrl = "https://www.bilibili.com/video/BV1BVideo";
+  let activeSharedUrl: string | null =
+    "https://www.bilibili.com/video/BV1AVideo";
+  const controller = createAutoShareNextController({
+    settleDelayMs: 900,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeTestVideoPageUrl,
+    getActiveSharedUrl: () => activeSharedUrl,
+    runtimeSendMessage: async (message) => {
+      sentMessages.push(message);
+      return { ok: true };
+    },
+    debugLog: () => {},
+  });
+
+  try {
+    // A→B: fresh chain, sent while the room is still on A.
+    controller.scheduleForNavigation({
+      previousSharedUrl: "https://www.bilibili.com/video/BV1AVideo",
+      nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1BVideo",
+      previousAutoShareTargetUrl: null,
+    });
+    windowHarness.runTimers();
+    await Promise.resolve();
+
+    // B→C then C→D before B confirms: C's pending timer is superseded by D, so
+    // only D is ever sent. Both stay anchored to A (B unconfirmed at schedule).
+    currentUrl = "https://www.bilibili.com/video/BV1CVideo";
+    controller.scheduleForNavigation({
+      previousSharedUrl: "https://www.bilibili.com/video/BV1AVideo",
+      nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1CVideo",
+      previousAutoShareTargetUrl: "https://www.bilibili.com/video/BV1BVideo",
+    });
+    currentUrl = "https://www.bilibili.com/video/BV1DVideo";
+    controller.scheduleForNavigation({
+      previousSharedUrl: "https://www.bilibili.com/video/BV1AVideo",
+      nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1DVideo",
+      previousAutoShareTargetUrl: "https://www.bilibili.com/video/BV1CVideo",
+    });
+    // B (the only step actually sent before D) confirms during D's settle window.
+    activeSharedUrl = "https://www.bilibili.com/video/BV1BVideo";
+    windowHarness.runTimers();
+    await Promise.resolve();
+
+    assert.deepEqual(sentMessages, [
+      {
+        type: "content:auto-share-next-video",
+        payload: {
+          previousSharedUrl: "https://www.bilibili.com/video/BV1AVideo",
+          targetNormalizedUrl: "https://www.bilibili.com/video/BV1BVideo",
+        },
+      },
+      {
+        type: "content:auto-share-next-video",
+        payload: {
+          previousSharedUrl: "https://www.bilibili.com/video/BV1BVideo",
+          targetNormalizedUrl: "https://www.bilibili.com/video/BV1DVideo",
+        },
+      },
+    ]);
+  } finally {
+    currentUrl = "";
     controller.destroy();
     windowHarness.restore();
   }

--- a/extension/test/background-share-controller.test.ts
+++ b/extension/test/background-share-controller.test.ts
@@ -130,6 +130,44 @@ test("background share controller forwards a share without playback when content
   }
 });
 
+test("background share controller distinguishes manual and auto pending local shares", async () => {
+  const selfHarness = installSelfStub();
+  const harness = createControllerHarness();
+  harness.runtimeState.connection.connected = true;
+  harness.runtimeState.room.roomCode = "ROOM01";
+  harness.runtimeState.room.memberToken = "member-token-1";
+  harness.runtimeState.room.memberId = "member-1";
+
+  const video = {
+    video: {
+      videoId: "BV199W9zEEcH",
+      url: "https://www.bilibili.com/video/BV199W9zEEcH",
+      title: "New Video",
+    },
+    playback: null,
+  };
+
+  try {
+    // A manual share leaves a pending marker that blocks a chained auto-share.
+    await harness.controller.queueOrSendSharedVideo(video, 123);
+    assert.equal(harness.controller.hasActivePendingLocalShare(), true);
+    assert.equal(harness.controller.hasActivePendingManualShare(), true);
+
+    // An auto-share's own in-flight marker must NOT count as a manual share, so
+    // the next chain step can advance past it.
+    await harness.controller.queueOrSendSharedVideo(video, 123, true);
+    assert.equal(harness.controller.hasActivePendingLocalShare(), true);
+    assert.equal(harness.controller.hasActivePendingManualShare(), false);
+
+    // Clearing the marker resets the auto flag too.
+    harness.controller.clearPendingLocalShare("test");
+    assert.equal(harness.controller.hasActivePendingLocalShare(), false);
+    assert.equal(harness.controller.hasActivePendingManualShare(), false);
+  } finally {
+    selfHarness.restore();
+  }
+});
+
 test("background share controller queues the share for reconnect when the socket is closing", async () => {
   const selfHarness = installSelfStub();
   const harness = createControllerHarness();

--- a/extension/test/message-controller.test.ts
+++ b/extension/test/message-controller.test.ts
@@ -53,6 +53,7 @@ function createControllerHarness(
     queueOrSendSharedVideoResult?: { ok: true } | { ok: false; error: string };
     onReadTabPayload?: () => void;
     hasActivePendingLocalShare?: boolean;
+    hasActivePendingManualShare?: boolean;
     activePendingLocalShareUrl?: string | null;
   } = {},
 ) {
@@ -73,6 +74,7 @@ function createControllerHarness(
       payload: unknown;
       tabId: number | null;
     }>,
+    queueOrSendSharedVideoAutoFlags: [] as boolean[],
     getVideoPayloadFromTab: [] as Array<
       Pick<chrome.tabs.Tab, "id" | "url"> | null | undefined
     >,
@@ -200,12 +202,16 @@ function createControllerHarness(
           tabId: tab?.id ?? null,
         };
       },
-      async queueOrSendSharedVideo(payload, tabId) {
+      async queueOrSendSharedVideo(payload, tabId, isAutoShare) {
         calls.queueOrSendSharedVideo.push({ payload, tabId });
+        calls.queueOrSendSharedVideoAutoFlags.push(isAutoShare ?? false);
         return overrides.queueOrSendSharedVideoResult ?? { ok: true };
       },
       hasActivePendingLocalShare() {
         return overrides.hasActivePendingLocalShare ?? false;
+      },
+      hasActivePendingManualShare() {
+        return overrides.hasActivePendingManualShare ?? false;
       },
       getActivePendingLocalShareUrl() {
         return overrides.activePendingLocalShareUrl ?? null;
@@ -965,6 +971,7 @@ test("message controller skips auto-share when a manual share is awaiting confir
     // The user just made an explicit share that is still awaiting server
     // confirmation; roomState.sharedVideo still holds the previous video.
     hasActivePendingLocalShare: true,
+    hasActivePendingManualShare: true,
     roomSessionState: {
       roomCode: "ROOM01",
       memberToken: "member-token-1",
@@ -996,6 +1003,55 @@ test("message controller skips auto-share when a manual share is awaiting confir
 
   // The auto-share must not overwrite the unconfirmed manual share.
   assert.deepEqual(harness.calls.queueOrSendSharedVideo, []);
+  assert.deepEqual(response, { ok: true });
+});
+
+test("message controller advances chained autoplay past its own in-flight auto-share", async () => {
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD",
+    title: "Video A",
+    sharedByMemberId: "member-1",
+  };
+  const harness = createControllerHarness({
+    isRememberedSharedSourceTab: true,
+    // Our OWN previous auto-share (B) is still awaiting confirmation — a pending
+    // local share exists, but it is NOT a manual share. The chain must advance.
+    hasActivePendingLocalShare: true,
+    hasActivePendingManualShare: false,
+    roomSessionState: {
+      roomCode: "ROOM01",
+      memberToken: "member-token-1",
+      memberId: "member-1",
+      displayName: "Alice",
+      roomState: {
+        roomCode: "ROOM01",
+        sharedVideo,
+        playback: null,
+        members: [{ id: "member-1", name: "Alice" }],
+      },
+    },
+  });
+  let response: unknown;
+
+  await harness.controller.handleRuntimeMessage(
+    {
+      type: "content:auto-share-next-video",
+      payload: {
+        previousSharedUrl: "https://www.bilibili.com/video/BV1xx411c7mD",
+        targetNormalizedUrl: "https://www.bilibili.com/video/BV199W9zEEcH",
+      },
+    },
+    { tab: { id: 456, url: "https://www.bilibili.com/video/BV199W9zEEcH" } },
+    (nextResponse) => {
+      response = nextResponse;
+    },
+  );
+
+  // It must NOT skip: the next video is shared, flagged as an auto-share so the
+  // following chain step recognises it as its own in-flight share too.
+  assert.equal(harness.calls.queueOrSendSharedVideo.length, 1);
+  assert.deepEqual(harness.calls.queueOrSendSharedVideoAutoFlags, [true]);
   assert.deepEqual(response, { ok: true });
 });
 

--- a/extension/test/message-controller.test.ts
+++ b/extension/test/message-controller.test.ts
@@ -53,6 +53,7 @@ function createControllerHarness(
     queueOrSendSharedVideoResult?: { ok: true } | { ok: false; error: string };
     onReadTabPayload?: () => void;
     hasActivePendingLocalShare?: boolean;
+    activePendingLocalShareUrl?: string | null;
   } = {},
 ) {
   const calls = {
@@ -205,6 +206,9 @@ function createControllerHarness(
       },
       hasActivePendingLocalShare() {
         return overrides.hasActivePendingLocalShare ?? false;
+      },
+      getActivePendingLocalShareUrl() {
+        return overrides.activePendingLocalShareUrl ?? null;
       },
     },
     tabController: {
@@ -619,6 +623,105 @@ test("message controller auto-shares the next video from the original sharer's s
   assert.equal(harness.calls.persistState, 1);
   assert.equal(harness.calls.notifyAll, 1);
   assert.deepEqual(response, { ok: true });
+});
+
+test("message controller defers a chained auto-share until the previous share is confirmed", async () => {
+  // Chained autoplay A→B→C outran the room round-trip: the room is still on A
+  // (shared by us), this auto-share is scheduled from B (`previousSharedUrl`),
+  // and B is the video we just shared but whose `room:state` has not returned
+  // yet (still the active pending local-share marker). The handler must defer
+  // (retryable, no budget consumed) instead of skipping, so C is re-sent once B
+  // confirms — rather than being lost, stranding the room behind the sharer.
+  const sharedVideoA = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD",
+    title: "Video A",
+    sharedByMemberId: "member-1",
+  };
+  const harness = createControllerHarness({
+    isRememberedSharedSourceTab: true,
+    activePendingLocalShareUrl: "https://www.bilibili.com/video/BV199W9zEEcH",
+    roomSessionState: {
+      roomCode: "ROOM01",
+      memberToken: "member-token-1",
+      memberId: "member-1",
+      displayName: "Alice",
+      roomState: {
+        roomCode: "ROOM01",
+        sharedVideo: sharedVideoA,
+        playback: null,
+        members: [{ id: "member-1", name: "Alice" }],
+      },
+    },
+  });
+  let response: unknown;
+
+  await harness.controller.handleRuntimeMessage(
+    {
+      type: "content:auto-share-next-video",
+      payload: {
+        // Scheduled from B (the in-flight share), advancing to C.
+        previousSharedUrl: "https://www.bilibili.com/video/BV199W9zEEcH",
+        targetNormalizedUrl: "https://www.bilibili.com/video/BV1aa411c7zz",
+      },
+    },
+    { tab: { id: 456, url: "https://www.bilibili.com/video/BV1aa411c7zz" } },
+    (nextResponse) => {
+      response = nextResponse;
+    },
+  );
+
+  // Deferred: no tab read, no share, retry expected.
+  assert.deepEqual(response, { ok: false, deferred: true });
+  assert.deepEqual(harness.calls.getVideoPayloadFromTab, []);
+  assert.deepEqual(harness.calls.queueOrSendSharedVideo, []);
+});
+
+test("message controller skips a chained auto-share when the room genuinely moved on", async () => {
+  // The room is on A (shared by us) but our in-flight marker is for a different
+  // video than `previousSharedUrl` (B), so the room has not simply lagged behind
+  // our share of B — it moved on for another reason. Skip rather than defer.
+  const sharedVideoA = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD",
+    title: "Video A",
+    sharedByMemberId: "member-1",
+  };
+  const harness = createControllerHarness({
+    isRememberedSharedSourceTab: true,
+    activePendingLocalShareUrl: "https://www.bilibili.com/video/BV1zz411c7qq",
+    roomSessionState: {
+      roomCode: "ROOM01",
+      memberToken: "member-token-1",
+      memberId: "member-1",
+      displayName: "Alice",
+      roomState: {
+        roomCode: "ROOM01",
+        sharedVideo: sharedVideoA,
+        playback: null,
+        members: [{ id: "member-1", name: "Alice" }],
+      },
+    },
+  });
+  let response: unknown;
+
+  await harness.controller.handleRuntimeMessage(
+    {
+      type: "content:auto-share-next-video",
+      payload: {
+        previousSharedUrl: "https://www.bilibili.com/video/BV199W9zEEcH",
+        targetNormalizedUrl: "https://www.bilibili.com/video/BV1aa411c7zz",
+      },
+    },
+    { tab: { id: 456, url: "https://www.bilibili.com/video/BV1aa411c7zz" } },
+    (nextResponse) => {
+      response = nextResponse;
+    },
+  );
+
+  assert.deepEqual(response, { ok: true });
+  assert.deepEqual(harness.calls.getVideoPayloadFromTab, []);
+  assert.deepEqual(harness.calls.queueOrSendSharedVideo, []);
 });
 
 test("message controller re-claims the shared source tab after a worker restart lost the binding", async () => {

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -259,6 +259,79 @@ test("navigation controller schedules auto-share when a shared source autoplays 
   }
 });
 
+test("navigation controller chains the next auto-share before the room confirms the previous one", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BV1aaaaaaaaa";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+
+  let currentUrl = "https://www.bilibili.com/video/BV1aaaaaaaaa";
+  const autoShareRequests: Array<{
+    previousSharedUrl: string;
+    nextNormalizedPageUrl: string;
+  }> = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeTestVideoPageUrl,
+    isSupportedVideoPage: (url) => url.includes("/video/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {},
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+
+    // A→B autoplay: the room is on A and we own it, so this is a sharer autoplay.
+    currentUrl = "https://www.bilibili.com/video/BV1bbbbbbbbb";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(
+      runtimeState.pendingAutoShareTargetUrl,
+      "https://www.bilibili.com/video/BV1bbbbbbbbb",
+    );
+
+    // B→C autoplay BEFORE B's room:state returns: `activeSharedUrl` is still A,
+    // but the previous page (B) matches the in-flight auto-share target, so this
+    // must still be recognised as a sharer autoplay and schedule C (from B).
+    currentUrl = "https://www.bilibili.com/video/BV1ccccccccc";
+    windowHarness.intervals[0]?.();
+
+    assert.deepEqual(autoShareRequests, [
+      {
+        previousSharedUrl: "https://www.bilibili.com/video/BV1aaaaaaaaa",
+        nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1bbbbbbbbb",
+      },
+      {
+        previousSharedUrl: "https://www.bilibili.com/video/BV1bbbbbbbbb",
+        nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1ccccccccc",
+      },
+    ]);
+    assert.equal(
+      runtimeState.pendingAutoShareTargetUrl,
+      "https://www.bilibili.com/video/BV1ccccccccc",
+    );
+  } finally {
+    windowHarness.restore();
+  }
+});
+
 test("navigation controller does not auto-share a recent user-initiated navigation", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -309,7 +309,10 @@ test("navigation controller chains the next auto-share before the room confirms 
 
     // B→C autoplay BEFORE B's room:state returns: `activeSharedUrl` is still A,
     // but the previous page (B) matches the in-flight auto-share target, so this
-    // must still be recognised as a sharer autoplay and schedule C (from B).
+    // must still be recognised as a sharer autoplay and schedule C. It advances
+    // FROM the room's confirmed video (A) — not the page B — so the background can
+    // jump the room straight to the latest video the sharer is on (intermediates
+    // the tab already left cannot be replayed).
     currentUrl = "https://www.bilibili.com/video/BV1ccccccccc";
     windowHarness.intervals[0]?.();
 
@@ -319,7 +322,7 @@ test("navigation controller chains the next auto-share before the room confirms 
         nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1bbbbbbbbb",
       },
       {
-        previousSharedUrl: "https://www.bilibili.com/video/BV1bbbbbbbbb",
+        previousSharedUrl: "https://www.bilibili.com/video/BV1aaaaaaaaa",
         nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1ccccccccc",
       },
     ]);

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -207,6 +207,7 @@ test("navigation controller schedules auto-share when a shared source autoplays 
   const autoShareRequests: Array<{
     previousSharedUrl: string;
     nextNormalizedPageUrl: string;
+    previousAutoShareTargetUrl: string | null;
   }> = [];
 
   const controller = createNavigationController({
@@ -252,6 +253,8 @@ test("navigation controller schedules auto-share when a shared source autoplays 
       {
         previousSharedUrl: "https://www.bilibili.com/video/BV1DbiMBwEry",
         nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1Em421N7uU",
+        // Not a chained step: no previous in-flight auto-share to re-anchor to.
+        previousAutoShareTargetUrl: null,
       },
     ]);
   } finally {
@@ -272,6 +275,7 @@ test("navigation controller chains the next auto-share before the room confirms 
   const autoShareRequests: Array<{
     previousSharedUrl: string;
     nextNormalizedPageUrl: string;
+    previousAutoShareTargetUrl: string | null;
   }> = [];
 
   const controller = createNavigationController({
@@ -320,10 +324,16 @@ test("navigation controller chains the next auto-share before the room confirms 
       {
         previousSharedUrl: "https://www.bilibili.com/video/BV1aaaaaaaaa",
         nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1bbbbbbbbb",
+        // First step: came straight from the room's confirmed video A.
+        previousAutoShareTargetUrl: null,
       },
       {
         previousSharedUrl: "https://www.bilibili.com/video/BV1aaaaaaaaa",
         nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1ccccccccc",
+        // Chained step: came from our own in-flight auto-share target B, so the
+        // controller may re-anchor to B if it confirms during the settle window.
+        previousAutoShareTargetUrl:
+          "https://www.bilibili.com/video/BV1bbbbbbbbb",
       },
     ]);
     assert.equal(

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -302,6 +302,121 @@ test("syncs the cached shared url and sharer when the page bridge has no current
   assert.equal(harness.runtimeState.activeSharedByMemberId, "member-2");
 });
 
+test("clears the pending auto-share target once the room confirms it", async () => {
+  const video = createStubVideo(true);
+  const harness = createController({ video, now: 10_000, currentVideo: null });
+
+  harness.runtimeState.localMemberId = "member-1";
+  harness.runtimeState.activeSharedByMemberId = "member-1";
+  harness.runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep1111111";
+  // Our chain's in-flight target is the video the room is now confirming.
+  harness.runtimeState.pendingAutoShareTargetUrl =
+    "https://www.bilibili.com/bangumi/play/ep1231523";
+  harness.runtimeState.pendingRoomStateHydration = false;
+
+  await harness.controller.applyRoomState({
+    roomCode: "ROOM01",
+    sharedVideo: {
+      videoId: "ep1231523",
+      url: "https://www.bilibili.com/bangumi/play/ep1231523",
+      title: "第2话",
+      sharedByMemberId: "member-1",
+    },
+    playback: {
+      url: "https://www.bilibili.com/bangumi/play/ep1231523",
+      playState: "playing",
+      currentTime: 0,
+      playbackRate: 1,
+      actorId: "member-1",
+      seq: 1,
+      serverTime: 1_000,
+    },
+    members: [{ id: "member-1", name: "Alice" }],
+  });
+
+  assert.equal(harness.runtimeState.pendingAutoShareTargetUrl, null);
+});
+
+test("keeps the pending auto-share target while the room is still catching up the chain", async () => {
+  const video = createStubVideo(true);
+  const harness = createController({ video, now: 10_000, currentVideo: null });
+
+  harness.runtimeState.localMemberId = "member-1";
+  harness.runtimeState.activeSharedByMemberId = "member-1";
+  harness.runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep1111111";
+  // The chain already advanced to C while the room is only now confirming B.
+  harness.runtimeState.pendingAutoShareTargetUrl =
+    "https://www.bilibili.com/bangumi/play/ep_C";
+  harness.runtimeState.pendingRoomStateHydration = false;
+
+  await harness.controller.applyRoomState({
+    roomCode: "ROOM01",
+    sharedVideo: {
+      videoId: "ep1231523",
+      url: "https://www.bilibili.com/bangumi/play/ep1231523",
+      title: "第2话 B",
+      sharedByMemberId: "member-1",
+    },
+    playback: {
+      url: "https://www.bilibili.com/bangumi/play/ep1231523",
+      playState: "playing",
+      currentTime: 0,
+      playbackRate: 1,
+      actorId: "member-1",
+      seq: 1,
+      serverTime: 1_000,
+    },
+    members: [{ id: "member-1", name: "Alice" }],
+  });
+
+  // Still ours and not yet the confirmed target → the chain marker survives so
+  // the next B→C autoplay is still recognised.
+  assert.equal(
+    harness.runtimeState.pendingAutoShareTargetUrl,
+    "https://www.bilibili.com/bangumi/play/ep_C",
+  );
+});
+
+test("clears the pending auto-share target when another member takes over the share", async () => {
+  const video = createStubVideo(true);
+  const harness = createController({ video, now: 10_000, currentVideo: null });
+
+  harness.runtimeState.localMemberId = "member-1";
+  harness.runtimeState.activeSharedByMemberId = "member-1";
+  harness.runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep1111111";
+  harness.runtimeState.pendingAutoShareTargetUrl =
+    "https://www.bilibili.com/bangumi/play/ep_C";
+  harness.runtimeState.pendingRoomStateHydration = false;
+
+  await harness.controller.applyRoomState({
+    roomCode: "ROOM01",
+    sharedVideo: {
+      videoId: "ep2222222",
+      url: "https://www.bilibili.com/bangumi/play/ep2222222",
+      title: "别人分享的",
+      sharedByMemberId: "member-2",
+    },
+    playback: {
+      url: "https://www.bilibili.com/bangumi/play/ep2222222",
+      playState: "playing",
+      currentTime: 0,
+      playbackRate: 1,
+      actorId: "member-2",
+      seq: 1,
+      serverTime: 1_000,
+    },
+    members: [
+      { id: "member-1", name: "Alice" },
+      { id: "member-2", name: "Bob" },
+    ],
+  });
+
+  assert.equal(harness.runtimeState.pendingAutoShareTargetUrl, null);
+});
+
 test("pauses video when gesture age exactly equals the grace window boundary", async () => {
   const video = createStubVideo(false);
   const harness = createController({


### PR DESCRIPTION
Part 3 of #132 (auto-share-next 收尾). Part 1 was dropped after browser verification (href always updates on part/autoplay transitions — see issue comment); this is the remaining independent race.

## Problem
When the sharer's player chains autoplay faster than the room confirmation round-trip — A→B→C before B's `room:state` returns — the next video was lost:
- `activeSharedUrl` still held A, so `navigation-controller`'s `navigatedFromSharedVideo` (requires `prev === activeSharedUrl`) treated B→C as a local detour and never scheduled C.
- Even if scheduled, `message-controller`'s binary room check skipped it because the room had not yet reached `previousSharedUrl` (B) — indistinguishable from "room genuinely moved on".

## Fix
**Content (`navigation-controller`)**
- New `pendingAutoShareTargetUrl`: tracks the sharer's own in-flight auto-share target. A navigation whose previous page equals it is recognised as a sharer autoplay, so the chain keeps scheduling before each step confirms.
- Advance from `previousNormalizedPageUrl` (= `activeSharedUrl` in the normal single step; the in-flight target mid-chain).
- Cleared on room confirmation of the target, another member taking over the share, or room leave/empty.

**Background (`message-controller`)**
- Binary room check → three-state classifier (`on-scheduled` / `share-in-flight` / `moved-on`). When the room hasn't reached `previousSharedUrl` because our own share of it is still in flight (the pending local-share marker), defer with a retryable response (no page-bridge budget consumed) so the next video is re-sent once the previous share confirms.
- `shareController.getActivePendingLocalShareUrl()` exposes the in-flight marker URL.

## Tests
- `message-controller`: chained auto-share defers while the previous share is in flight; skips when the room genuinely moved on.
- `navigation-controller`: chains the next auto-share before the room confirms the previous one.
- `room-state-apply-controller`: marker cleared on confirm / takeover, kept while the room is still catching up.

All 391 extension tests pass; full pre-commit (format/lint/typecheck/build/test) green. Local Codex review found no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)