### PR TITLE
fix: 消除 Firefox 对 shadow root innerHTML 赋值的安全告警

### DIFF
--- a/extension/src/content/page-share-button.ts
+++ b/extension/src/content/page-share-button.ts
@@ -15,6 +15,7 @@ import {
   type PageShareButtonPosition,
 } from "../shared/storage";
 import { areSharedVideoUrlsEqual } from "../shared/url";
+import { setShadowRootTemplate } from "./shadow-template";
 
 type RuntimeSendMessage = <T>(
   message: ContentToBackgroundMessage,
@@ -568,7 +569,9 @@ export function createPageShareButtonController(args: {
     host.style.zIndex = "2147482999";
 
     const shadowRoot = host.attachShadow({ mode: "open" });
-    shadowRoot.innerHTML = `
+    setShadowRootTemplate(
+      shadowRoot,
+      `
       <style>
         :host {
           all: initial;
@@ -795,7 +798,8 @@ export function createPageShareButtonController(args: {
           </span>
         </label>
       </div>
-    `;
+    `,
+    );
     button = shadowRoot.querySelector("button");
     popover = shadowRoot.querySelector(".share-popover");
     popoverStatus = shadowRoot.querySelector(".popover-status");

--- a/extension/src/content/shadow-template.ts
+++ b/extension/src/content/shadow-template.ts
@@ -1,0 +1,20 @@
+/**
+ * 用 DOMParser 解析静态模板并挂载到 shadow root，替代 `innerHTML` 赋值。
+ *
+ * 模板均为内置静态字符串（仅含常量与 i18n 文案，无任何用户输入），
+ * DOMParser 不会执行脚本，addons-linter/Firefox 也不会对其发出
+ * “对 innerHTML 进行不安全赋值” 告警，是 innerHTML 的官方安全替代。
+ */
+export function setShadowRootTemplate(
+  shadowRoot: ShadowRoot,
+  template: string,
+): void {
+  const parsed = new DOMParser().parseFromString(template, "text/html");
+  const nodes = [
+    ...Array.from(parsed.head.childNodes),
+    ...Array.from(parsed.body.childNodes),
+  ];
+  shadowRoot.replaceChildren(
+    ...nodes.map((node) => document.importNode(node, true)),
+  );
+}

--- a/extension/src/content/toast.ts
+++ b/extension/src/content/toast.ts
@@ -1,6 +1,7 @@
 import type { PlaybackState, RoomState } from "@bili-syncplay/protocol";
 import type { SharedVideoToastPayload } from "../shared/messages";
 import { t } from "../shared/i18n";
+import { setShadowRootTemplate } from "./shadow-template";
 
 const SEEK_TOAST_THRESHOLD_SECONDS = 1.5;
 const SEEK_START_TOAST_SUPPRESSION_MS = 1600;
@@ -54,7 +55,9 @@ export function createToastPresenter(): {
     toastHost.style.zIndex = "2147483000";
 
     const shadowRoot = toastHost.attachShadow({ mode: "open" });
-    shadowRoot.innerHTML = `
+    setShadowRootTemplate(
+      shadowRoot,
+      `
       <style>
         .toast-stack {
           position: absolute;
@@ -79,7 +82,8 @@ export function createToastPresenter(): {
         }
       </style>
       <div class="toast-stack" id="toast-stack"></div>
-    `;
+    `,
+    );
 
     mountTarget.appendChild(toastHost);
     toastContainer = shadowRoot.getElementById(


### PR DESCRIPTION
## 问题

Firefox / addons-linter 对 `shadowRoot.innerHTML = ...` 赋值发出「对 innerHTML 进行不安全赋值」告警（`content.js:1877` 等）。对应源码有两处：`page-share-button.ts` 的分享按钮模板与 `toast.ts` 的 toast 容器模板。两者都是内置静态字符串（仅含常量与 i18n 文案，无用户输入），但校验器只要检测到 `innerHTML` 赋值就一律告警。

## 改动

- 新增 `extension/src/content/shadow-template.ts`,导出 `setShadowRootTemplate(shadowRoot, template)`:用 `DOMParser`（不执行脚本）解析静态模板,再 `importNode` 把 head(`<style>`)+body 节点 `replaceChildren` 到 shadow root。这是 innerHTML 的官方安全替代,沿用了 popup（`popup/index.ts`）已有的做法。
- `page-share-button.ts`、`toast.ts` 改用该工具,替换原 `innerHTML` 赋值。

功能等价:`getElementById` / `querySelector` 等后续查询依赖的 id、class 均由 `importNode` 保留。

## 验证

`format:check` / `lint` / `typecheck` / `build`(chrome+firefox) / `npm test`(476 通过)全部通过;重新构建后 `dist/content.js` 与 `dist-firefox/content.js` 均不再包含 `innerHTML`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)