### PR TITLE
feat: 服务端发布 Docker 容器版（多阶段构建 + GHCR/Docker Hub 双推送）

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+.claude
+node_modules
+**/node_modules
+packages/protocol/dist
+server/dist
+server/test
+extension/*
+!extension/package.json
+bench
+docs
+release
+coverage
+*.md
+**/*.md

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -20,9 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/bili-syncplay-server
-      # Docker Hub 为可选目标：仓库未配置 DOCKERHUB_USERNAME/DOCKERHUB_TOKEN
-      # secrets 时自动跳过，不会让发布失败。
+      # Docker Hub 为可选目标：DOCKERHUB_USERNAME/DOCKERHUB_TOKEN 两个 secrets
+      # 缺任意一个都完全跳过 Docker Hub（避免半配置时空凭据登录失败，阻断 GHCR 发布）。
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_ENABLED: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
 
     steps:
       - name: Checkout repository
@@ -40,7 +41,7 @@ jobs:
           {
             echo "images<<EOF"
             echo "$GHCR_IMAGE"
-            if [ -n "$DOCKERHUB_USERNAME" ]; then
+            if [ "$DOCKERHUB_ENABLED" = "true" ]; then
               echo "docker.io/$DOCKERHUB_USERNAME/bili-syncplay-server"
             fi
             echo "EOF"
@@ -55,7 +56,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME != ''
+        if: github.event_name != 'pull_request' && env.DOCKERHUB_ENABLED == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,86 @@
+name: Docker Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/docker-release.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    env:
+      GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/bili-syncplay-server
+      # Docker Hub 为可选目标：仓库未配置 DOCKERHUB_USERNAME/DOCKERHUB_TOKEN
+      # secrets 时自动跳过，不会让发布失败。
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute target image list
+        id: images
+        run: |
+          {
+            echo "images<<EOF"
+            echo "$GHCR_IMAGE"
+            if [ -n "$DOCKERHUB_USERNAME" ]; then
+              echo "docker.io/$DOCKERHUB_USERNAME/bili-syncplay-server"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.images.outputs.images }}
+          # flavor 默认 latest=auto：semver tag 发布时自动追加 latest。
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          # PR 仅做 amd64 构建验证；tag 发布构建双架构并推送。
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+# npm workspaces 安装要求所有成员的 package.json 在位（含 extension，仅清单不拷源码）。
+COPY package.json package-lock.json ./
+COPY packages/protocol/package.json packages/protocol/
+COPY server/package.json server/
+COPY extension/package.json extension/
+RUN npm ci
+
+COPY tsconfig.base.json ./
+COPY packages/protocol/tsconfig.json packages/protocol/
+COPY packages/protocol/src packages/protocol/src
+COPY server/tsconfig.json server/
+COPY server/src server/src
+RUN npm run build -w @bili-syncplay/protocol && npm run build -w @bili-syncplay/server
+
+# 重装仅生产依赖（ws、ioredis 及 workspace 链接），供运行阶段拷贝。
+RUN npm ci --omit=dev
+
+FROM node:22-alpine
+ENV NODE_ENV=production
+WORKDIR /app
+
+# node_modules 中的 @bili-syncplay/protocol 是指向 packages/protocol 的
+# workspace 软链接，因此运行阶段必须保留同样的目录布局。
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/node_modules node_modules
+COPY --from=builder /app/packages/protocol/package.json packages/protocol/
+COPY --from=builder /app/packages/protocol/dist packages/protocol/dist
+COPY --from=builder /app/server/package.json server/
+COPY --from=builder /app/server/dist server/dist
+# 服务端按 dist/../admin-ui 解析管理面板静态资源。
+COPY server/admin-ui server/admin-ui
+
+USER node
+EXPOSE 8787
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- "http://127.0.0.1:${PORT:-8787}/healthz" >/dev/null || exit 1
+
+CMD ["node", "server/dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -243,6 +243,35 @@ After login, the current UI includes:
 - existing admin actions such as close room, expire room, clear shared video, kick member, and disconnect session
 - kicked members are temporarily blocked from immediately rejoining with their previous `memberToken`
 
+## Docker Deployment
+
+The server is also published as a container image on every `v*` release tag:
+
+- `ghcr.io/sky1wu/bili-syncplay-server`
+- `docker.io/<dockerhub-username>/bili-syncplay-server` (mirror)
+
+Image tags: `latest`, `<major>.<minor>`, and the full version (e.g. `1.2.2`). Both `linux/amd64` and `linux/arm64` are supported.
+
+Run directly:
+
+```bash
+docker run -d --name bili-syncplay-server \
+  -p 8787:8787 \
+  -e ALLOWED_ORIGINS=chrome-extension://lbmckljnginagfabglpfdepofoglfdkj \
+  ghcr.io/sky1wu/bili-syncplay-server:latest
+```
+
+Or use the repository's [`docker-compose.yml`](./docker-compose.yml), which includes an optional Redis service for multi-node / restart-persistent deployments.
+
+Notes:
+
+- The container listens on `8787` (override with `PORT`), exposes `/healthz` and `/readyz`, and ships a built-in Docker `HEALTHCHECK`.
+- Configuration is entirely environment-variable based, identical to a bare-metal deployment: `ALLOWED_ORIGINS` (required for extensions to connect), `REDIS_URL`, admin panel variables (`ADMIN_USERNAME` / `ADMIN_PASSWORD_HASH` / `ADMIN_SESSION_SECRET`), and so on — see "Local Defaults" above and the [multi-node runbook](./docs/runbook/multi-node-operations.zh-CN.md).
+- In production, terminate TLS at a reverse proxy so the extension connects over `wss://` (see the version matrix).
+- Build locally from the repository root: `docker build -t bili-syncplay-server .` (the image contains only the server; the extension is distributed separately).
+
+For maintainers: the `Docker Release` workflow pushes to GHCR automatically using the built-in `GITHUB_TOKEN`. To also publish to Docker Hub, configure the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets; when they are absent the Docker Hub push is skipped without failing the release.
+
 ## Developer Reference
 
 ### Local Development

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Or use the repository's [`docker-compose.yml`](./docker-compose.yml), which incl
 Notes:
 
 - The container listens on `8787` (override with `PORT`), exposes `/healthz` and `/readyz`, and ships a built-in Docker `HEALTHCHECK`.
-- Configuration is entirely environment-variable based, identical to a bare-metal deployment: `ALLOWED_ORIGINS` (required for extensions to connect), `REDIS_URL`, admin panel variables (`ADMIN_USERNAME` / `ADMIN_PASSWORD_HASH` / `ADMIN_SESSION_SECRET`), and so on — see "Local Defaults" above and the [multi-node runbook](./docs/runbook/multi-node-operations.zh-CN.md).
+- Configuration is entirely environment-variable based, identical to a bare-metal deployment: `ALLOWED_ORIGINS` (required for extensions to connect), Redis persistence (`ROOM_STORE_PROVIDER=redis` plus `REDIS_URL`; `REDIS_URL` alone keeps the in-memory store), admin panel variables (`ADMIN_USERNAME` / `ADMIN_PASSWORD_HASH` / `ADMIN_SESSION_SECRET`), and so on — see "Local Defaults" above and the [multi-node runbook](./docs/runbook/multi-node-operations.zh-CN.md).
 - In production, terminate TLS at a reverse proxy so the extension connects over `wss://` (see the version matrix).
 - Build locally from the repository root: `docker build -t bili-syncplay-server .` (the image contains only the server; the extension is distributed separately).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -243,6 +243,35 @@ node -e "const { createHash } = require('node:crypto'); const password = 'secret
 - 关房、过期、清空共享视频、踢人、断开会话等现有管理动作
 - 被踢成员会被临时阻止使用旧 `memberToken` 立即自动重连
 
+## Docker 部署
+
+服务端在每个 `v*` release tag 上同步发布容器镜像：
+
+- `ghcr.io/sky1wu/bili-syncplay-server`
+- `docker.io/<dockerhub-username>/bili-syncplay-server`（镜像仓库）
+
+镜像 tag 包括 `latest`、`<major>.<minor>` 和完整版本号（如 `1.2.2`），支持 `linux/amd64` 与 `linux/arm64` 双架构。
+
+直接运行：
+
+```bash
+docker run -d --name bili-syncplay-server \
+  -p 8787:8787 \
+  -e ALLOWED_ORIGINS=chrome-extension://lbmckljnginagfabglpfdepofoglfdkj \
+  ghcr.io/sky1wu/bili-syncplay-server:latest
+```
+
+也可以使用仓库内的 [`docker-compose.yml`](./docker-compose.yml)，其中附带可选的 Redis 服务，用于多节点或需要重启后保留状态的部署。
+
+说明：
+
+- 容器监听 `8787`（可用 `PORT` 覆盖），提供 `/healthz` 与 `/readyz`，并内置 Docker `HEALTHCHECK`。
+- 配置完全通过环境变量完成，与裸机部署一致：`ALLOWED_ORIGINS`（扩展连接必填）、`REDIS_URL`、管理面板变量（`ADMIN_USERNAME` / `ADMIN_PASSWORD_HASH` / `ADMIN_SESSION_SECRET`）等——参见上文"本地默认值"和[多节点运维手册](./docs/runbook/multi-node-operations.zh-CN.md)。
+- 生产环境应在前置反向代理终结 TLS，让扩展通过 `wss://` 连接（见版本矩阵）。
+- 从源码构建：在仓库根目录执行 `docker build -t bili-syncplay-server .`（镜像只包含服务端，扩展另行分发）。
+
+维护者说明：`Docker Release` workflow 使用内置 `GITHUB_TOKEN` 自动推送 GHCR；如需同步发布 Docker Hub，配置仓库 secrets `DOCKERHUB_USERNAME` 与 `DOCKERHUB_TOKEN`，缺省时会跳过 Docker Hub 推送而不影响发布。
+
 ## 开发参考
 
 ### 本地开发

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -266,7 +266,7 @@ docker run -d --name bili-syncplay-server \
 说明：
 
 - 容器监听 `8787`（可用 `PORT` 覆盖），提供 `/healthz` 与 `/readyz`，并内置 Docker `HEALTHCHECK`。
-- 配置完全通过环境变量完成，与裸机部署一致：`ALLOWED_ORIGINS`（扩展连接必填）、`REDIS_URL`、管理面板变量（`ADMIN_USERNAME` / `ADMIN_PASSWORD_HASH` / `ADMIN_SESSION_SECRET`）等——参见上文"本地默认值"和[多节点运维手册](./docs/runbook/multi-node-operations.zh-CN.md)。
+- 配置完全通过环境变量完成，与裸机部署一致：`ALLOWED_ORIGINS`（扩展连接必填）、Redis 持久化（需同时设置 `ROOM_STORE_PROVIDER=redis` 与 `REDIS_URL`，只设 `REDIS_URL` 仍是内存存储）、管理面板变量（`ADMIN_USERNAME` / `ADMIN_PASSWORD_HASH` / `ADMIN_SESSION_SECRET`）等——参见上文"本地默认值"和[多节点运维手册](./docs/runbook/multi-node-operations.zh-CN.md)。
 - 生产环境应在前置反向代理终结 TLS，让扩展通过 `wss://` 连接（见版本矩阵）。
 - 从源码构建：在仓库根目录执行 `docker build -t bili-syncplay-server .`（镜像只包含服务端，扩展另行分发）。
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+# 自托管示例：docker compose up -d
+# 默认使用发布镜像；想从源码构建时改用 `docker compose up -d --build`（走同目录 Dockerfile）。
+services:
+  server:
+    image: ghcr.io/sky1wu/bili-syncplay-server:latest
+    build: .
+    restart: unless-stopped
+    ports:
+      - "8787:8787"
+    environment:
+      # 必填：允许连接的扩展 origin，多个用逗号分隔。
+      # Chrome/Edge 固定为扩展 ID；Firefox 的 moz-extension UUID 见 README“Quick Start”。
+      ALLOWED_ORIGINS: "chrome-extension://lbmckljnginagfabglpfdepofoglfdkj"
+      # 多节点部署或需要重启后保留房间状态时启用 Redis：
+      # REDIS_URL: "redis://redis:6379"
+      # 管理面板（可选）：
+      # ADMIN_USERNAME: "admin"
+      # ADMIN_PASSWORD_HASH: "sha256:<hex-password-hash>"
+      # ADMIN_SESSION_SECRET: "<random-secret>"
+
+  # 可选的 Redis 依赖，启用时取消注释并同时设置上面的 REDIS_URL。
+  # redis:
+  #   image: redis:7-alpine
+  #   restart: unless-stopped
+  #   volumes:
+  #     - redis-data:/data
+
+# volumes:
+#   redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,18 @@ services:
       # 必填：允许连接的扩展 origin，多个用逗号分隔。
       # Chrome/Edge 固定为扩展 ID；Firefox 的 moz-extension UUID 见 README“Quick Start”。
       ALLOWED_ORIGINS: "chrome-extension://lbmckljnginagfabglpfdepofoglfdkj"
-      # 多节点部署或需要重启后保留房间状态时启用 Redis：
+      # 需要重启后保留房间状态时启用 Redis（两个变量都要设；只设 REDIS_URL
+      # 时仍是内存存储）。多节点部署所需的完整 provider 变量集见
+      # docs/runbook/multi-node-operations.zh-CN.md：
+      # ROOM_STORE_PROVIDER: "redis"
       # REDIS_URL: "redis://redis:6379"
       # 管理面板（可选）：
       # ADMIN_USERNAME: "admin"
       # ADMIN_PASSWORD_HASH: "sha256:<hex-password-hash>"
       # ADMIN_SESSION_SECRET: "<random-secret>"
 
-  # 可选的 Redis 依赖，启用时取消注释并同时设置上面的 REDIS_URL。
+  # 可选的 Redis 依赖，启用时取消注释并同时设置上面的
+  # ROOM_STORE_PROVIDER + REDIS_URL。
   # redis:
   #   image: redis:7-alpine
   #   restart: unless-stopped


### PR DESCRIPTION
## Summary

- 根目录新增多阶段 `Dockerfile`（Node 22-alpine，与 `.nvmrc` 一致）：builder 阶段安装 workspace 依赖并构建 protocol + server，随后 `npm ci --omit=dev` 裁剪；运行阶段仅拷贝生产 `node_modules`、`packages/protocol/dist`、`server/dist`、`server/admin-ui`，保留 workspace 软链接与 `dist/../admin-ui` 相对路径布局，以 `node` 用户运行，`EXPOSE 8787`，内置 `/healthz` HEALTHCHECK
- 新增 `.dockerignore` 与 `docker-compose.yml` 自托管示例（含可选 Redis 服务，用于多节点/重启保留状态）
- 新增 `Docker Release` workflow：`v*` tag 触发，构建 `linux/amd64 + linux/arm64` 双架构；GHCR 用内置 `GITHUB_TOKEN` 直接推送；配置 `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets 后同步推送 Docker Hub（缺省时自动跳过不阻塞发布）；PR 改动 Docker 相关文件时触发 build-only（amd64、不推送）验证
- README 中英双语新增「Docker 部署」章节，说明镜像地址、tag 策略、环境变量与维护者发布配置

## Test plan

- [x] 本机无容器运行时，已在隔离目录逐条模拟 Dockerfile 两个阶段的 COPY 清单与命令：`npm ci` → 构建 protocol+server → `npm ci --omit=dev` → 按运行阶段布局启动 `node server/dist/index.js`
- [x] 手动验证（golden path）：`/healthz`、`/readyz` 返回 healthy/ready，`/admin` 返回 200（`dist/../admin-ui` 相对路径解析正确），带扩展 Origin 的 WebSocket 握手成功
- [x] 真实 `docker build` 由本 PR 的 `Docker Release` workflow（PR build-only 任务）在 CI 中验证
- [x] 完整预提交序列：`format:check` / `lint` / `typecheck` / `build` / `npm test`（477 passed）

## 合并后需要的一次性配置

- Docker Hub：创建 `bili-syncplay-server` 仓库，并在 GitHub 仓库 secrets 配置 `DOCKERHUB_USERNAME`、`DOCKERHUB_TOKEN`（Access Token）；不配置则只发 GHCR
- 首次发布后建议把 GHCR package 可见性设为 public

🤖 Generated with [Claude Code](https://claude.com/claude-code)