### PR TITLE
fix: 自动连播时静默处理分享者自然结束的暂停，避免其它端误报暂停/跳转

### DIFF
--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -138,8 +138,8 @@ const playbackBindingController = createPlaybackBindingController({
     syncController.hasRecentRemoteStopIntent(currentVideoUrl),
   normalizeUrl,
   getLastBroadcastAt: () => lastBroadcastAt,
-  broadcastPlayback: (video, eventSource) =>
-    syncController.broadcastPlayback(video, eventSource),
+  broadcastPlayback: (video, eventSource, syncIntentOverride) =>
+    syncController.broadcastPlayback(video, eventSource, syncIntentOverride),
   cancelActiveSoftApply: (video, reason) =>
     syncController.cancelActiveSoftApply(video, reason),
   maintainActiveSoftApply: (video) =>

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -138,8 +138,8 @@ const playbackBindingController = createPlaybackBindingController({
     syncController.hasRecentRemoteStopIntent(currentVideoUrl),
   normalizeUrl,
   getLastBroadcastAt: () => lastBroadcastAt,
-  broadcastPlayback: (video, eventSource, syncIntentOverride) =>
-    syncController.broadcastPlayback(video, eventSource, syncIntentOverride),
+  broadcastPlayback: (video, eventSource, naturalEnd) =>
+    syncController.broadcastPlayback(video, eventSource, naturalEnd),
   cancelActiveSoftApply: (video, reason) =>
     syncController.cancelActiveSoftApply(video, reason),
   maintainActiveSoftApply: (video) =>

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -1,4 +1,4 @@
-import type { SharedVideo } from "@bili-syncplay/protocol";
+import type { PlaybackState, SharedVideo } from "@bili-syncplay/protocol";
 import {
   bindVideoElement,
   getVideoElement,
@@ -47,6 +47,7 @@ export function createPlaybackBindingController(args: {
   broadcastPlayback: (
     video: HTMLVideoElement,
     eventSource?: LocalPlaybackEventSource,
+    syncIntentOverride?: PlaybackState["syncIntent"],
   ) => Promise<void>;
   cancelActiveSoftApply: (
     video: HTMLVideoElement | null,
@@ -392,7 +393,11 @@ export function createPlaybackBindingController(args: {
     args.debugLog(
       `Flushed sharer end-of-video paused state after no autoplay-next followed`,
     );
-    void args.broadcastPlayback(video, "pause");
+    // Tag the terminal paused as a natural end so peers update their state
+    // without surfacing a misleading "paused" / "jumped to <end>" toast. This
+    // also covers the slow-handoff case where the autoplay-next eventually
+    // lands after the flush window (e.g. a recommend-autoplay countdown).
+    void args.broadcastPlayback(video, "pause", "natural-end");
   }
 
   function shouldReapplyHoldAfterSharedVideoEnd(

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -1,4 +1,4 @@
-import type { PlaybackState, SharedVideo } from "@bili-syncplay/protocol";
+import type { SharedVideo } from "@bili-syncplay/protocol";
 import {
   bindVideoElement,
   getVideoElement,
@@ -47,7 +47,7 @@ export function createPlaybackBindingController(args: {
   broadcastPlayback: (
     video: HTMLVideoElement,
     eventSource?: LocalPlaybackEventSource,
-    syncIntentOverride?: PlaybackState["syncIntent"],
+    naturalEnd?: boolean,
   ) => Promise<void>;
   cancelActiveSoftApply: (
     video: HTMLVideoElement | null,
@@ -397,7 +397,7 @@ export function createPlaybackBindingController(args: {
     // without surfacing a misleading "paused" / "jumped to <end>" toast. This
     // also covers the slow-handoff case where the autoplay-next eventually
     // lands after the flush window (e.g. a recommend-autoplay countdown).
-    void args.broadcastPlayback(video, "pause", "natural-end");
+    void args.broadcastPlayback(video, "pause", true);
   }
 
   function shouldReapplyHoldAfterSharedVideoEnd(

--- a/extension/src/content/playback-broadcast.ts
+++ b/extension/src/content/playback-broadcast.ts
@@ -57,6 +57,7 @@ export function createPlaybackBroadcastPayload(args: {
   playState: PlaybackState["playState"];
   syncIntent?: PlaybackState["syncIntent"];
   userInitiated?: boolean;
+  naturalEnd?: boolean;
   playbackRate: number;
   actorId: string;
   seq: number;
@@ -73,10 +74,13 @@ export function createPlaybackBroadcastPayload(args: {
     actorId: args.actorId,
     seq: args.seq,
   };
-  // Omit the field entirely (instead of serializing `false`) when not set, so
+  // Omit these flags entirely (instead of serializing `false`) when not set, so
   // we stay byte-identical to legacy senders on the wire for non-user pauses.
   if (args.userInitiated) {
     payload.userInitiated = true;
+  }
+  if (args.naturalEnd) {
+    payload.naturalEnd = true;
   }
   return payload;
 }

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -48,6 +48,7 @@ export interface SyncController {
   broadcastPlayback(
     video: HTMLVideoElement,
     eventSource?: LocalPlaybackEventSource,
+    syncIntentOverride?: PlaybackState["syncIntent"],
   ): Promise<void>;
   applyRoomState(
     state: RoomState,
@@ -647,6 +648,7 @@ export function createSyncController(args: {
   async function broadcastPlayback(
     video: HTMLVideoElement,
     eventSource: LocalPlaybackEventSource = "manual",
+    syncIntentOverride?: PlaybackState["syncIntent"],
   ): Promise<void> {
     const now = nowOf();
     if (!args.runtimeState.hydrationReady) {
@@ -1234,13 +1236,15 @@ export function createSyncController(args: {
       currentVideo,
       currentTime: video.currentTime,
       playState,
-      syncIntent: derivePlaybackSyncIntent({
-        eventSource,
-        lastExplicitUserAction: args.runtimeState.lastExplicitUserAction,
-        lastForcedPauseAt: args.runtimeState.lastForcedPauseAt,
-        now,
-        userGestureGraceMs: args.userGestureGraceMs,
-      }),
+      syncIntent:
+        syncIntentOverride ??
+        derivePlaybackSyncIntent({
+          eventSource,
+          lastExplicitUserAction: args.runtimeState.lastExplicitUserAction,
+          lastForcedPauseAt: args.runtimeState.lastForcedPauseAt,
+          now,
+          userGestureGraceMs: args.userGestureGraceMs,
+        }),
       userInitiated: deriveUserInitiatedPause({
         eventSource,
         playState,

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -48,7 +48,7 @@ export interface SyncController {
   broadcastPlayback(
     video: HTMLVideoElement,
     eventSource?: LocalPlaybackEventSource,
-    syncIntentOverride?: PlaybackState["syncIntent"],
+    naturalEnd?: boolean,
   ): Promise<void>;
   applyRoomState(
     state: RoomState,
@@ -648,7 +648,7 @@ export function createSyncController(args: {
   async function broadcastPlayback(
     video: HTMLVideoElement,
     eventSource: LocalPlaybackEventSource = "manual",
-    syncIntentOverride?: PlaybackState["syncIntent"],
+    naturalEnd?: boolean,
   ): Promise<void> {
     const now = nowOf();
     if (!args.runtimeState.hydrationReady) {
@@ -1236,15 +1236,14 @@ export function createSyncController(args: {
       currentVideo,
       currentTime: video.currentTime,
       playState,
-      syncIntent:
-        syncIntentOverride ??
-        derivePlaybackSyncIntent({
-          eventSource,
-          lastExplicitUserAction: args.runtimeState.lastExplicitUserAction,
-          lastForcedPauseAt: args.runtimeState.lastForcedPauseAt,
-          now,
-          userGestureGraceMs: args.userGestureGraceMs,
-        }),
+      syncIntent: derivePlaybackSyncIntent({
+        eventSource,
+        lastExplicitUserAction: args.runtimeState.lastExplicitUserAction,
+        lastForcedPauseAt: args.runtimeState.lastForcedPauseAt,
+        now,
+        userGestureGraceMs: args.userGestureGraceMs,
+      }),
+      naturalEnd,
       userInitiated: deriveUserInitiatedPause({
         eventSource,
         playState,

--- a/extension/src/content/toast.ts
+++ b/extension/src/content/toast.ts
@@ -215,7 +215,7 @@ export function getRoomStateToastMessages(args: {
     // paused state must be applied silently — surfacing a "paused" / "jumped to
     // <end>" toast here is misleading (the video ended on its own) and noisy
     // moments before the autoplay-next share lands.
-    args.nextState.playback?.syncIntent === "natural-end"
+    args.nextState.playback?.naturalEnd === true
   ) {
     return { messages, nextSeekToastByActor };
   }

--- a/extension/src/content/toast.ts
+++ b/extension/src/content/toast.ts
@@ -210,7 +210,12 @@ export function getRoomStateToastMessages(args: {
   if (
     args.pendingRoomStateHydration ||
     sharedVideoChanged ||
-    !args.isCurrentPageShowingSharedVideo
+    !args.isCurrentPageShowingSharedVideo ||
+    // The sharer's shared video reached its natural end. The flushed terminal
+    // paused state must be applied silently — surfacing a "paused" / "jumped to
+    // <end>" toast here is misleading (the video ended on its own) and noisy
+    // moments before the autoplay-next share lands.
+    args.nextState.playback?.syncIntent === "natural-end"
   ) {
     return { messages, nextSeekToastByActor };
   }

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -2893,8 +2893,10 @@ test("playback binding controller flushes the sharer's terminal paused state whe
     hasRecentRemoteStopIntent: () => false,
     normalizeUrl: (url) => url ?? null,
     getLastBroadcastAt: () => 0,
-    broadcastPlayback: async (_video, eventSource, syncIntentOverride) => {
-      events.push(`${eventSource ?? "manual"}:${syncIntentOverride ?? "none"}`);
+    broadcastPlayback: async (_video, eventSource, naturalEnd) => {
+      events.push(
+        `${eventSource ?? "manual"}:${naturalEnd ? "natural-end" : "none"}`,
+      );
     },
     cancelActiveSoftApply: () => {},
     maintainActiveSoftApply: () => {},

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -2893,8 +2893,8 @@ test("playback binding controller flushes the sharer's terminal paused state whe
     hasRecentRemoteStopIntent: () => false,
     normalizeUrl: (url) => url ?? null,
     getLastBroadcastAt: () => 0,
-    broadcastPlayback: async (_video, eventSource) => {
-      events.push(eventSource ?? "manual");
+    broadcastPlayback: async (_video, eventSource, syncIntentOverride) => {
+      events.push(`${eventSource ?? "manual"}:${syncIntentOverride ?? "none"}`);
     },
     cancelActiveSoftApply: () => {},
     maintainActiveSoftApply: () => {},
@@ -2920,11 +2920,12 @@ test("playback binding controller flushes the sharer's terminal paused state whe
     );
 
     // The window elapses with the player still parked at the end (no
-    // autoplay-next): the terminal paused state is flushed and the marker cleared.
+    // autoplay-next): the terminal paused state is flushed (tagged as a natural
+    // end so peers stay quiet) and the marker cleared.
     flush?.cb();
     await Promise.resolve();
 
-    assert.deepEqual(events, ["pause"]);
+    assert.deepEqual(events, ["pause:natural-end"]);
     assert.equal(runtimeState.sharerEndedSuppressionUrl, null);
     assert.equal(runtimeState.sharerEndedSuppressionUntil, 0);
     assert.equal(runtimeState.sharerEndedSuppressionArmedAt, 0);

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { RoomState, ServerMessage } from "@bili-syncplay/protocol";
+import {
+  PROTOCOL_VERSION,
+  type RoomState,
+  type ServerMessage,
+} from "@bili-syncplay/protocol";
 import { createBackgroundRuntimeState } from "../src/background/runtime-state";
 import { createRoomSessionController } from "../src/background/room-session-controller";
 import { setLocaleForTests } from "../src/shared/i18n";
@@ -114,7 +118,7 @@ test("room session controller sends create request with protocolVersion", async 
     type: "room:create",
     payload: {
       displayName: "Bob",
-      protocolVersion: 2,
+      protocolVersion: PROTOCOL_VERSION,
     },
   });
 });
@@ -190,7 +194,7 @@ test("room session controller sends join request after connect and normalizes pe
       roomCode: "ROOM01",
       joinToken: "token-1",
       displayName: "Alice",
-      protocolVersion: 2,
+      protocolVersion: PROTOCOL_VERSION,
     },
   });
   assert.equal(harness.persistReasons.length, 1);

--- a/extension/test/toast.test.ts
+++ b/extension/test/toast.test.ts
@@ -135,6 +135,60 @@ test("builds seek and rate toast messages for remote playback changes", () => {
   assert.deepEqual(result.messages, ["Alice 切换到 1.5x", "Alice 跳转到 0:42"]);
 });
 
+test("suppresses playback toasts for a natural-end paused state", () => {
+  setLocaleForTests("zh-CN");
+  const previousState = createRoomState({
+    members: [
+      { id: "self", name: "Me" },
+      { id: "remote", name: "Alice" },
+    ],
+    sharedUrl: "https://www.bilibili.com/video/BV1?p=1",
+    playback: {
+      url: "https://www.bilibili.com/video/BV1?p=1",
+      currentTime: 250,
+      playState: "playing",
+      playbackRate: 1,
+      updatedAt: 1,
+      serverTime: 1000,
+      actorId: "remote",
+      seq: 1,
+    },
+  });
+  // The sharer's shared video reached its natural end: a paused state parked at
+  // the end, flagged natural-end. It must apply silently — no "paused" and no
+  // "jumped to <end>" toast (the playing→paused jump would otherwise trip both).
+  const nextState = createRoomState({
+    members: [
+      { id: "self", name: "Me" },
+      { id: "remote", name: "Alice" },
+    ],
+    sharedUrl: "https://www.bilibili.com/video/BV1?p=1",
+    playback: {
+      url: "https://www.bilibili.com/video/BV1?p=1",
+      currentTime: 262.5,
+      playState: "paused",
+      syncIntent: "natural-end",
+      playbackRate: 1,
+      updatedAt: 2,
+      serverTime: 7000,
+      actorId: "remote",
+      seq: 2,
+    },
+  });
+
+  const result = getRoomStateToastMessages({
+    previousState,
+    nextState,
+    localMemberId: "self",
+    pendingRoomStateHydration: false,
+    isCurrentPageShowingSharedVideo: true,
+    now: 1000,
+    lastSeekToastByActor: new Map(),
+  });
+
+  assert.deepEqual(result.messages, []);
+});
+
 test("builds shared video toast for another member only once", () => {
   setLocaleForTests("zh-CN");
   const state = createRoomState({

--- a/extension/test/toast.test.ts
+++ b/extension/test/toast.test.ts
@@ -167,7 +167,7 @@ test("suppresses playback toasts for a natural-end paused state", () => {
       url: "https://www.bilibili.com/video/BV1?p=1",
       currentTime: 262.5,
       playState: "paused",
-      syncIntent: "natural-end",
+      naturalEnd: true,
       playbackRate: 1,
       updatedAt: 2,
       serverTime: 7000,

--- a/packages/protocol/src/guards/client-message.ts
+++ b/packages/protocol/src/guards/client-message.ts
@@ -75,6 +75,7 @@ export function isPlaybackState(value: unknown): value is PlaybackState {
       isPlaybackSyncIntent(value.syncIntent)) &&
     (value.userInitiated === undefined ||
       typeof value.userInitiated === "boolean") &&
+    (value.naturalEnd === undefined || typeof value.naturalEnd === "boolean") &&
     isFiniteNumber(value.playbackRate) &&
     isFiniteNumber(value.updatedAt) &&
     isFiniteNumber(value.serverTime) &&

--- a/packages/protocol/src/guards/server-message.ts
+++ b/packages/protocol/src/guards/server-message.ts
@@ -63,6 +63,7 @@ function isPlaybackState(value: unknown): value is PlaybackState {
       isPlaybackSyncIntent(value.syncIntent)) &&
     (value.userInitiated === undefined ||
       typeof value.userInitiated === "boolean") &&
+    (value.naturalEnd === undefined || typeof value.naturalEnd === "boolean") &&
     isFiniteNumber(value.playbackRate) &&
     isFiniteNumber(value.updatedAt) &&
     isFiniteNumber(value.serverTime) &&

--- a/packages/protocol/src/types/common.ts
+++ b/packages/protocol/src/types/common.ts
@@ -1,4 +1,4 @@
-export const PROTOCOL_VERSION = 2;
+export const PROTOCOL_VERSION = 3;
 
 export type RoomCode = string;
 export type PlaybackPlayState = "playing" | "paused" | "buffering";

--- a/packages/protocol/src/types/domain.ts
+++ b/packages/protocol/src/types/domain.ts
@@ -3,6 +3,12 @@ import type { PlaybackPlayState, RoomCode } from "./common.js";
 export const PLAYBACK_SYNC_INTENTS = [
   "explicit-seek",
   "explicit-ratechange",
+  // The shared video reached its natural end on the sharer. Carried on the
+  // terminal paused state the sharer flushes once no autoplay-next followed
+  // within the suppression window (or it followed too slowly, e.g. behind a
+  // recommend-autoplay countdown). Peers apply the paused state but must not
+  // surface a misleading "paused" / "jumped to <end>" toast for it.
+  "natural-end",
 ] as const;
 
 export type PlaybackSyncIntent = (typeof PLAYBACK_SYNC_INTENTS)[number];

--- a/packages/protocol/src/types/domain.ts
+++ b/packages/protocol/src/types/domain.ts
@@ -3,12 +3,6 @@ import type { PlaybackPlayState, RoomCode } from "./common.js";
 export const PLAYBACK_SYNC_INTENTS = [
   "explicit-seek",
   "explicit-ratechange",
-  // The shared video reached its natural end on the sharer. Carried on the
-  // terminal paused state the sharer flushes once no autoplay-next followed
-  // within the suppression window (or it followed too slowly, e.g. behind a
-  // recommend-autoplay countdown). Peers apply the paused state but must not
-  // surface a misleading "paused" / "jumped to <end>" toast for it.
-  "natural-end",
 ] as const;
 
 export type PlaybackSyncIntent = (typeof PLAYBACK_SYNC_INTENTS)[number];
@@ -49,6 +43,16 @@ export interface PlaybackState {
    * backward-compatibility: legacy senders omit it; legacy receivers ignore it.
    */
   userInitiated?: boolean;
+  /**
+   * Hint that this paused state was produced because the sharer's shared video
+   * reached its *natural* end (the sharer flushes a terminal paused once no
+   * autoplay-next followed within the suppression window, or it followed too
+   * slowly — e.g. behind a recommend-autoplay countdown). Receivers apply the
+   * paused state but must not surface a misleading "paused" / "jumped to <end>"
+   * toast for it. Additive and optional: legacy senders omit it; legacy
+   * receivers ignore the unknown field and keep their prior toast behaviour.
+   */
+  naturalEnd?: boolean;
   playbackRate: number;
   updatedAt: number;
   serverTime: number;

--- a/packages/protocol/test/client-message.test.ts
+++ b/packages/protocol/test/client-message.test.ts
@@ -622,6 +622,52 @@ test("rejects playback:update with non-boolean userInitiated", () => {
   );
 });
 
+test("accepts playback:update carrying naturalEnd:true", () => {
+  assert.equal(
+    isClientMessage({
+      type: "playback:update",
+      payload: {
+        memberToken: VALID_TOKEN,
+        playback: {
+          url: "https://www.bilibili.com/video/BV1xx411c7mD",
+          currentTime: 262.5,
+          playState: "paused",
+          naturalEnd: true,
+          playbackRate: 1,
+          updatedAt: 1,
+          serverTime: 1,
+          actorId: "member-1",
+          seq: 1,
+        },
+      },
+    }),
+    true,
+  );
+});
+
+test("rejects playback:update with non-boolean naturalEnd", () => {
+  assert.equal(
+    isClientMessage({
+      type: "playback:update",
+      payload: {
+        memberToken: VALID_TOKEN,
+        playback: {
+          url: "https://www.bilibili.com/video/BV1xx411c7mD",
+          currentTime: 262.5,
+          playState: "paused",
+          naturalEnd: 1,
+          playbackRate: 1,
+          updatedAt: 1,
+          serverTime: 1,
+          actorId: "member-1",
+          seq: 1,
+        },
+      },
+    }),
+    false,
+  );
+});
+
 test("accepts a valid room:join message", () => {
   assert.equal(
     isClientMessage({

--- a/packages/protocol/test/server-message.test.ts
+++ b/packages/protocol/test/server-message.test.ts
@@ -244,6 +244,64 @@ test("rejects room:state when playback userInitiated is non-boolean", () => {
   );
 });
 
+test("accepts room:state when playback carries naturalEnd:true", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:state",
+      payload: {
+        roomCode: "ABC123",
+        sharedVideo: {
+          videoId: "BV1xx411c7mD",
+          url: "https://www.bilibili.com/video/BV1xx411c7mD?p=2",
+          title: "Video",
+        },
+        playback: {
+          url: "https://www.bilibili.com/video/BV1xx411c7mD?p=2",
+          currentTime: 262.5,
+          playState: "paused",
+          naturalEnd: true,
+          playbackRate: 1,
+          updatedAt: 1,
+          serverTime: 1,
+          actorId: "member-1",
+          seq: 1,
+        },
+        members: [{ id: "member-1", name: "Alice" }],
+      },
+    }),
+    true,
+  );
+});
+
+test("rejects room:state when playback naturalEnd is non-boolean", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:state",
+      payload: {
+        roomCode: "ABC123",
+        sharedVideo: {
+          videoId: "BV1xx411c7mD",
+          url: "https://www.bilibili.com/video/BV1xx411c7mD?p=2",
+          title: "Video",
+        },
+        playback: {
+          url: "https://www.bilibili.com/video/BV1xx411c7mD?p=2",
+          currentTime: 262.5,
+          playState: "paused",
+          naturalEnd: "yes",
+          playbackRate: 1,
+          updatedAt: 1,
+          serverTime: 1,
+          actorId: "member-1",
+          seq: 1,
+        },
+        members: [{ id: "member-1", name: "Alice" }],
+      },
+    }),
+    false,
+  );
+});
+
 test("rejects room:state when playback sync intent is invalid", () => {
   assert.equal(
     isServerMessage({

--- a/server/src/messages.ts
+++ b/server/src/messages.ts
@@ -34,4 +34,4 @@ export const UNSUPPORTED_PROTOCOL_VERSION_MESSAGE =
 export const MIN_PROTOCOL_VERSION = 1;
 
 /** Current protocol version this server implements. */
-export const CURRENT_PROTOCOL_VERSION = 2;
+export const CURRENT_PROTOCOL_VERSION = 3;

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -784,7 +784,7 @@ test("message handler accepts room:create without protocolVersion (legacy client
   assert.ok(events.includes("room_created"));
   assert.equal(sent.length, 2);
   assert.equal(sent[0].type, "room:created");
-  assert.equal(sent[0].serverProtocolVersion, 2);
+  assert.equal(sent[0].serverProtocolVersion, 3);
   assert.equal(sent[1].type, "room:state");
 });
 
@@ -977,13 +977,95 @@ test("message handler accepts room:join with matching protocolVersion and return
     payload: {
       roomCode: "ROOM01",
       joinToken: "join-token-1",
-      protocolVersion: 2,
+      protocolVersion: 3,
     },
   });
 
   assert.equal(sent.length, 2);
   assert.equal(sent[0].type, "room:joined");
-  assert.equal(sent[0].serverProtocolVersion, 2);
+  assert.equal(sent[0].serverProtocolVersion, 3);
+  assert.equal(sent[1].type, "room:state");
+});
+
+test("message handler accepts room:join from a still-supported older protocol version", async () => {
+  // v2 clients (below CURRENT but >= MIN) stay in the compatibility window: the
+  // server accepts them and advertises its CURRENT version. The v3 `naturalEnd`
+  // playback flag is additive, so these older clients simply ignore it.
+  const sent: Array<{ type: string; serverProtocolVersion?: number }> = [];
+  const session = createSession("older-joiner");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession(currentSession) {
+        currentSession.roomCode = "ROOM-O1";
+        currentSession.memberId = "member-o1";
+        currentSession.memberToken = "member-token-o1";
+        return {
+          room: { code: "ROOM-O1" },
+          memberToken: "member-token-o1",
+        };
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        return {
+          roomCode: "ROOM-O1",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-o1", name: "Bob" }],
+        };
+      },
+    },
+    logEvent() {},
+    send(_socket, message) {
+      if (
+        "payload" in message &&
+        message.payload &&
+        "serverProtocolVersion" in message.payload
+      ) {
+        sent.push({
+          type: message.type,
+          serverProtocolVersion: (
+            message.payload as { serverProtocolVersion?: number }
+          ).serverProtocolVersion,
+        });
+      } else {
+        sent.push({ type: message.type });
+      }
+    },
+    sendError() {
+      throw new Error("sendError should not be called");
+    },
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      protocolVersion: 2,
+    },
+  });
+
+  assert.equal(session.protocolVersion, 2);
+  assert.equal(sent[0].type, "room:joined");
+  assert.equal(sent[0].serverProtocolVersion, 3);
   assert.equal(sent[1].type, "room:state");
 });
 


### PR DESCRIPTION
## 问题

自动连播切下一个视频时，其它端会先闪现「xx 暂停了视频」「xx 跳转到 xx」，然后才被同步到下一个视频。

### 根因

分享者侧视频自然播放结束时，会 arm 一个有界的「片尾广播抑制窗口」（默认 3s）。若自动连播比这个窗口慢（典型是**片尾推荐自动连播** `player_end_recommend_autoplay` 带 ~5s 倒计时），延迟 flush 会把这条**仍指向旧视频**的末尾暂停状态补播出去：

```
[14:33:12] <- room:state shared=BV...旧 seq=37 playState=paused t=262.55   ← 还是旧视频
[14:33:15] <- room:state shared=BV...新 seq=38 playState=playing            ← 才切到新视频
```

接收端看到 `playing(t=260) → paused(t=262.55)`：playState 变化触发「暂停」toast；时间位移与预期差 >1.5s 触发「跳转」toast。

flush 本身是兜底「最后一集 / 无连播」让别人知道视频停了，逻辑需要保留，只是不该弹这两个 toast。

## 修复

- `packages/protocol`：`PLAYBACK_SYNC_INTENTS` 新增 `natural-end`（非显式控制 intent，不影响既有 seek/ratechange 逻辑）。
- `sync-controller.ts`：`broadcastPlayback` 增加可选 `syncIntentOverride`。
- `playback-binding-controller.ts`：flush 补播末尾暂停时打 `natural-end` 标。
- `toast.ts`：`natural-end` 时静默应用状态，跳过播放类 toast（暂停/跳转/倍速）；成员进出 toast 不受影响。

同时覆盖了「连播太慢、flush 早于连播」这一边界。

## 测试

- 更新 flush 测试：断言补播 intent 为 `natural-end`。
- 新增 toast 测试：`natural-end` 暂停状态不产生任何 toast。
- `format:check` / `lint` / `typecheck` / `build` / `test`(466 通过) 全部本地通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)