### PR TITLE
fix: auto-share festival autoplay-next via the resolved page-bridge video URL

### DIFF
--- a/extension/src/content/auto-share-next-controller.ts
+++ b/extension/src/content/auto-share-next-controller.ts
@@ -2,7 +2,10 @@ import type {
   ContentToBackgroundMessage,
   ShareCurrentVideoResponse,
 } from "../shared/messages";
-import { isUnstableSharedVideoUrl } from "./video-identity";
+import {
+  isAddressBarOpaqueVideoUrl,
+  isUnstableSharedVideoUrl,
+} from "./video-identity";
 
 export interface AutoShareNextController {
   scheduleForNavigation(args: {
@@ -97,21 +100,25 @@ export function createAutoShareNextController(args: {
   }
 
   async function requestAutoShare(pending: PendingAutoShare): Promise<void> {
-    const currentNormalizedUrl = args.normalizeVideoPageUrl(
-      args.getCurrentPageUrl(),
-    );
+    const currentPageUrl = args.getCurrentPageUrl();
+    const currentNormalizedUrl = args.normalizeVideoPageUrl(currentPageUrl);
     // Only skip when we can POSITIVELY confirm the page is now on a *different,
     // concrete* video. On festival pages the resolved-video snapshot can be
     // momentarily cleared or stale during the settle window — the navigation
     // handler clears it right before scheduling, and the next page-bridge refresh
-    // may not have landed yet — so `currentNormalizedUrl` falls back to the bare
-    // `/festival/<id>` route (unstable) or null. Treating that as "page moved"
-    // here would drop a valid festival auto-share *without retrying*. Instead
-    // proceed: the background runs the authoritative, retrying tab-resolution
-    // check against the target, so a genuine moved-on page is still caught there.
+    // may not have landed yet — so `getCurrentPageUrl()` falls back to the address
+    // bar. That can be the bare `/festival/<id>` route (unstable) OR, when the
+    // page was opened from a share link, a frozen `?bvid=A&cid=...` that
+    // normalizes to a *stable* but stale `/video/A`. Either way the address bar is
+    // not a trustworthy current-video signal here, so treating it as "page moved"
+    // would drop a valid festival auto-share *without retrying*. Detect such pages
+    // by their `/festival/` pathname (not just URL instability) and proceed: the
+    // background runs the authoritative, retrying tab-resolution check against the
+    // target, so a genuine moved-on page is still caught there.
     if (
       currentNormalizedUrl !== null &&
       !isUnstableSharedVideoUrl(currentNormalizedUrl) &&
+      !isAddressBarOpaqueVideoUrl(currentPageUrl) &&
       currentNormalizedUrl !== pending.targetNormalizedUrl
     ) {
       args.debugLog(

--- a/extension/src/content/auto-share-next-controller.ts
+++ b/extension/src/content/auto-share-next-controller.ts
@@ -2,6 +2,7 @@ import type {
   ContentToBackgroundMessage,
   ShareCurrentVideoResponse,
 } from "../shared/messages";
+import { isUnstableSharedVideoUrl } from "./video-identity";
 
 export interface AutoShareNextController {
   scheduleForNavigation(args: {
@@ -99,9 +100,22 @@ export function createAutoShareNextController(args: {
     const currentNormalizedUrl = args.normalizeVideoPageUrl(
       args.getCurrentPageUrl(),
     );
-    if (currentNormalizedUrl !== pending.targetNormalizedUrl) {
+    // Only skip when we can POSITIVELY confirm the page is now on a *different,
+    // concrete* video. On festival pages the resolved-video snapshot can be
+    // momentarily cleared or stale during the settle window — the navigation
+    // handler clears it right before scheduling, and the next page-bridge refresh
+    // may not have landed yet — so `currentNormalizedUrl` falls back to the bare
+    // `/festival/<id>` route (unstable) or null. Treating that as "page moved"
+    // here would drop a valid festival auto-share *without retrying*. Instead
+    // proceed: the background runs the authoritative, retrying tab-resolution
+    // check against the target, so a genuine moved-on page is still caught there.
+    if (
+      currentNormalizedUrl !== null &&
+      !isUnstableSharedVideoUrl(currentNormalizedUrl) &&
+      currentNormalizedUrl !== pending.targetNormalizedUrl
+    ) {
       args.debugLog(
-        `Skipped auto-share next video because page moved from ${pending.targetNormalizedUrl} to ${currentNormalizedUrl ?? "unknown"}`,
+        `Skipped auto-share next video because page moved from ${pending.targetNormalizedUrl} to ${currentNormalizedUrl}`,
       );
       return;
     }

--- a/extension/src/content/auto-share-next-controller.ts
+++ b/extension/src/content/auto-share-next-controller.ts
@@ -2,10 +2,7 @@ import type {
   ContentToBackgroundMessage,
   ShareCurrentVideoResponse,
 } from "../shared/messages";
-import {
-  isAddressBarOpaqueVideoUrl,
-  isUnstableSharedVideoUrl,
-} from "./video-identity";
+import { isAddressBarOpaqueVideoUrl } from "./video-identity";
 
 export interface AutoShareNextController {
   scheduleForNavigation(args: {
@@ -102,27 +99,24 @@ export function createAutoShareNextController(args: {
   async function requestAutoShare(pending: PendingAutoShare): Promise<void> {
     const currentPageUrl = args.getCurrentPageUrl();
     const currentNormalizedUrl = args.normalizeVideoPageUrl(currentPageUrl);
-    // Only skip when we can POSITIVELY confirm the page is now on a *different,
-    // concrete* video. On festival pages the resolved-video snapshot can be
-    // momentarily cleared or stale during the settle window — the navigation
-    // handler clears it right before scheduling, and the next page-bridge refresh
-    // may not have landed yet — so `getCurrentPageUrl()` falls back to the address
-    // bar. That can be the bare `/festival/<id>` route (unstable) OR, when the
-    // page was opened from a share link, a frozen `?bvid=A&cid=...` that
-    // normalizes to a *stable* but stale `/video/A`. Either way the address bar is
-    // not a trustworthy current-video signal here, so treating it as "page moved"
-    // would drop a valid festival auto-share *without retrying*. Detect such pages
-    // by their `/festival/` pathname (not just URL instability) and proceed: the
-    // background runs the authoritative, retrying tab-resolution check against the
-    // target, so a genuine moved-on page is still caught there.
+    // Skip when the page has left the scheduled target — a manual detour during
+    // the settle window must cancel the auto-share. The ONE exception is an
+    // address-bar-opaque page (festival): there the snapshot can be momentarily
+    // cleared or stale, so `getCurrentPageUrl()` falls back to the address bar
+    // (the bare `/festival/<id>` route, or a frozen `?bvid=A&cid=...` that
+    // normalizes to a stale `/video/A`) — an untrustworthy current-video signal.
+    // Only for such pages do we treat a non-matching URL as "cannot tell" and
+    // proceed, letting the background's authoritative, retrying tab-resolution
+    // check decide. On every other page (including a `null` normalization, i.e.
+    // the user left to a non-video page) a non-matching URL means the page genuinely
+    // moved on, so skip rather than risk firing a stale auto-share if the user
+    // returns within the background's retry window.
     if (
-      currentNormalizedUrl !== null &&
-      !isUnstableSharedVideoUrl(currentNormalizedUrl) &&
       !isAddressBarOpaqueVideoUrl(currentPageUrl) &&
       currentNormalizedUrl !== pending.targetNormalizedUrl
     ) {
       args.debugLog(
-        `Skipped auto-share next video because page moved from ${pending.targetNormalizedUrl} to ${currentNormalizedUrl}`,
+        `Skipped auto-share next video because page moved from ${pending.targetNormalizedUrl} to ${currentNormalizedUrl ?? "unknown"}`,
       );
       return;
     }

--- a/extension/src/content/auto-share-next-controller.ts
+++ b/extension/src/content/auto-share-next-controller.ts
@@ -49,6 +49,15 @@ export function createAutoShareNextController(args: {
   getCurrentPageUrl: () => string;
   normalizeVideoPageUrl: (url: string) => string | null;
   /**
+   * The in-player video URL resolved from the page-bridge snapshot for an
+   * address-bar-opaque (festival) page, or `null` when it has not resolved (or on
+   * non-opaque pages). Lets the pre-send self-check tell a *trustworthy* current
+   * video (the snapshot resolved a concrete `/video/...`) from the untrustworthy
+   * address-bar fallback (bare route / frozen `?bvid=`): only the latter is
+   * treated as "cannot tell". Optional; when absent the address bar is used.
+   */
+  getResolvedVideoUrl?: () => string | null;
+  /**
    * The room's *currently* confirmed shared video, read fresh when a request is
    * about to be sent. Used to re-anchor `previousSharedUrl` so a chained autoplay
    * that confirms an intermediate step during the settle window is not sent with
@@ -100,19 +109,20 @@ export function createAutoShareNextController(args: {
     const currentPageUrl = args.getCurrentPageUrl();
     const currentNormalizedUrl = args.normalizeVideoPageUrl(currentPageUrl);
     // Skip when the page has left the scheduled target — a manual detour during
-    // the settle window must cancel the auto-share. The ONE exception is an
-    // address-bar-opaque page (festival): there the snapshot can be momentarily
-    // cleared or stale, so `getCurrentPageUrl()` falls back to the address bar
-    // (the bare `/festival/<id>` route, or a frozen `?bvid=A&cid=...` that
-    // normalizes to a stale `/video/A`) — an untrustworthy current-video signal.
-    // Only for such pages do we treat a non-matching URL as "cannot tell" and
-    // proceed, letting the background's authoritative, retrying tab-resolution
-    // check decide. On every other page (including a `null` normalization, i.e.
-    // the user left to a non-video page) a non-matching URL means the page genuinely
-    // moved on, so skip rather than risk firing a stale auto-share if the user
-    // returns within the background's retry window.
+    // the settle window must cancel the auto-share. We treat a non-matching URL as
+    // "cannot tell" (and proceed, letting the background's authoritative, retrying
+    // tab-resolution check decide) ONLY when the current-video signal is genuinely
+    // untrustworthy: an address-bar-opaque (festival) page whose page-bridge
+    // snapshot has NOT resolved, so `getCurrentPageUrl()` fell back to the address
+    // bar (bare `/festival/<id>` route, or a frozen `?bvid=A&cid=...` normalizing
+    // to a stale `/video/A`). When the snapshot HAS resolved a concrete video
+    // (`getResolvedVideoUrl()` is non-null), that URL is trustworthy — including a
+    // manual same-page jump to another video — so a mismatch must still skip.
+    const cannotTellCurrentVideo =
+      (args.getResolvedVideoUrl?.() ?? null) === null &&
+      isAddressBarOpaqueVideoUrl(currentPageUrl);
     if (
-      !isAddressBarOpaqueVideoUrl(currentPageUrl) &&
+      !cannotTellCurrentVideo &&
       currentNormalizedUrl !== pending.targetNormalizedUrl
     ) {
       args.debugLog(

--- a/extension/src/content/festival-bridge.ts
+++ b/extension/src/content/festival-bridge.ts
@@ -24,6 +24,16 @@ interface PageVideoSnapshot extends SharedVideo {
 export interface FestivalBridgeController {
   clearSnapshot: () => void;
   getSnapshot: () => FestivalSnapshot | null;
+  /**
+   * Resolves the in-player video URL for an address-bar-opaque festival page from
+   * the cached snapshot. Festival pages keep a fixed `/festival/<id>` route while
+   * the player swaps videos, so this is the only reliable way for the navigation
+   * watcher and auto-share self-check to observe the current video. Returns the
+   * snapshot's resolved share URL (with `bvid`/`cid`) when the cached snapshot
+   * belongs to `pathname`, otherwise `null` (non-festival page, or no/stale
+   * matching snapshot — callers fall back to the address bar).
+   */
+  resolveVideoUrlForPage: (pathname: string) => string | null;
   refreshSnapshot: (args: {
     pathname: string;
     pageUrl: string;
@@ -148,6 +158,19 @@ export function createFestivalBridgeController(): FestivalBridgeController {
       festivalSnapshot = null;
     },
     getSnapshot: () => festivalSnapshot,
+    resolveVideoUrlForPage: (pathname: string): string | null => {
+      if (!pathname.startsWith("/festival/")) {
+        return null;
+      }
+      if (
+        !festivalSnapshot?.pathname?.startsWith("/festival/") ||
+        normalizeCachedPagePathname(festivalSnapshot.pathname) !==
+          normalizeCachedPagePathname(pathname)
+      ) {
+        return null;
+      }
+      return festivalSnapshot.url;
+    },
     refreshSnapshot: async ({ pathname, pageUrl, maxAgeMs }) => {
       const isBangumiPage = pathname.startsWith("/bangumi/play/");
       if (!pathname.startsWith("/festival/") && !isBangumiPage) {

--- a/extension/src/content/festival-bridge.ts
+++ b/extension/src/content/festival-bridge.ts
@@ -32,8 +32,17 @@ export interface FestivalBridgeController {
    * snapshot's resolved share URL (with `bvid`/`cid`) when the cached snapshot
    * belongs to `pathname`, otherwise `null` (non-festival page, or no/stale
    * matching snapshot — callers fall back to the address bar).
+   *
+   * When `maxAgeMs` is provided, a snapshot older than it is treated as stale and
+   * `null` is returned: a cached video the user may already have left must not be
+   * reported as the *trustworthy current* video (it would let the auto-share
+   * self-check confirm a now-wrong target). Omit `maxAgeMs` to accept any cached
+   * snapshot regardless of age.
    */
-  resolveVideoUrlForPage: (pathname: string) => string | null;
+  resolveVideoUrlForPage: (
+    pathname: string,
+    maxAgeMs?: number,
+  ) => string | null;
   refreshSnapshot: (args: {
     pathname: string;
     pageUrl: string;
@@ -158,7 +167,10 @@ export function createFestivalBridgeController(): FestivalBridgeController {
       festivalSnapshot = null;
     },
     getSnapshot: () => festivalSnapshot,
-    resolveVideoUrlForPage: (pathname: string): string | null => {
+    resolveVideoUrlForPage: (
+      pathname: string,
+      maxAgeMs?: number,
+    ): string | null => {
       if (!pathname.startsWith("/festival/")) {
         return null;
       }
@@ -166,6 +178,16 @@ export function createFestivalBridgeController(): FestivalBridgeController {
         !festivalSnapshot?.pathname?.startsWith("/festival/") ||
         normalizeCachedPagePathname(festivalSnapshot.pathname) !==
           normalizeCachedPagePathname(pathname)
+      ) {
+        return null;
+      }
+      // A snapshot older than the freshness bound may no longer reflect the page
+      // (the user could have moved to another video within the same festival route
+      // without the snapshot being refreshed). Don't report it as the current
+      // video, so the auto-share self-check cannot confirm a stale target.
+      if (
+        maxAgeMs !== undefined &&
+        Date.now() - festivalSnapshot.updatedAt >= maxAgeMs
       ) {
         return null;
       }
@@ -196,9 +218,15 @@ export function createFestivalBridgeController(): FestivalBridgeController {
         pageUrl,
       );
       if (!nextSnapshot) {
+        // Mirror the fast-path freshness gate above: when a fresh read fails, only
+        // fall back to the cached snapshot while it is still within `maxAgeMs`.
+        // Without the TTL bound a read failure could resurrect an arbitrarily stale
+        // snapshot for the authoritative auto-share target validation, sharing a
+        // video the user has already left.
         return !isBangumiPage &&
           festivalSnapshot &&
-          canUseCachedFestivalSnapshot(pathname)
+          canUseCachedFestivalSnapshot(pathname) &&
+          Date.now() - festivalSnapshot.updatedAt < maxAgeMs
           ? {
               videoId: festivalSnapshot.videoId,
               url: festivalSnapshot.url,

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -60,7 +60,11 @@ const shareController = createShareController({
 });
 const autoShareNextController = createAutoShareNextController({
   settleDelayMs: AUTO_SHARE_NEXT_SETTLE_DELAY_MS,
-  getCurrentPageUrl: () => window.location.href.split("#")[0],
+  // Prefer the resolved festival video so the pre-send "page still on target"
+  // check matches the scheduled `/video/...` target rather than the bare
+  // `/festival/<id>` route (which would wrongly skip the auto-share).
+  getCurrentPageUrl: () =>
+    resolveFestivalVideoUrl() ?? window.location.href.split("#")[0],
   normalizeVideoPageUrl: (url) => normalizeSharedVideoUrl(url),
   getActiveSharedUrl: () => runtimeState.activeSharedUrl,
   runtimeSendMessage,
@@ -139,6 +143,10 @@ const navigationController = createNavigationController({
   initialRoomStatePauseHoldMs: INITIAL_ROOM_STATE_PAUSE_HOLD_MS,
   getCurrentPageUrl: () => window.location.href.split("#")[0],
   normalizeVideoPageUrl: (url) => normalizeSharedVideoUrl(url),
+  // Festival pages keep a fixed `/festival/<id>` route in the address bar while
+  // the player swaps videos, so the navigation watcher can only observe an
+  // autoplay-next through the page-bridge snapshot's resolved share URL.
+  getResolvedVideoUrl: resolveFestivalVideoUrl,
   isSupportedVideoPage: (url) => Boolean(normalizeSharedVideoUrl(url)),
   clearFestivalSnapshot: () => {
     festivalBridge.clearSnapshot();
@@ -162,6 +170,28 @@ const pageShareButtonController = createPageShareButtonController({
 });
 
 void init();
+
+// Festival pages keep a fixed `/festival/<id>` route in the address bar while the
+// player swaps videos, so `window.location.href` never reflects the in-player
+// video. This resolves the page-bridge snapshot's share URL (with `bvid`/`cid`)
+// for the current festival page, or `null` on other pages (whose address bar
+// already tracks the video) and before the snapshot resolves. Both the
+// navigation watcher and the auto-share self-check rely on it so a festival
+// autoplay-next is observed and not skipped as "page moved".
+function resolveFestivalVideoUrl(): string | null {
+  const pathname = window.location.pathname;
+  if (!pathname.startsWith("/festival/")) {
+    return null;
+  }
+  const snapshot = festivalBridge.getSnapshot();
+  if (
+    !snapshot?.pathname?.startsWith("/festival/") ||
+    snapshot.pathname.replace(/\/+$/, "") !== pathname.replace(/\/+$/, "")
+  ) {
+    return null;
+  }
+  return snapshot.url;
+}
 
 function debugLog(message: string): void {
   void runtimeSendMessage({

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -64,7 +64,8 @@ const autoShareNextController = createAutoShareNextController({
   // check matches the scheduled `/video/...` target rather than the bare
   // `/festival/<id>` route (which would wrongly skip the auto-share).
   getCurrentPageUrl: () =>
-    resolveFestivalVideoUrl() ?? window.location.href.split("#")[0],
+    festivalBridge.resolveVideoUrlForPage(window.location.pathname) ??
+    window.location.href.split("#")[0],
   normalizeVideoPageUrl: (url) => normalizeSharedVideoUrl(url),
   getActiveSharedUrl: () => runtimeState.activeSharedUrl,
   runtimeSendMessage,
@@ -146,7 +147,8 @@ const navigationController = createNavigationController({
   // Festival pages keep a fixed `/festival/<id>` route in the address bar while
   // the player swaps videos, so the navigation watcher can only observe an
   // autoplay-next through the page-bridge snapshot's resolved share URL.
-  getResolvedVideoUrl: resolveFestivalVideoUrl,
+  getResolvedVideoUrl: () =>
+    festivalBridge.resolveVideoUrlForPage(window.location.pathname),
   isSupportedVideoPage: (url) => Boolean(normalizeSharedVideoUrl(url)),
   clearFestivalSnapshot: () => {
     festivalBridge.clearSnapshot();
@@ -170,28 +172,6 @@ const pageShareButtonController = createPageShareButtonController({
 });
 
 void init();
-
-// Festival pages keep a fixed `/festival/<id>` route in the address bar while the
-// player swaps videos, so `window.location.href` never reflects the in-player
-// video. This resolves the page-bridge snapshot's share URL (with `bvid`/`cid`)
-// for the current festival page, or `null` on other pages (whose address bar
-// already tracks the video) and before the snapshot resolves. Both the
-// navigation watcher and the auto-share self-check rely on it so a festival
-// autoplay-next is observed and not skipped as "page moved".
-function resolveFestivalVideoUrl(): string | null {
-  const pathname = window.location.pathname;
-  if (!pathname.startsWith("/festival/")) {
-    return null;
-  }
-  const snapshot = festivalBridge.getSnapshot();
-  if (
-    !snapshot?.pathname?.startsWith("/festival/") ||
-    snapshot.pathname.replace(/\/+$/, "") !== pathname.replace(/\/+$/, "")
-  ) {
-    return null;
-  }
-  return snapshot.url;
-}
 
 function debugLog(message: string): void {
   void runtimeSendMessage({

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -64,12 +64,18 @@ const autoShareNextController = createAutoShareNextController({
   // check matches the scheduled `/video/...` target rather than the bare
   // `/festival/<id>` route (which would wrongly skip the auto-share).
   getCurrentPageUrl: () =>
-    festivalBridge.resolveVideoUrlForPage(window.location.pathname) ??
-    window.location.href.split("#")[0],
+    festivalBridge.resolveVideoUrlForPage(
+      window.location.pathname,
+      FESTIVAL_SNAPSHOT_TTL_MS,
+    ) ?? window.location.href.split("#")[0],
   // Lets the self-check distinguish a trustworthy resolved current video from the
-  // untrustworthy address-bar fallback on opaque festival pages.
+  // untrustworthy address-bar fallback on opaque festival pages. A snapshot older
+  // than the TTL is treated as untrustworthy so a stale target cannot be confirmed.
   getResolvedVideoUrl: () =>
-    festivalBridge.resolveVideoUrlForPage(window.location.pathname),
+    festivalBridge.resolveVideoUrlForPage(
+      window.location.pathname,
+      FESTIVAL_SNAPSHOT_TTL_MS,
+    ),
   normalizeVideoPageUrl: (url) => normalizeSharedVideoUrl(url),
   getActiveSharedUrl: () => runtimeState.activeSharedUrl,
   runtimeSendMessage,
@@ -152,7 +158,10 @@ const navigationController = createNavigationController({
   // the player swaps videos, so the navigation watcher can only observe an
   // autoplay-next through the page-bridge snapshot's resolved share URL.
   getResolvedVideoUrl: () =>
-    festivalBridge.resolveVideoUrlForPage(window.location.pathname),
+    festivalBridge.resolveVideoUrlForPage(
+      window.location.pathname,
+      FESTIVAL_SNAPSHOT_TTL_MS,
+    ),
   isSupportedVideoPage: (url) => Boolean(normalizeSharedVideoUrl(url)),
   clearFestivalSnapshot: () => {
     festivalBridge.clearSnapshot();

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -66,6 +66,10 @@ const autoShareNextController = createAutoShareNextController({
   getCurrentPageUrl: () =>
     festivalBridge.resolveVideoUrlForPage(window.location.pathname) ??
     window.location.href.split("#")[0],
+  // Lets the self-check distinguish a trustworthy resolved current video from the
+  // untrustworthy address-bar fallback on opaque festival pages.
+  getResolvedVideoUrl: () =>
+    festivalBridge.resolveVideoUrlForPage(window.location.pathname),
   normalizeVideoPageUrl: (url) => normalizeSharedVideoUrl(url),
   getActiveSharedUrl: () => runtimeState.activeSharedUrl,
   runtimeSendMessage,

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -320,25 +320,24 @@ export function createNavigationController(args: {
         args.runtimeState.sharedVideoNaturalEndUrl === activeSharedUrl &&
         now - args.runtimeState.sharedVideoNaturalEndAt <
           args.initialRoomStatePauseHoldMs;
-      // The page bridge resolved this address-bar-opaque (festival) page for the
-      // first time only *after* the player had already auto-advanced past the
-      // shared video: the previous identity is still the page's bare (unresolved)
-      // route and the old video's `ended` never recorded a natural-end marker
-      // (there was no matching snapshot then). With `canConfirmDifferentVideo`
-      // already true (the room's share is a known, stable, different video) and no
-      // recent gesture (gated below), the most likely explanation is the shared
-      // video's autoplay-next — so the sharer still schedules the auto-share and a
-      // non-sharer is still paused, rather than leaving the room behind. The
-      // recent-gesture gate keeps a genuine manual navigation to a festival page
-      // from being misread as this case.
-      const navigatedFromUnresolvedFestivalPage =
-        isAddressBarOpaqueVideoUrl(rawPageUrl) &&
-        previousNormalizedPageUrl !== null &&
-        isUnstableSharedVideoUrl(previousNormalizedPageUrl) &&
-        samePathname(previousNormalizedPageUrl, rawPageUrl);
+      // Classify as the shared video's autoplay only on *provable* evidence that
+      // the advance came from the room's shared video:
+      //   - a durable natural-end marker for it (`navigatedFromSharedVideoEnd`), or
+      //   - the previous page equals the shared anchor — either `activeSharedUrl`
+      //     directly, the resolved identity of a bare-route festival share
+      //     (`effectiveSharedUrl`), or our own in-flight chained target.
+      // We deliberately do NOT infer it from "the first resolution of this festival
+      // page landed on some different video": when the page bridge resolves a
+      // manually opened/clicked festival page slowly (past `userGestureGraceMs`, or
+      // when the navigation was not gesture-tracked), the previous identity is
+      // still the bare route and that heuristic would auto-share a manual detour
+      // (and pause non-sharers) without proof it came from the shared video. The
+      // cost is that an autoplay-next whose page bridge resolves only after the
+      // player already advanced past the shared video — and which left no natural-
+      // end marker — is not auto-shared; that ambiguous case is indistinguishable
+      // from a manual detour, so we err on the side of not hijacking the room.
       const navigatedFromSharedVideo =
         navigatedFromSharedVideoEnd ||
-        navigatedFromUnresolvedFestivalPage ||
         (previousNormalizedPageUrl !== null &&
           (previousNormalizedPageUrl === effectiveSharedUrl ||
             previousNormalizedPageUrl === previousPendingAutoShareTargetUrl));

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -105,10 +105,37 @@ export function createNavigationController(args: {
     }
 
     const nextNormalizedPageUrl = args.normalizeVideoPageUrl(nextPageUrl);
+
+    // The room shares THIS page by its bare (unstable) festival route — the page
+    // bridge could not resolve a `bvid`/`cid` when it was shared. Resolving it now
+    // is discovery of that share's concrete video.
+    const sharedUrlForDiscovery = args.runtimeState.activeSharedUrl;
+    const sharedIsUnstableSamePageRoute =
+      isUnstableSharedVideoUrl(sharedUrlForDiscovery) &&
+      samePathname(sharedUrlForDiscovery, nextPageUrl);
+    // The first snapshot resolution of a bare-route festival share to its concrete
+    // stable `/video/...`. Record it as the stable "from" anchor for the next
+    // same-page autoplay (`activeSharedUrl` itself stays the unstable route until
+    // the room confirms a concrete video). This must run even when the resolved URL
+    // is unchanged from the baseline: a festival page opened from a share link
+    // keeps a frozen `?bvid=A&cid=...` whose baseline already normalizes to the
+    // same stable `/video/A`, so the resolution hits the "normalized unchanged"
+    // short-circuit below before reaching the discovery guard further down —
+    // without this it would never anchor and the later A→B autoplay could not be
+    // classified as the room share's autoplay.
+    const isBareRouteShareResolution =
+      resolvedVideoUrl !== null &&
+      nextNormalizedPageUrl !== null &&
+      !isUnstableSharedVideoUrl(nextNormalizedPageUrl) &&
+      sharedIsUnstableSamePageRoute;
+
     if (
       nextNormalizedPageUrl !== null &&
       nextNormalizedPageUrl === lastObservedNormalizedPageUrl
     ) {
+      if (isBareRouteShareResolution) {
+        args.runtimeState.resolvedSharedVideoUrl = nextNormalizedPageUrl;
+      }
       lastObservedPageUrl = nextPageUrl;
       return;
     }
@@ -147,13 +174,6 @@ export function createNavigationController(args: {
     // ended and the player auto-advanced before the snapshot resolved — likewise
     // fall through so the sharer still schedules the auto-share and a non-sharer
     // is still paused.
-    const sharedUrlForDiscovery = args.runtimeState.activeSharedUrl;
-    // The room shares THIS page by its bare (unstable) festival route — the page
-    // bridge could not resolve a `bvid`/`cid` when it was shared. Resolving it now
-    // is discovery of that share's concrete video.
-    const sharedIsUnstableSamePageRoute =
-      isUnstableSharedVideoUrl(sharedUrlForDiscovery) &&
-      samePathname(sharedUrlForDiscovery, nextPageUrl);
     if (
       resolvedVideoUrl !== null &&
       isUnstableSharedVideoUrl(previousNormalizedPageUrl) &&

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -148,6 +148,12 @@ export function createNavigationController(args: {
     // fall through so the sharer still schedules the auto-share and a non-sharer
     // is still paused.
     const sharedUrlForDiscovery = args.runtimeState.activeSharedUrl;
+    // The room shares THIS page by its bare (unstable) festival route — the page
+    // bridge could not resolve a `bvid`/`cid` when it was shared. Resolving it now
+    // is discovery of that share's concrete video.
+    const sharedIsUnstableSamePageRoute =
+      isUnstableSharedVideoUrl(sharedUrlForDiscovery) &&
+      samePathname(sharedUrlForDiscovery, nextPageUrl);
     if (
       resolvedVideoUrl !== null &&
       isUnstableSharedVideoUrl(previousNormalizedPageUrl) &&
@@ -155,9 +161,14 @@ export function createNavigationController(args: {
       !isUnstableSharedVideoUrl(nextNormalizedPageUrl) &&
       (!args.runtimeState.activeRoomCode ||
         nextNormalizedPageUrl === sharedUrlForDiscovery ||
-        (isUnstableSharedVideoUrl(sharedUrlForDiscovery) &&
-          samePathname(sharedUrlForDiscovery, nextPageUrl)))
+        sharedIsUnstableSamePageRoute)
     ) {
+      // Record the resolved identity of a bare-route festival share so the next
+      // same-page autoplay can use it as a stable "from" anchor (`activeSharedUrl`
+      // itself stays the unstable route until the room confirms a concrete video).
+      if (sharedIsUnstableSamePageRoute) {
+        args.runtimeState.resolvedSharedVideoUrl = nextNormalizedPageUrl;
+      }
       lastObservedPageUrl = nextPageUrl;
       lastObservedNormalizedPageUrl = nextNormalizedPageUrl;
       args.debugLog(
@@ -177,12 +188,18 @@ export function createNavigationController(args: {
     // is itself a sharer autoplay-next.
     const previousPendingAutoShareTargetUrl =
       args.runtimeState.pendingAutoShareTargetUrl;
+    // The resolved identity of a bare-route festival share, captured before the
+    // reset below clears it. Used as the stable "from" anchor for a same-page
+    // autoplay off a share whose `activeSharedUrl` is still the unstable route.
+    const previousResolvedSharedVideoUrl =
+      args.runtimeState.resolvedSharedVideoUrl;
     lastObservedPageUrl = nextPageUrl;
     lastObservedNormalizedPageUrl = nextNormalizedPageUrl;
     args.clearFestivalSnapshot();
     args.runtimeState.pendingPlaybackApplication = null;
     args.runtimeState.explicitNonSharedPlaybackUrl = null;
     args.runtimeState.pendingAutoShareTargetUrl = null;
+    args.runtimeState.resolvedSharedVideoUrl = null;
     // Any genuine navigation invalidates an auto-share scheduled by an earlier
     // autoplay. A manual detour — even one that returns to the same target — must
     // not let a stale settle timer fire and auto-share without the manual
@@ -209,6 +226,16 @@ export function createNavigationController(args: {
     }
 
     const activeSharedUrl = args.runtimeState.activeSharedUrl;
+    // The stable anchor for the room's share. Normally `activeSharedUrl`, but when
+    // the room shares an address-bar-opaque *route* (a bare-route festival share),
+    // `activeSharedUrl` is unstable; fall back to the resolved identity captured
+    // for it so a same-page autoplay off that share can still be classified. The
+    // background still receives the bare `activeSharedUrl` as `previousSharedUrl`
+    // (it must match the room's stored share), so this only affects classification.
+    const effectiveSharedUrl =
+      activeSharedUrl !== null && isUnstableSharedVideoUrl(activeSharedUrl)
+        ? (previousResolvedSharedVideoUrl ?? activeSharedUrl)
+        : activeSharedUrl;
     const now = nowOf();
     // Captured before `resetUserGestureState` below zeroes it, so the
     // natural-end check can tell whether a gesture postdates the natural end.
@@ -227,11 +254,11 @@ export function createNavigationController(args: {
     //   - the shared URL is not yet known (just joined/switched room before the
     //     initial room state arrives) — the page may well be the shared video.
     const canConfirmDifferentVideo =
-      activeSharedUrl !== null &&
-      !isUnstableSharedVideoUrl(activeSharedUrl) &&
+      effectiveSharedUrl !== null &&
+      !isUnstableSharedVideoUrl(effectiveSharedUrl) &&
       nextNormalizedPageUrl !== null &&
       !isUnstableSharedVideoUrl(nextNormalizedPageUrl) &&
-      nextNormalizedPageUrl !== activeSharedUrl;
+      nextNormalizedPageUrl !== effectiveSharedUrl;
 
     // Anchor the previous shared URL so that broadcasts stay suppressed until
     // the page bridge resolves the new page to a different normalized URL or
@@ -293,10 +320,27 @@ export function createNavigationController(args: {
         args.runtimeState.sharedVideoNaturalEndUrl === activeSharedUrl &&
         now - args.runtimeState.sharedVideoNaturalEndAt <
           args.initialRoomStatePauseHoldMs;
+      // The page bridge resolved this address-bar-opaque (festival) page for the
+      // first time only *after* the player had already auto-advanced past the
+      // shared video: the previous identity is still the page's bare (unresolved)
+      // route and the old video's `ended` never recorded a natural-end marker
+      // (there was no matching snapshot then). With `canConfirmDifferentVideo`
+      // already true (the room's share is a known, stable, different video) and no
+      // recent gesture (gated below), the most likely explanation is the shared
+      // video's autoplay-next — so the sharer still schedules the auto-share and a
+      // non-sharer is still paused, rather than leaving the room behind. The
+      // recent-gesture gate keeps a genuine manual navigation to a festival page
+      // from being misread as this case.
+      const navigatedFromUnresolvedFestivalPage =
+        isAddressBarOpaqueVideoUrl(rawPageUrl) &&
+        previousNormalizedPageUrl !== null &&
+        isUnstableSharedVideoUrl(previousNormalizedPageUrl) &&
+        samePathname(previousNormalizedPageUrl, rawPageUrl);
       const navigatedFromSharedVideo =
         navigatedFromSharedVideoEnd ||
+        navigatedFromUnresolvedFestivalPage ||
         (previousNormalizedPageUrl !== null &&
-          (previousNormalizedPageUrl === activeSharedUrl ||
+          (previousNormalizedPageUrl === effectiveSharedUrl ||
             previousNormalizedPageUrl === previousPendingAutoShareTargetUrl));
       // The ONLY recent gesture that should not block autoplay classification is
       // a seek-to-end: the sharer dragged to the last seconds and let the video
@@ -365,6 +409,16 @@ export function createNavigationController(args: {
         // Remember this target so the next chained autoplay (next → next+1) is
         // recognised as a sharer autoplay even before the room confirms it.
         args.runtimeState.pendingAutoShareTargetUrl = nextNormalizedPageUrl;
+        // When the room's share is still a bare festival route (its `room:state`
+        // has not yet confirmed a concrete next video), keep the resolved anchor
+        // advancing to the latest auto-shared target so a further same-page
+        // autoplay (B→C) still resolves a stable `effectiveSharedUrl` and chains.
+        if (
+          activeSharedUrl !== null &&
+          isUnstableSharedVideoUrl(activeSharedUrl)
+        ) {
+          args.runtimeState.resolvedSharedVideoUrl = nextNormalizedPageUrl;
+        }
       } else if (shouldPauseNonSharerAutoplay) {
         args.runtimeState.intendedPlayState = "paused";
         // Mark this as a non-sharer autoplay page so the playback binding will

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -2,7 +2,10 @@ import {
   resetUserGestureState,
   type ContentRuntimeState,
 } from "./runtime-state";
-import { isUnstableSharedVideoUrl } from "./video-identity";
+import {
+  isAddressBarOpaqueVideoUrl,
+  isUnstableSharedVideoUrl,
+} from "./video-identity";
 
 export interface NavigationController {
   start(): void;
@@ -77,18 +80,21 @@ export function createNavigationController(args: {
   function handlePotentialNavigation(): void {
     const rawPageUrl = args.getCurrentPageUrl();
     const resolvedVideoUrl = args.getResolvedVideoUrl?.() ?? null;
-    // On an unstable route (festival) the address bar never reflects the
+    // On an address-bar-opaque page (festival) the URL never reflects the
     // in-player video, so the page-bridge snapshot is the only reliable identity.
     // While it has not resolved yet — including the brief window right after a
-    // same-page autoplay clears it — defer instead of falling back to the bare
-    // route: that route normalizes to an unstable id and would masquerade as a
-    // navigation away from the resolved video, spuriously pausing it. A real
-    // navigation to a *different* path is still handled immediately so autoplay
-    // there stays suppressed until room state confirms.
+    // same-page autoplay clears it — defer instead of falling back to the address
+    // bar: that URL would masquerade as a navigation away from the resolved video
+    // and spuriously cancel the just-scheduled auto-share / pause it. Detect the
+    // page by its `/festival/` pathname, NOT by whether the normalized URL is
+    // unstable: a festival page opened from a share link keeps a frozen
+    // `?bvid=A&cid=...` that normalizes to a *stable* old `/video/...`, which the
+    // unstable check would miss. A real navigation to a different path is still
+    // handled immediately so autoplay there stays suppressed until room state.
     if (
       resolvedVideoUrl === null &&
       args.getResolvedVideoUrl !== undefined &&
-      isUnstableSharedVideoUrl(args.normalizeVideoPageUrl(rawPageUrl)) &&
+      isAddressBarOpaqueVideoUrl(rawPageUrl) &&
       samePathname(rawPageUrl, lastObservedPageUrl)
     ) {
       return;
@@ -125,19 +131,28 @@ export function createNavigationController(args: {
     // never silently swallowed here.
     //
     // Restricted to the discovery of a video we cannot confirm as *different* from
-    // the room's share: either it equals `activeSharedUrl`, or there is no shared
-    // url to compare against yet. If the very first resolution is already a
-    // confirmably different video — the shared video ended and the player
-    // auto-advanced before the snapshot resolved — fall through to the normal
-    // navigation path so the sharer still schedules the auto-share and a
-    // non-sharer is still paused, instead of silently adopting the new video.
+    // the room's share. We can confirm "different" only against a stable, known,
+    // different shared url; treat as discovery when:
+    //   - there is no shared url to compare against yet, or
+    //   - the resolved video equals `activeSharedUrl`, or
+    //   - `activeSharedUrl` is itself an unstable route on this same page (e.g. a
+    //     manual share whose page bridge failed fell back to the bare
+    //     `/festival/<id>` url) — the route may well resolve to this very video,
+    //     so resolving it is discovery, not a switch.
+    // If the very first resolution is already a confirmably different video — the
+    // shared video ended and the player auto-advanced before the snapshot
+    // resolved — fall through to the normal navigation path so the sharer still
+    // schedules the auto-share and a non-sharer is still paused.
+    const sharedUrlForDiscovery = args.runtimeState.activeSharedUrl;
     if (
       resolvedVideoUrl !== null &&
       isUnstableSharedVideoUrl(previousNormalizedPageUrl) &&
       nextNormalizedPageUrl !== null &&
       !isUnstableSharedVideoUrl(nextNormalizedPageUrl) &&
-      (args.runtimeState.activeSharedUrl === null ||
-        nextNormalizedPageUrl === args.runtimeState.activeSharedUrl)
+      (sharedUrlForDiscovery === null ||
+        nextNormalizedPageUrl === sharedUrlForDiscovery ||
+        (isUnstableSharedVideoUrl(sharedUrlForDiscovery) &&
+          samePathname(sharedUrlForDiscovery, nextPageUrl)))
     ) {
       lastObservedPageUrl = nextPageUrl;
       lastObservedNormalizedPageUrl = nextNormalizedPageUrl;

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -16,6 +16,18 @@ export function createNavigationController(args: {
   initialRoomStatePauseHoldMs: number;
   getCurrentPageUrl: () => string;
   normalizeVideoPageUrl: (url: string) => string | null;
+  /**
+   * Resolves the in-player video URL for pages whose address bar does not reflect
+   * the currently playing video. Festival pages keep a fixed `/festival/<id>`
+   * route in the address bar while the player swaps videos, so `getCurrentPageUrl`
+   * never changes across an autoplay-next and the navigation watcher would never
+   * observe it. This returns the page-bridge snapshot's resolved share URL (with
+   * `bvid`/`cid`) when available, or `null` to fall back to
+   * {@link getCurrentPageUrl} (e.g. before the snapshot resolves, or on pages
+   * whose address bar already reflects the video such as `/video/` and bangumi
+   * episode pages).
+   */
+  getResolvedVideoUrl?: () => string | null;
   isSupportedVideoPage: (url: string) => boolean;
   clearFestivalSnapshot: () => void;
   attachPlaybackListeners: () => void;
@@ -40,13 +52,48 @@ export function createNavigationController(args: {
   getNow?: () => number;
 }): NavigationController {
   const nowOf = () => args.getNow?.() ?? Date.now();
+  // Compares the path portion of two page URLs (ignoring query/hash), used to
+  // tell a same-page festival autoplay from a navigation to a different page.
+  const samePathname = (a: string, b: string): boolean => {
+    try {
+      return (
+        new URL(a).pathname.replace(/\/+$/, "") ===
+        new URL(b).pathname.replace(/\/+$/, "")
+      );
+    } catch {
+      return a === b;
+    }
+  };
+  // The observed page identity: the resolved in-player video URL when available
+  // (festival pages), otherwise the address bar. Used to seed the initial
+  // baseline so a later resolution is recognised as a change.
+  const readObservedPageUrl = (): string =>
+    args.getResolvedVideoUrl?.() ?? args.getCurrentPageUrl();
   let navigationWatchTimer: number | null = null;
-  let lastObservedPageUrl = args.getCurrentPageUrl();
+  let lastObservedPageUrl = readObservedPageUrl();
   let lastObservedNormalizedPageUrl =
     args.normalizeVideoPageUrl(lastObservedPageUrl);
 
   function handlePotentialNavigation(): void {
-    const nextPageUrl = args.getCurrentPageUrl();
+    const rawPageUrl = args.getCurrentPageUrl();
+    const resolvedVideoUrl = args.getResolvedVideoUrl?.() ?? null;
+    // On an unstable route (festival) the address bar never reflects the
+    // in-player video, so the page-bridge snapshot is the only reliable identity.
+    // While it has not resolved yet — including the brief window right after a
+    // same-page autoplay clears it — defer instead of falling back to the bare
+    // route: that route normalizes to an unstable id and would masquerade as a
+    // navigation away from the resolved video, spuriously pausing it. A real
+    // navigation to a *different* path is still handled immediately so autoplay
+    // there stays suppressed until room state confirms.
+    if (
+      resolvedVideoUrl === null &&
+      args.getResolvedVideoUrl !== undefined &&
+      isUnstableSharedVideoUrl(args.normalizeVideoPageUrl(rawPageUrl)) &&
+      samePathname(rawPageUrl, lastObservedPageUrl)
+    ) {
+      return;
+    }
+    const nextPageUrl = resolvedVideoUrl ?? rawPageUrl;
     if (nextPageUrl === lastObservedPageUrl) {
       return;
     }
@@ -64,6 +111,31 @@ export function createNavigationController(args: {
     // Used to confirm an autoplay actually started from the room's shared video
     // rather than from a local detour the user manually navigated to.
     const previousNormalizedPageUrl = lastObservedNormalizedPageUrl;
+
+    // First concrete resolution of an unstable route (festival): the page-bridge
+    // snapshot just resolved the in-player video to a stable `/video/...` URL.
+    // This is the *discovery* of the already-playing video, not an autoplay
+    // navigation, so adopt the resolved identity silently instead of running the
+    // suppress/pause/auto-share path below — otherwise the sharer's own
+    // just-resolved video would be needlessly paused on load. Genuine festival
+    // autoplay-next transitions are stable→stable (a resolved video to another
+    // resolved video) and skip this guard, so they still schedule the auto-share.
+    // Gated on the identity coming from the snapshot (`resolvedVideoUrl`) so a
+    // bangumi season→episode navigation, whose address bar genuinely changes, is
+    // never silently swallowed here.
+    if (
+      resolvedVideoUrl !== null &&
+      isUnstableSharedVideoUrl(previousNormalizedPageUrl) &&
+      nextNormalizedPageUrl !== null &&
+      !isUnstableSharedVideoUrl(nextNormalizedPageUrl)
+    ) {
+      lastObservedPageUrl = nextPageUrl;
+      lastObservedNormalizedPageUrl = nextNormalizedPageUrl;
+      args.debugLog(
+        `Adopted resolved video identity ${nextNormalizedPageUrl} from ${previousNormalizedPageUrl} without treating snapshot resolution as a navigation`,
+      );
+      return;
+    }
     // The local video the user was explicitly watching before this navigation
     // (if any). Captured before the reset below so an explicit local-playback
     // intent can be transferred across a detour that auto-advances.

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -133,23 +133,27 @@ export function createNavigationController(args: {
     // Restricted to the discovery of a video we cannot confirm as *different* from
     // the room's share. We can confirm "different" only against a stable, known,
     // different shared url; treat as discovery when:
-    //   - there is no shared url to compare against yet, or
+    //   - we are not in a room (no room state governs playback), or
     //   - the resolved video equals `activeSharedUrl`, or
     //   - `activeSharedUrl` is itself an unstable route on this same page (e.g. a
     //     manual share whose page bridge failed fell back to the bare
     //     `/festival/<id>` url) — the route may well resolve to this very video,
     //     so resolving it is discovery, not a switch.
-    // If the very first resolution is already a confirmably different video — the
-    // shared video ended and the player auto-advanced before the snapshot
-    // resolved — fall through to the normal navigation path so the sharer still
-    // schedules the auto-share and a non-sharer is still paused.
+    // Deliberately NOT a discovery when we are in a room but `activeSharedUrl` is
+    // still null (joined but the initial `room:state` has not arrived): fall
+    // through to the in-room hydration/pause path so a festival video already
+    // playing is suppressed until the room's actual shared video is known. If the
+    // first resolution is already a confirmably different video — the shared video
+    // ended and the player auto-advanced before the snapshot resolved — likewise
+    // fall through so the sharer still schedules the auto-share and a non-sharer
+    // is still paused.
     const sharedUrlForDiscovery = args.runtimeState.activeSharedUrl;
     if (
       resolvedVideoUrl !== null &&
       isUnstableSharedVideoUrl(previousNormalizedPageUrl) &&
       nextNormalizedPageUrl !== null &&
       !isUnstableSharedVideoUrl(nextNormalizedPageUrl) &&
-      (sharedUrlForDiscovery === null ||
+      (!args.runtimeState.activeRoomCode ||
         nextNormalizedPageUrl === sharedUrlForDiscovery ||
         (isUnstableSharedVideoUrl(sharedUrlForDiscovery) &&
           samePathname(sharedUrlForDiscovery, nextPageUrl)))

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -123,11 +123,21 @@ export function createNavigationController(args: {
     // Gated on the identity coming from the snapshot (`resolvedVideoUrl`) so a
     // bangumi season→episode navigation, whose address bar genuinely changes, is
     // never silently swallowed here.
+    //
+    // Restricted to the discovery of a video we cannot confirm as *different* from
+    // the room's share: either it equals `activeSharedUrl`, or there is no shared
+    // url to compare against yet. If the very first resolution is already a
+    // confirmably different video — the shared video ended and the player
+    // auto-advanced before the snapshot resolved — fall through to the normal
+    // navigation path so the sharer still schedules the auto-share and a
+    // non-sharer is still paused, instead of silently adopting the new video.
     if (
       resolvedVideoUrl !== null &&
       isUnstableSharedVideoUrl(previousNormalizedPageUrl) &&
       nextNormalizedPageUrl !== null &&
-      !isUnstableSharedVideoUrl(nextNormalizedPageUrl)
+      !isUnstableSharedVideoUrl(nextNormalizedPageUrl) &&
+      (args.runtimeState.activeSharedUrl === null ||
+        nextNormalizedPageUrl === args.runtimeState.activeSharedUrl)
     ) {
       lastObservedPageUrl = nextPageUrl;
       lastObservedNormalizedPageUrl = nextNormalizedPageUrl;

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -100,10 +100,6 @@ export function createNavigationController(args: {
       return;
     }
     const nextPageUrl = resolvedVideoUrl ?? rawPageUrl;
-    if (nextPageUrl === lastObservedPageUrl) {
-      return;
-    }
-
     const nextNormalizedPageUrl = args.normalizeVideoPageUrl(nextPageUrl);
 
     // The room shares THIS page by its bare (unstable) festival route — the page
@@ -116,18 +112,28 @@ export function createNavigationController(args: {
     // The first snapshot resolution of a bare-route festival share to its concrete
     // stable `/video/...`. Record it as the stable "from" anchor for the next
     // same-page autoplay (`activeSharedUrl` itself stays the unstable route until
-    // the room confirms a concrete video). This must run even when the resolved URL
-    // is unchanged from the baseline: a festival page opened from a share link
-    // keeps a frozen `?bvid=A&cid=...` whose baseline already normalizes to the
-    // same stable `/video/A`, so the resolution hits the "normalized unchanged"
-    // short-circuit below before reaching the discovery guard further down —
-    // without this it would never anchor and the later A→B autoplay could not be
-    // classified as the room share's autoplay.
+    // the room confirms a concrete video). Computed before the no-op short-circuits
+    // below and recorded inside *each* of them — but never on the fall-through
+    // navigation path, where overwriting the anchor with the *new* video would
+    // defeat the `effectiveSharedUrl` classification of the very autoplay it is
+    // meant to enable. A festival page opened from a share link keeps a frozen
+    // `?bvid=A&cid=...`; depending on whether the resolved URL's query order
+    // matches the address bar, this discovery hits either the exact-URL no-op or
+    // the normalized no-op, so both must anchor it (otherwise the later A→B
+    // autoplay cannot be classified as the room share's autoplay and falls into
+    // hydration/pause instead of scheduling the auto-share).
     const isBareRouteShareResolution =
       resolvedVideoUrl !== null &&
       nextNormalizedPageUrl !== null &&
       !isUnstableSharedVideoUrl(nextNormalizedPageUrl) &&
       sharedIsUnstableSamePageRoute;
+
+    if (nextPageUrl === lastObservedPageUrl) {
+      if (isBareRouteShareResolution) {
+        args.runtimeState.resolvedSharedVideoUrl = nextNormalizedPageUrl;
+      }
+      return;
+    }
 
     if (
       nextNormalizedPageUrl !== null &&

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -199,6 +199,9 @@ export function createRoomStateApplyController(args: {
       return;
     }
     args.runtimeState.activeSharedUrl = normalizedSharedUrl ?? null;
+    // The room moved to a different shared video, so any resolved identity tracked
+    // for a previous bare-route festival share no longer applies.
+    args.runtimeState.resolvedSharedVideoUrl = null;
     args.resetPlaybackSyncState(
       `shared url changed to ${sharedVideoUrl ?? "none"}`,
     );
@@ -482,6 +485,7 @@ export function createRoomStateApplyController(args: {
       args.runtimeState.activeSharedUrl = null;
       args.runtimeState.activeSharedByMemberId = null;
       args.runtimeState.pendingAutoShareTargetUrl = null;
+      args.runtimeState.resolvedSharedVideoUrl = null;
       args.runtimeState.suppressedLocalEndPauseUrl = null;
       args.runtimeState.suppressedLocalEndPauseUntil = 0;
       args.runtimeState.nonSharerAutoplayHoldUrl = null;

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -182,7 +182,19 @@ export function createRoomStateApplyController(args: {
     sharedVideoUrl: string | null | undefined,
     sharedByMemberId: string | null | undefined,
   ): void => {
+    const previousSharedByMemberId = args.runtimeState.activeSharedByMemberId;
     args.runtimeState.activeSharedByMemberId = sharedByMemberId ?? null;
+    // Clear the resolved identity tracked for a bare-route festival share when the
+    // share changes owner, even if its (bare) URL is unchanged: another member
+    // re-sharing the same `/festival/<id>` route makes the previous sharer's
+    // resolved `/video/A` anchor stale. Leaving it set would let a same-page A→B
+    // autoplay be misclassified as the current room share's autoplay (wrongly
+    // pausing/holding a non-sharer). The shared-url-changed reset below covers the
+    // differing-URL case; this covers the same-URL ownership transfer that returns
+    // early before reaching it.
+    if ((sharedByMemberId ?? null) !== previousSharedByMemberId) {
+      args.runtimeState.resolvedSharedVideoUrl = null;
+    }
     // Clear the chained auto-share target once the room confirms it, or once
     // another member takes over the share: the in-flight chain marker that lets a
     // sharer schedule the next autoplay before `room:state` catches up is no

--- a/extension/src/content/room-state-controller.ts
+++ b/extension/src/content/room-state-controller.ts
@@ -87,6 +87,7 @@ export function createRoomStateController(args: {
     args.runtimeState.activeSharedUrl = null;
     args.runtimeState.activeSharedByMemberId = null;
     args.runtimeState.pendingAutoShareTargetUrl = null;
+    args.runtimeState.resolvedSharedVideoUrl = null;
     args.runtimeState.explicitNonSharedPlaybackUrl = null;
     args.runtimeState.suppressedLocalEndPauseUrl = null;
     args.runtimeState.suppressedLocalEndPauseUntil = 0;

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -105,6 +105,19 @@ export interface ContentRuntimeState {
    * confirms it (or another member takes over the share) and on room teardown.
    */
   pendingAutoShareTargetUrl: string | null;
+  /**
+   * The resolved `/video/...` identity of the room's current shared video when
+   * that share is an address-bar-opaque *route* (a festival page shared by its
+   * bare `/festival/<id>` url because the page bridge failed to resolve a
+   * `bvid`/`cid`). In that state `activeSharedUrl` is itself unstable, so a
+   * same-page autoplay to the next video could not be classified or auto-shared.
+   * The navigation controller records the resolved identity here when it first
+   * discovers the bare-route share's concrete video, then uses it as the stable
+   * "from" anchor for the subsequent autoplay. Cleared when the shared url changes
+   * (the room confirmed a concrete next video), on leaving the page, and on room
+   * teardown.
+   */
+  resolvedSharedVideoUrl: string | null;
   lastForcedPauseAt: number;
   pauseHoldUntil: number;
   pendingPlaybackApplication: PlaybackState | null;
@@ -251,6 +264,7 @@ export function createContentRuntimeState(): ContentRuntimeState {
     suppressedLocalEndPauseUntil: 0,
     nonSharerAutoplayHoldUrl: null,
     pendingAutoShareTargetUrl: null,
+    resolvedSharedVideoUrl: null,
     lastForcedPauseAt: 0,
     pauseHoldUntil: 0,
     pendingPlaybackApplication: null,

--- a/extension/src/content/video-identity.ts
+++ b/extension/src/content/video-identity.ts
@@ -13,6 +13,25 @@ export function hasStableSharedVideoIdentity(
   );
 }
 
+/**
+ * Pages whose address bar never reflects the in-player video. Festival pages keep
+ * a fixed `/festival/<id>` route while the player swaps videos; any `bvid`/`cid`
+ * query carried in from a share link stays frozen at the entry video, so the
+ * normalized URL can look stable yet point at the wrong (old) video. The
+ * in-player video is only knowable via the page-bridge snapshot. Detect these by
+ * pathname rather than by whether the normalized URL is unstable.
+ */
+export function isAddressBarOpaqueVideoUrl(url: string | null): boolean {
+  if (!url) {
+    return false;
+  }
+  try {
+    return new URL(url).pathname.startsWith("/festival/");
+  } catch {
+    return false;
+  }
+}
+
 export function isUnstableSharedVideoUrl(url: string | null): boolean {
   if (!url) {
     return false;

--- a/extension/test/auto-share-next-controller.test.ts
+++ b/extension/test/auto-share-next-controller.test.ts
@@ -414,6 +414,58 @@ test("auto-share next controller skips when a non-festival page leaves to an uns
   }
 });
 
+test("auto-share next controller skips when a festival snapshot resolves a different video during settle", async () => {
+  const windowHarness = installWindowStub();
+  const sentMessages: unknown[] = [];
+  const debugLogs: string[] = [];
+  function normalizeFestivalAwareUrl(url: string): string | null {
+    if (url.includes("/festival/")) {
+      const bvid = url.match(/[?&]bvid=([^&]+)/);
+      const cid = url.match(/[?&]cid=([^&]+)/);
+      if (bvid && cid) {
+        return `https://www.bilibili.com/video/${bvid[1]}?cid=${cid[1]}`;
+      }
+      return "https://www.bilibili.com/festival/MyMuji";
+    }
+    return normalizeTestVideoPageUrl(url);
+  }
+  // The user manually jumped to another video C within the same festival page
+  // during settle. The page bridge resolved it (a trustworthy current video), so
+  // a mismatch with the target must still cancel the auto-share.
+  const resolvedUrl = "https://www.bilibili.com/festival/MyMuji?bvid=BVc&cid=3";
+  const controller = createAutoShareNextController({
+    settleDelayMs: 900,
+    getCurrentPageUrl: () => resolvedUrl,
+    getResolvedVideoUrl: () => resolvedUrl,
+    normalizeVideoPageUrl: normalizeFestivalAwareUrl,
+    runtimeSendMessage: async (message) => {
+      sentMessages.push(message);
+      return { ok: true };
+    },
+    debugLog: (message) => {
+      debugLogs.push(message);
+    },
+  });
+
+  try {
+    controller.scheduleForNavigation({
+      previousSharedUrl: "https://www.bilibili.com/video/BVa?cid=1",
+      nextNormalizedPageUrl: "https://www.bilibili.com/video/BVb?cid=2",
+    });
+    windowHarness.runTimers();
+    await Promise.resolve();
+
+    assert.deepEqual(sentMessages, []);
+    assert.match(
+      debugLogs[debugLogs.length - 1],
+      /^Skipped auto-share next video because page moved /,
+    );
+  } finally {
+    controller.destroy();
+    windowHarness.restore();
+  }
+});
+
 test("auto-share next controller still sends when a festival address bar keeps a frozen bvid", async () => {
   const windowHarness = installWindowStub();
   const sentMessages: unknown[] = [];

--- a/extension/test/auto-share-next-controller.test.ts
+++ b/extension/test/auto-share-next-controller.test.ts
@@ -321,6 +321,59 @@ test("auto-share next controller skips a settled request when the page moved aga
   }
 });
 
+test("auto-share next controller still sends when a festival snapshot is cleared during settle", async () => {
+  const windowHarness = installWindowStub();
+  const sentMessages: unknown[] = [];
+  // The navigation handler clears the festival snapshot before scheduling, so by
+  // the time the settle timer fires the page resolves only to the bare
+  // `/festival/<id>` route (unstable) — not the scheduled `/video/...` target.
+  function normalizeFestivalAwareUrl(url: string): string | null {
+    if (url.includes("/festival/")) {
+      const bvid = url.match(/[?&]bvid=([^&]+)/);
+      const cid = url.match(/[?&]cid=([^&]+)/);
+      if (bvid && cid) {
+        return `https://www.bilibili.com/video/${bvid[1]}?cid=${cid[1]}`;
+      }
+      return "https://www.bilibili.com/festival/MyMuji";
+    }
+    return normalizeTestVideoPageUrl(url);
+  }
+  const controller = createAutoShareNextController({
+    settleDelayMs: 900,
+    getCurrentPageUrl: () => "https://www.bilibili.com/festival/MyMuji",
+    normalizeVideoPageUrl: normalizeFestivalAwareUrl,
+    runtimeSendMessage: async (message) => {
+      sentMessages.push(message);
+      return { ok: true };
+    },
+    debugLog: () => {},
+  });
+
+  try {
+    controller.scheduleForNavigation({
+      previousSharedUrl: "https://www.bilibili.com/video/BVa?cid=1",
+      nextNormalizedPageUrl: "https://www.bilibili.com/video/BVb?cid=2",
+    });
+    windowHarness.runTimers();
+    await Promise.resolve();
+
+    // The unstable route is "cannot tell", not a confirmed move-on, so the
+    // request must be sent (the background performs the authoritative check)
+    // rather than silently dropped without a retry.
+    assert.equal(sentMessages.length, 1);
+    assert.deepEqual(sentMessages[0], {
+      type: "content:auto-share-next-video",
+      payload: {
+        previousSharedUrl: "https://www.bilibili.com/video/BVa?cid=1",
+        targetNormalizedUrl: "https://www.bilibili.com/video/BVb?cid=2",
+      },
+    });
+  } finally {
+    controller.destroy();
+    windowHarness.restore();
+  }
+});
+
 test("auto-share next controller retries when the background reports the page is not ready", async () => {
   const windowHarness = installWindowStub();
   const sentMessages: unknown[] = [];

--- a/extension/test/auto-share-next-controller.test.ts
+++ b/extension/test/auto-share-next-controller.test.ts
@@ -374,6 +374,46 @@ test("auto-share next controller still sends when a festival snapshot is cleared
   }
 });
 
+test("auto-share next controller skips when a non-festival page leaves to an unsupported page", async () => {
+  const windowHarness = installWindowStub();
+  const sentMessages: unknown[] = [];
+  const debugLogs: string[] = [];
+  // The user navigated off to a non-video page during settle: it normalizes to
+  // null. On a normal (non-opaque) page this means the page genuinely left the
+  // target, so the auto-share must be cancelled — not deferred to the background
+  // where it could still fire if the user returns within the retry window.
+  const controller = createAutoShareNextController({
+    settleDelayMs: 900,
+    getCurrentPageUrl: () => "https://www.bilibili.com/account/history",
+    normalizeVideoPageUrl: normalizeTestVideoPageUrl,
+    runtimeSendMessage: async (message) => {
+      sentMessages.push(message);
+      return { ok: true };
+    },
+    debugLog: (message) => {
+      debugLogs.push(message);
+    },
+  });
+
+  try {
+    controller.scheduleForNavigation({
+      previousSharedUrl: "https://www.bilibili.com/video/BV1OldVideo",
+      nextNormalizedPageUrl: "https://www.bilibili.com/video/BV1NextVideo",
+    });
+    windowHarness.runTimers();
+    await Promise.resolve();
+
+    assert.deepEqual(sentMessages, []);
+    assert.match(
+      debugLogs[debugLogs.length - 1],
+      /^Skipped auto-share next video because page moved /,
+    );
+  } finally {
+    controller.destroy();
+    windowHarness.restore();
+  }
+});
+
 test("auto-share next controller still sends when a festival address bar keeps a frozen bvid", async () => {
   const windowHarness = installWindowStub();
   const sentMessages: unknown[] = [];

--- a/extension/test/auto-share-next-controller.test.ts
+++ b/extension/test/auto-share-next-controller.test.ts
@@ -374,6 +374,59 @@ test("auto-share next controller still sends when a festival snapshot is cleared
   }
 });
 
+test("auto-share next controller still sends when a festival address bar keeps a frozen bvid", async () => {
+  const windowHarness = installWindowStub();
+  const sentMessages: unknown[] = [];
+  // Opened from a share link: after the snapshot clears, the page resolves to the
+  // frozen `?bvid=A&cid=...` which normalizes to a *stable* (but stale) /video/A.
+  function normalizeFestivalAwareUrl(url: string): string | null {
+    if (url.includes("/festival/")) {
+      const bvid = url.match(/[?&]bvid=([^&]+)/);
+      const cid = url.match(/[?&]cid=([^&]+)/);
+      if (bvid && cid) {
+        return `https://www.bilibili.com/video/${bvid[1]}?cid=${cid[1]}`;
+      }
+      return "https://www.bilibili.com/festival/MyMuji";
+    }
+    return normalizeTestVideoPageUrl(url);
+  }
+  const controller = createAutoShareNextController({
+    settleDelayMs: 900,
+    getCurrentPageUrl: () =>
+      "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1",
+    normalizeVideoPageUrl: normalizeFestivalAwareUrl,
+    runtimeSendMessage: async (message) => {
+      sentMessages.push(message);
+      return { ok: true };
+    },
+    debugLog: () => {},
+  });
+
+  try {
+    controller.scheduleForNavigation({
+      previousSharedUrl: "https://www.bilibili.com/video/BVa?cid=1",
+      nextNormalizedPageUrl: "https://www.bilibili.com/video/BVb?cid=2",
+    });
+    windowHarness.runTimers();
+    await Promise.resolve();
+
+    // The frozen bvid normalizes to a stable /video/BVa that differs from the
+    // target /video/BVb, but the festival address bar is untrustworthy, so the
+    // request must still be sent rather than skipped as "page moved".
+    assert.equal(sentMessages.length, 1);
+    assert.deepEqual(sentMessages[0], {
+      type: "content:auto-share-next-video",
+      payload: {
+        previousSharedUrl: "https://www.bilibili.com/video/BVa?cid=1",
+        targetNormalizedUrl: "https://www.bilibili.com/video/BVb?cid=2",
+      },
+    });
+  } finally {
+    controller.destroy();
+    windowHarness.restore();
+  }
+});
+
 test("auto-share next controller retries when the background reports the page is not ready", async () => {
   const windowHarness = installWindowStub();
   const sentMessages: unknown[] = [];

--- a/extension/test/festival-bridge.test.ts
+++ b/extension/test/festival-bridge.test.ts
@@ -189,6 +189,46 @@ test("festival bridge reuses cached festival snapshot across trailing slash path
   }
 });
 
+test("festival bridge resolves the cached video url for the matching festival page", async () => {
+  const dom = installBridgeDomStub([
+    {
+      bvid: "BVfestival",
+      cid: 123,
+      title: "Festival Episode",
+    },
+  ]);
+  const controller = createFestivalBridgeController();
+
+  try {
+    // No snapshot yet.
+    assert.equal(controller.resolveVideoUrlForPage("/festival/demo"), null);
+
+    await controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl: "https://www.bilibili.com/festival/demo",
+      maxAgeMs: 0,
+    });
+
+    // Same page (incl. trailing-slash variant) resolves to the snapshot url.
+    assert.equal(
+      controller.resolveVideoUrlForPage("/festival/demo"),
+      "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123",
+    );
+    assert.equal(
+      controller.resolveVideoUrlForPage("/festival/demo/"),
+      "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123",
+    );
+    // A different festival page or a non-festival page does not match.
+    assert.equal(controller.resolveVideoUrlForPage("/festival/other"), null);
+    assert.equal(controller.resolveVideoUrlForPage("/video/BVx"), null);
+
+    controller.clearSnapshot();
+    assert.equal(controller.resolveVideoUrlForPage("/festival/demo"), null);
+  } finally {
+    dom.restore();
+  }
+});
+
 test("festival bridge does not fall back to another festival page snapshot", async () => {
   const dom = installBridgeDomStub([
     {

--- a/extension/test/festival-bridge.test.ts
+++ b/extension/test/festival-bridge.test.ts
@@ -229,6 +229,72 @@ test("festival bridge resolves the cached video url for the matching festival pa
   }
 });
 
+test("festival bridge treats a stale cached snapshot as unresolved when a max age is given", async () => {
+  const dom = installBridgeDomStub([
+    {
+      bvid: "BVfestival",
+      cid: 123,
+      title: "Festival Episode",
+    },
+  ]);
+  const controller = createFestivalBridgeController();
+
+  try {
+    await controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl: "https://www.bilibili.com/festival/demo",
+      maxAgeMs: 0,
+    });
+
+    const url =
+      "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123";
+    // Within the freshness bound (and with no bound) the snapshot resolves.
+    assert.equal(
+      controller.resolveVideoUrlForPage("/festival/demo", 60_000),
+      url,
+    );
+    assert.equal(controller.resolveVideoUrlForPage("/festival/demo"), url);
+    // Older than the bound: treated as stale so a possibly-left video is not
+    // reported as the trustworthy current one.
+    assert.equal(controller.resolveVideoUrlForPage("/festival/demo", 0), null);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("festival bridge does not fall back to a stale cached snapshot on read failure", async () => {
+  const dom = installBridgeDomStub([
+    {
+      bvid: "BVfestival",
+      cid: 123,
+      title: "Festival Episode",
+    },
+    null,
+  ]);
+  const controller = createFestivalBridgeController();
+
+  try {
+    const firstSnapshot = await controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl: "https://www.bilibili.com/festival/demo",
+      maxAgeMs: 0,
+    });
+    assert.equal(firstSnapshot?.videoId, "BVfestival:123");
+
+    // Fast-path skipped (cache is older than maxAgeMs) and the fresh read fails;
+    // the cache must not be resurrected for the authoritative target validation.
+    const staleRead = await controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl: "https://www.bilibili.com/festival/demo",
+      maxAgeMs: 0,
+    });
+
+    assert.equal(staleRead, null);
+  } finally {
+    dom.restore();
+  }
+});
+
 test("festival bridge does not fall back to another festival page snapshot", async () => {
   const dom = installBridgeDomStub([
     {

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -2013,3 +2013,245 @@ test("navigation controller defers, not cancels, when a festival address bar kee
     windowHarness.restore();
   }
 });
+
+test("navigation controller auto-shares a same-page autoplay off a bare-route festival share", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  // The room shares this festival page by its bare route (the page bridge failed
+  // to resolve a bvid/cid when it was shared), so `activeSharedUrl` is unstable.
+  runtimeState.activeSharedUrl = FESTIVAL_ROUTE;
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+  const autoShareRequests: Array<{
+    previousSharedUrl: string;
+    nextNormalizedPageUrl: string;
+    previousAutoShareTargetUrl: string | null;
+  }> = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    // First resolution discovers the bare-route share's concrete video A and
+    // records the resolved anchor without pausing/sharing.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1";
+    windowHarness.intervals[0]?.();
+    assert.deepEqual(autoShareRequests, []);
+    assert.equal(
+      runtimeState.resolvedSharedVideoUrl,
+      "https://www.bilibili.com/video/BVa?cid=1",
+    );
+
+    // Same-page autoplay to B: classified via the resolved anchor, auto-shared
+    // with the room's bare route as `previousSharedUrl` so the background matches.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(pauseCalls, 0);
+    assert.deepEqual(autoShareRequests, [
+      {
+        previousSharedUrl: FESTIVAL_ROUTE,
+        nextNormalizedPageUrl: "https://www.bilibili.com/video/BVb?cid=2",
+        previousAutoShareTargetUrl: null,
+      },
+    ]);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller auto-shares when the first festival resolution already advanced past the shared video without an end marker", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+  // No natural-end marker was recorded (the snapshot was unresolved when A ended).
+  runtimeState.sharedVideoNaturalEndUrl = null;
+
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+  const autoShareRequests: Array<{
+    previousSharedUrl: string;
+    nextNormalizedPageUrl: string;
+    previousAutoShareTargetUrl: string | null;
+  }> = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    // The page bridge resolves only after the player auto-advanced to B; the
+    // previous identity is still the bare festival route and there is no end
+    // marker, yet this must still be recognised as the shared video's autoplay.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(pauseCalls, 0);
+    assert.deepEqual(autoShareRequests, [
+      {
+        previousSharedUrl: "https://www.bilibili.com/video/BVa?cid=1",
+        nextNormalizedPageUrl: "https://www.bilibili.com/video/BVb?cid=2",
+        previousAutoShareTargetUrl: null,
+      },
+    ]);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller pauses a non-sharer when the first festival resolution advanced past the shared video", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-2";
+  runtimeState.sharedVideoNaturalEndUrl = null;
+
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: () => {},
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(pauseCalls, 1);
+    assert.equal(runtimeState.intendedPlayState, "paused");
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller does not auto-share a gesture-driven first festival resolution past the shared video", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+  runtimeState.sharedVideoNaturalEndUrl = null;
+  // A recent manual gesture means this is a user navigation, not an autoplay.
+  runtimeState.lastUserGestureAt = 9_900;
+
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+  const autoShareRequests: unknown[] = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    windowHarness.intervals[0]?.();
+
+    // The recent-gesture gate keeps a manual navigation from being misread as the
+    // shared video's autoplay.
+    assert.deepEqual(autoShareRequests, []);
+    assert.equal(pauseCalls, 0);
+  } finally {
+    windowHarness.restore();
+  }
+});

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -2088,7 +2088,7 @@ test("navigation controller auto-shares a same-page autoplay off a bare-route fe
   }
 });
 
-test("navigation controller auto-shares when the first festival resolution already advanced past the shared video without an end marker", () => {
+test("navigation controller does not auto-share a first festival resolution to a different video without a natural-end marker", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();
   runtimeState.activeRoomCode = "ROOM01";
@@ -2096,7 +2096,9 @@ test("navigation controller auto-shares when the first festival resolution alrea
   runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
   runtimeState.activeSharedByMemberId = "member-1";
   runtimeState.localMemberId = "member-1";
-  // No natural-end marker was recorded (the snapshot was unresolved when A ended).
+  // No natural-end marker, and the previous identity is the bare festival route:
+  // a slow-resolving manual detour is indistinguishable from an autoplay past the
+  // shared video, so it must NOT be auto-shared (no proof it came from the share).
   runtimeState.sharedVideoNaturalEndUrl = null;
 
   let resolved: string | null = null;
@@ -2134,26 +2136,20 @@ test("navigation controller auto-shares when the first festival resolution alrea
 
   try {
     controller.start();
-    // The page bridge resolves only after the player auto-advanced to B; the
-    // previous identity is still the bare festival route and there is no end
-    // marker, yet this must still be recognised as the shared video's autoplay.
+    // The page bridge resolves to a different video B with only the bare route as
+    // the previous identity and no end marker. Without provable shared-source
+    // evidence this is treated as a (possible) manual detour, not auto-shared.
     resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
     windowHarness.intervals[0]?.();
 
     assert.equal(pauseCalls, 0);
-    assert.deepEqual(autoShareRequests, [
-      {
-        previousSharedUrl: "https://www.bilibili.com/video/BVa?cid=1",
-        nextNormalizedPageUrl: "https://www.bilibili.com/video/BVb?cid=2",
-        previousAutoShareTargetUrl: null,
-      },
-    ]);
+    assert.deepEqual(autoShareRequests, []);
   } finally {
     windowHarness.restore();
   }
 });
 
-test("navigation controller pauses a non-sharer when the first festival resolution advanced past the shared video", () => {
+test("navigation controller does not pause a non-sharer on a first festival resolution to a different video without a natural-end marker", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();
   runtimeState.activeRoomCode = "ROOM01";
@@ -2194,8 +2190,10 @@ test("navigation controller pauses a non-sharer when the first festival resoluti
     resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
     windowHarness.intervals[0]?.();
 
-    assert.equal(pauseCalls, 1);
-    assert.equal(runtimeState.intendedPlayState, "paused");
+    // Without proof the advance came from the shared video, a follower's first
+    // resolution to a different video is left alone (it may be a manual detour);
+    // the room corrects them via room state if it was a genuine sharer advance.
+    assert.equal(pauseCalls, 0);
   } finally {
     windowHarness.restore();
   }

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -1707,6 +1707,59 @@ test("navigation controller pauses when the first festival resolution is a diffe
   }
 });
 
+test("navigation controller suppresses a first festival resolution while a joined room has no shared url yet", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  // Joined a room, but the initial room:state has not arrived yet.
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = null;
+
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+  let hydrateCalls = 0;
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {
+      hydrateCalls += 1;
+    },
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1";
+    windowHarness.intervals[0]?.();
+
+    // Not a discovery: in a room with an unknown shared url, the first resolution
+    // must engage the initial pause protection until room state confirms, instead
+    // of letting the local festival video keep playing.
+    assert.equal(pauseCalls, 1);
+    assert.equal(hydrateCalls, 1);
+    assert.equal(runtimeState.pendingRoomStateHydration, true);
+    assert.equal(runtimeState.intendedPlayState, "paused");
+  } finally {
+    windowHarness.restore();
+  }
+});
+
 test("navigation controller adopts a first festival resolution without pausing the shared video", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -1496,3 +1496,212 @@ test("navigation controller clears stale gesture state on in-room navigation", (
     windowHarness.restore();
   }
 });
+
+// Festival pages keep a fixed `/festival/<id>` route in the address bar while the
+// player swaps videos, so the navigation watcher observes the in-player video
+// only through the resolved page-bridge snapshot URL. The route itself
+// normalizes to an unstable id; a `?bvid=&cid=` snapshot URL normalizes to the
+// resolved `/video/...` page.
+const FESTIVAL_ROUTE = "https://www.bilibili.com/festival/MyMuji";
+function normalizeFestivalPageUrl(url: string): string | null {
+  if (url.includes("/festival/")) {
+    const bvid = url.match(/[?&]bvid=([^&]+)/);
+    const cid = url.match(/[?&]cid=([^&]+)/);
+    if (bvid && cid) {
+      return `https://www.bilibili.com/video/${bvid[1]}?cid=${cid[1]}`;
+    }
+    return FESTIVAL_ROUTE;
+  }
+  return normalizeTestVideoPageUrl(url);
+}
+
+test("navigation controller schedules auto-share when a festival page autoplays to the next video", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  // The room shares the resolved `/video/...` form of the festival video.
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+  const autoShareRequests: Array<{
+    previousSharedUrl: string;
+    nextNormalizedPageUrl: string;
+    previousAutoShareTargetUrl: string | null;
+  }> = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    // The snapshot first resolves to the *shared* video A — this is discovery of
+    // the already-playing video, not an autoplay, so it must not pause or share.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1";
+    windowHarness.intervals[0]?.();
+    assert.equal(pauseCalls, 0);
+    assert.deepEqual(autoShareRequests, []);
+
+    // The festival player autoplays to the next video B; the address bar stays on
+    // the festival route, but the resolved snapshot now points at B.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(pauseCalls, 0);
+    assert.deepEqual(autoShareRequests, [
+      {
+        previousSharedUrl: "https://www.bilibili.com/video/BVa?cid=1",
+        nextNormalizedPageUrl: "https://www.bilibili.com/video/BVb?cid=2",
+        previousAutoShareTargetUrl: null,
+      },
+    ]);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller adopts a first festival resolution without pausing the shared video", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+  runtimeState.intendedPlayState = "playing";
+
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+  let hydrateCalls = 0;
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {
+      hydrateCalls += 1;
+    },
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1";
+    windowHarness.intervals[0]?.();
+
+    // The shared video that just resolved must not be paused, re-hydrated, or
+    // flipped into a pending-hydration/paused state.
+    assert.equal(pauseCalls, 0);
+    assert.equal(hydrateCalls, 0);
+    assert.equal(runtimeState.pendingRoomStateHydration, false);
+    assert.equal(runtimeState.intendedPlayState, "playing");
+
+    // A redundant re-resolution of the same video is a no-op (identity adopted).
+    windowHarness.intervals[0]?.();
+    assert.equal(pauseCalls, 0);
+    assert.equal(hydrateCalls, 0);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller does not flip-flop when a festival snapshot is briefly cleared", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+  let hydrateCalls = 0;
+  const autoShareRequests: unknown[] = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {
+      hydrateCalls += 1;
+    },
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1";
+    windowHarness.intervals[0]?.();
+
+    // The snapshot is momentarily cleared (as the nav handler does after a real
+    // navigation). The watcher must defer, not treat the bare route as a switch
+    // to a non-video page and pause the still-playing shared video.
+    resolved = null;
+    windowHarness.intervals[0]?.();
+    windowHarness.intervals[0]?.();
+
+    assert.equal(pauseCalls, 0);
+    assert.equal(hydrateCalls, 0);
+    assert.deepEqual(autoShareRequests, []);
+    assert.equal(runtimeState.pendingRoomStateHydration, false);
+  } finally {
+    windowHarness.restore();
+  }
+});

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -2088,6 +2088,87 @@ test("navigation controller auto-shares a same-page autoplay off a bare-route fe
   }
 });
 
+test("navigation controller anchors a bare-route festival share even when the address bar keeps a frozen bvid", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  // The room shares this festival page by its bare route, so `activeSharedUrl` is
+  // unstable — but this tab opened the page from a share link whose address bar
+  // keeps a frozen `?bvid=BVa&cid=1`, so the baseline normalizes to a *stable*
+  // `/video/BVa`. The first snapshot resolution to the same A therefore lands on
+  // the "normalized unchanged" short-circuit, not the discovery guard.
+  runtimeState.activeSharedUrl = FESTIVAL_ROUTE;
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+  const autoShareRequests: Array<{
+    previousSharedUrl: string;
+    nextNormalizedPageUrl: string;
+    previousAutoShareTargetUrl: string | null;
+  }> = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    // Frozen address bar: keeps the bvid of the video the page was opened on.
+    getCurrentPageUrl: () =>
+      "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1",
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    // First resolution discovers the bare-route share's concrete video A. Its
+    // string differs from the frozen address bar (query order) but normalizes to
+    // the same stable `/video/BVa`, so it hits the "normalized unchanged" branch —
+    // which must still record the resolved anchor.
+    resolved = "https://www.bilibili.com/festival/MyMuji?cid=1&bvid=BVa";
+    windowHarness.intervals[0]?.();
+    assert.deepEqual(autoShareRequests, []);
+    assert.equal(
+      runtimeState.resolvedSharedVideoUrl,
+      "https://www.bilibili.com/video/BVa?cid=1",
+    );
+
+    // Same-page autoplay to B is then classified via the recorded anchor and
+    // auto-shared with the room's bare route as `previousSharedUrl`.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(pauseCalls, 0);
+    assert.deepEqual(autoShareRequests, [
+      {
+        previousSharedUrl: FESTIVAL_ROUTE,
+        nextNormalizedPageUrl: "https://www.bilibili.com/video/BVb?cid=2",
+        previousAutoShareTargetUrl: null,
+      },
+    ]);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
 test("navigation controller does not auto-share a first festival resolution to a different video without a natural-end marker", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -2169,6 +2169,80 @@ test("navigation controller anchors a bare-route festival share even when the ad
   }
 });
 
+test("navigation controller anchors a bare-route festival share when the resolved url exactly matches the frozen address bar", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = FESTIVAL_ROUTE;
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+
+  const FROZEN_A = "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1";
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+  const autoShareRequests: Array<{
+    previousSharedUrl: string;
+    nextNormalizedPageUrl: string;
+    previousAutoShareTargetUrl: string | null;
+  }> = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FROZEN_A,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    // The common share-link case: the page bridge resolves A to the exact same
+    // URL the frozen address bar holds, hitting the `nextPageUrl ===
+    // lastObservedPageUrl` short-circuit before the normalized one. The anchor
+    // must still be recorded there.
+    resolved = FROZEN_A;
+    windowHarness.intervals[0]?.();
+    assert.deepEqual(autoShareRequests, []);
+    assert.equal(
+      runtimeState.resolvedSharedVideoUrl,
+      "https://www.bilibili.com/video/BVa?cid=1",
+    );
+
+    // Same-page autoplay to B is then classified via the recorded anchor.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(pauseCalls, 0);
+    assert.deepEqual(autoShareRequests, [
+      {
+        previousSharedUrl: FESTIVAL_ROUTE,
+        nextNormalizedPageUrl: "https://www.bilibili.com/video/BVb?cid=2",
+        previousAutoShareTargetUrl: null,
+      },
+    ]);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
 test("navigation controller does not auto-share a first festival resolution to a different video without a natural-end marker", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -1585,6 +1585,128 @@ test("navigation controller schedules auto-share when a festival page autoplays 
   }
 });
 
+test("navigation controller schedules auto-share when the first festival resolution is already a different video", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+  // The shared video A ended on this festival page (durable natural-end marker
+  // within the hold window of getNow 10_000 / initialRoomStatePauseHoldMs 1_500).
+  runtimeState.sharedVideoNaturalEndUrl =
+    "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.sharedVideoNaturalEndAt = 9_000;
+
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+  const autoShareRequests: Array<{
+    previousSharedUrl: string;
+    nextNormalizedPageUrl: string;
+    previousAutoShareTargetUrl: string | null;
+  }> = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    // The page-bridge resolves only after the player already auto-advanced to B,
+    // so the very first resolution is a confirmably different video. It must NOT
+    // be silently adopted — the auto-share has to be scheduled from the room's
+    // confirmed video A.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(pauseCalls, 0);
+    assert.deepEqual(autoShareRequests, [
+      {
+        previousSharedUrl: "https://www.bilibili.com/video/BVa?cid=1",
+        nextNormalizedPageUrl: "https://www.bilibili.com/video/BVb?cid=2",
+        previousAutoShareTargetUrl: null,
+      },
+    ]);
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller pauses when the first festival resolution is a different video for a non-sharer", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
+  // A different member owns the share; this client is a follower.
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-2";
+  runtimeState.sharedVideoNaturalEndUrl =
+    "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.sharedVideoNaturalEndAt = 9_000;
+
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: () => {},
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    windowHarness.intervals[0]?.();
+
+    // A follower's local autoplay to a different video must be paused, not
+    // silently adopted.
+    assert.equal(pauseCalls, 1);
+    assert.equal(runtimeState.intendedPlayState, "paused");
+  } finally {
+    windowHarness.restore();
+  }
+});
+
 test("navigation controller adopts a first festival resolution without pausing the shared video", () => {
   const windowHarness = installWindowStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -1827,3 +1827,136 @@ test("navigation controller does not flip-flop when a festival snapshot is brief
     windowHarness.restore();
   }
 });
+
+test("navigation controller adopts a first festival resolution when the room shares the bare festival route", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  // A manual share whose page bridge failed fell back to the bare festival route,
+  // so the room's shared url is unstable rather than a `/video/...` form.
+  runtimeState.activeSharedUrl = FESTIVAL_ROUTE;
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+  runtimeState.intendedPlayState = "playing";
+
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+  let hydrateCalls = 0;
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {
+      hydrateCalls += 1;
+    },
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    // Resolving the same festival page to a concrete video is discovery, not a
+    // switch to a different video — even though it does not equal the unstable
+    // shared url. It must not pause/re-hydrate the sharer's own playing video.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1";
+    windowHarness.intervals[0]?.();
+
+    assert.equal(pauseCalls, 0);
+    assert.equal(hydrateCalls, 0);
+    assert.equal(runtimeState.pendingRoomStateHydration, false);
+    assert.equal(runtimeState.intendedPlayState, "playing");
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller defers, not cancels, when a festival address bar keeps a frozen bvid after the snapshot clears", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+
+  // Opened from a share link: the address bar keeps a frozen `?bvid=BVa&cid=1`
+  // that normalizes to a *stable* old `/video/BVa` even after the player advances.
+  const FROZEN_FESTIVAL_URL =
+    "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1";
+  let resolved: string | null = null;
+  let pauseCalls = 0;
+  let cancelCalls = 0;
+  const autoShareRequests: Array<{ nextNormalizedPageUrl: string }> = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    getCurrentPageUrl: () => FROZEN_FESTIVAL_URL,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    pauseVideo: () => {
+      pauseCalls += 1;
+    },
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    cancelAutoShareNextVideo: () => {
+      cancelCalls += 1;
+    },
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    // Snapshot resolves to the shared video A (matches the frozen url): no-op.
+    resolved = FROZEN_FESTIVAL_URL;
+    windowHarness.intervals[0]?.();
+    // Same-page autoplay to B is detected and schedules the auto-share.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    windowHarness.intervals[0]?.();
+    assert.equal(autoShareRequests.length, 1);
+    assert.equal(
+      autoShareRequests[0].nextNormalizedPageUrl,
+      "https://www.bilibili.com/video/BVb?cid=2",
+    );
+    const cancelsAfterSchedule = cancelCalls;
+
+    // The nav handler cleared the snapshot; the next poll sees only the frozen
+    // `?bvid=BVa` url (normalizes to stable old A). It must DEFER on the festival
+    // pathname, not treat it as a navigation B→A that cancels the B auto-share.
+    resolved = null;
+    windowHarness.intervals[0]?.();
+    windowHarness.intervals[0]?.();
+
+    assert.equal(pauseCalls, 0);
+    assert.equal(cancelCalls, cancelsAfterSchedule);
+    assert.equal(autoShareRequests.length, 1);
+  } finally {
+    windowHarness.restore();
+  }
+});

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -417,6 +417,87 @@ test("clears the pending auto-share target when another member takes over the sh
   assert.equal(harness.runtimeState.pendingAutoShareTargetUrl, null);
 });
 
+test("clears the resolved bare-route anchor when another member re-shares the same festival route", async () => {
+  const harness = createController({ now: 10_000, currentVideo: null });
+
+  // We are a follower; member-1 originally shared this festival page by its bare
+  // route and our snapshot resolved its concrete video as the anchor.
+  harness.runtimeState.localMemberId = "member-2";
+  harness.runtimeState.activeSharedByMemberId = "member-1";
+  harness.runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/festival/MyMuji";
+  harness.runtimeState.resolvedSharedVideoUrl =
+    "https://www.bilibili.com/video/BVa?cid=1";
+  harness.runtimeState.pendingRoomStateHydration = false;
+
+  await harness.controller.applyRoomState({
+    roomCode: "ROOM01",
+    // Same bare festival route, but a different member now owns the share.
+    sharedVideo: {
+      videoId: "MyMuji",
+      url: "https://www.bilibili.com/festival/MyMuji",
+      title: "别人重新分享的",
+      sharedByMemberId: "member-2",
+    },
+    playback: {
+      url: "https://www.bilibili.com/festival/MyMuji",
+      playState: "playing",
+      currentTime: 0,
+      playbackRate: 1,
+      actorId: "member-2",
+      seq: 1,
+      serverTime: 1_000,
+    },
+    members: [
+      { id: "member-1", name: "Alice" },
+      { id: "member-2", name: "Bob" },
+    ],
+  });
+
+  // The previous sharer's resolved `/video/A` anchor must not survive the
+  // ownership transfer, or a later same-page A→B autoplay would be misclassified.
+  assert.equal(harness.runtimeState.resolvedSharedVideoUrl, null);
+});
+
+test("keeps the resolved bare-route anchor when the same member re-applies the same festival route", async () => {
+  const harness = createController({ now: 10_000, currentVideo: null });
+
+  harness.runtimeState.localMemberId = "member-1";
+  harness.runtimeState.activeSharedByMemberId = "member-1";
+  harness.runtimeState.activeSharedUrl =
+    "https://www.bilibili.com/festival/MyMuji";
+  harness.runtimeState.resolvedSharedVideoUrl =
+    "https://www.bilibili.com/video/BVa?cid=1";
+  harness.runtimeState.pendingRoomStateHydration = false;
+
+  await harness.controller.applyRoomState({
+    roomCode: "ROOM01",
+    sharedVideo: {
+      videoId: "MyMuji",
+      url: "https://www.bilibili.com/festival/MyMuji",
+      title: "同一人的房间状态",
+      sharedByMemberId: "member-1",
+    },
+    playback: {
+      url: "https://www.bilibili.com/festival/MyMuji",
+      playState: "playing",
+      currentTime: 0,
+      playbackRate: 1,
+      actorId: "member-1",
+      seq: 1,
+      serverTime: 1_000,
+    },
+    members: [{ id: "member-1", name: "Alice" }],
+  });
+
+  // Unchanged URL and owner: the anchor recorded for the still-active bare-route
+  // share must survive so a same-page autoplay can still chain.
+  assert.equal(
+    harness.runtimeState.resolvedSharedVideoUrl,
+    "https://www.bilibili.com/video/BVa?cid=1",
+  );
+});
+
 test("pauses video when gesture age exactly equals the grace window boundary", async () => {
   const video = createStubVideo(false);
   const harness = createController({


### PR DESCRIPTION
## 问题

festival 页连播时自动共享失效：sharer 看完一个视频、播放器自动连播到下一个时，房间不会自动切换到新视频。

## 根因

festival 页（`/festival/<id>`）地址栏保持固定路由，播放器内部切视频时 `window.location.href` **完全不变**——真实在播的 bvid/cid 只存在于播放器内部，靠 page-bridge 快照读出。

而自动共享的唯一触发入口是 `navigation-controller` 的导航监听器，它只轮询 `window.location.href`。于是 festival 连播它**根本检测不到**，`scheduleAutoShareNextVideo` 永不触发。日志佐证：视频从 `BV1KeZkBVE7E` 跳到 `BV1fDzmBcEhD` 时没有任何 `Nav decision` / `Auto-share scheduled`，只有 `Suppressed non-shared playback broadcast`。

退一步说，即使排程了，`auto-share-next-controller` 发送前的"是否仍在目标视频"自检同样读裸路由，也会把它跳过。

## 改动（源头修复）

新增共享 helper `resolveFestivalVideoUrl()`，取 page-bridge 快照解析出的 `/video/...` URL，喂给两处此前对 festival 失明的地方：

- **`navigation-controller`**：新增 `getResolvedVideoUrl`，让监听器以快照解析的视频身份判断导航。两道守卫保证安全：
  - **defer 守卫**——快照未解析（含 autoplay 后清快照的瞬间）时不回退到裸路由，避免把路由误判成"切到非视频页"而误暂停。
  - **首解析静默采纳守卫**——把"路由→视频"的首次解析当作*发现*而非 autoplay，避免加载时误暂停 sharer 自己正在播的视频。
- **`auto-share-next-controller`**：`getCurrentPageUrl` 改为优先返回解析后的视频 URL，使发送前自检匹配排程目标。

## 边界与审计

- background `getVideoPayloadFromTab` → content `resolveCurrentSharePayload` 本就 snapshot-aware，无需改。
- bangumi 季页地址栏会真切到 ep（resolver 对它返回 null），不受影响，#137 的自然结束逻辑照常运行。

## 测试

- `format:check` / `lint` / `typecheck` / `build` 全绿；`npm test` **421 通过 0 失败**。
- 新增 3 个回归测试：festival 连播排程自动共享、首解析不暂停、快照清空不抖动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)