### PR TITLE
feat: 管理页房间状态直观化（同步中断分级、位置外推、复合徽章、自动刷新）

### DIFF
--- a/server/admin-ui/app-runtime.js
+++ b/server/admin-ui/app-runtime.js
@@ -246,6 +246,19 @@ export function createAdminApp({
 
     if (page.autoRefresh) {
       state.refreshHandle = setInterval(() => {
+        // 整页重绘会丢掉未提交的表单输入和打开中的对话框内容，
+        // 用户正在交互时跳过本轮自动刷新。
+        if (state.dialog) {
+          return;
+        }
+        const activeTag = document.activeElement?.tagName;
+        if (
+          activeTag === "INPUT" ||
+          activeTag === "TEXTAREA" ||
+          activeTag === "SELECT"
+        ) {
+          return;
+        }
         rerender();
       }, AUTO_REFRESH_MS);
     }

--- a/server/admin-ui/page-renderers.js
+++ b/server/admin-ui/page-renderers.js
@@ -242,6 +242,7 @@ function bindRoomsListEvents(options, query) {
   const {
     document,
     history,
+    state,
     routeHref,
     withDemoQuery,
     serializeQuery,
@@ -284,6 +285,13 @@ function bindRoomsListEvents(options, query) {
   document
     .querySelector("[data-refresh-rooms]")
     ?.addEventListener("click", () => rerender());
+
+  document
+    .querySelector("[data-toggle-rooms-refresh]")
+    ?.addEventListener("click", () => {
+      state.roomsAutoRefresh = !state.roomsAutoRefresh;
+      rerender();
+    });
 
   document
     .querySelectorAll("[data-open-room],[data-room-link]")
@@ -518,6 +526,7 @@ export function createPageLoaders(options) {
       const query = roomsQueryFromLocation(location.search);
       const data = await api.listRooms(query);
       return {
+        autoRefresh: state.roomsAutoRefresh,
         instanceId: state.lastOverviewData?.instanceId,
         html: `
           <div class="section">
@@ -559,6 +568,8 @@ export function createPageLoaders(options) {
               <div class="toolbar table-toolbar">
                 <div class="table-title">房间列表</div>
                 <div class="table-toolbar-actions">
+                  <div class="pill">${state.roomsAutoRefresh ? "自动刷新中" : "自动刷新已关"}</div>
+                  <button class="button ghost" data-toggle-rooms-refresh>${state.roomsAutoRefresh ? "关闭" : "开启"}</button>
                   <button class="button" data-refresh-rooms>刷新</button>
                 </div>
               </div>
@@ -645,6 +656,7 @@ export function createPageLoaders(options) {
             title: `房间 ${detail.room.roomCode}`,
             description: "查看房间摘要、共享视频、在线成员与最近事件。",
           },
+          autoRefresh: state.roomsAutoRefresh,
           instanceId: detail.instanceId,
           html: `
             <div class="section">
@@ -669,6 +681,8 @@ export function createPageLoaders(options) {
               <div class="toolbar">
                 <div class="actions">
                   <button class="button ghost" data-nav-back>返回房间列表</button>
+                  <div class="pill">${state.roomsAutoRefresh ? "自动刷新中" : "自动刷新已关"}</div>
+                  <button class="button ghost" data-toggle-rooms-refresh>${state.roomsAutoRefresh ? "关闭" : "开启"}</button>
                   <button class="button" data-refresh-detail>刷新</button>
                 </div>
                 ${
@@ -808,6 +822,12 @@ export function createPageLoaders(options) {
             document
               .querySelector("[data-refresh-detail]")
               ?.addEventListener("click", () => rerender());
+            document
+              .querySelector("[data-toggle-rooms-refresh]")
+              ?.addEventListener("click", () => {
+                state.roomsAutoRefresh = !state.roomsAutoRefresh;
+                rerender();
+              });
             document
               .querySelector("[data-jump-events]")
               ?.addEventListener("click", (event) => {

--- a/server/admin-ui/page-renderers.js
+++ b/server/admin-ui/page-renderers.js
@@ -4,6 +4,7 @@ import {
   formatDuration,
   formatJson,
   formatPlaybackPosition,
+  getPlaybackDisplayPosition,
   getPlaybackSyncedAt,
   formatRelativeDuration,
   getRoomPlaybackSummary,
@@ -710,7 +711,7 @@ export function createPageLoaders(options) {
                     <dt>视频 ID</dt><dd>${detail.room.sharedVideo?.videoId ? `<span class="code">${escapeHtml(detail.room.sharedVideo.videoId)}</span>` : renderEmptyValue()}</dd>
                     <dt>URL</dt><dd>${detail.room.sharedVideo?.url ? `<a href="${escapeHtml(detail.room.sharedVideo.url)}" target="_blank" rel="noreferrer">${escapeHtml(detail.room.sharedVideo.url)}</a>` : renderEmptyValue()}</dd>
                     <dt>播放状态</dt><dd>${detail.room.playback ? renderStatus(playbackSummary.tone, playbackSummary.primary) : renderEmptyValue("未同步")}</dd>
-                    <dt>当前时间</dt><dd>${detail.room.playback ? formatPlaybackPosition(detail.room.playback.currentTime) : renderEmptyValue()}</dd>
+                    <dt>当前时间</dt><dd>${detail.room.playback ? formatPlaybackPosition(getPlaybackDisplayPosition(detail.room)) : renderEmptyValue()}</dd>
                     <dt>播放速度</dt><dd>${detail.room.playback ? `x${Number(detail.room.playback.playbackRate || 1).toFixed(2)}` : renderEmptyValue()}</dd>
                     <dt>上次同步</dt><dd>${formatDateTime(getPlaybackSyncedAt(detail.room))}</dd>
                   </dl>

--- a/server/admin-ui/page-renderers.js
+++ b/server/admin-ui/page-renderers.js
@@ -8,6 +8,7 @@ import {
   getPlaybackSyncedAt,
   formatRelativeDuration,
   getRoomPlaybackSummary,
+  getRoomStatusSummary,
   getRoomOwnerSummary,
   getRoomVideoSummary,
   groupRuntimeEventsByRoom,
@@ -574,7 +575,6 @@ export function createPageLoaders(options) {
                       <th>创建者</th>
                       <th>成员</th>
                       <th>视频</th>
-                      <th>播放状态</th>
                       <th>时间</th>
                       <th>操作</th>
                     </tr>
@@ -583,16 +583,15 @@ export function createPageLoaders(options) {
                     ${data.items
                       .map((item) => {
                         const videoSummary = getRoomVideoSummary(item);
-                        const playbackSummary = getRoomPlaybackSummary(item);
+                        const statusSummary = getRoomStatusSummary(item);
                         const ownerSummary = getRoomOwnerSummary(item);
                         return `
                       <tr>
                         <td><a href="${withDemoQuery(routeHref(`/rooms/${item.roomCode}`))}" data-room-link="${escapeHtml(item.roomCode)}" class="primary-cell-link"><strong>${escapeHtml(item.roomCode)}</strong></a></td>
-                        <td>${renderStatus(item.isActive ? "success" : "neutral", item.isActive ? "活跃" : "空闲")}</td>
+                        <td>${renderDataPair(renderStatus(statusSummary.tone, statusSummary.primary), escapeHtml(statusSummary.secondary))}</td>
                         <td>${renderDataPair(escapeHtml(ownerSummary.primary), escapeHtml(ownerSummary.secondary))}</td>
                         <td><strong>${item.memberCount}</strong></td>
                         <td>${renderDataPair(escapeHtml(videoSummary.primary), escapeHtml(videoSummary.secondary))}</td>
-                        <td>${renderDataPair(renderStatus(playbackSummary.tone, playbackSummary.primary), escapeHtml(playbackSummary.secondary))}</td>
                         <td>${renderDataPair(
                           `${formatDateTime(item.lastActiveAt)}`,
                           item.expiresAt
@@ -656,7 +655,7 @@ export function createPageLoaders(options) {
                 </div>
                 <div class="room-summary-chip">
                   <span class="room-summary-label">状态</span>
-                  ${renderStatus(detail.room.isActive ? "success" : "neutral", detail.room.isActive ? "active" : "idle")}
+                  ${renderStatus(detail.room.isActive ? "success" : "neutral", detail.room.isActive ? "活跃" : "空闲")}
                 </div>
                 <div class="room-summary-chip">
                   <span class="room-summary-label">在线成员</span>
@@ -690,7 +689,7 @@ export function createPageLoaders(options) {
                   <dl class="kv">
                     <dt>房间号</dt><dd><strong>${escapeHtml(detail.room.roomCode)}</strong></dd>
                     <dt>实例</dt><dd>${escapeHtml(detail.room.instanceId || "—")}</dd>
-                    <dt>在线状态</dt><dd>${renderStatus(detail.room.isActive ? "success" : "neutral", detail.room.isActive ? "active" : "idle")}</dd>
+                    <dt>在线状态</dt><dd>${renderStatus(detail.room.isActive ? "success" : "neutral", detail.room.isActive ? "活跃" : "空闲")}</dd>
                     <dt>成员数</dt><dd>${detail.room.memberCount}</dd>
                     <dt>创建时间</dt><dd>${formatDateTime(detail.room.createdAt)}</dd>
                     <dt>最近活跃</dt><dd>${formatDateTime(detail.room.lastActiveAt)}</dd>

--- a/server/admin-ui/render-utils.js
+++ b/server/admin-ui/render-utils.js
@@ -220,6 +220,27 @@ export function isRoomPlaybackStale(item, currentTime = Date.now()) {
   return syncedAt !== null && currentTime - syncedAt > PLAYBACK_STALE_AFTER_MS;
 }
 
+export function getPlaybackDisplayPosition(item, currentTime = Date.now()) {
+  if (!item?.playback) {
+    return null;
+  }
+  const basePosition = Number(item.playback.currentTime);
+  if (!Number.isFinite(basePosition)) {
+    return null;
+  }
+  const syncedAt = getPlaybackSyncedAt(item);
+  if (
+    getPlaybackState(item.playback) !== "playing" ||
+    isRoomPlaybackStale(item, currentTime) ||
+    syncedAt === null
+  ) {
+    return basePosition;
+  }
+  const rate = Number(item.playback.playbackRate || 1);
+  const elapsedSeconds = Math.max(0, (currentTime - syncedAt) / 1000);
+  return basePosition + elapsedSeconds * rate;
+}
+
 export function getRoomVideoSummary(item) {
   if (!item.sharedVideo) {
     return {
@@ -236,7 +257,7 @@ export function getRoomVideoSummary(item) {
   };
 }
 
-export function getRoomPlaybackSummary(item) {
+export function getRoomPlaybackSummary(item, currentTime = Date.now()) {
   if (!item.playback) {
     return {
       tone: "neutral",
@@ -247,21 +268,59 @@ export function getRoomPlaybackSummary(item) {
 
   const state = getPlaybackState(item.playback);
   const syncedAt = getPlaybackSyncedAt(item);
-  const stale = isRoomPlaybackStale(item);
+  const stale = isRoomPlaybackStale(item, currentTime);
+
+  // 客户端只在播放中发送 steady tick，暂停后同步静默是常态而非异常，
+  // 因此暂停态超时不告警；播放/缓冲态超时才意味着同步链路真的断了。
+  if (stale && state === "paused") {
+    return {
+      tone: "neutral",
+      primary: "已暂停",
+      secondary: `${formatPlaybackPosition(item.playback.currentTime)} · 暂停于 ${formatElapsedDuration(currentTime - syncedAt)}`,
+    };
+  }
+
+  if (stale) {
+    return {
+      tone: "danger",
+      primary: "同步中断",
+      secondary: `${getPlaybackStateLabel(state)}停留在 ${formatPlaybackPosition(item.playback.currentTime)} · 上次同步 ${formatElapsedDuration(currentTime - syncedAt)}`,
+    };
+  }
+
   return {
-    tone: stale
-      ? "warning"
-      : state === "playing"
+    tone:
+      state === "playing"
         ? "success"
         : state === "buffering"
           ? "warning"
           : "neutral",
-    primary: stale
-      ? `${getPlaybackStateLabel(state)}（已陈旧）`
-      : getPlaybackStateLabel(state),
-    secondary: stale
-      ? `${formatPlaybackPosition(item.playback.currentTime)} · 上次同步 ${formatElapsedDuration(Date.now() - syncedAt)}`
-      : `${formatPlaybackPosition(item.playback.currentTime)} · x${Number(item.playback.playbackRate || 1).toFixed(2)}`,
+    primary: getPlaybackStateLabel(state),
+    secondary: `${formatPlaybackPosition(getPlaybackDisplayPosition(item, currentTime))} · x${Number(item.playback.playbackRate || 1).toFixed(2)}`,
+  };
+}
+
+export function getRoomStatusSummary(item, currentTime = Date.now()) {
+  if (!item.isActive) {
+    return { tone: "neutral", primary: "空闲", secondary: "" };
+  }
+
+  const playbackSummary = getRoomPlaybackSummary(item, currentTime);
+  if (!item.playback) {
+    return {
+      tone: "neutral",
+      primary: "活跃 · 未同步",
+      secondary: playbackSummary.secondary,
+    };
+  }
+
+  return {
+    tone: playbackSummary.tone,
+    primary:
+      playbackSummary.tone === "danger"
+        ? playbackSummary.primary
+        : `活跃 · ${playbackSummary.primary}`,
+    secondary: playbackSummary.secondary,
   };
 }
 

--- a/server/admin-ui/state.js
+++ b/server/admin-ui/state.js
@@ -54,6 +54,7 @@ export const state = {
   lastOverviewData: null,
   instanceId: "",
   overviewAutoRefresh: true,
+  roomsAutoRefresh: true,
 };
 
 export function resolveApiPath(path) {

--- a/server/test/admin-ui-page-renderers.test.ts
+++ b/server/test/admin-ui-page-renderers.test.ts
@@ -435,6 +435,83 @@ test("room pages surface interrupted sync for stale playing playback", async () 
   assert.equal(detailPage.html.includes("<dt>上次同步</dt>"), true);
 });
 
+test("rooms list and detail pages expose auto refresh with a shared toggle", async () => {
+  const toggleButton = createButton();
+  let rerenderCount = 0;
+  const state = {
+    roomsAutoRefresh: true,
+    lastOverviewData: { instanceId: "instance-1" },
+  };
+
+  const pageLoaders = createPageLoaders({
+    document: createDocumentStub({
+      single: { "[data-toggle-rooms-refresh]": toggleButton },
+    }),
+    location: { search: "" },
+    history: { replaceState() {} },
+    state,
+    api: {
+      async listRooms() {
+        return { items: [], pagination: { total: 0 } };
+      },
+      async getRoomDetail() {
+        return {
+          instanceId: "instance-1",
+          room: {
+            roomCode: "ROOM8A",
+            isActive: false,
+            memberCount: 0,
+            instanceId: "instance-1",
+            createdAt: Date.now(),
+            lastActiveAt: Date.now(),
+            expiresAt: Date.now() + 60_000,
+            sharedVideo: null,
+            playback: null,
+          },
+          members: [],
+          recentEvents: [],
+        };
+      },
+    },
+    routeHref(path: string) {
+      return `/admin${path}`;
+    },
+    withDemoQuery(url: string) {
+      return url;
+    },
+    serializeQuery() {
+      return "";
+    },
+    navigate() {},
+    navigateToUrl() {},
+    rerender() {
+      rerenderCount += 1;
+    },
+    canManage() {
+      return false;
+    },
+    confirmAction() {},
+    openReasonDialog() {},
+  });
+
+  const roomsPage = await pageLoaders.renderRoomsPage();
+  assert.equal(roomsPage.autoRefresh, true);
+  assert.equal(roomsPage.html.includes("自动刷新中"), true);
+
+  roomsPage.bind?.();
+  await toggleButton.click();
+  assert.equal(state.roomsAutoRefresh, false);
+  assert.equal(rerenderCount, 1);
+
+  const detailPage = await pageLoaders.renderRoomDetailPage("ROOM8A");
+  assert.equal(detailPage.autoRefresh, false);
+  assert.equal(detailPage.html.includes("自动刷新已关"), true);
+
+  detailPage.bind?.();
+  await toggleButton.click();
+  assert.equal(state.roomsAutoRefresh, true);
+});
+
 test("danger room actions require confirmed config before execution", async () => {
   const roomActionButton = createButton({
     "data-room-action": "close",

--- a/server/test/admin-ui-page-renderers.test.ts
+++ b/server/test/admin-ui-page-renderers.test.ts
@@ -256,8 +256,8 @@ test("rooms and events pages render direct admin ui tables", async () => {
   const eventsPage = await pageLoaders.renderEventsPage();
 
   assert.equal(roomsPage.html.includes("ROOM8A"), true);
-  assert.equal(roomsPage.html.includes("<th>播放状态</th>"), true);
-  assert.equal(roomsPage.html.includes("播放中"), true);
+  assert.equal(roomsPage.html.includes("<th>播放状态</th>"), false);
+  assert.equal(roomsPage.html.includes("活跃 · 播放中"), true);
   assert.equal(roomsPage.html.includes("关闭房间"), true);
   assert.equal(eventsPage.html.includes("房间 ROOM8A"), true);
   assert.equal(eventsPage.html.includes("Alice 加入了房间"), true);

--- a/server/test/admin-ui-page-renderers.test.ts
+++ b/server/test/admin-ui-page-renderers.test.ts
@@ -295,7 +295,8 @@ test("room detail renders playback position as media timestamp", async () => {
               url: "https://www.bilibili.com/video/BV1TEST",
             },
             playback: {
-              playState: "playing",
+              // paused：播放中会按经过时间外推显示位置，无法稳定断言精确时间戳
+              playState: "paused",
               currentTime: 3723.4,
               playbackRate: 1,
               serverTime: Date.now(),
@@ -343,7 +344,7 @@ test("room detail renders playback position as media timestamp", async () => {
   assert.equal(page.html.includes("Alice 加入了房间 · 房间 ROOM8A"), false);
 });
 
-test("room pages mark stale playback snapshots instead of presenting them as live", async () => {
+test("room pages surface interrupted sync for stale playing playback", async () => {
   const staleServerTime = Date.now() - 3 * 60 * 60 * 1000;
   const pageLoaders = createPageLoaders({
     document: createDocumentStub(),
@@ -427,9 +428,10 @@ test("room pages mark stale playback snapshots instead of presenting them as liv
   const roomsPage = await pageLoaders.renderRoomsPage();
   const detailPage = await pageLoaders.renderRoomDetailPage("ROOM8A");
 
-  assert.equal(roomsPage.html.includes("播放中（已陈旧）"), true);
+  assert.equal(roomsPage.html.includes("同步中断"), true);
+  assert.equal(roomsPage.html.includes("已陈旧"), false);
   assert.equal(roomsPage.html.includes("上次同步 3 小时前"), true);
-  assert.equal(detailPage.html.includes("播放中（已陈旧）"), true);
+  assert.equal(detailPage.html.includes("同步中断"), true);
   assert.equal(detailPage.html.includes("<dt>上次同步</dt>"), true);
 });
 

--- a/server/test/admin-ui-render-utils.test.ts
+++ b/server/test/admin-ui-render-utils.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getPlaybackDisplayPosition,
+  getRoomPlaybackSummary,
+  getRoomStatusSummary,
+} from "../admin-ui/render-utils.js";
+
+const NOW = 1_700_000_000_000;
+
+function roomWithPlayback(playback: Record<string, unknown>, extra = {}) {
+  return {
+    roomCode: "ROOM8A",
+    isActive: true,
+    memberCount: 1,
+    sharedVideo: { title: "测试视频" },
+    playback,
+    lastActiveAt: NOW - 5_000,
+    ...extra,
+  };
+}
+
+test("playing playback within stale window extrapolates display position", () => {
+  const room = roomWithPlayback({
+    playState: "playing",
+    currentTime: 100,
+    playbackRate: 2,
+    serverTime: NOW - 10_000,
+  });
+
+  assert.equal(getPlaybackDisplayPosition(room, NOW), 120);
+  assert.equal(getRoomPlaybackSummary(room, NOW).secondary, "2:00 · x2.00");
+});
+
+test("paused and stale playback keep the last synced position", () => {
+  const paused = roomWithPlayback({
+    playState: "paused",
+    currentTime: 100,
+    playbackRate: 1,
+    serverTime: NOW - 10_000,
+  });
+  const stalePlaying = roomWithPlayback({
+    playState: "playing",
+    currentTime: 100,
+    playbackRate: 1,
+    serverTime: NOW - 120_000,
+  });
+
+  assert.equal(getPlaybackDisplayPosition(paused, NOW), 100);
+  assert.equal(getPlaybackDisplayPosition(stalePlaying, NOW), 100);
+  assert.equal(getPlaybackDisplayPosition({ playback: null }, NOW), null);
+});
+
+test("stale paused playback stays neutral instead of warning", () => {
+  const summary = getRoomPlaybackSummary(
+    roomWithPlayback({
+      playState: "paused",
+      currentTime: 61,
+      playbackRate: 1,
+      serverTime: NOW - 20 * 60_000,
+    }),
+    NOW,
+  );
+
+  assert.equal(summary.tone, "neutral");
+  assert.equal(summary.primary, "已暂停");
+  assert.equal(summary.secondary, "1:01 · 暂停于 20 分钟前");
+});
+
+test("stale playing playback escalates to interrupted sync", () => {
+  const summary = getRoomPlaybackSummary(
+    roomWithPlayback({
+      playState: "playing",
+      currentTime: 61,
+      playbackRate: 1,
+      serverTime: NOW - 3 * 60 * 60 * 1000,
+    }),
+    NOW,
+  );
+
+  assert.equal(summary.tone, "danger");
+  assert.equal(summary.primary, "同步中断");
+  assert.equal(summary.secondary, "播放中停留在 1:01 · 上次同步 3 小时前");
+});
+
+test("stale buffering playback also escalates to interrupted sync", () => {
+  const summary = getRoomPlaybackSummary(
+    roomWithPlayback({
+      playState: "buffering",
+      currentTime: 61,
+      playbackRate: 1,
+      serverTime: NOW - 60_000,
+    }),
+    NOW,
+  );
+
+  assert.equal(summary.tone, "danger");
+  assert.equal(summary.primary, "同步中断");
+});
+
+test("room status summary composes activity and playback state", () => {
+  assert.deepEqual(
+    getRoomStatusSummary({ isActive: false, playback: null }, NOW),
+    { tone: "neutral", primary: "空闲", secondary: "" },
+  );
+
+  const unsynced = getRoomStatusSummary(
+    { isActive: true, playback: null, sharedVideo: { title: "测试视频" } },
+    NOW,
+  );
+  assert.equal(unsynced.primary, "活跃 · 未同步");
+  assert.equal(unsynced.secondary, "等待播放状态");
+
+  const playing = getRoomStatusSummary(
+    roomWithPlayback({
+      playState: "playing",
+      currentTime: 10,
+      playbackRate: 1,
+      serverTime: NOW - 1_000,
+    }),
+    NOW,
+  );
+  assert.equal(playing.tone, "success");
+  assert.equal(playing.primary, "活跃 · 播放中");
+
+  const pausedStale = getRoomStatusSummary(
+    roomWithPlayback({
+      playState: "paused",
+      currentTime: 10,
+      playbackRate: 1,
+      serverTime: NOW - 60_000,
+    }),
+    NOW,
+  );
+  assert.equal(pausedStale.tone, "neutral");
+  assert.equal(pausedStale.primary, "活跃 · 已暂停");
+
+  const interrupted = getRoomStatusSummary(
+    roomWithPlayback({
+      playState: "playing",
+      currentTime: 10,
+      playbackRate: 1,
+      serverTime: NOW - 60_000,
+    }),
+    NOW,
+  );
+  assert.equal(interrupted.tone, "danger");
+  assert.equal(interrupted.primary, "同步中断");
+});


### PR DESCRIPTION
## Summary
- **陈旧语义分级**：暂停后客户端不发 steady tick，长时间暂停是常态——不再显示「已暂停（已陈旧）」warning，改为 neutral「已暂停 · 暂停于 X 前」；播放中/缓冲中超 30 秒无同步才升级为 danger「同步中断」徽章，真异常不再被正常暂停的噪音淹没。
- **播放位置外推**：播放中且未超时的房间，按 `currentTime + 距上次同步经过时间 × 倍速` 外推显示进度（列表副标题与详情页「当前时间」），避免进度看似冻结。
- **复合状态徽章**：房间列表「状态」「播放状态」两列合并为单一徽章（空闲 / 活跃 · 播放中 / 活跃 · 已暂停 / 活跃 · 缓冲中 / 同步中断），细节保留在第二行。
- **自动刷新**：房间列表与详情页复用 `page.autoRefresh` 机制，新增 `roomsAutoRefresh` 开关（两页共享，工具栏可关）。刷新 tick 在对话框打开或焦点位于表单控件时跳过，避免整页重绘丢失未提交输入。
- **文案统一**：详情页状态徽章 `active`/`idle` 改为「活跃 / 空闲」。

## Test plan
- [x] 新增 `server/test/admin-ui-render-utils.test.ts`：外推位置、暂停/播放/缓冲三态陈旧语义、复合徽章组合（固定 currentTime，确定性断言）
- [x] 更新 `admin-ui-page-renderers.test.ts`：列表/详情页同步中断展示、列合并后表头、自动刷新开关绑定
- [x] `format:check` / `lint` / `typecheck` / `build` / `npm test` 全部通过
- [ ] 浏览器手动验证（本环境无浏览器，未执行；建议合并前用 `/admin?demo=1` 或真实房间过一遍列表与详情页）

🤖 Generated with [Claude Code](https://claude.com/claude-code)