### PR TITLE
fix: auto-share next episode from bangumi season pages (+ auto-share diagnostics)

### DIFF
--- a/extension/src/content/auto-share-next-controller.ts
+++ b/extension/src/content/auto-share-next-controller.ts
@@ -141,6 +141,9 @@ export function createAutoShareNextController(args: {
         targetNormalizedUrl: pending.targetNormalizedUrl,
       },
     };
+    args.debugLog(
+      `Auto-share sending to background target=${pending.targetNormalizedUrl} from=${previousSharedUrl} attempt=${pending.attempt}/${maxAttempts} gen=${pending.generation}`,
+    );
     const response =
       await args.runtimeSendMessage<ShareCurrentVideoResponse>(message);
 
@@ -148,6 +151,9 @@ export function createAutoShareNextController(args: {
     // generation, even if it targets the same URL). Abandon this stale request
     // so its retry cannot cancel the newer navigation's pending timer.
     if (pending.generation !== scheduleGeneration) {
+      args.debugLog(
+        `Auto-share response ignored: superseded gen ${pending.generation} != ${scheduleGeneration} target=${pending.targetNormalizedUrl}`,
+      );
       return;
     }
 
@@ -182,6 +188,14 @@ export function createAutoShareNextController(args: {
       args.debugLog(
         `Auto-share next video gave up after ${maxAttempts} attempts${response.error ? `: ${response.error}` : ""}`,
       );
+    } else {
+      // ok:true (or a null response) — the background either shared the next
+      // video or intentionally skipped it (moved-on / not the source tab).
+      // Either way the request was delivered, so a "no auto-share happened"
+      // report can be told apart from "the request was never sent".
+      args.debugLog(
+        `Auto-share accepted by background (ok=${response?.ok ?? "null"}) target=${pending.targetNormalizedUrl} from=${previousSharedUrl}`,
+      );
     }
   }
 
@@ -197,6 +211,9 @@ export function createAutoShareNextController(args: {
     previousAutoShareTargetUrl?: string | null;
   }): void {
     if (input.previousSharedUrl === input.nextNormalizedPageUrl) {
+      args.debugLog(
+        `Auto-share schedule skipped: target equals previous shared url ${input.nextNormalizedPageUrl}`,
+      );
       return;
     }
     // A fresh (non-chained) auto-share starts a new lineage: the room cannot be
@@ -218,10 +235,16 @@ export function createAutoShareNextController(args: {
       pendingNormalizedUrl === input.nextNormalizedPageUrl &&
       pendingPreviousSharedUrl === input.previousSharedUrl
     ) {
+      args.debugLog(
+        `Auto-share schedule coalesced into the pending request for ${input.nextNormalizedPageUrl} (from ${input.previousSharedUrl})`,
+      );
       return;
     }
 
     scheduleGeneration += 1;
+    args.debugLog(
+      `Auto-share scheduled target=${input.nextNormalizedPageUrl} from=${input.previousSharedUrl} chained=${input.previousAutoShareTargetUrl != null} gen=${scheduleGeneration} delayMs=${args.settleDelayMs}`,
+    );
     scheduleRequest(
       {
         previousSharedUrl: input.previousSharedUrl,
@@ -234,6 +257,12 @@ export function createAutoShareNextController(args: {
   }
 
   function cancelPending(): void {
+    // DIAGNOSTIC: capture whether a request was actually pending/in-flight
+    // before we tear it down, so a cancel that drops a legitimately-scheduled
+    // auto-share (e.g. a follow-up navigation tick firing before the settle
+    // delay elapses) is visible rather than silent.
+    const hadTimer = pendingTimer !== null;
+    const pendingTarget = pendingNormalizedUrl;
     clearPendingTimer();
     pendingNormalizedUrl = null;
     pendingPreviousSharedUrl = null;
@@ -241,6 +270,11 @@ export function createAutoShareNextController(args: {
     // rescheduling — a manual/non-autoplay navigation must fully invalidate a
     // pending auto-share, including one already awaiting the background.
     scheduleGeneration += 1;
+    if (hadTimer || pendingTarget !== null) {
+      args.debugLog(
+        `Auto-share cancelled (hadPendingTimer=${hadTimer} pendingTarget=${pendingTarget}); generation bumped to ${scheduleGeneration}`,
+      );
+    }
   }
 
   function destroy(): void {

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -76,14 +76,22 @@ export function createNavigationController(args: {
     // is itself a sharer autoplay-next.
     const previousPendingAutoShareTargetUrl =
       args.runtimeState.pendingAutoShareTargetUrl;
-    // End-of-shared-video markers, captured before `resetUserGestureState` below
-    // clears the non-sharer one (`suppressedLocalEndPauseUrl`). They let the
+    // End-of-shared-video markers (with their expiry), captured before
+    // `resetUserGestureState` below clears the non-sharer one
+    // (`suppressedLocalEndPauseUrl` / `...Until`). They let the
     // autoplay-from-shared check recognise a season-page autoplay whose previous
-    // page URL is the season URL rather than the shared episode URL.
+    // page URL is the season URL rather than the shared episode URL. The expiry
+    // matters because these markers are cleared lazily: a stale one left past
+    // its hold window must not turn a later unrelated navigation (still on the
+    // same `activeSharedUrl`) into a misclassified autoplay-next.
     const previousSharerEndedSuppressionUrl =
       args.runtimeState.sharerEndedSuppressionUrl;
+    const previousSharerEndedSuppressionUntil =
+      args.runtimeState.sharerEndedSuppressionUntil;
     const previousSuppressedLocalEndPauseUrl =
       args.runtimeState.suppressedLocalEndPauseUrl;
+    const previousSuppressedLocalEndPauseUntil =
+      args.runtimeState.suppressedLocalEndPauseUntil;
     lastObservedPageUrl = nextPageUrl;
     lastObservedNormalizedPageUrl = nextNormalizedPageUrl;
     args.clearFestivalSnapshot();
@@ -190,8 +198,10 @@ export function createNavigationController(args: {
       // change / room reset, so they cannot leak into an unrelated navigation.
       const navigatedFromSharedVideoEnd =
         activeSharedUrl !== null &&
-        (previousSharerEndedSuppressionUrl === activeSharedUrl ||
-          previousSuppressedLocalEndPauseUrl === activeSharedUrl);
+        ((previousSharerEndedSuppressionUrl === activeSharedUrl &&
+          now < previousSharerEndedSuppressionUntil) ||
+          (previousSuppressedLocalEndPauseUrl === activeSharedUrl &&
+            now < previousSuppressedLocalEndPauseUntil));
       const navigatedFromSharedVideo =
         navigatedFromSharedVideoEnd ||
         (previousNormalizedPageUrl !== null &&

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -93,6 +93,17 @@ export function createNavigationController(args: {
       !args.runtimeState.activeRoomCode ||
       !args.isSupportedVideoPage(nextPageUrl)
     ) {
+      // DIAGNOSTIC: this early bail runs *after* cancelAutoShareNextVideo above,
+      // so a transient non-video URL (e.g. a mid-SPA redirect during bangumi
+      // autoplay) silently cancels a still-pending auto-share without logging.
+      // Surface it so we can confirm whether it is what drops the auto-share.
+      args.debugLog(
+        `Navigation to ${nextPageUrl} bailed early (activeRoom=${Boolean(
+          args.runtimeState.activeRoomCode,
+        )} supportedVideoPage=${args.isSupportedVideoPage(
+          nextPageUrl,
+        )}); any pending auto-share was cancelled`,
+      );
       return;
     }
 
@@ -237,10 +248,24 @@ export function createNavigationController(args: {
       if (!shouldPauseNonSharerAutoplay) {
         args.runtimeState.pauseHoldUntil = 0;
       }
+      // DIAGNOSTIC: the previous single message could not tell whether the
+      // auto-share branch actually ran (it logged "skipping autoplay
+      // suppression" for both the scheduled-auto-share case and the
+      // user-driven/no-op case). Spell out the decision inputs so a failed
+      // auto-continue can be traced to the exact false condition.
+      const navOutcome = shouldPauseNonSharerAutoplay
+        ? "holding paused state (non-sharer autoplay)"
+        : shouldTreatAsAutoplay && isLocalSharedSource
+          ? "scheduled auto-share"
+          : isUserDrivenLocalNavigation
+            ? "user-driven local navigation, no auto-share"
+            : "no autoplay branch taken, no auto-share";
       args.debugLog(
-        shouldPauseNonSharerAutoplay
-          ? `Detected non-sharer autoplay to ${nextPageUrl}, holding paused state`
-          : `Detected in-room navigation to non-shared video ${nextPageUrl}, skipping autoplay suppression`,
+        `Nav decision to ${nextPageUrl}: ${navOutcome} ` +
+          `[autoplay=${shouldTreatAsAutoplay} localSharer=${isLocalSharedSource} ` +
+          `navFromShared=${navigatedFromSharedVideo} recentGesture=${hadRecentUserGesture} ` +
+          `prevPage=${previousNormalizedPageUrl} activeShared=${activeSharedUrl} ` +
+          `prevAutoShareTarget=${previousPendingAutoShareTargetUrl}]`,
       );
       void args.hydrateRoomState();
       return;

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -76,6 +76,14 @@ export function createNavigationController(args: {
     // is itself a sharer autoplay-next.
     const previousPendingAutoShareTargetUrl =
       args.runtimeState.pendingAutoShareTargetUrl;
+    // End-of-shared-video markers, captured before `resetUserGestureState` below
+    // clears the non-sharer one (`suppressedLocalEndPauseUrl`). They let the
+    // autoplay-from-shared check recognise a season-page autoplay whose previous
+    // page URL is the season URL rather than the shared episode URL.
+    const previousSharerEndedSuppressionUrl =
+      args.runtimeState.sharerEndedSuppressionUrl;
+    const previousSuppressedLocalEndPauseUrl =
+      args.runtimeState.suppressedLocalEndPauseUrl;
     lastObservedPageUrl = nextPageUrl;
     lastObservedNormalizedPageUrl = nextNormalizedPageUrl;
     args.clearFestivalSnapshot();
@@ -168,10 +176,27 @@ export function createNavigationController(args: {
       // C would never be shared, stranding the room behind the sharer. (The
       // background still defers/skips if the room is not actually behind our
       // share, so a stale target cannot force an out-of-turn share.)
+      // A bangumi season page keeps the season URL (`/bangumi/play/ss<season>`)
+      // in the address bar while it actually plays a resolved episode, and the
+      // room shares the resolved episode URL (`/bangumi/play/ep<id>`). So the
+      // previous *page* URL (the season URL) never equals `activeSharedUrl` (the
+      // episode), and a season-page autoplay would be misclassified as a local
+      // detour — the sharer would never auto-share the next episode, and a
+      // non-sharer would never be held. The end-of-shared-video markers give a
+      // URL-form-independent signal that the shared video just naturally ended on
+      // this page: the sharer's broadcast-suppression marker, or the non-sharer's
+      // end-pause hold marker, still pointing at `activeSharedUrl` means this
+      // navigation is that video's autoplay-next. Both are cleared on a shared-url
+      // change / room reset, so they cannot leak into an unrelated navigation.
+      const navigatedFromSharedVideoEnd =
+        activeSharedUrl !== null &&
+        (previousSharerEndedSuppressionUrl === activeSharedUrl ||
+          previousSuppressedLocalEndPauseUrl === activeSharedUrl);
       const navigatedFromSharedVideo =
-        previousNormalizedPageUrl !== null &&
-        (previousNormalizedPageUrl === activeSharedUrl ||
-          previousNormalizedPageUrl === previousPendingAutoShareTargetUrl);
+        navigatedFromSharedVideoEnd ||
+        (previousNormalizedPageUrl !== null &&
+          (previousNormalizedPageUrl === activeSharedUrl ||
+            previousNormalizedPageUrl === previousPendingAutoShareTargetUrl));
       const shouldTreatAsAutoplay =
         !hadRecentUserGesture &&
         navigatedFromSharedVideo &&
@@ -263,7 +288,7 @@ export function createNavigationController(args: {
       args.debugLog(
         `Nav decision to ${nextPageUrl}: ${navOutcome} ` +
           `[autoplay=${shouldTreatAsAutoplay} localSharer=${isLocalSharedSource} ` +
-          `navFromShared=${navigatedFromSharedVideo} recentGesture=${hadRecentUserGesture} ` +
+          `navFromShared=${navigatedFromSharedVideo} navFromSharedEnd=${navigatedFromSharedVideoEnd} recentGesture=${hadRecentUserGesture} ` +
           `prevPage=${previousNormalizedPageUrl} activeShared=${activeSharedUrl} ` +
           `prevAutoShareTarget=${previousPendingAutoShareTargetUrl}]`,
       );

--- a/extension/test/auto-share-next-controller.test.ts
+++ b/extension/test/auto-share-next-controller.test.ts
@@ -77,7 +77,12 @@ test("auto-share next controller sends a request after the navigation settles", 
         },
       },
     ]);
-    assert.deepEqual(debugLogs, []);
+    // Diagnostic logs trace the full happy path: schedule → send → accepted.
+    assert.deepEqual(debugLogs, [
+      "Auto-share scheduled target=https://www.bilibili.com/video/BV1NextVideo from=https://www.bilibili.com/video/BV1OldVideo chained=false gen=1 delayMs=900",
+      "Auto-share sending to background target=https://www.bilibili.com/video/BV1NextVideo from=https://www.bilibili.com/video/BV1OldVideo attempt=1/4 gen=1",
+      "Auto-share accepted by background (ok=true) target=https://www.bilibili.com/video/BV1NextVideo from=https://www.bilibili.com/video/BV1OldVideo",
+    ]);
   } finally {
     currentUrl = "";
     controller.destroy();
@@ -303,7 +308,13 @@ test("auto-share next controller skips a settled request when the page moved aga
     await Promise.resolve();
 
     assert.deepEqual(sentMessages, []);
-    assert.equal(debugLogs.length, 1);
+    // The schedule diagnostic plus the moved-page skip diagnostic.
+    assert.equal(debugLogs.length, 2);
+    assert.match(debugLogs[0], /^Auto-share scheduled /);
+    assert.match(
+      debugLogs[1],
+      /^Skipped auto-share next video because page moved /,
+    );
   } finally {
     controller.destroy();
     windowHarness.restore();

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -285,9 +285,11 @@ test("navigation controller schedules auto-share when a bangumi season page auto
   runtimeState.activeSharedByMemberId = "member-1";
   runtimeState.localMemberId = "member-1";
   // The shared episode just naturally ended on this page (the sharer marker is
-  // still set — it is cleared later by the broadcast gate / shared-url reset).
+  // still set and unexpired — it is cleared later by the broadcast gate /
+  // shared-url reset).
   runtimeState.sharerEndedSuppressionUrl =
     "https://www.bilibili.com/bangumi/play/ep249469";
+  runtimeState.sharerEndedSuppressionUntil = 12_000; // > getNow (10_000)
 
   // The address bar is the SEASON url while playing the shared episode.
   let currentUrl = "https://www.bilibili.com/bangumi/play/ss357";
@@ -350,9 +352,10 @@ test("navigation controller holds a non-sharer when a bangumi season page autopl
   runtimeState.activeSharedByMemberId = "member-2";
   runtimeState.localMemberId = "member-1";
   // The non-sharer was held at the shared episode's natural end (its end-pause
-  // hold marker still points at the shared episode).
+  // hold marker still points at the shared episode and is unexpired).
   runtimeState.suppressedLocalEndPauseUrl =
     "https://www.bilibili.com/bangumi/play/ep249469";
+  runtimeState.suppressedLocalEndPauseUntil = 12_000; // > getNow (10_000)
 
   let currentUrl = "https://www.bilibili.com/bangumi/play/ss357";
   let pauseCalls = 0;
@@ -395,6 +398,61 @@ test("navigation controller holds a non-sharer when a bangumi season page autopl
       "https://www.bilibili.com/bangumi/play/ep249470",
     );
     assert.deepEqual(autoShareRequests, []);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller does not treat an expired end marker as a season-page autoplay", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep249469";
+  runtimeState.activeSharedByMemberId = "member-2";
+  runtimeState.localMemberId = "member-1";
+  // A non-sharer end-pause marker that was never cleared and is now EXPIRED
+  // (its hold window elapsed). A later unrelated navigation must not be
+  // misread as the shared episode's autoplay-next.
+  runtimeState.suppressedLocalEndPauseUrl =
+    "https://www.bilibili.com/bangumi/play/ep249469";
+  runtimeState.suppressedLocalEndPauseUntil = 9_000; // < getNow (10_000)
+
+  let currentUrl = "https://www.bilibili.com/bangumi/play/ss357";
+  let pauseCalls = 0;
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeTestBangumiPageUrl,
+    isSupportedVideoPage: (url) => url.includes("/bangumi/play/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: () => {},
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    currentUrl =
+      "https://www.bilibili.com/bangumi/play/ep249480?from_spmid=666.25.episode.0";
+    windowHarness.intervals[0]?.();
+
+    // The expired marker is ignored: this is treated as an ordinary navigation,
+    // so the non-sharer is not force-paused and no autoplay hold is armed.
+    assert.equal(pauseCalls, 0);
+    assert.equal(runtimeState.nonSharerAutoplayHoldUrl, null);
   } finally {
     windowHarness.restore();
   }

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -11,6 +11,18 @@ function normalizeTestVideoPageUrl(url: string): string | null {
   return url.match(/https:\/\/www\.bilibili\.com\/video\/[^/?]+/)?.[0] ?? null;
 }
 
+// Bangumi pages keep the season URL (`/bangumi/play/ss<id>`) in the address bar
+// while playing a resolved episode (`/bangumi/play/ep<id>`); the room shares the
+// episode URL. Strips the query so `ep249470?from_spmid=...` normalizes to the
+// bare episode URL.
+function normalizeTestBangumiPageUrl(url: string): string | null {
+  return (
+    url.match(
+      /https:\/\/www\.bilibili\.com\/bangumi\/play\/(?:ep|ss)\d+/,
+    )?.[0] ?? null
+  );
+}
+
 function installWindowStub() {
   const originalWindow = globalThis.window;
   const intervals: Array<() => void> = [];
@@ -257,6 +269,132 @@ test("navigation controller schedules auto-share when a shared source autoplays 
         previousAutoShareTargetUrl: null,
       },
     ]);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller schedules auto-share when a bangumi season page autoplays to the next episode", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  // The room shares the resolved episode URL, not the season URL.
+  runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep249469";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+  // The shared episode just naturally ended on this page (the sharer marker is
+  // still set — it is cleared later by the broadcast gate / shared-url reset).
+  runtimeState.sharerEndedSuppressionUrl =
+    "https://www.bilibili.com/bangumi/play/ep249469";
+
+  // The address bar is the SEASON url while playing the shared episode.
+  let currentUrl = "https://www.bilibili.com/bangumi/play/ss357";
+  const autoShareRequests: Array<{
+    previousSharedUrl: string;
+    nextNormalizedPageUrl: string;
+    previousAutoShareTargetUrl: string | null;
+  }> = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeTestBangumiPageUrl,
+    isSupportedVideoPage: (url) => url.includes("/bangumi/play/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {},
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    currentUrl =
+      "https://www.bilibili.com/bangumi/play/ep249470?from_spmid=666.25.episode.0";
+    windowHarness.intervals[0]?.();
+
+    // Despite the previous page URL being the season URL (≠ activeSharedUrl), the
+    // end-of-shared-video marker identifies this as the shared episode's autoplay
+    // and the auto-share is scheduled from the room's confirmed episode.
+    assert.deepEqual(autoShareRequests, [
+      {
+        previousSharedUrl: "https://www.bilibili.com/bangumi/play/ep249469",
+        nextNormalizedPageUrl: "https://www.bilibili.com/bangumi/play/ep249470",
+        previousAutoShareTargetUrl: null,
+      },
+    ]);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller holds a non-sharer when a bangumi season page autoplays to the next episode", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/bangumi/play/ep249469";
+  // The shared video belongs to another member: the local member is a non-sharer.
+  runtimeState.activeSharedByMemberId = "member-2";
+  runtimeState.localMemberId = "member-1";
+  // The non-sharer was held at the shared episode's natural end (its end-pause
+  // hold marker still points at the shared episode).
+  runtimeState.suppressedLocalEndPauseUrl =
+    "https://www.bilibili.com/bangumi/play/ep249469";
+
+  let currentUrl = "https://www.bilibili.com/bangumi/play/ss357";
+  let pauseCalls = 0;
+  const autoShareRequests: unknown[] = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => currentUrl,
+    normalizeVideoPageUrl: normalizeTestBangumiPageUrl,
+    isSupportedVideoPage: (url) => url.includes("/bangumi/play/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    currentUrl =
+      "https://www.bilibili.com/bangumi/play/ep249470?from_spmid=666.25.episode.0";
+    windowHarness.intervals[0]?.();
+
+    // The non-sharer's autoplay to the next episode is recognised and paused,
+    // and no auto-share is sent (it is not the sharer).
+    assert.equal(pauseCalls, 1);
+    assert.equal(
+      runtimeState.nonSharerAutoplayHoldUrl,
+      "https://www.bilibili.com/bangumi/play/ep249470",
+    );
+    assert.deepEqual(autoShareRequests, []);
   } finally {
     windowHarness.restore();
   }


### PR DESCRIPTION
## 问题

从**番剧季号页**观看时,共享端自动连播到下一集**不会**触发自动共享(房间停在上一集),非共享端也不会被暂停。

## 根因

番剧季号页地址栏一直停在季号 URL `/bangumi/play/ss<id>`,但实际播放的是解析后的分集 `/bangumi/play/ep<id>`,房间共享的是分集 URL。导航控制器判断"这次自动连播是否从共享视频开始"时,用的是**上一个页面 URL(季号)** 和 `activeSharedUrl(分集)` 比较——两者永远不等,于是把季号页的自动连播误判成本地跳转:

```
Nav decision ...: no autoplay branch taken, no auto-share
  [autoplay=false navFromShared=false
   prevPage=.../ss357 activeShared=.../ep249469 ...]
```

结果共享端不排程自动共享、非共享端不暂停。只要从 `ss` 页看就必现;从 `ep` 页看则正常——这解释了"有时触发有时不触发"。

## 修复

新增一个**与 URL 形态无关**的信号 `navigatedFromSharedVideoEnd`:换集这一刻只要片尾标记仍指向 `activeSharedUrl`,就说明共享视频刚在本页自然结束、这次导航就是它的自动连播下一集(无论地址栏是 `ss` 还是 `ep`):

- 共享端 → `sharerEndedSuppressionUrl`
- 非共享端 → `suppressedLocalEndPauseUrl`(对称修了非共享端季号页不被暂停、跑在房间前面的同类 bug)

非共享端标记会被 `resetUserGestureState` 在导航中途清掉,所以在重置前**先捕获**(与 `previousPendingAutoShareTargetUrl` 同样处理)。两个标记都在 shared-url 变更 / 房间重置时清除,不会泄漏到无关导航。

## 诊断日志(一并保留)

定位本问题靠的就是这批埋点,它们**只在导航 / 自动共享事件**上打印(episode 边界,非每秒热路径),价值高、噪音低,故保留:

- `navigation-controller`:把原来有歧义的 `skipping autoplay suppression` 换成完整决策摘要(`autoplay/localSharer/navFromShared/navFromSharedEnd/recentGesture/prevPage/activeShared/...`),并给 `cancel` 之后的提前 bail 加日志。
- `auto-share-next-controller`:补齐 schedule / coalesce / cancel(仅在确有待发请求时)/ send / accepted / superseded。

## 测试

新增 2 个回归测试:季号页自动连播下,共享端排程自动共享、非共享端暂停。`format / lint / typecheck / build / test` 全绿(**413 tests pass**)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
