### PR TITLE
fix: 远端暂停去抖时标记初始房间态已接收，消除 sync:request 重试风暴

### DIFF
--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -62,6 +62,7 @@ export function createRoomStateApplyController(args: {
   clearRemoteFollowPlayingWindow: () => void;
   acceptInitialRoomStateHydration: () => void;
   acceptInitialRoomStateHydrationIfPending: () => void;
+  markInitialRoomStateReceived: () => void;
   logIgnoredRemotePlayback: (argsForLog: {
     playback: PlaybackState;
     video: HTMLVideoElement;
@@ -469,6 +470,14 @@ export function createRoomStateApplyController(args: {
       args.debugLog(
         `Deferred remote paused url=${deferredPlayback.url} seq=${deferredPlayback.seq} for ${remotePauseDebounceMs}ms`,
       );
+      // The room's initial state is now known (we are merely debouncing the
+      // paused frame). Mark it received so `handleSyncStatus` stops re-arming a
+      // 150ms hydrate retry: otherwise each retry re-enters here and resets this
+      // 250ms defer timer (150ms < 250ms), so it never fires, hydration never
+      // completes, and the retry loop floods the server with `sync:request`
+      // until it rate-limits us. `pendingRoomStateHydration` is deliberately
+      // left true — it clears only when the deferred snapshot fires and applies.
+      args.markInitialRoomStateReceived();
       return;
     }
 

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -373,6 +373,19 @@ export function createSyncController(args: {
     }
   }
 
+  // Mark the room's initial state as *received* without clearing
+  // `pendingRoomStateHydration`. Used when the state is known but its
+  // application is intentionally deferred (e.g. a remote `paused` held by the
+  // flicker debounce): `hasReceivedInitialRoomState` gates `handleSyncStatus`'s
+  // 150ms hydrate retry, so leaving it false while re-deferring the paused every
+  // ~150ms (< the 250ms debounce) resets the defer timer forever, spamming
+  // `sync:request` until the server rate-limits us. `pendingRoomStateHydration`
+  // stays true so the longer initial pause hold / protection still apply when
+  // the deferred snapshot finally fires and accepts hydration for real.
+  function markInitialRoomStateReceived(): void {
+    args.runtimeState.hasReceivedInitialRoomState = true;
+  }
+
   function logIgnoredRemotePlayback(argsForLog: {
     playback: PlaybackState;
     video: HTMLVideoElement;
@@ -1403,6 +1416,7 @@ export function createSyncController(args: {
     clearRemoteFollowPlayingWindow,
     acceptInitialRoomStateHydration,
     acceptInitialRoomStateHydrationIfPending,
+    markInitialRoomStateReceived,
     logIgnoredRemotePlayback,
     getPendingLocalPlaybackOverrideDecision:
       pendingLocalOverride.getPendingLocalPlaybackOverrideDecision,

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -87,6 +87,9 @@ function createController(overrides: {
       _acceptedHydration = true;
     },
     acceptInitialRoomStateHydrationIfPending: () => {},
+    markInitialRoomStateReceived: () => {
+      runtimeState.hasReceivedInitialRoomState = true;
+    },
     logIgnoredRemotePlayback: () => {},
     getPendingLocalPlaybackOverrideDecision: () => ({ shouldIgnore: false }),
     shouldCancelActiveSoftApplyForPlayback: () => null,
@@ -842,6 +845,55 @@ test("defers remote paused room state when remotePauseDebounceMs > 0", async () 
       applyPending,
       0,
       "apply should be deferred, not run synchronously",
+    );
+  } finally {
+    win.restore();
+  }
+});
+
+test("deferring initial paused marks room state received but keeps hydration pending", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const video = createStubVideo(false);
+    const harness = createController({
+      video,
+      now: 30_000,
+      remotePauseDebounceMs: 250,
+    });
+    harness.runtimeState.localMemberId = "local-member";
+    // Simulate the in-room navigation / initial-hydration state: we are still
+    // waiting to apply the first room state and have not marked it received.
+    harness.runtimeState.pendingRoomStateHydration = true;
+    harness.runtimeState.hasReceivedInitialRoomState = false;
+
+    await harness.controller.applyRoomState(
+      createRoomStateWithPlayback({
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        currentTime: 42,
+        playState: "paused",
+        actorId: "remote-member",
+        seq: 5,
+      }) as never,
+    );
+
+    assert.equal(
+      harness.runtimeState.deferredRemotePausedState !== null,
+      true,
+      "paused room state should be captured for deferred apply",
+    );
+    // The retry loop that floods the server with `sync:request` is gated on
+    // `hasReceivedInitialRoomState`; deferring must flip it so retries stop.
+    assert.equal(
+      harness.runtimeState.hasReceivedInitialRoomState,
+      true,
+      "initial room state must be marked received once deferred",
+    );
+    // But hydration is not finished until the deferred snapshot applies, so the
+    // longer initial pause hold / protection must still be armed.
+    assert.equal(
+      harness.runtimeState.pendingRoomStateHydration,
+      true,
+      "pending hydration must stay true until the deferred snapshot applies",
     );
   } finally {
     win.restore();


### PR DESCRIPTION
## 问题

房间初始态为 `paused` 时（如切换共享视频后落在暂停帧），日志出现 `sync:request` 洪泛并持续触发服务器限流 `Received server error code=rate_limited message="Too many requests."`。

## 根因

`sync:request` 服务器限流为 **6 次 / 10 秒**（`server/src/bootstrap/server-bootstrap.ts` + `server/src/message-handler.ts`），但内容脚本进入了自我维持的 hydrate 循环：

1. 初始 `paused` 状态命中 250ms 去抖分支（`room-state-apply-controller.ts`），该分支提前 `return`，既不 `accept` 也不标记 `hasReceivedInitialRoomState`。
2. 因该标记为 false，每来一次 `background:sync-status`，`handleSyncStatus`（`room-state-controller.ts`）就重排一个 **150ms** 的 hydrate 重试。
3. 每次 hydrate 发一次 `content:get-room-state` → 后台随即向服务器发 `sync:request`；服务器回 `room:state`（server message）→ `notifyAll()` → 又一条 `sync-status` → 又一次 150ms 重试。
4. 每次 hydrate 又把**同一个** `paused`（seq/serverTime 相同、非 older）重新 defer，**取消并重置** 250ms 定时器。
5. 关键：**重试节奏 150ms < 去抖 250ms**，定时器被无限重置、永不 fire，hydration 永不完成，重试无休止 → `sync:request` ≈5–6 次/秒 → 撞限流。

## 修复

新增 `markInitialRoomStateReceived()`：在 defer 分支只置 `hasReceivedInitialRoomState = true` 切断重试循环，**保留** `pendingRoomStateHydration = true`，使延迟快照真正 fire 时仍走更长的初始暂停保护并正常 `acceptInitialRoomStateHydration`。

审计了 `applyRoomState` 其它提前 return 分支：`empty-room` / `ignore-non-shared` / `ignore-local-guard` / apply 路径均已正常 accept；`no-current-video` / video 未就绪是合法等待态（自带 350ms 节流重试，>250ms 不自锁），此处标记 received 反而语义错误，保持不动。

## 测试

- 新增回归测试：deferring 初始 paused 时 `hasReceivedInitialRoomState` 置 true、`pendingRoomStateHydration` 保持 true。
- `format:check` / `lint` / `typecheck` / `build` / `test`（477 全绿）均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)