### PR TITLE
feat: toast the sharer when autoplay auto-continues to the next video

### DIFF
--- a/extension/src/content/room-state-controller.ts
+++ b/extension/src/content/room-state-controller.ts
@@ -75,6 +75,7 @@ export function createRoomStateController(args: {
       lastSharedVideoToastKey: args.toastState.lastSharedVideoToastKey,
       normalizedToastUrl: args.normalizeUrl(toast?.videoUrl),
       normalizedSharedUrl: args.normalizeUrl(state.sharedVideo?.url),
+      localAutoShareTargetUrl: args.runtimeState.pendingAutoShareTargetUrl,
     });
     args.toastState.lastSharedVideoToastKey = plan.nextSharedVideoToastKey;
     if (plan.message) {

--- a/extension/src/content/toast.ts
+++ b/extension/src/content/toast.ts
@@ -301,6 +301,14 @@ export function getSharedVideoToastMessage(args: {
   lastSharedVideoToastKey: string | null;
   normalizedToastUrl: string | null;
   normalizedSharedUrl: string | null;
+  /**
+   * The normalized URL the local sharer is auto-continuing to (set while a
+   * sharer-autoplay auto-share is pending confirmation). When the confirmed
+   * shared video is the local member's own and matches this URL, surface a
+   * dedicated "auto-continued" toast instead of staying silent — unlike a
+   * manual share, the sharer did not explicitly act, so a hint is warranted.
+   */
+  localAutoShareTargetUrl?: string | null;
 }): {
   message: string | null;
   nextSharedVideoToastKey: string | null;
@@ -323,8 +331,20 @@ export function getSharedVideoToastMessage(args: {
     };
   }
 
+  if (args.toast.actorId === args.localMemberId) {
+    const isLocalAutoShareContinuation =
+      args.localAutoShareTargetUrl != null &&
+      args.normalizedToastUrl === args.localAutoShareTargetUrl;
+    return {
+      message: isLocalAutoShareContinuation
+        ? t("toastAutoSharedNextVideo", { title: args.toast.title })
+        : null,
+      nextSharedVideoToastKey: args.toast.key,
+    };
+  }
+
   const actorName = getMemberName(args.state, args.toast.actorId);
-  if (!actorName || args.toast.actorId === args.localMemberId) {
+  if (!actorName) {
     return {
       message: null,
       nextSharedVideoToastKey: args.toast.key,

--- a/extension/src/shared/i18n.ts
+++ b/extension/src/shared/i18n.ts
@@ -99,6 +99,7 @@ const MESSAGES: Record<"zh" | "en", MessageCatalog> = {
     toastSwitchedRate: "{name} 切换到 {rate}",
     toastSeekedTo: "{name} 跳转到 {time}",
     toastSharedNewVideo: "{name} 共享了新视频：{title}",
+    toastAutoSharedNextVideo: "已自动连播并共享下一个视频：{title}",
   },
   en: {
     popupTitle: "Bili SyncPlay",
@@ -198,6 +199,8 @@ const MESSAGES: Record<"zh" | "en", MessageCatalog> = {
     toastSwitchedRate: "{name} switched to {rate}",
     toastSeekedTo: "{name} jumped to {time}",
     toastSharedNewVideo: "{name} shared a new video: {title}",
+    toastAutoSharedNextVideo:
+      "Auto-continued and shared the next video: {title}",
   },
 };
 

--- a/extension/test/room-state-controller.test.ts
+++ b/extension/test/room-state-controller.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { RoomState } from "@bili-syncplay/protocol";
+import type { SharedVideoToastPayload } from "../src/shared/messages";
+import { createRoomStateController } from "../src/content/room-state-controller";
+import { createContentRuntimeState } from "../src/content/runtime-state";
+import { createToastCoordinatorState } from "../src/content/toast";
+import { setLocaleForTests } from "../src/shared/i18n";
+
+function createController(shownToasts: string[]) {
+  const runtimeState = createContentRuntimeState();
+  runtimeState.localMemberId = "self";
+  const controller = createRoomStateController({
+    runtimeState,
+    toastState: createToastCoordinatorState(),
+    toastPresenter: {
+      resetMountTarget: () => {},
+      show: (message) => shownToasts.push(message),
+    },
+    getSharedVideo: () => null,
+    normalizeUrl: (url) => url ?? null,
+    debugLog: () => {},
+    resetPlaybackSyncState: () => {},
+    scheduleHydrationRetry: () => {},
+  });
+  return { controller, runtimeState };
+}
+
+const sharedUrl = "https://www.bilibili.com/video/BV1?p=2";
+
+function createState(): RoomState {
+  return {
+    roomCode: "ROOM01",
+    sharedVideo: { videoId: "BV1:p2", url: sharedUrl, title: "第 2 集" },
+    playback: null,
+    members: [{ id: "self", name: "Me" }],
+  };
+}
+
+function createToast(): SharedVideoToastPayload {
+  return {
+    key: "toast-1",
+    actorId: "self",
+    title: "第 2 集",
+    videoUrl: sharedUrl,
+  };
+}
+
+test("room state controller shows an auto-continue toast for the local sharer's pending auto-share", () => {
+  setLocaleForTests("zh-CN");
+  const shownToasts: string[] = [];
+  const { controller, runtimeState } = createController(shownToasts);
+  // The sharer autoplayed to the next episode and is auto-sharing it.
+  runtimeState.pendingAutoShareTargetUrl = sharedUrl;
+
+  controller.maybeShowSharedVideoToast(createToast(), createState());
+
+  assert.deepEqual(shownToasts, ["已自动连播并共享下一个视频：第 2 集"]);
+  setLocaleForTests(null);
+});
+
+test("room state controller stays silent for the local sharer's manual share", () => {
+  setLocaleForTests("zh-CN");
+  const shownToasts: string[] = [];
+  const { controller, runtimeState } = createController(shownToasts);
+  // No pending auto-share: this is a manual self-share.
+  runtimeState.pendingAutoShareTargetUrl = null;
+
+  controller.maybeShowSharedVideoToast(createToast(), createState());
+
+  assert.deepEqual(shownToasts, []);
+  setLocaleForTests(null);
+});

--- a/extension/test/toast.test.ts
+++ b/extension/test/toast.test.ts
@@ -248,3 +248,86 @@ test("builds English toast messages when the UI language is English", () => {
   assert.equal(sharedVideo.message, "Alice shared a new video: New Video");
   setLocaleForTests(null);
 });
+
+test("stays silent for the local member's own manual share", () => {
+  setLocaleForTests("zh-CN");
+  const state = createRoomState({
+    members: [{ id: "self", name: "Me" }],
+    sharedUrl: "https://www.bilibili.com/video/BV1?p=2",
+  });
+
+  const result = getSharedVideoToastMessage({
+    toast: {
+      key: "toast-self-1",
+      actorId: "self",
+      title: "My Video",
+      videoUrl: "https://www.bilibili.com/video/BV1?p=2",
+    },
+    state,
+    localMemberId: "self",
+    lastSharedVideoToastKey: null,
+    normalizedToastUrl: "https://www.bilibili.com/video/BV1?p=2",
+    normalizedSharedUrl: "https://www.bilibili.com/video/BV1?p=2",
+    // No pending auto-share: a manual self-share must stay silent.
+    localAutoShareTargetUrl: null,
+  });
+
+  assert.equal(result.message, null);
+  assert.equal(result.nextSharedVideoToastKey, "toast-self-1");
+  setLocaleForTests(null);
+});
+
+test("surfaces an auto-continue toast for the local sharer's autoplay-next share", () => {
+  setLocaleForTests("zh-CN");
+  const state = createRoomState({
+    members: [{ id: "self", name: "Me" }],
+    sharedUrl: "https://www.bilibili.com/video/BV1?p=2",
+  });
+
+  const result = getSharedVideoToastMessage({
+    toast: {
+      key: "toast-self-auto-1",
+      actorId: "self",
+      title: "第 2 集",
+      videoUrl: "https://www.bilibili.com/video/BV1?p=2",
+    },
+    state,
+    localMemberId: "self",
+    lastSharedVideoToastKey: null,
+    normalizedToastUrl: "https://www.bilibili.com/video/BV1?p=2",
+    normalizedSharedUrl: "https://www.bilibili.com/video/BV1?p=2",
+    // The room confirmed the very video this sharer auto-continued to.
+    localAutoShareTargetUrl: "https://www.bilibili.com/video/BV1?p=2",
+  });
+
+  assert.equal(result.message, "已自动连播并共享下一个视频：第 2 集");
+  assert.equal(result.nextSharedVideoToastKey, "toast-self-auto-1");
+  setLocaleForTests(null);
+});
+
+test("does not auto-continue toast when the pending target is a different video", () => {
+  setLocaleForTests("en");
+  const state = createRoomState({
+    members: [{ id: "self", name: "Me" }],
+    sharedUrl: "https://www.bilibili.com/video/BV1?p=2",
+  });
+
+  const result = getSharedVideoToastMessage({
+    toast: {
+      key: "toast-self-auto-2",
+      actorId: "self",
+      title: "Episode 2",
+      videoUrl: "https://www.bilibili.com/video/BV1?p=2",
+    },
+    state,
+    localMemberId: "self",
+    lastSharedVideoToastKey: null,
+    normalizedToastUrl: "https://www.bilibili.com/video/BV1?p=2",
+    normalizedSharedUrl: "https://www.bilibili.com/video/BV1?p=2",
+    // A stale pending target for a different episode must not trigger the toast.
+    localAutoShareTargetUrl: "https://www.bilibili.com/video/BV1?p=3",
+  });
+
+  assert.equal(result.message, null);
+  setLocaleForTests(null);
+});


### PR DESCRIPTION
## 背景

自动连播时,共享者自动共享下一集,**其它端**会收到 `xx 共享了新视频:` 的 toast,但**共享端自己看不到任何提示**——因为共享者对自己分享的视频是刻意静音的(`getSharedVideoToastMessage` 对 `actorId === localMemberId` 返回 `null`,手动分享无需回显)。但自动连播并非用户的显式操作,共享者应当知道房间已经切到了下一集。

## 改动

当满足以下条件时,给共享端补一条专用 toast:

- 确认的共享视频是**本地成员自己**的(`actorId === localMemberId`),且
- 其 URL 命中待确认的连播自动共享目标(`runtimeState.pendingAutoShareTargetUrl`)

`maybeShowSharedVideoToast` 在 `switchActiveSharedUrlWithReset` 清除该标记**之前**执行,所以 toast 时刻信号仍然有效;现有的 `lastSharedVideoToastKey` 去重保证每次分享只弹一次。手动自分享(无 pending 目标)仍保持静音。

新增文案 `toastAutoSharedNextVideo`:
- 中文:`已自动连播并共享下一个视频:{title}`
- English:`Auto-continued and shared the next video: {title}`

## 兼容性

**纯发送端、纯本地**:不改协议、不加任何线上消息类型,因此与旧客户端在混合房间里完全兼容。

## 测试

新增 5 个回归测试:
- `toast.test.ts`:手动自分享静音 / 连播自分享弹 toast / pending 目标是别的视频时不弹
- `room-state-controller.test.ts`:端到端验证 `pendingAutoShareTargetUrl` 接线(弹/不弹)

`format:check / lint / typecheck / build / test` 全绿(411 tests pass)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
