### PR TITLE
chore: release 1.2.3

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.2.2"
+    "@bili-syncplay/protocol": "1.2.3"
   },
   "devDependencies": {
     "@types/chrome": "^0.1.40",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "workspaces": [
         "packages/*",
         "server",
@@ -24,9 +24,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.2.2"
+        "@bili-syncplay/protocol": "1.2.3"
       },
       "devDependencies": {
         "@types/chrome": "^0.1.40",
@@ -2740,16 +2740,16 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "devDependencies": {
         "typescript": "^5.9.3"
       }
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.2.2",
+        "@bili-syncplay/protocol": "1.2.3",
         "ioredis": "^5.10.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.2.2",
+    "@bili-syncplay/protocol": "1.2.3",
     "ioredis": "^5.10.0",
     "ws": "^8.21.0"
   },


### PR DESCRIPTION
## Summary
- 工作区版本 1.2.2 → 1.2.3（package.json ×4、extension/public/manifest.json、package-lock.json）
- 本版本将首次触发 #152 引入的 `Docker Release` workflow，发布首个服务端容器镜像（GHCR + Docker Hub，amd64/arm64）

## Test plan
- [x] 完整预提交序列：format:check / lint / typecheck / build / npm test（477 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)