### PR TITLE
fix: silence sharer autoplay-next handoff toasts on peers

### DIFF
--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -239,6 +239,40 @@ export function createPlaybackBindingController(args: {
     return true;
   }
 
+  /**
+   * Arm broadcast suppression when the local *sharer's* own shared video reaches
+   * its natural end. Unlike the non-sharer hold this does not pause the player —
+   * the sharer must keep playing to autoplay into the next episode — it only
+   * stops the end `pause` (and the next-episode seek-to-0 emitted while the page
+   * URL still resolves the old video) from being broadcast as updates against
+   * the still-shared old video. Without it every peer would briefly see
+   * "{sharer} paused the video" and "{sharer} jumped to 0:00" right before the
+   * auto-share of the next video lands. The suppression is released by
+   * {@link createSyncController}'s broadcast gate once the next share confirms, a
+   * fresh user gesture replays it, the page moves on, or the timeout elapses.
+   */
+  function armSharerSharedVideoEndSuppression(): boolean {
+    if (
+      !args.runtimeState.activeRoomCode ||
+      !args.runtimeState.activeSharedUrl ||
+      !args.runtimeState.localMemberId ||
+      !args.runtimeState.activeSharedByMemberId ||
+      !isLocalSharedSource() ||
+      !isCurrentVideoShared(args.getSharedVideo())
+    ) {
+      return false;
+    }
+
+    args.runtimeState.sharerEndedSuppressionUrl =
+      args.runtimeState.activeSharedUrl;
+    args.runtimeState.sharerEndedSuppressionUntil =
+      nowOf() + args.initialRoomStatePauseHoldMs;
+    args.debugLog(
+      `Suppressed sharer end-of-video broadcasts to keep autoplay-next handoff quiet`,
+    );
+    return true;
+  }
+
   function shouldReapplyHoldAfterSharedVideoEnd(
     video: HTMLVideoElement,
     currentVideo: SharedVideo | null,
@@ -578,6 +612,13 @@ export function createPlaybackBindingController(args: {
         if (video.ended && holdNonSharerAtSharedVideoEnd(video)) {
           return;
         }
+        // Same natural-end window for the sharer: do not pause (autoplay-next
+        // must continue) but suppress this end `pause` broadcast so peers are not
+        // shown a spurious "paused"/"jumped to 0:00" against the old video before
+        // the next auto-share lands. See armSharerSharedVideoEndSuppression.
+        if (video.ended && armSharerSharedVideoEndSuppression()) {
+          return;
+        }
         if (hasRecentUserGesture()) {
           args.cancelActiveSoftApply(video, "pause");
         }
@@ -691,7 +732,9 @@ export function createPlaybackBindingController(args: {
         scheduleBroadcast(video, "ratechange", 120);
       },
       onEnded: () => {
-        holdNonSharerAtSharedVideoEnd(video);
+        if (!holdNonSharerAtSharedVideoEnd(video)) {
+          armSharerSharedVideoEndSuppression();
+        }
       },
       onTimeUpdate: () => {
         args.maintainActiveSoftApply(video);

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -60,6 +60,7 @@ export function createPlaybackBindingController(args: {
 }): PlaybackBindingController {
   let videoBindingTimer: number | null = null;
   let pauseBufferUpgradeTimerId: number | null = null;
+  let sharerEndedFlushTimerId: number | null = null;
   const nowOf = () => args.getNow?.() ?? Date.now();
   const scheduleUpgradeTimer = (cb: () => void, ms: number): number | null => {
     if (
@@ -89,6 +90,12 @@ export function createPlaybackBindingController(args: {
     if (pauseBufferUpgradeTimerId !== null) {
       cancelUpgradeTimer(pauseBufferUpgradeTimerId);
       pauseBufferUpgradeTimerId = null;
+    }
+  };
+  const clearSharerEndedFlushTimer = () => {
+    if (sharerEndedFlushTimerId !== null) {
+      cancelUpgradeTimer(sharerEndedFlushTimerId);
+      sharerEndedFlushTimerId = null;
     }
   };
   const clearActivePauseClassification = () => {
@@ -250,6 +257,12 @@ export function createPlaybackBindingController(args: {
    * auto-share of the next video lands. The suppression is released by
    * {@link createSyncController}'s broadcast gate once the next share confirms, a
    * fresh user gesture replays it, the page moves on, or the timeout elapses.
+   *
+   * When no autoplay-next actually follows (the last episode, or Bilibili
+   * autoplay disabled) there is no later navigation/share/seek to drive the
+   * gate's lazy clear, so a deferred flush re-broadcasts the terminal paused
+   * state once the suppression window elapses; otherwise the room — and any
+   * new joiners — would keep seeing the shared video as still playing.
    */
   function armSharerSharedVideoEndSuppression(): boolean {
     if (
@@ -263,14 +276,58 @@ export function createPlaybackBindingController(args: {
       return false;
     }
 
-    args.runtimeState.sharerEndedSuppressionUrl =
-      args.runtimeState.activeSharedUrl;
+    const armedUrl = args.runtimeState.activeSharedUrl;
+    args.runtimeState.sharerEndedSuppressionUrl = armedUrl;
     args.runtimeState.sharerEndedSuppressionUntil =
       nowOf() + args.initialRoomStatePauseHoldMs;
+    args.runtimeState.sharerEndedSuppressionArmedAt = nowOf();
+    clearSharerEndedFlushTimer();
+    sharerEndedFlushTimerId = scheduleUpgradeTimer(() => {
+      sharerEndedFlushTimerId = null;
+      flushSharerEndedSuppressionIfTerminal(armedUrl);
+    }, args.initialRoomStatePauseHoldMs);
     args.debugLog(
       `Suppressed sharer end-of-video broadcasts to keep autoplay-next handoff quiet`,
     );
     return true;
+  }
+
+  /**
+   * Resolve the armed sharer end-of-video suppression once its window elapses.
+   * If the marker is still set for the same shared URL and the player is still
+   * the sharer parked at the end of that video, no autoplay-next followed: clear
+   * the marker and broadcast the terminal paused state so peers and new joiners
+   * stop seeing the shared video as playing. If anything moved on (handoff,
+   * navigation, ownership change) the gate/reset already cleared it, so this is
+   * a no-op beyond tidying the marker.
+   */
+  function flushSharerEndedSuppressionIfTerminal(armedUrl: string): void {
+    if (args.runtimeState.sharerEndedSuppressionUrl !== armedUrl) {
+      return;
+    }
+    const video = getVideoElement();
+    const currentVideo = args.getSharedVideo();
+    // Require `ended` specifically: a genuine terminal end leaves the element
+    // parked at `ended`, whereas any autoplay continuation (cross-video or
+    // multi-part) clears it. This avoids flushing a spurious pause during a
+    // slow handoff where the next episode is mid-load.
+    const stillTerminalOnSameSharedVideo = Boolean(
+      video &&
+      video.ended &&
+      isLocalSharedSource() &&
+      isCurrentVideoShared(currentVideo) &&
+      args.normalizeUrl(currentVideo?.url) === armedUrl,
+    );
+    args.runtimeState.sharerEndedSuppressionUrl = null;
+    args.runtimeState.sharerEndedSuppressionUntil = 0;
+    args.runtimeState.sharerEndedSuppressionArmedAt = 0;
+    if (!video || !stillTerminalOnSameSharedVideo) {
+      return;
+    }
+    args.debugLog(
+      `Flushed sharer end-of-video paused state after no autoplay-next followed`,
+    );
+    void args.broadcastPlayback(video, "pause");
   }
 
   function shouldReapplyHoldAfterSharedVideoEnd(
@@ -762,6 +819,7 @@ export function createPlaybackBindingController(args: {
         videoBindingTimer = null;
       }
       clearBufferUpgradeTimer();
+      clearSharerEndedFlushTimer();
     },
   };
 }

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -144,6 +144,15 @@ export interface ContentRuntimeState {
    */
   sharerEndedSuppressionUrl: string | null;
   sharerEndedSuppressionUntil: number;
+  /**
+   * Timestamp at which [[sharerEndedSuppressionUrl]] was armed. A user replay
+   * gesture only releases the suppression when it postdates this; an older
+   * gesture (e.g. the sharer dragging to the end or pressing play moments
+   * before the natural end) must not be mistaken for a fresh replay, otherwise
+   * the next-episode seek-to-0 it precedes would leak out as the very
+   * "jumped to 0:00" noise this suppression exists to hide.
+   */
+  sharerEndedSuppressionArmedAt: number;
   festivalSnapshot: FestivalVideoSnapshot | null;
   /**
    * Timestamp of the most recent `waiting`/`stalled` event from the local
@@ -235,6 +244,7 @@ export function createContentRuntimeState(): ContentRuntimeState {
     postNavigationAnchorSetAt: 0,
     sharerEndedSuppressionUrl: null,
     sharerEndedSuppressionUntil: 0,
+    sharerEndedSuppressionArmedAt: 0,
     festivalSnapshot: null,
     lastBufferSignalAt: 0,
     pauseStartedAt: 0,

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -129,6 +129,21 @@ export interface ContentRuntimeState {
    */
   postNavigationAnchorSharedUrl: string | null;
   postNavigationAnchorSetAt: number;
+  /**
+   * Set when the local sharer's *own* shared video reaches its natural end.
+   * While set, playback broadcasts for this (still the room's) shared URL are
+   * suppressed so the autoplay-next handoff does not relay a misleading
+   * "paused"/"jumped to 0:00" against the old video to every peer: at a natural
+   * end the browser emits an end `pause`, and when Bilibili autoplays the next
+   * episode into the same element before the page URL refreshes, a `seek` back
+   * to 0 while the page bridge still resolves the old URL. The next auto-share
+   * lands moments later; suppressing this transition keeps peers from seeing
+   * those two spurious notifications before "shared a new video". Cleared when
+   * the next share confirms (via [[resetPlaybackSyncState]]), a fresh user
+   * gesture replays it, the page moves on, or [[sharerEndedSuppressionUntil]].
+   */
+  sharerEndedSuppressionUrl: string | null;
+  sharerEndedSuppressionUntil: number;
   festivalSnapshot: FestivalVideoSnapshot | null;
   /**
    * Timestamp of the most recent `waiting`/`stalled` event from the local
@@ -218,6 +233,8 @@ export function createContentRuntimeState(): ContentRuntimeState {
     lastNonSharedGuardUrl: null,
     postNavigationAnchorSharedUrl: null,
     postNavigationAnchorSetAt: 0,
+    sharerEndedSuppressionUrl: null,
+    sharerEndedSuppressionUntil: 0,
     festivalSnapshot: null,
     lastBufferSignalAt: 0,
     pauseStartedAt: 0,

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -253,6 +253,8 @@ export function createSyncController(args: {
     args.runtimeState.nonSharerAutoplayHoldUrl = null;
     args.runtimeState.postNavigationAnchorSharedUrl = null;
     args.runtimeState.postNavigationAnchorSetAt = 0;
+    args.runtimeState.sharerEndedSuppressionUrl = null;
+    args.runtimeState.sharerEndedSuppressionUntil = 0;
     args.debugLog(`Reset playback sync state: ${reason}`);
   }
 
@@ -733,6 +735,63 @@ export function createSyncController(args: {
       normalizedCurrentVideoUrl,
       now,
     );
+    // Sharer end-of-video handoff gate.
+    //
+    // When the local sharer's own shared video reaches its natural end, the
+    // browser emits an end `pause`, and when Bilibili autoplays the next episode
+    // into the same element before the page URL refreshes, a `seek` back to 0
+    // while the page bridge still resolves the *old* shared URL. Broadcasting
+    // either would relay a misleading "paused"/"jumped to 0:00" against the
+    // still-shared old video to every peer, moments before the auto-share of the
+    // next video lands. Suppress broadcasts for the ended shared URL until the
+    // next share confirms (which clears the marker via resetPlaybackSyncState),
+    // a fresh user gesture replays it, the page moves on to a different URL, or
+    // the bounded timeout elapses.
+    const sharerEndedUrl = args.runtimeState.sharerEndedSuppressionUrl;
+    if (sharerEndedUrl) {
+      const expired = now >= args.runtimeState.sharerEndedSuppressionUntil;
+      const movedOn = normalizedCurrentVideoUrl !== sharerEndedUrl;
+      const userReplayed =
+        now - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs;
+      if (!expired && !movedOn && !userReplayed) {
+        if (shouldLogSuppressedBroadcastDetail(eventSource)) {
+          args.debugLog(
+            `Skip broadcast ${formatPlaybackDiagnostic({
+              actor: args.runtimeState.localMemberId,
+              playState: getPlayState(
+                video,
+                args.runtimeState.intendedPlayState,
+              ),
+              url: currentVideo.url,
+              localTime: video.currentTime,
+              targetTime: video.currentTime,
+              result: "sharer-ended-handoff",
+              extra: `endedUrl=${sharerEndedUrl}`,
+            })}`,
+          );
+        }
+        logBroadcastTrace(
+          "sharer-ended-handoff",
+          eventSource,
+          formatBroadcastTrace({
+            eventSource,
+            currentVideoUrl: currentVideo.url,
+            normalizedCurrentVideoUrl,
+            playState: getPlayState(video, args.runtimeState.intendedPlayState),
+            currentTime: video.currentTime,
+            playbackRate: video.playbackRate,
+          }),
+          normalizedCurrentVideoUrl,
+          now,
+        );
+        return;
+      }
+      args.runtimeState.sharerEndedSuppressionUrl = null;
+      args.runtimeState.sharerEndedSuppressionUntil = 0;
+      args.debugLog(
+        `Cleared sharer end-of-video suppression (was ${sharerEndedUrl}, expired=${expired} movedOn=${movedOn} userReplayed=${userReplayed})`,
+      );
+    }
     // Post-navigation settle gate.
     //
     // After in-room SPA navigation, the page bridge can briefly return the

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -255,6 +255,7 @@ export function createSyncController(args: {
     args.runtimeState.postNavigationAnchorSetAt = 0;
     args.runtimeState.sharerEndedSuppressionUrl = null;
     args.runtimeState.sharerEndedSuppressionUntil = 0;
+    args.runtimeState.sharerEndedSuppressionArmedAt = 0;
     args.debugLog(`Reset playback sync state: ${reason}`);
   }
 
@@ -751,9 +752,23 @@ export function createSyncController(args: {
     if (sharerEndedUrl) {
       const expired = now >= args.runtimeState.sharerEndedSuppressionUntil;
       const movedOn = normalizedCurrentVideoUrl !== sharerEndedUrl;
+      // Only a gesture that postdates the arming counts as a fresh replay. An
+      // older gesture (the sharer dragging to the end / pressing play just
+      // before the natural end) precedes the next-episode seek-to-0 we are
+      // suppressing, so treating it as a replay would leak that seek out.
       const userReplayed =
-        now - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs;
-      if (!expired && !movedOn && !userReplayed) {
+        now - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs &&
+        args.runtimeState.lastUserGestureAt >
+          args.runtimeState.sharerEndedSuppressionArmedAt;
+      // Once the local member is no longer the sharer of this URL (e.g. another
+      // member re-shared the same URL, which updates the sharer id without
+      // changing the URL and so does not run resetPlaybackSyncState), the
+      // suppression must release so the new sharer's takeover can be reported.
+      const ownershipLost =
+        !args.runtimeState.localMemberId ||
+        args.runtimeState.activeSharedByMemberId !==
+          args.runtimeState.localMemberId;
+      if (!expired && !movedOn && !userReplayed && !ownershipLost) {
         if (shouldLogSuppressedBroadcastDetail(eventSource)) {
           args.debugLog(
             `Skip broadcast ${formatPlaybackDiagnostic({
@@ -788,8 +803,9 @@ export function createSyncController(args: {
       }
       args.runtimeState.sharerEndedSuppressionUrl = null;
       args.runtimeState.sharerEndedSuppressionUntil = 0;
+      args.runtimeState.sharerEndedSuppressionArmedAt = 0;
       args.debugLog(
-        `Cleared sharer end-of-video suppression (was ${sharerEndedUrl}, expired=${expired} movedOn=${movedOn} userReplayed=${userReplayed})`,
+        `Cleared sharer end-of-video suppression (was ${sharerEndedUrl}, expired=${expired} movedOn=${movedOn} userReplayed=${userReplayed} ownershipLost=${ownershipLost})`,
       );
     }
     // Post-navigation settle gate.

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -2008,3 +2008,132 @@ test("playback binding controller suppresses the natural-end pause for a non-sha
     dom.restore();
   }
 });
+
+test("playback binding controller suppresses the natural-end pause broadcast for the sharer without pausing it", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVshared";
+  runtimeState.pendingRoomStateHydration = false;
+  // The local member IS the sharer. Its own end-of-video pause must not be
+  // broadcast (it would relay a misleading "paused"/"jumped to 0:00" against the
+  // old video before the auto-share of the next video lands) — but unlike a
+  // non-sharer the sharer is NOT paused, so autoplay-next can continue.
+  runtimeState.localMemberId = "member-1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.intendedPlayState = "playing";
+  const events: string[] = [];
+  let pauseCalls = 0;
+  const originalPause = dom.video.pause;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    getSharedVideo: () => ({
+      videoId: "BVshared",
+      url: "https://www.bilibili.com/video/BVshared",
+      title: "Shared Video",
+      sharedByMemberId: "member-1",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async (_video, eventSource) => {
+      events.push(eventSource ?? "manual");
+    },
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 5_000,
+  });
+
+  dom.video.pause = () => {
+    pauseCalls += 1;
+    dom.video.paused = true;
+    return Promise.resolve();
+  };
+
+  try {
+    controller.attachPlaybackListeners();
+    // The browser dispatches `pause` (with `ended` already true) right before
+    // `ended` at the natural end of the sharer's own shared video.
+    (dom.video as { ended?: boolean }).ended = true;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+
+    await Promise.resolve();
+
+    // The end-pause is suppressed, the sharer is not force-paused, and broadcast
+    // suppression for the ended shared URL is armed for the autoplay-next handoff.
+    assert.deepEqual(events, []);
+    assert.equal(pauseCalls, 0);
+    assert.equal(runtimeState.intendedPlayState, "playing");
+    assert.equal(
+      runtimeState.sharerEndedSuppressionUrl,
+      "https://www.bilibili.com/video/BVshared",
+    );
+    assert.equal(runtimeState.sharerEndedSuppressionUntil, 8_000);
+  } finally {
+    dom.video.pause = originalPause;
+    dom.restore();
+  }
+});
+
+test("playback binding controller does not arm sharer end suppression for a non-sharer", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVshared";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.localMemberId = "member-2";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.intendedPlayState = "playing";
+  const originalPause = dom.video.pause;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    getSharedVideo: () => ({
+      videoId: "BVshared",
+      url: "https://www.bilibili.com/video/BVshared",
+      title: "Shared Video",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 5_000,
+  });
+
+  dom.video.pause = () => {
+    dom.video.paused = true;
+    return Promise.resolve();
+  };
+
+  try {
+    controller.attachPlaybackListeners();
+    (dom.video as { ended?: boolean }).ended = true;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+
+    await Promise.resolve();
+
+    // The non-sharer end-hold path handles this; the sharer marker stays unset.
+    assert.equal(runtimeState.sharerEndedSuppressionUrl, null);
+    assert.equal(runtimeState.sharerEndedSuppressionUntil, 0);
+  } finally {
+    dom.video.pause = originalPause;
+    dom.restore();
+  }
+});

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -2077,8 +2077,151 @@ test("playback binding controller suppresses the natural-end pause broadcast for
       "https://www.bilibili.com/video/BVshared",
     );
     assert.equal(runtimeState.sharerEndedSuppressionUntil, 8_000);
+    assert.equal(runtimeState.sharerEndedSuppressionArmedAt, 5_000);
   } finally {
     dom.video.pause = originalPause;
+    dom.restore();
+  }
+});
+
+test("playback binding controller flushes the sharer's terminal paused state when no autoplay-next follows", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  const sharedUrl = "https://www.bilibili.com/video/BVshared";
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.activeSharedUrl = sharedUrl;
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.localMemberId = "member-1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.intendedPlayState = "playing";
+  const events: string[] = [];
+  const scheduled: Array<{ cb: () => void; ms: number }> = [];
+  const originalSetTimeout = globalThis.window.setTimeout;
+  // Capture the deferred flush timer instead of letting it fire on a real clock.
+  globalThis.window.setTimeout = ((cb: () => void, ms?: number) => {
+    scheduled.push({ cb, ms: ms ?? 0 });
+    return scheduled.length;
+  }) as unknown as typeof globalThis.window.setTimeout;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    getSharedVideo: () => ({
+      videoId: "BVshared",
+      url: sharedUrl,
+      title: "Shared Video",
+      sharedByMemberId: "member-1",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async (_video, eventSource) => {
+      events.push(eventSource ?? "manual");
+    },
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 5_000,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    (dom.video as { ended?: boolean }).ended = true;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+    await Promise.resolve();
+
+    // The end-pause was suppressed and a flush timer armed.
+    assert.deepEqual(events, []);
+    const flush = scheduled.find((entry) => entry.ms === 3_000);
+    assert.ok(
+      flush,
+      "a flush timer should be scheduled for the suppression window",
+    );
+
+    // The window elapses with the player still parked at the end (no
+    // autoplay-next): the terminal paused state is flushed and the marker cleared.
+    flush?.cb();
+    await Promise.resolve();
+
+    assert.deepEqual(events, ["pause"]);
+    assert.equal(runtimeState.sharerEndedSuppressionUrl, null);
+    assert.equal(runtimeState.sharerEndedSuppressionUntil, 0);
+    assert.equal(runtimeState.sharerEndedSuppressionArmedAt, 0);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.restore();
+  }
+});
+
+test("playback binding controller does not flush a sharer end state once autoplay-next has continued", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  const sharedUrl = "https://www.bilibili.com/video/BVshared";
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.activeSharedUrl = sharedUrl;
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.localMemberId = "member-1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.intendedPlayState = "playing";
+  const events: string[] = [];
+  const scheduled: Array<{ cb: () => void; ms: number }> = [];
+  const originalSetTimeout = globalThis.window.setTimeout;
+  globalThis.window.setTimeout = ((cb: () => void, ms?: number) => {
+    scheduled.push({ cb, ms: ms ?? 0 });
+    return scheduled.length;
+  }) as unknown as typeof globalThis.window.setTimeout;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    getSharedVideo: () => ({
+      videoId: "BVshared",
+      url: sharedUrl,
+      title: "Shared Video",
+      sharedByMemberId: "member-1",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async (_video, eventSource) => {
+      events.push(eventSource ?? "manual");
+    },
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 5_000,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    (dom.video as { ended?: boolean }).ended = true;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+    await Promise.resolve();
+
+    const flush = scheduled.find((entry) => entry.ms === 3_000);
+    assert.ok(flush);
+
+    // Autoplay-next started: the element resumed (no longer `ended`).
+    (dom.video as { ended?: boolean }).ended = false;
+    dom.video.paused = false;
+    flush?.cb();
+    await Promise.resolve();
+
+    // No terminal pause is broadcast; the marker is just tidied.
+    assert.deepEqual(events, []);
+    assert.equal(runtimeState.sharerEndedSuppressionUrl, null);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
     dom.restore();
   }
 });

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -1301,6 +1301,137 @@ test("sync controller releases post-navigation anchor and broadcasts once resolv
   );
 });
 
+test("sync controller suppresses broadcast while sharer end-of-video marker matches the shared url", async () => {
+  const harness = createControllerHarness();
+  const sharedUrl = "https://www.bilibili.com/video/BVshared?p=1";
+  const sharedVideo: SharedVideo = {
+    videoId: "BVshared:p1",
+    url: sharedUrl,
+    title: "Shared Video",
+  };
+  const video = createVideo({ paused: false, currentTime: 0 });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.activeRoomCode = "ROOM01";
+  harness.runtimeState.activeSharedUrl = sharedUrl;
+  harness.runtimeState.sharerEndedSuppressionUrl = sharedUrl;
+  harness.runtimeState.sharerEndedSuppressionUntil = 23_000;
+  harness.runtimeState.lastUserGestureAt = 0;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+
+  // The natural-end pause for the old shared video must not leak out as a
+  // "paused the video" against it during the autoplay-next handoff.
+  await harness.controller.broadcastPlayback(video, "pause");
+
+  assert.equal(harness.runtimeMessages.length, 0);
+  assert.equal(
+    harness.runtimeState.sharerEndedSuppressionUrl,
+    sharedUrl,
+    "marker must remain set while still suppressing the ended shared url",
+  );
+  assert.equal(
+    harness.debugLogs.some((message) =>
+      message.includes("sharer-ended-handoff"),
+    ),
+    true,
+  );
+});
+
+test("sync controller releases sharer end-of-video marker after timeout", async () => {
+  const harness = createControllerHarness();
+  const sharedUrl = "https://www.bilibili.com/video/BVshared?p=1";
+  const sharedVideo: SharedVideo = {
+    videoId: "BVshared:p1",
+    url: sharedUrl,
+    title: "Shared Video",
+  };
+  const video = createVideo({ paused: false, currentTime: 0 });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.activeRoomCode = "ROOM01";
+  harness.runtimeState.activeSharedUrl = sharedUrl;
+  harness.runtimeState.sharerEndedSuppressionUrl = sharedUrl;
+  harness.runtimeState.sharerEndedSuppressionUntil = 19_000;
+  harness.runtimeState.lastUserGestureAt = 0;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+
+  await harness.controller.broadcastPlayback(video, "seeked");
+
+  assert.equal(harness.runtimeState.sharerEndedSuppressionUrl, null);
+  assert.equal(harness.runtimeState.sharerEndedSuppressionUntil, 0);
+  assert.equal(harness.runtimeMessages.length >= 1, true);
+});
+
+test("sync controller releases sharer end-of-video marker on a fresh user replay gesture", async () => {
+  const harness = createControllerHarness();
+  const sharedUrl = "https://www.bilibili.com/video/BVshared?p=1";
+  const sharedVideo: SharedVideo = {
+    videoId: "BVshared:p1",
+    url: sharedUrl,
+    title: "Shared Video",
+  };
+  const video = createVideo({ paused: false, currentTime: 0 });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.activeRoomCode = "ROOM01";
+  harness.runtimeState.activeSharedUrl = sharedUrl;
+  harness.runtimeState.sharerEndedSuppressionUrl = sharedUrl;
+  harness.runtimeState.sharerEndedSuppressionUntil = 23_000;
+  // The sharer manually replays the ended video within the gesture grace window.
+  harness.runtimeState.lastUserGestureAt = 19_900;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+
+  await harness.controller.broadcastPlayback(video, "seeked");
+
+  assert.equal(harness.runtimeState.sharerEndedSuppressionUrl, null);
+  assert.equal(harness.runtimeMessages.length >= 1, true);
+});
+
+test("sync controller releases sharer end-of-video marker once the resolved url moves on", async () => {
+  const harness = createControllerHarness();
+  const oldUrl = "https://www.bilibili.com/video/BVshared?p=1";
+  const newUrl = "https://www.bilibili.com/video/BVshared?p=2";
+  const newSharedVideo: SharedVideo = {
+    videoId: "BVshared:p2",
+    url: newUrl,
+    title: "Shared Video Part 2",
+  };
+  const video = createVideo({ paused: false, currentTime: 3 });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.activeRoomCode = "ROOM01";
+  // The room has not confirmed the next share yet, so activeSharedUrl is still
+  // the old video; the resolved page url already moved to the next episode.
+  harness.runtimeState.activeSharedUrl = oldUrl;
+  harness.runtimeState.sharerEndedSuppressionUrl = oldUrl;
+  harness.runtimeState.sharerEndedSuppressionUntil = 23_000;
+  harness.runtimeState.lastUserGestureAt = 0;
+  harness.setSharedVideo(newSharedVideo);
+  harness.setCurrentPlaybackVideo(newSharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+
+  await harness.controller.broadcastPlayback(video, "seeked");
+
+  // The marker is released; the broadcast for the new (not-yet-shared) url is
+  // then handled by the existing non-shared-video guard, so no message leaks.
+  assert.equal(harness.runtimeState.sharerEndedSuppressionUrl, null);
+  assert.equal(harness.runtimeState.sharerEndedSuppressionUntil, 0);
+});
+
 test("sync controller broadcasts buffering when active pause is classified as buffer", async () => {
   const harness = createControllerHarness();
   const sharedVideo = {

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -1315,8 +1315,11 @@ test("sync controller suppresses broadcast while sharer end-of-video marker matc
   harness.runtimeState.pendingRoomStateHydration = false;
   harness.runtimeState.activeRoomCode = "ROOM01";
   harness.runtimeState.activeSharedUrl = sharedUrl;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.activeSharedByMemberId = "local-member";
   harness.runtimeState.sharerEndedSuppressionUrl = sharedUrl;
   harness.runtimeState.sharerEndedSuppressionUntil = 23_000;
+  harness.runtimeState.sharerEndedSuppressionArmedAt = 19_000;
   harness.runtimeState.lastUserGestureAt = 0;
   harness.setSharedVideo(sharedVideo);
   harness.setCurrentPlaybackVideo(sharedVideo);
@@ -1355,8 +1358,11 @@ test("sync controller releases sharer end-of-video marker after timeout", async 
   harness.runtimeState.pendingRoomStateHydration = false;
   harness.runtimeState.activeRoomCode = "ROOM01";
   harness.runtimeState.activeSharedUrl = sharedUrl;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.activeSharedByMemberId = "local-member";
   harness.runtimeState.sharerEndedSuppressionUrl = sharedUrl;
   harness.runtimeState.sharerEndedSuppressionUntil = 19_000;
+  harness.runtimeState.sharerEndedSuppressionArmedAt = 16_000;
   harness.runtimeState.lastUserGestureAt = 0;
   harness.setSharedVideo(sharedVideo);
   harness.setCurrentPlaybackVideo(sharedVideo);
@@ -1367,6 +1373,7 @@ test("sync controller releases sharer end-of-video marker after timeout", async 
 
   assert.equal(harness.runtimeState.sharerEndedSuppressionUrl, null);
   assert.equal(harness.runtimeState.sharerEndedSuppressionUntil, 0);
+  assert.equal(harness.runtimeState.sharerEndedSuppressionArmedAt, 0);
   assert.equal(harness.runtimeMessages.length >= 1, true);
 });
 
@@ -1384,9 +1391,14 @@ test("sync controller releases sharer end-of-video marker on a fresh user replay
   harness.runtimeState.pendingRoomStateHydration = false;
   harness.runtimeState.activeRoomCode = "ROOM01";
   harness.runtimeState.activeSharedUrl = sharedUrl;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.activeSharedByMemberId = "local-member";
   harness.runtimeState.sharerEndedSuppressionUrl = sharedUrl;
   harness.runtimeState.sharerEndedSuppressionUntil = 23_000;
-  // The sharer manually replays the ended video within the gesture grace window.
+  // The suppression was armed before the replay gesture below.
+  harness.runtimeState.sharerEndedSuppressionArmedAt = 19_000;
+  // The sharer manually replays the ended video within the gesture grace window,
+  // and the gesture postdates the arming, so it counts as a fresh replay.
   harness.runtimeState.lastUserGestureAt = 19_900;
   harness.setSharedVideo(sharedVideo);
   harness.setCurrentPlaybackVideo(sharedVideo);
@@ -1396,6 +1408,76 @@ test("sync controller releases sharer end-of-video marker on a fresh user replay
   await harness.controller.broadcastPlayback(video, "seeked");
 
   assert.equal(harness.runtimeState.sharerEndedSuppressionUrl, null);
+  assert.equal(harness.runtimeMessages.length >= 1, true);
+});
+
+test("sync controller keeps suppressing when a stale gesture predates the end-of-video arming", async () => {
+  const harness = createControllerHarness();
+  const sharedUrl = "https://www.bilibili.com/video/BVshared?p=1";
+  const sharedVideo: SharedVideo = {
+    videoId: "BVshared:p1",
+    url: sharedUrl,
+    title: "Shared Video",
+  };
+  const video = createVideo({ paused: false, currentTime: 0 });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.activeRoomCode = "ROOM01";
+  harness.runtimeState.activeSharedUrl = sharedUrl;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.activeSharedByMemberId = "local-member";
+  harness.runtimeState.sharerEndedSuppressionUrl = sharedUrl;
+  harness.runtimeState.sharerEndedSuppressionUntil = 23_000;
+  // The suppression was armed AFTER the last gesture: the sharer dragged to the
+  // end / pressed play moments before the natural end, then the video ended.
+  harness.runtimeState.sharerEndedSuppressionArmedAt = 19_950;
+  harness.runtimeState.lastUserGestureAt = 19_900;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+
+  // The next-episode seek-to-0 must stay suppressed: the stale gesture is not a
+  // replay, so it must not release the marker and leak a "jumped to 0:00".
+  await harness.controller.broadcastPlayback(video, "seeked");
+
+  assert.equal(harness.runtimeMessages.length, 0);
+  assert.equal(harness.runtimeState.sharerEndedSuppressionUrl, sharedUrl);
+});
+
+test("sync controller releases end-of-video suppression once the local member is no longer the sharer", async () => {
+  const harness = createControllerHarness();
+  const sharedUrl = "https://www.bilibili.com/video/BVshared?p=1";
+  const sharedVideo: SharedVideo = {
+    videoId: "BVshared:p1",
+    url: sharedUrl,
+    title: "Shared Video",
+  };
+  const video = createVideo({ paused: false, currentTime: 5 });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.activeRoomCode = "ROOM01";
+  harness.runtimeState.activeSharedUrl = sharedUrl;
+  harness.runtimeState.localMemberId = "local-member";
+  // Another member re-shared the same URL: the sharer id flips without a URL
+  // change, so resetPlaybackSyncState never ran to clear the marker.
+  harness.runtimeState.activeSharedByMemberId = "other-member";
+  harness.runtimeState.sharerEndedSuppressionUrl = sharedUrl;
+  harness.runtimeState.sharerEndedSuppressionUntil = 23_000;
+  harness.runtimeState.sharerEndedSuppressionArmedAt = 19_000;
+  harness.runtimeState.lastUserGestureAt = 0;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+
+  await harness.controller.broadcastPlayback(video, "seeked");
+
+  assert.equal(harness.runtimeState.sharerEndedSuppressionUrl, null);
+  assert.equal(harness.runtimeState.sharerEndedSuppressionUntil, 0);
+  assert.equal(harness.runtimeState.sharerEndedSuppressionArmedAt, 0);
   assert.equal(harness.runtimeMessages.length >= 1, true);
 });
 
@@ -1416,8 +1498,11 @@ test("sync controller releases sharer end-of-video marker once the resolved url 
   // The room has not confirmed the next share yet, so activeSharedUrl is still
   // the old video; the resolved page url already moved to the next episode.
   harness.runtimeState.activeSharedUrl = oldUrl;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.activeSharedByMemberId = "local-member";
   harness.runtimeState.sharerEndedSuppressionUrl = oldUrl;
   harness.runtimeState.sharerEndedSuppressionUntil = 23_000;
+  harness.runtimeState.sharerEndedSuppressionArmedAt = 19_000;
   harness.runtimeState.lastUserGestureAt = 0;
   harness.setSharedVideo(newSharedVideo);
   harness.setCurrentPlaybackVideo(newSharedVideo);


### PR DESCRIPTION
## 问题

自动连播时,共享者自动共享下一个视频,其它端会同时弹出三条 toast:

1. `xx 暂停了视频`
2. `xx 跳转到 0:00`
3. `xx 共享了新视频:`

只有第三条是预期的,前两条有误导性。

## 根因

前两条来自**共享者**在"旧视频自然结束 → 自动换集"的过渡窗口里,对**旧共享 URL** 广播的瞬时播放状态:

1. 视频自然结束 → 浏览器派发 `pause`(旧视频),共享者广播出去 → 接收端 `xx 暂停了视频`
2. B 站把下一集载入同一 `<video>` 元素、`currentTime` 归 0,而页面桥此刻仍解析为旧 URL → 广播一条 seek-to-0 → 接收端 `xx 跳转到 0:00`
3. 随后 auto-share 落地 → `xx 共享了新视频`(预期)

接收端 toast 逻辑本就在 `sharedVideoChanged` 时抑制 pause/seek 通知,所以这纯粹是**时序问题**——前两条广播比新共享早到一拍。

## 修复(发送端根治)

- 当**本地共享者自己的**共享视频自然结束时(`onPause` / `onEnded`),置位抑制标记 `sharerEndedSuppressionUrl`,**但不暂停播放器**(自动连播需要继续播放)。
- `broadcastPlayback` 新增闸门:丢弃对该旧共享 URL 的所有后续播放广播,直到以下任一条件:
  - 新共享确认(经 `resetPlaybackSyncState` 清除标记)
  - 用户手动操作重播(`lastUserGestureAt` 命中宽限期)
  - 页面切到不同 URL
  - 3s 超时兜底

相比接收端去抖,发送端根治还顺带消除了旧视频在各端被瞬时翻成"暂停 / 0:00"的状态抖动。手动暂停/拖动、非共享者的结束保持逻辑均不受影响。

## 测试

新增 6 个回归测试:

- `playback-binding-controller.test.ts`:共享者结束置位标记且不暂停 / 非共享者不误置位
- `sync-controller.test.ts`:闸门抑制广播 / 超时释放 / 用户重播释放 / 页面切走释放

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` 全部通过(402 tests pass)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
