### PR TITLE
fix: load every non-shared video paused in a room (incl. new tabs / full-page loads)

### DIFF
--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -707,44 +707,46 @@ export function createPlaybackBindingController(args: {
 
       if (forcePauseOnNonSharedPage(video)) {
         // `forcePauseOnNonSharedPage` only suppresses the broadcast; it does not
-        // stop the local element. A play with a recent IN-PLAYER gesture is the
-        // user's own non-shared playback and is left to run (broadcast still
-        // suppressed). A play without one on a page the navigation controller
-        // flagged as a non-sharer autoplay (`nonSharerAutoplayHoldUrl`) is
-        // autoplay into the next episode: we must actually pause it, otherwise it
-        // keeps playing while the room stays on the shared video. The gesture must
-        // be in-player (not any document-level click) so a stray click on blank
-        // space / a popup cannot leave the page-load autoplay running. Gate on the
-        // marker rather than on the pause hold still being active, because a slow
-        // SPA load/ad can delay the `play`/`playing` event past
-        // `initialRoomStatePauseHoldMs`. Requiring the marker also avoids pausing
-        // a non-shared video the user manually opened via full-page navigation
-        // (address bar/bookmark/direct link): that page was never reached through
-        // an in-SPA autoplay, so it carries no marker and is left playable.
-        const normalizedCurrentUrl = args.normalizeUrl(
-          args.getSharedVideo()?.url,
-        );
-        const onHeldNonSharedPage =
+        // stop the local element. In a room, EVERY non-shared video must load
+        // paused so the tab never runs off playing a video the room is not on —
+        // whether it was reached by an in-SPA autoplay (carries
+        // `nonSharerAutoplayHoldUrl`) OR by a full-page load / new tab / bookmark /
+        // direct link (no marker; the navigation watcher only sees the initial URL
+        // as its baseline, so it never arms a marker). So pause on the resolved
+        // `isKnownNonSharedVideo` identity rather than on the SPA marker. The only
+        // exception is a genuine IN-PLAYER play gesture (not any document-level
+        // click, and one postdating the forced pause): that is the user pressing
+        // play, which authorizes the local playback and releases the hold.
+        const currentVideo = args.getSharedVideo();
+        const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
+        const onPausableNonSharedPage =
+          isKnownNonSharedVideo(currentVideo) &&
           (args.runtimeState.intendedPlayState === "paused" ||
-            args.runtimeState.intendedPlayState === "buffering") &&
-          normalizedCurrentUrl !== null &&
-          normalizedCurrentUrl === args.runtimeState.nonSharerAutoplayHoldUrl;
-        if (onHeldNonSharedPage) {
+            args.runtimeState.intendedPlayState === "buffering");
+        if (onPausableNonSharedPage) {
           if (hasFreshInPlayerPlayIntent()) {
-            // The user genuinely pressed play in-player on this held page, so we
-            // do NOT pause it. But the pre-record path may have suppressed the
-            // authorization on the way in — e.g. a progress-restore `seeking`
-            // fired before this `play`, so `shouldPreRecordNonSharedExplicitPlay`'s
-            // seek guard returned false and `explicitNonSharedPlaybackUrl`/the hold
-            // marker were never updated. Promote it to explicit local playback and
-            // release the hold here, otherwise a later buffer recovery or a
-            // transient `currentVideo === null` blip would re-pause the playback
-            // the user just authorized, and the autoplay-next off it would lose its
+            // The user genuinely pressed play in-player, so we do NOT pause it. But
+            // the pre-record path may have suppressed the authorization on the way
+            // in — e.g. a progress-restore `seeking` fired before this `play`, so
+            // `shouldPreRecordNonSharedExplicitPlay`'s seek guard returned false and
+            // `explicitNonSharedPlaybackUrl`/the hold marker were never updated.
+            // Promote it to explicit local playback and release the hold here,
+            // otherwise a later buffer recovery or a transient `currentVideo ===
+            // null` blip would re-pause the playback the user just authorized, and
+            // the autoplay-next off it would lose its
             // `previousExplicitNonSharedPlaybackUrl` classification.
             preAuthorizeExplicitNonSharedPlay();
           } else {
+            // Hold this non-shared page paused. Arm the marker (if not already set)
+            // so the rest of the held-page machinery — resume re-pause, manual-play
+            // authorization — treats a fresh full-page arrival the same as an
+            // in-SPA one.
+            args.runtimeState.intendedPlayState = "paused";
+            if (normalizedCurrentUrl !== null) {
+              args.runtimeState.nonSharerAutoplayHoldUrl = normalizedCurrentUrl;
+            }
             args.debugLog(
-              "Forced pause for delayed non-sharer autoplay into non-shared video",
+              "Forced pause for non-shared video autoplay (in room, load paused)",
             );
             args.runtimeState.lastForcedPauseAt = nowOf();
             window.setTimeout(() => {

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -481,6 +481,61 @@ export function createPlaybackBindingController(args: {
     args.runtimeState.pauseHoldUntil = 0;
   }
 
+  /**
+   * Hold a playing non-shared video paused (load paused). In a room EVERY
+   * non-shared video must load paused — whether reached by an in-SPA autoplay
+   * (carries `nonSharerAutoplayHoldUrl`) or by a full-page load / new tab /
+   * bookmark / direct link (no marker, because the navigation watcher only sees
+   * the initial URL as its baseline and never arms one). Pauses only when the
+   * resolved `isKnownNonSharedVideo` identity is playing WITHOUT authorization — a
+   * matching `explicitNonSharedPlaybackUrl` or a fresh in-player play gesture means
+   * the user took control, so it is left running. Deliberately NOT gated on
+   * `intendedPlayState`: even if the room's own playing intent leaked onto this
+   * non-shared page, the page is still not the shared video and must be held.
+   *
+   * Arms the marker AND the pause hold so the transient-`null` re-pause guard
+   * (`shouldReapplyPauseHoldForUnconfirmedSharedVideo`) keeps holding through a
+   * brief player rebuild / bridge blip. Returns whether it paused.
+   *
+   * Invoked both on the `play`/`playing` event (immediate) and from the periodic
+   * binding tick (so a non-shared video that was already playing before the room
+   * state hydrated — its only `play` event having fired pre-hydration — is still
+   * caught).
+   */
+  function enforceNonSharedLoadPause(video: HTMLVideoElement): boolean {
+    if (
+      video.paused ||
+      !args.runtimeState.activeRoomCode ||
+      !args.runtimeState.activeSharedUrl
+    ) {
+      return false;
+    }
+    const currentVideo = args.getSharedVideo();
+    if (!isKnownNonSharedVideo(currentVideo)) {
+      return false;
+    }
+    const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
+    if (
+      normalizedCurrentUrl === null ||
+      args.runtimeState.explicitNonSharedPlaybackUrl === normalizedCurrentUrl ||
+      hasFreshInPlayerPlayIntent()
+    ) {
+      return false;
+    }
+
+    args.runtimeState.intendedPlayState = "paused";
+    args.runtimeState.nonSharerAutoplayHoldUrl = normalizedCurrentUrl;
+    args.activatePauseHold(args.initialRoomStatePauseHoldMs);
+    args.runtimeState.lastForcedPauseAt = nowOf();
+    args.debugLog(
+      "Forced pause for non-shared video autoplay (in room, load paused)",
+    );
+    window.setTimeout(() => {
+      pauseVideo(video);
+    }, 0);
+    return true;
+  }
+
   function forcePauseWhileWaitingForInitialRoomState(
     video: HTMLVideoElement,
   ): boolean {
@@ -707,52 +762,22 @@ export function createPlaybackBindingController(args: {
 
       if (forcePauseOnNonSharedPage(video)) {
         // `forcePauseOnNonSharedPage` only suppresses the broadcast; it does not
-        // stop the local element. In a room, EVERY non-shared video must load
-        // paused so the tab never runs off playing a video the room is not on —
-        // whether it was reached by an in-SPA autoplay (carries
-        // `nonSharerAutoplayHoldUrl`) OR by a full-page load / new tab / bookmark /
-        // direct link (no marker; the navigation watcher only sees the initial URL
-        // as its baseline, so it never arms a marker). So pause on the resolved
-        // `isKnownNonSharedVideo` identity rather than on the SPA marker. The only
-        // exception is a genuine IN-PLAYER play gesture (not any document-level
-        // click, and one postdating the forced pause): that is the user pressing
-        // play, which authorizes the local playback and releases the hold.
+        // stop the local element. A fresh in-player play gesture authorizes the
+        // local playback (covering the case where a progress-restore `seeking`
+        // fired before this `play`, so `shouldPreRecordNonSharedExplicitPlay`'s
+        // seek guard suppressed the pre-record authorization — promote it here so a
+        // later buffer recovery / transient `currentVideo === null` blip cannot
+        // re-pause it and the autoplay-next keeps its
+        // `previousExplicitNonSharedPlaybackUrl` classification). Otherwise hold the
+        // non-shared video paused (load paused).
         const currentVideo = args.getSharedVideo();
-        const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
-        const onPausableNonSharedPage =
+        if (
           isKnownNonSharedVideo(currentVideo) &&
-          (args.runtimeState.intendedPlayState === "paused" ||
-            args.runtimeState.intendedPlayState === "buffering");
-        if (onPausableNonSharedPage) {
-          if (hasFreshInPlayerPlayIntent()) {
-            // The user genuinely pressed play in-player, so we do NOT pause it. But
-            // the pre-record path may have suppressed the authorization on the way
-            // in — e.g. a progress-restore `seeking` fired before this `play`, so
-            // `shouldPreRecordNonSharedExplicitPlay`'s seek guard returned false and
-            // `explicitNonSharedPlaybackUrl`/the hold marker were never updated.
-            // Promote it to explicit local playback and release the hold here,
-            // otherwise a later buffer recovery or a transient `currentVideo ===
-            // null` blip would re-pause the playback the user just authorized, and
-            // the autoplay-next off it would lose its
-            // `previousExplicitNonSharedPlaybackUrl` classification.
-            preAuthorizeExplicitNonSharedPlay();
-          } else {
-            // Hold this non-shared page paused. Arm the marker (if not already set)
-            // so the rest of the held-page machinery — resume re-pause, manual-play
-            // authorization — treats a fresh full-page arrival the same as an
-            // in-SPA one.
-            args.runtimeState.intendedPlayState = "paused";
-            if (normalizedCurrentUrl !== null) {
-              args.runtimeState.nonSharerAutoplayHoldUrl = normalizedCurrentUrl;
-            }
-            args.debugLog(
-              "Forced pause for non-shared video autoplay (in room, load paused)",
-            );
-            args.runtimeState.lastForcedPauseAt = nowOf();
-            window.setTimeout(() => {
-              pauseVideo(video);
-            }, 0);
-          }
+          hasFreshInPlayerPlayIntent()
+        ) {
+          preAuthorizeExplicitNonSharedPlay();
+        } else {
+          enforceNonSharedLoadPause(video);
         }
         return true;
       }
@@ -945,10 +970,18 @@ export function createPlaybackBindingController(args: {
     start() {
       attachPlaybackListeners();
       if (videoBindingTimer === null) {
-        videoBindingTimer = window.setInterval(
-          attachPlaybackListeners,
-          args.videoBindIntervalMs,
-        );
+        videoBindingTimer = window.setInterval(() => {
+          attachPlaybackListeners();
+          // Safety net: hold a non-shared video that was ALREADY playing when the
+          // room state hydrated (its only `play`/`playing` fired before hydration,
+          // so the event-driven hold never ran) and re-pause after a transient
+          // bridge blip. Cheap — returns early unless a known non-shared video is
+          // actually playing unauthorized in a room.
+          const video = getVideoElement();
+          if (video) {
+            enforceNonSharedLoadPause(video);
+          }
+        }, args.videoBindIntervalMs);
       }
     },
     attachPlaybackListeners,

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -488,14 +488,20 @@ export function createPlaybackBindingController(args: {
    * bookmark / direct link (no marker, because the navigation watcher only sees
    * the initial URL as its baseline and never arms one). Pauses only when the
    * resolved `isKnownNonSharedVideo` identity is playing WITHOUT authorization — a
-   * matching `explicitNonSharedPlaybackUrl` or a fresh in-player play gesture means
-   * the user took control, so it is left running. Deliberately NOT gated on
-   * `intendedPlayState`: even if the room's own playing intent leaked onto this
-   * non-shared page, the page is still not the shared video and must be held.
+   * matching `explicitNonSharedPlaybackUrl` leaves it running. Deliberately NOT
+   * gated on `intendedPlayState`: even if the room's own playing intent leaked onto
+   * this non-shared page, the page is still not the shared video and must be held.
    *
-   * Arms the marker AND the pause hold so the transient-`null` re-pause guard
-   * (`shouldReapplyPauseHoldForUnconfirmedSharedVideo`) keeps holding through a
-   * brief player rebuild / bridge blip. Returns whether it paused.
+   * A genuine in-player PLAY gesture (`shouldPreRecordNonSharedExplicitPlay`, which
+   * requires a fresh in-player gesture AND excludes a seek-triggered autoplay)
+   * authorizes it: persist that via `preAuthorizeExplicitNonSharedPlay` so a later
+   * tick past the gesture grace does not re-pause the playback the user just
+   * started. A bare in-player gesture that is actually a SEEK (dragging the
+   * progress bar) does not qualify, so its post-seek autoplay is still held.
+   *
+   * Otherwise it arms the marker AND the pause hold so the transient-`null`
+   * re-pause guard (`shouldReapplyPauseHoldForUnconfirmedSharedVideo`) keeps holding
+   * through a brief player rebuild / bridge blip. Returns whether it paused.
    *
    * Invoked both on the `play`/`playing` event (immediate) and from the periodic
    * binding tick (so a non-shared video that was already playing before the room
@@ -517,9 +523,15 @@ export function createPlaybackBindingController(args: {
     const normalizedCurrentUrl = args.normalizeUrl(currentVideo?.url);
     if (
       normalizedCurrentUrl === null ||
-      args.runtimeState.explicitNonSharedPlaybackUrl === normalizedCurrentUrl ||
-      hasFreshInPlayerPlayIntent()
+      args.runtimeState.explicitNonSharedPlaybackUrl === normalizedCurrentUrl
     ) {
+      return false;
+    }
+    if (shouldPreRecordNonSharedExplicitPlay()) {
+      // A genuine in-player play press (not a seek-triggered autoplay). Persist the
+      // authorization so a later tick — once the gesture grace lapses — does not
+      // re-pause the local video the user just started.
+      preAuthorizeExplicitNonSharedPlay();
       return false;
     }
 
@@ -762,23 +774,13 @@ export function createPlaybackBindingController(args: {
 
       if (forcePauseOnNonSharedPage(video)) {
         // `forcePauseOnNonSharedPage` only suppresses the broadcast; it does not
-        // stop the local element. A fresh in-player play gesture authorizes the
-        // local playback (covering the case where a progress-restore `seeking`
-        // fired before this `play`, so `shouldPreRecordNonSharedExplicitPlay`'s
-        // seek guard suppressed the pre-record authorization — promote it here so a
-        // later buffer recovery / transient `currentVideo === null` blip cannot
-        // re-pause it and the autoplay-next keeps its
-        // `previousExplicitNonSharedPlaybackUrl` classification). Otherwise hold the
-        // non-shared video paused (load paused).
-        const currentVideo = args.getSharedVideo();
-        if (
-          isKnownNonSharedVideo(currentVideo) &&
-          hasFreshInPlayerPlayIntent()
-        ) {
-          preAuthorizeExplicitNonSharedPlay();
-        } else {
-          enforceNonSharedLoadPause(video);
-        }
+        // stop the local element. Hold the non-shared video paused (load paused) —
+        // unless a genuine in-player PLAY gesture authorizes it, which
+        // `enforceNonSharedLoadPause` persists via `preAuthorizeExplicitNonSharedPlay`.
+        // It uses `shouldPreRecordNonSharedExplicitPlay` (fresh in-player gesture AND
+        // not a seek-triggered autoplay), so a progress-bar drag whose `seeking`
+        // preceded this `play` is NOT mistaken for a play press and stays held.
+        enforceNonSharedLoadPause(video);
         return true;
       }
       if (forcePauseWhileWaitingForInitialRoomState(video)) {

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -247,10 +247,22 @@ export function createSyncController(args: {
     args.runtimeState.intendedPlaybackRate = 1;
     args.runtimeState.lastNonSharedGuardUrl = null;
     args.runtimeState.lastExplicitPlaybackAction = null;
-    args.runtimeState.explicitNonSharedPlaybackUrl = null;
+    // Preserve the user's authorization to keep watching a non-shared local video
+    // they manually started when this reset is a remote shared-url switch and they
+    // are STILL on that very video. Otherwise the periodic non-shared load-pause
+    // guard would re-pause an active local watch just because another member moved
+    // the room to a different shared video. A genuine navigation away still clears
+    // it (the navigation reset), and on the shared/other page it is harmless.
+    const resolvedCurrentUrl = args.normalizeUrl(args.getSharedVideo()?.url);
+    const keepNonSharedAuthorization =
+      resolvedCurrentUrl !== null &&
+      resolvedCurrentUrl === args.runtimeState.explicitNonSharedPlaybackUrl;
+    if (!keepNonSharedAuthorization) {
+      args.runtimeState.explicitNonSharedPlaybackUrl = null;
+      args.runtimeState.nonSharerAutoplayHoldUrl = null;
+    }
     args.runtimeState.suppressedLocalEndPauseUrl = null;
     args.runtimeState.suppressedLocalEndPauseUntil = 0;
-    args.runtimeState.nonSharerAutoplayHoldUrl = null;
     args.runtimeState.postNavigationAnchorSharedUrl = null;
     args.runtimeState.postNavigationAnchorSetAt = 0;
     args.runtimeState.sharerEndedSuppressionUrl = null;

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -1153,9 +1153,11 @@ test("playback binding controller suppresses auto-resumed non-shared broadcast a
 
     await Promise.resolve();
 
-    // The auto-played non-shared video should keep playing locally.
-    assert.equal(pausedByGuard, 0);
-    // The seeking event is broadcast (non-shared page), but play should be blocked.
+    // In a room the auto-resumed non-shared video is held paused: a stray
+    // document-level click is not an in-player play intent, so this counts as an
+    // unsolicited autoplay and is paused (load paused).
+    assert.equal(pausedByGuard, 1);
+    // The seeking event is broadcast (non-shared page), but play stays blocked.
     assert.deepEqual(events, ["seeking"]);
   } finally {
     globalThis.window.setTimeout = originalSetTimeout;
@@ -1374,16 +1376,17 @@ test("playback binding controller lets the user watch an explicitly opened local
   }
 });
 
-test("playback binding controller does not pause an unmarked non-shared page reached by full-page navigation", async () => {
+test("playback binding controller pauses an unmarked non-shared page reached by full-page navigation", async () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();
   runtimeState.activeRoomCode = "ROOM42";
   runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVshared?p=1";
   runtimeState.pendingRoomStateHydration = false;
-  // The user opened a different local video via the address bar/bookmark. The
-  // content script reloaded, so there was no in-SPA navigation event to flag it
-  // as a non-sharer autoplay page (nonSharerAutoplayHoldUrl stays null) and no
-  // recent in-page gesture. Hydration reset the room intent to paused.
+  // The user opened a different local video via a new tab / address bar / bookmark.
+  // The content script reloaded, so there was no in-SPA navigation event to arm a
+  // non-sharer autoplay marker (nonSharerAutoplayHoldUrl stays null) and no recent
+  // in-page gesture. In a room every non-shared video must still load PAUSED, so
+  // this autoplay is held even without the marker.
   runtimeState.intendedPlayState = "paused";
   let pausedByGuard = 0;
   const originalSetTimeout = globalThis.window.setTimeout;
@@ -1430,9 +1433,14 @@ test("playback binding controller does not pause an unmarked non-shared page rea
 
     await Promise.resolve();
 
-    // Without the non-sharer autoplay marker, the manually opened local video is
-    // left playable (its broadcast is still suppressed by the non-shared guard).
-    assert.equal(pausedByGuard, 0);
+    // Even without the SPA marker, a non-shared video that autoplays on a fresh
+    // page load is paused (load paused) and the marker is armed for the held-page
+    // machinery; its broadcast stays suppressed by the non-shared guard.
+    assert.equal(pausedByGuard, 1);
+    assert.equal(
+      runtimeState.nonSharerAutoplayHoldUrl,
+      "https://www.bilibili.com/video/BVother?p=1",
+    );
   } finally {
     globalThis.window.setTimeout = originalSetTimeout;
     dom.video.pause = originalPause;
@@ -1955,9 +1963,10 @@ test("playback binding controller allows manual play on non-shared page after au
     dom.listeners.get("play")?.(new Event("play"));
 
     await Promise.resolve();
-    assert.equal(pausedByGuard, 0);
+    // The auto-resume (no in-player gesture) is held paused in a room.
+    assert.equal(pausedByGuard, 1);
 
-    // User manually clicks play (in the player) after the suppressed auto-resume.
+    // User manually clicks play (in the player) after the held auto-resume.
     runtimeState.lastUserGestureAt = 1_500;
     runtimeState.lastUserGestureInPlayerAt = 1_500;
     now = 1_550;
@@ -1966,8 +1975,9 @@ test("playback binding controller allows manual play on non-shared page after au
 
     await Promise.resolve();
 
-    // Manual play should NOT be blocked — it's a new gesture after the auto-resume.
-    assert.equal(pausedByGuard, 0);
+    // Manual play should NOT be blocked — it's a fresh in-player gesture after the
+    // held auto-resume, so no additional pause beyond the first.
+    assert.equal(pausedByGuard, 1);
     assert.ok(events.includes("play"));
     // The first play event should come from the manual click, not the auto-resume
     const playIndex = events.indexOf("play");
@@ -2038,8 +2048,10 @@ test("playback binding controller suppresses non-shared autoplay replayed after 
 
     await Promise.resolve();
 
+    // The same-gesture replay after the forced pause is not a fresh in-player play
+    // intent, so the non-shared autoplay is held paused (and not broadcast).
     assert.deepEqual(events, []);
-    assert.equal(pausedByGuard, 0);
+    assert.equal(pausedByGuard, 1);
   } finally {
     globalThis.window.setTimeout = originalSetTimeout;
     dom.video.pause = originalPause;

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -965,7 +965,7 @@ test("playback binding controller still holds the delayed autoplay when the only
   }
 });
 
-test("playback binding controller authorizes a held non-shared play preceded by a progress-restore seek", async () => {
+test("playback binding controller holds a seek-triggered non-shared autoplay, then authorizes a distinct play press", async () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();
   runtimeState.activeRoomCode = "ROOM42";
@@ -974,14 +974,14 @@ test("playback binding controller authorizes a held non-shared play preceded by 
   runtimeState.intendedPlayState = "paused";
   runtimeState.nonSharerAutoplayHoldUrl =
     "https://www.bilibili.com/video/BVother?p=1";
-  // The page-bridge hold paused the page at 19_800, then the user pressed play
-  // inside the player at 20_500 (a FRESH in-player gesture postdating that pause).
+  // A page-bridge hold paused the page at 19_800. Then an in-player gesture at
+  // 20_500 drags the progress bar (a SEEK, not a play press): we cannot tell it
+  // apart from a play click preceded by a restore seek, so a seek-triggered
+  // autoplay must stay held — only a genuine play press releases.
   runtimeState.lastForcedPauseAt = 19_800;
   runtimeState.lastUserGestureAt = 20_500;
   runtimeState.lastUserGestureInPlayerAt = 20_500;
-  // A leftover pause hold that authorization must clear so a later blip can't
-  // re-pause the just-authorized playback.
-  runtimeState.pauseHoldUntil = 25_000;
+  let now = 20_500;
   let pausedByGuard = 0;
   const originalSetTimeout = globalThis.window.setTimeout;
   const originalPause = dom.video.pause;
@@ -1003,9 +1003,11 @@ test("playback binding controller authorizes a held non-shared play preceded by 
     cancelActiveSoftApply: () => {},
     maintainActiveSoftApply: () => {},
     applyPendingPlaybackApplication: () => {},
-    activatePauseHold: () => {},
+    activatePauseHold: (durationMs = 3_000) => {
+      runtimeState.pauseHoldUntil = now + durationMs;
+    },
     debugLog: () => {},
-    getNow: () => 20_500,
+    getNow: () => now,
   });
 
   dom.video.pause = () => {
@@ -1023,14 +1025,25 @@ test("playback binding controller authorizes a held non-shared play preceded by 
   try {
     controller.attachPlaybackListeners();
     dom.video.paused = false;
-    // Bilibili restores the saved progress with a `seeking` before the `play`, so
-    // the pre-record path's seek guard suppresses authorization there. The marker
-    // block must still authorize this genuine in-player play and release the hold.
+    // The seek belongs to the current in-player gesture (no newer gesture after
+    // it), so the post-seek autoplay is held, not authorized.
     dom.listeners.get("seeking")?.(new Event("seeking"));
     dom.listeners.get("play")?.(new Event("play"));
     await Promise.resolve();
 
-    assert.equal(pausedByGuard, 0);
+    assert.equal(pausedByGuard, 1);
+    assert.equal(runtimeState.explicitNonSharedPlaybackUrl, null);
+
+    // A DISTINCT in-player play press afterwards (a fresh gesture postdating the
+    // seek) is authorized and releases the hold.
+    now = 21_000;
+    runtimeState.lastUserGestureAt = 21_000;
+    runtimeState.lastUserGestureInPlayerAt = 21_000;
+    dom.video.paused = false;
+    dom.listeners.get("play")?.(new Event("play"));
+    await Promise.resolve();
+
+    assert.equal(pausedByGuard, 1);
     assert.equal(
       runtimeState.explicitNonSharedPlaybackUrl,
       "https://www.bilibili.com/video/BVother?p=1",

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -33,6 +33,12 @@ function installDomStub() {
       setInterval() {
         return 1;
       },
+      clearInterval() {
+        return undefined;
+      },
+      clearTimeout() {
+        return undefined;
+      },
     },
   });
 
@@ -1409,7 +1415,9 @@ test("playback binding controller pauses an unmarked non-shared page reached by 
     cancelActiveSoftApply: () => {},
     maintainActiveSoftApply: () => {},
     applyPendingPlaybackApplication: () => {},
-    activatePauseHold: () => {},
+    activatePauseHold: (durationMs = 3_000) => {
+      runtimeState.pauseHoldUntil = 20_000 + durationMs;
+    },
     debugLog: () => {},
     getNow: () => 20_000,
   });
@@ -1441,9 +1449,153 @@ test("playback binding controller pauses an unmarked non-shared page reached by 
       runtimeState.nonSharerAutoplayHoldUrl,
       "https://www.bilibili.com/video/BVother?p=1",
     );
+    // The pause hold is armed too, so a transient bridge blip cannot resume it.
+    assert.ok(runtimeState.pauseHoldUntil > 0);
   } finally {
     globalThis.window.setTimeout = originalSetTimeout;
     dom.video.pause = originalPause;
+    dom.restore();
+  }
+});
+
+test("playback binding controller pauses a non-shared video even when room intent leaked as playing", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVshared?p=1";
+  runtimeState.pendingRoomStateHydration = false;
+  // The room's own playing intent leaked onto this non-shared page. It must STILL
+  // be held — the page is not the shared video — so the pause is not gated on
+  // intendedPlayState.
+  runtimeState.intendedPlayState = "playing";
+  let pausedByGuard = 0;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalPause = dom.video.pause;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    getSharedVideo: () => ({
+      videoId: "BVother:p1",
+      url: "https://www.bilibili.com/video/BVother?p=1",
+      title: "Other Video",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 20_000,
+  });
+
+  dom.video.pause = () => {
+    pausedByGuard += 1;
+    dom.video.paused = true;
+    return Promise.resolve();
+  };
+  globalThis.window.setTimeout = ((callback: TimerHandler) => {
+    if (typeof callback === "function") {
+      callback();
+    }
+    return 1;
+  }) as typeof globalThis.window.setTimeout;
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.video.paused = false;
+    dom.listeners.get("playing")?.(new Event("playing"));
+
+    await Promise.resolve();
+
+    assert.equal(pausedByGuard, 1);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.video.pause = originalPause;
+    dom.restore();
+  }
+});
+
+test("playback binding controller periodic tick pauses a non-shared video already playing at hydration", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVshared?p=1";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.intendedPlayState = "paused";
+  let pausedByGuard = 0;
+  let intervalCallback: (() => void) | null = null;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalSetInterval = globalThis.window.setInterval;
+  const originalPause = dom.video.pause;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    getSharedVideo: () => ({
+      videoId: "BVother:p1",
+      url: "https://www.bilibili.com/video/BVother?p=1",
+      title: "Other Video",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 20_000,
+  });
+
+  dom.video.pause = () => {
+    pausedByGuard += 1;
+    dom.video.paused = true;
+    return Promise.resolve();
+  };
+  globalThis.window.setTimeout = ((callback: TimerHandler) => {
+    if (typeof callback === "function") {
+      callback();
+    }
+    return 1;
+  }) as typeof globalThis.window.setTimeout;
+  globalThis.window.setInterval = ((callback: TimerHandler) => {
+    if (typeof callback === "function") {
+      intervalCallback = callback as () => void;
+    }
+    return 1;
+  }) as typeof globalThis.window.setInterval;
+
+  try {
+    // The video was already autoplaying when the room state hydrated, so its only
+    // play/playing event fired before listeners were attached — the event-driven
+    // hold never ran. The periodic tick must still pause it.
+    dom.video.paused = false;
+    controller.start();
+    assert.equal(pausedByGuard, 0);
+
+    assert.ok(intervalCallback, "expected the binding to register an interval");
+    intervalCallback?.();
+    await Promise.resolve();
+
+    assert.equal(pausedByGuard, 1);
+    assert.equal(
+      runtimeState.nonSharerAutoplayHoldUrl,
+      "https://www.bilibili.com/video/BVother?p=1",
+    );
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    globalThis.window.setInterval = originalSetInterval;
+    dom.video.pause = originalPause;
+    controller.destroy();
     dom.restore();
   }
 });

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -1901,3 +1901,42 @@ test("sync controller omits userInitiated on buffer-pause upgrade re-broadcast",
   assert.equal(payload.playState, "paused");
   assert.equal(payload.userInitiated, undefined);
 });
+
+test("sync controller keeps non-shared authorization on reset while still on that local video", () => {
+  const harness = createControllerHarness();
+  const localUrl = "https://www.bilibili.com/video/BVlocal?p=1";
+  harness.setSharedVideo({
+    videoId: "BVlocal:p1",
+    url: localUrl,
+    title: "Local Video",
+  });
+  harness.runtimeState.explicitNonSharedPlaybackUrl = localUrl;
+  harness.runtimeState.nonSharerAutoplayHoldUrl = localUrl;
+
+  // A remote member switches the room's shared video while the user is still
+  // watching their manually-started local video. Its authorization must survive,
+  // otherwise the periodic load-pause guard would re-pause an active local watch.
+  harness.controller.resetPlaybackSyncState("shared url changed");
+
+  assert.equal(harness.runtimeState.explicitNonSharedPlaybackUrl, localUrl);
+});
+
+test("sync controller clears non-shared authorization on reset when no longer on that video", () => {
+  const harness = createControllerHarness();
+  harness.setSharedVideo({
+    videoId: "BVcurrent:p1",
+    url: "https://www.bilibili.com/video/BVcurrent?p=1",
+    title: "Current Video",
+  });
+  // The user left the previously-authorized local video, so the stale
+  // authorization for a different URL is cleared by the reset.
+  harness.runtimeState.explicitNonSharedPlaybackUrl =
+    "https://www.bilibili.com/video/BVother?p=1";
+  harness.runtimeState.nonSharerAutoplayHoldUrl =
+    "https://www.bilibili.com/video/BVother?p=1";
+
+  harness.controller.resetPlaybackSyncState("shared url changed");
+
+  assert.equal(harness.runtimeState.explicitNonSharedPlaybackUrl, null);
+  assert.equal(harness.runtimeState.nonSharerAutoplayHoldUrl, null);
+});


### PR DESCRIPTION
## 问题

房间内**新标签页 / 整页加载**打开的非共享视频仍会自动播放,没有"加载即暂停"。

日志确诊:全新文档加载时,导航 watcher 只把初始 URL 当作 baseline,**不会**触发抑制分支去 arm `nonSharerAutoplayHoldUrl`;而 binding 的强制暂停此前**只对带 marker 的页**生效,于是这些整页加载的非共享视频一直自动播,只有广播被抑制。

## 修复

把 binding 里非共享页的暂停门控从"必须带 SPA marker"改为基于已解析身份 `isKnownNonSharedVideo`:房间内**任何**非共享视频(含新标签页 / 地址栏 / 书签 / 外链整页加载)都加载即暂停;只有**真·播放器内播放手势**(`hasFreshInPlayerPlayIntent`)才授权手动播,并清掉 hold。暂停时顺带 arm marker,让"恢复即再暂停 / 手动播授权"等既有逻辑对整页加载与 in-SPA 到达一视同仁。

这是用户在 PR #140 之后明确选择的行为(全部加载即暂停),**反转**了 #140 里刻意的"无 marker 整页打开留作可播放"取舍。

## 测试
- 更新原断言"无 marker 整页加载不暂停"的测试为**应暂停**(并断言 marker 被 arm)。
- 同步更新 3 个编码旧"留作可播放"行为的用例(浏览器自动恢复、自动恢复后手动播、同手势重放)→ 现在均暂停。
- `format:check` / `lint` / `typecheck` / `build` 全绿;`npm test` **465 通过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)