### PR TITLE
[codex] chore: release 1.2.0

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.1.2"
+    "@bili-syncplay/protocol": "1.2.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.1.40",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "workspaces": [
         "packages/*",
         "server",
@@ -24,9 +24,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.1.2"
+        "@bili-syncplay/protocol": "1.2.0"
       },
       "devDependencies": {
         "@types/chrome": "^0.1.40",
@@ -2740,16 +2740,16 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "devDependencies": {
         "typescript": "^5.9.3"
       }
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.1.2",
+        "@bili-syncplay/protocol": "1.2.0",
         "ioredis": "^5.10.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.1.2",
+    "@bili-syncplay/protocol": "1.2.0",
     "ioredis": "^5.10.0",
     "ws": "^8.21.0"
   },


### PR DESCRIPTION
## Summary

- bump the workspace, protocol package, server, extension, and manifest versions from 1.1.2 to 1.2.0
- update workspace protocol dependency pins and package-lock metadata
- prepare the v1.2.0 tag-driven GitHub release

## Protocol Changes

- [x] This PR does not change protocol fields, protocol semantics, protocol guards, or protocol versions.
- [ ] This PR changes the protocol and follows the checklist in `CONTRIBUTING.md`.

## Test Plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm run build:release`

Local release artifacts were generated for Chrome and Firefox, and both generated manifests report version 1.2.0.