### PR TITLE
ci: 更新 release lint 注释(移除已修复的 innerHTML 告警)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,9 @@ jobs:
 
       - name: Lint Firefox build (non-blocking)
         # Soft gate: dist-firefox has 0 errors but expected warnings
-        # (pre-existing innerHTML UNSAFE_VAR; data_collection_permissions
-        # KEY_FIREFOX_*_UNSUPPORTED_BY_MIN_VERSION because the key is only
-        # read by Firefox >=140 while strict_min_version is 121). Do not
-        # fail the release on warnings.
+        # (data_collection_permissions KEY_FIREFOX_*_UNSUPPORTED_BY_MIN_VERSION
+        # because the key is only read by Firefox >=140 while strict_min_version
+        # is 121). Do not fail the release on warnings.
         continue-on-error: true
         run: npx --yes web-ext lint --source-dir extension/dist-firefox --output text --no-config-discovery
 


### PR DESCRIPTION
PR #145 已用 DOMParser 替换 shadow root 的 `innerHTML` 赋值,`web-ext lint` 不再产生 innerHTML `UNSAFE_VAR` 告警。更新 `release.yml` 中「Lint Firefox build」步骤的注释,移除已过时的说明,仅保留仍存在的 `data_collection_permissions` 版本兼容告警说明。

纯注释改动,无行为变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)