### PR TITLE
fix: 事件窗口索引白名单 + playbackAuthority 过期清扫，修复 Redis 内存持续增长

### DIFF
--- a/server/src/admin/event-store.ts
+++ b/server/src/admin/event-store.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { shouldIncludeRuntimeEvent } from "./event-visibility.js";
 import type { RuntimeEvent } from "./types.js";
-import type {
-  GlobalEventStore,
-  GlobalEventStoreQuery,
+import {
+  isWindowIndexedEvent,
+  type GlobalEventStore,
+  type GlobalEventStoreQuery,
 } from "./global-event-store.js";
 
 export type EventStore = GlobalEventStore;
@@ -91,7 +92,7 @@ export function createEventStore(capacity = 1_000): EventStore {
   }
 
   function recordWindowEventTime(eventName: string, timestampMs: number): void {
-    if (!Number.isFinite(timestampMs)) {
+    if (!isWindowIndexedEvent(eventName) || !Number.isFinite(timestampMs)) {
       return;
     }
     const retentionReferenceMs = retentionReferenceTimestamp(timestampMs);

--- a/server/src/admin/global-event-store.ts
+++ b/server/src/admin/global-event-store.ts
@@ -1,5 +1,27 @@
 import type { RuntimeEvent } from "./types.js";
 
+// Only these events get a windowed timestamp index. Indexing every logged
+// event retained 24h of per-message system events (room_event_published /
+// room_event_consumed arrive on every playback heartbeat) in Redis or the
+// Node heap for windows no query ever reads — the admin overview is the
+// only windowed-count consumer and it reads exactly these names.
+export const WINDOW_INDEXED_EVENTS = [
+  "room_created",
+  "room_joined",
+  "rate_limited",
+  "ws_connection_rejected",
+] as const;
+
+export type WindowIndexedEventName = (typeof WINDOW_INDEXED_EVENTS)[number];
+
+const windowIndexedEventNames: ReadonlySet<string> = new Set(
+  WINDOW_INDEXED_EVENTS,
+);
+
+export function isWindowIndexedEvent(eventName: string): boolean {
+  return windowIndexedEventNames.has(eventName);
+}
+
 export type GlobalEventStoreQuery = {
   event?: string;
   roomCode?: string;

--- a/server/src/admin/overview-service.ts
+++ b/server/src/admin/overview-service.ts
@@ -1,4 +1,7 @@
-import type { GlobalEventStore } from "./global-event-store.js";
+import {
+  WINDOW_INDEXED_EVENTS,
+  type GlobalEventStore,
+} from "./global-event-store.js";
 import type { RoomStore } from "../room-store.js";
 import type { RuntimeStore } from "../runtime-store.js";
 import type {
@@ -7,12 +10,9 @@ import type {
   Session,
 } from "../types.js";
 
-const OVERVIEW_EVENT_NAMES = [
-  "room_created",
-  "room_joined",
-  "rate_limited",
-  "ws_connection_rejected",
-] as const;
+// The overview reads windowed counts, so it may only ask for event names the
+// stores actually index — reusing the allowlist keeps the two in lockstep.
+const OVERVIEW_EVENT_NAMES = WINDOW_INDEXED_EVENTS;
 
 const EVENT_WINDOWS_MS = {
   lastMinute: 60_000,

--- a/server/src/admin/redis-event-store.ts
+++ b/server/src/admin/redis-event-store.ts
@@ -114,6 +114,14 @@ function eventWindowIndexKey(prefix: string, eventName: string): string {
   return `${prefix}:${encodeURIComponent(eventName)}`;
 }
 
+// SCAN MATCH takes a glob-style pattern, so a configured prefix (via
+// REDIS_NAMESPACE) containing *, ?, [ or \ would match keys outside this
+// store's namespace and the startup cleanup could UNLINK another
+// namespace's indexes on a shared Redis.
+function escapeRedisGlob(value: string): string {
+  return value.replace(/[\\*?[\]]/g, "\\$&");
+}
+
 function retentionReferenceTimestamp(timestampMs: number): number {
   return Math.min(timestampMs, Date.now());
 }
@@ -231,17 +239,23 @@ export async function createRedisEventStore(
   {
     let cursor = "0";
     const staleKeys: string[] = [];
+    const literalKeyPrefix = `${windowIndexKeyPrefix}:`;
     do {
       const [nextCursor, keys] = await redis.scan(
         cursor,
         "MATCH",
-        `${windowIndexKeyPrefix}:*`,
+        `${escapeRedisGlob(windowIndexKeyPrefix)}:*`,
         "COUNT",
         100,
       );
       cursor = nextCursor;
       for (const key of keys) {
-        const encodedEventName = key.slice(windowIndexKeyPrefix.length + 1);
+        // Literal-prefix backstop in case the glob escaping above ever
+        // diverges from Redis's matching rules.
+        if (!key.startsWith(literalKeyPrefix)) {
+          continue;
+        }
+        const encodedEventName = key.slice(literalKeyPrefix.length);
         let eventName = encodedEventName;
         try {
           eventName = decodeURIComponent(encodedEventName);

--- a/server/src/admin/redis-event-store.ts
+++ b/server/src/admin/redis-event-store.ts
@@ -1,11 +1,12 @@
 import { Redis } from "ioredis";
 import { randomUUID } from "node:crypto";
 import { shouldIncludeRuntimeEvent } from "./event-visibility.js";
-import type {
-  GlobalEventStore,
-  GlobalEventStoreAppendInput,
-  GlobalEventStoreQuery,
-  GlobalEventStoreQueryResult,
+import {
+  isWindowIndexedEvent,
+  type GlobalEventStore,
+  type GlobalEventStoreAppendInput,
+  type GlobalEventStoreQuery,
+  type GlobalEventStoreQueryResult,
 } from "./global-event-store.js";
 import type { RuntimeEvent } from "./types.js";
 
@@ -221,6 +222,43 @@ export async function createRedisEventStore(
     }
   }
 
+  // Drop window indexes for event names that are no longer indexed. Nothing
+  // prunes those keys once appends stop touching them, so a deploy that
+  // narrows the allowlist would otherwise leave the old high-volume ZSETs
+  // (24h of per-heartbeat system events) in Redis forever. UNLINK reclaims
+  // them off the main thread. A node still running the previous version may
+  // recreate a key during a rolling restart; the next startup removes it.
+  {
+    let cursor = "0";
+    const staleKeys: string[] = [];
+    do {
+      const [nextCursor, keys] = await redis.scan(
+        cursor,
+        "MATCH",
+        `${windowIndexKeyPrefix}:*`,
+        "COUNT",
+        100,
+      );
+      cursor = nextCursor;
+      for (const key of keys) {
+        const encodedEventName = key.slice(windowIndexKeyPrefix.length + 1);
+        let eventName = encodedEventName;
+        try {
+          eventName = decodeURIComponent(encodedEventName);
+        } catch {
+          // Not produced by eventWindowIndexKey; treat the raw suffix as the
+          // event name so unknown keys under the prefix still get removed.
+        }
+        if (!isWindowIndexedEvent(eventName)) {
+          staleKeys.push(key);
+        }
+      }
+    } while (cursor !== "0");
+    if (staleKeys.length > 0) {
+      await redis.unlink(...staleKeys);
+    }
+  }
+
   // Backfill the window indexes from retained stream entries on every startup.
   // ZADD by stream id is idempotent, so this cannot overwrite or double-count
   // entries written concurrently by another node during a rolling restart.
@@ -234,6 +272,7 @@ export async function createRedisEventStore(
         const eventName = fields.event;
         const timestamp = fields.timestamp;
         if (!eventName || !timestamp) continue;
+        if (!isWindowIndexedEvent(eventName)) continue;
         const ts = Date.parse(timestamp);
         if (!Number.isFinite(ts)) continue;
         transaction.zadd(
@@ -385,7 +424,8 @@ export async function createRedisEventStore(
           redis.xtrim(streamKey, "MAXLEN", "=", maxLen),
           redis.hincrby(countsKey, input.event, 1),
         ];
-        if (Number.isFinite(timestampMs)) {
+        const shouldIndexWindow = isWindowIndexedEvent(input.event);
+        if (shouldIndexWindow && Number.isFinite(timestampMs)) {
           writeOperations.push(
             redis.zadd(
               eventWindowIndexKey(windowIndexKeyPrefix, input.event),
@@ -395,7 +435,9 @@ export async function createRedisEventStore(
           );
         }
         await Promise.all(writeOperations);
-        await pruneEventWindowIndexIfNeeded(input.event, timestampMs);
+        if (shouldIndexWindow) {
+          await pruneEventWindowIndexIfNeeded(input.event, timestampMs);
+        }
 
         return {
           ...runtimeEvent,
@@ -443,7 +485,9 @@ export async function createRedisEventStore(
       return Object.fromEntries(
         await Promise.all(
           eventNames.map(async (name) => {
-            await pruneEventWindowIndexIfNeeded(name, toMs);
+            if (isWindowIndexedEvent(name)) {
+              await pruneEventWindowIndexIfNeeded(name, toMs);
+            }
             const total = await redis.zcount(
               eventWindowIndexKey(windowIndexKeyPrefix, name),
               fromMs,

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -37,6 +37,7 @@ import type {
 } from "./types.js";
 
 const PLAYBACK_AUTHORITY_WINDOW_MS = 1200;
+const PLAYBACK_AUTHORITY_SWEEP_INTERVAL_MS = 60_000;
 const MAX_VERSION_RETRIES = 3;
 const ROOM_LAST_ACTIVE_WRITE_INTERVAL_MS = 30_000;
 const JOIN_ADMISSION_LOCK_KEY = "join-admission";
@@ -452,12 +453,34 @@ export function createRoomService(options: {
     return null;
   }
 
+  let lastAuthoritySweepAt = 0;
+
+  // getPlaybackAuthority only removes the entry for the room it is asked
+  // about, so authorities of rooms that are deleted (or simply never read
+  // again) would sit in the map forever. Sweeping on record keeps the map
+  // bounded across every room-deletion path without wiring into them.
+  function sweepExpiredPlaybackAuthorities(currentTime: number): void {
+    if (
+      currentTime - lastAuthoritySweepAt <
+      PLAYBACK_AUTHORITY_SWEEP_INTERVAL_MS
+    ) {
+      return;
+    }
+    lastAuthoritySweepAt = currentTime;
+    for (const [roomCode, authority] of playbackAuthorityByRoom) {
+      if (authority.until <= currentTime) {
+        playbackAuthorityByRoom.delete(roomCode);
+      }
+    }
+  }
+
   function recordPlaybackAuthority(args: {
     roomCode: string;
     actorId: string;
     kind: PlaybackAuthority["kind"];
     source: PlaybackAuthority["source"];
   }): void {
+    sweepExpiredPlaybackAuthorities(now());
     playbackAuthorityByRoom.set(args.roomCode, {
       actorId: args.actorId,
       until: now() + PLAYBACK_AUTHORITY_WINDOW_MS,

--- a/server/test/event-store.test.ts
+++ b/server/test/event-store.test.ts
@@ -351,3 +351,34 @@ test("in-memory event store hides system events by default and can include them 
   });
   assert.equal(fullView.total, 3);
 });
+
+test("countsByEventInWindow only indexes allowlisted events while totals count everything", async () => {
+  const store = createEventStore();
+  const base = Date.parse("2026-03-26T12:00:00.000Z");
+
+  await store.append({
+    event: "room_event_published",
+    timestamp: new Date(base).toISOString(),
+    data: { roomCode: "ROOM01", result: "ok" },
+  });
+  await store.append({
+    event: "room_created",
+    timestamp: new Date(base).toISOString(),
+    data: { roomCode: "ROOM01", result: "ok" },
+  });
+
+  const counts = await store.countsByEventInWindow(
+    ["room_event_published", "room_created"],
+    base - 60_000,
+    base,
+  );
+  assert.equal(counts.room_event_published, 0);
+  assert.equal(counts.room_created, 1);
+
+  const totals = await store.totalCountsByEvent([
+    "room_event_published",
+    "room_created",
+  ]);
+  assert.equal(totals.room_event_published, 1);
+  assert.equal(totals.room_created, 1);
+});

--- a/server/test/redis-event-store.test.ts
+++ b/server/test/redis-event-store.test.ts
@@ -628,3 +628,41 @@ test("window index allowlist skips system events and unlinks stale indexes on st
     await redis.quit();
   }
 });
+
+test("startup cleanup escapes glob metacharacters in the window index prefix", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const suffix = `${Date.now()}:${Math.random().toString(16).slice(2)}`;
+  const keys = {
+    streamKey: `bsp:test:events:${suffix}`,
+    countsKey: `bsp:test:event_counts:${suffix}`,
+    // Unescaped, "[ab]" would glob-match sibling prefixes ending in "a"/"b".
+    windowIndexKeyPrefix: `bsp:test:event_window_index:${suffix}[ab]`,
+  };
+  const redis = new Redis(REDIS_URL);
+  const ownStaleKey = `${keys.windowIndexKeyPrefix}:${encodeURIComponent(
+    "room_event_published",
+  )}`;
+  const siblingNamespaceKey = `bsp:test:event_window_index:${suffix}a:${encodeURIComponent(
+    "room_event_published",
+  )}`;
+
+  try {
+    await redis.zadd(ownStaleKey, "1", "1-1");
+    await redis.zadd(siblingNamespaceKey, "1", "1-1");
+
+    const store = await createRedisEventStore(REDIS_URL, keys);
+    try {
+      assert.equal(await redis.exists(ownStaleKey), 0);
+      assert.equal(await redis.exists(siblingNamespaceKey), 1);
+    } finally {
+      await store.close();
+    }
+  } finally {
+    await redis.del(siblingNamespaceKey);
+    await redis.quit();
+  }
+});

--- a/server/test/redis-event-store.test.ts
+++ b/server/test/redis-event-store.test.ts
@@ -560,3 +560,71 @@ test("redis event store hides system events by default and can include them on d
     await store.close();
   }
 });
+
+test("window index allowlist skips system events and unlinks stale indexes on startup", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keys = createKeyTriplet();
+  const redis = new Redis(REDIS_URL);
+  const staleKey = `${keys.windowIndexKeyPrefix}:${encodeURIComponent(
+    "room_event_published",
+  )}`;
+  const indexedKey = `${keys.windowIndexKeyPrefix}:${encodeURIComponent(
+    "room_created",
+  )}`;
+
+  try {
+    // Simulate an index left behind by a version that indexed every event.
+    await redis.zadd(staleKey, "1", "1-1");
+
+    const store = await createRedisEventStore(REDIS_URL, keys);
+    try {
+      assert.equal(await redis.exists(staleKey), 0);
+
+      await store.append({
+        event: "room_event_published",
+        timestamp: "2026-03-26T13:00:30.000Z",
+        data: { roomCode: "ROOM01", result: "ok" },
+      });
+      await store.append({
+        event: "room_created",
+        timestamp: "2026-03-26T13:00:31.000Z",
+        data: { roomCode: "ROOM01", result: "ok" },
+      });
+
+      const counts = await store.countsByEventInWindow(
+        ["room_event_published", "room_created"],
+        Date.parse("2026-03-26T13:00:00.000Z"),
+        Date.parse("2026-03-26T13:01:00.000Z"),
+      );
+      assert.equal(counts.room_event_published, 0);
+      assert.equal(counts.room_created, 1);
+      assert.equal(await redis.exists(staleKey), 0);
+      assert.equal(await redis.exists(indexedKey), 1);
+
+      const totals = await store.totalCountsByEvent([
+        "room_event_published",
+        "room_created",
+      ]);
+      assert.equal(totals.room_event_published, 1);
+      assert.equal(totals.room_created, 1);
+    } finally {
+      await store.close();
+    }
+
+    // Restart backfills the window indexes from the retained stream, which
+    // still holds the room_event_published entry; it must stay unindexed.
+    const reopened = await createRedisEventStore(REDIS_URL, keys);
+    try {
+      assert.equal(await redis.exists(staleKey), 0);
+      assert.equal(await redis.exists(indexedKey), 1);
+    } finally {
+      await reopened.close();
+    }
+  } finally {
+    await redis.quit();
+  }
+});

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -3390,3 +3390,74 @@ test("playback_update_applied skips steady ticks across actor handovers in multi
   );
   assert.deepEqual(applied, []);
 });
+
+test("room service sweeps expired playback authorities when recording new ones", async () => {
+  let currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const roomCodes = ["ROOMSW1", "ROOMSW2"];
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: createActiveRoomRegistry(),
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => roomCodes.shift() ?? "ROOMSWX",
+  });
+
+  const ownerA = createSession("owner-a");
+  const roomA = await service.createRoomForSession(ownerA, "Alice");
+  await service.shareVideoForSession(
+    ownerA,
+    roomA.memberToken,
+    createSharedVideo(),
+    createPlayback(ownerA.memberId ?? ownerA.id, {
+      playState: "paused",
+      currentTime: 10,
+    }),
+  );
+  currentTime = 2_000;
+  await service.updatePlaybackForSession(
+    ownerA,
+    roomA.memberToken,
+    createPlayback(ownerA.memberId ?? ownerA.id, {
+      playState: "playing",
+      currentTime: 10.1,
+      seq: 2,
+    }),
+  );
+  assert.equal(service.getPlaybackAuthority(roomA.room.code)?.kind, "play");
+
+  // Long past room A's authority window and the sweep interval; recording a
+  // new authority in room B triggers the sweep and must not clobber the
+  // entry it is about to record.
+  currentTime = 70_000;
+  const ownerB = createSession("owner-b");
+  const roomB = await service.createRoomForSession(ownerB, "Bob");
+  await service.shareVideoForSession(
+    ownerB,
+    roomB.memberToken,
+    createSharedVideo(),
+    createPlayback(ownerB.memberId ?? ownerB.id, {
+      playState: "paused",
+      currentTime: 5,
+    }),
+  );
+  currentTime = 71_000;
+  await service.updatePlaybackForSession(
+    ownerB,
+    roomB.memberToken,
+    createPlayback(ownerB.memberId ?? ownerB.id, {
+      playState: "playing",
+      currentTime: 5.05,
+      seq: 2,
+    }),
+  );
+
+  assert.equal(service.getPlaybackAuthority(roomB.room.code)?.kind, "play");
+  assert.equal(service.getPlaybackAuthority(roomA.room.code), null);
+});


### PR DESCRIPTION
## 背景

1.2.0 部署后 Redis 内存一天内从 ~600M 涨到 ~850M。线上排查数据：

- `bsp:event_window_index:room_event_published` / `room_event_consumed` 各 **928,351** 条成员（跨度恰好 24.0h，修剪本身工作正常），按实测 ~122B/条合计 ≈227MB，与观测增量吻合。
- 抽样 `bsp:events` 流：每 ~2.12s 一对 published/consumed，`eventType` 全部为 `room_state_updated`，中间没有任何业务日志。

## 根因

分享端每 ~2s 的播放心跳在 `updatePlaybackForSession` 被 steady-tick 逻辑跳过 `playback_update_applied` 日志（防面板刷屏），但 `room_state_updated` 发布照常进行——而**发布/消费本身各记一条系统日志事件**。防洪堤挡住了一个事件名，洪水从 `room_event_published`/`room_event_consumed` 溢出。1.2.0 起每条日志事件都会 ZADD 进保留 24h 的窗口索引，于是每个活跃房间每 2 秒稳定产出 2 条 ZSET 成员。

窗口计数的唯一消费方是管理面板总览（`overview-service.ts`），只查 4 个事件名；被索引的高频事件中两个还是对面板默认隐藏的系统事件。

## 修改

**Commit 1 — 窗口索引白名单**
- `WINDOW_INDEXED_EVENTS`（room_created / room_joined / rate_limited / ws_connection_rejected）定义在 `global-event-store.ts` 作为单一事实来源；`overview-service` 复用同一常量。
- 内存版 `recordWindowEventTime` 与 Redis 版 append/启动回填均只索引白名单事件。
- Redis 版启动时 SCAN 窗口前缀并 **UNLINK** 不在白名单内的遗留索引 → 部署重启后立即回收 ~227MB，无需手动清 key。滚动重启期间旧版本节点可能重建 key，下次启动会再次清除。
- `totalCountsByEvent` 不受影响，全事件累计计数保持完整。

**Commit 2 — playbackAuthorityByRoom 过期清扫**
- 原来只在读取时惰性删除单房间条目，房间删除后条目永久残留（微量无界泄漏）。
- `recordPlaybackAuthority` 时按 60s 节流全量清扫过期条目；授权窗口仅 1.2s ≪ 清扫间隔，不会触及有效条目。

## 验证

- `npm run format:check` / `lint` / `typecheck` / `build` 全部通过。
- `npm test`（CI 等价，无 REDIS_URL）：924 项 0 失败。
- 对干净的本地 Redis 实例跑全量：新增 3 个回归测试全过（含"启动 UNLINK 遗留索引 + 重启回填不复活"的真实 Redis 断言）。既有 3 个多节点广播测试在**未修改的 1.2.2 代码**上同样超时失败，属本机环境问题，与本 PR 无关。

预期效果：部署重启后 Redis 立即回落 ~227MB；窗口索引稳态从 ~193 万条/天降到 ~11 万条/天（当前主要是 rate_limited）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)