### PR TITLE
fix: release:version 写入版本文件后自动跑 Prettier 格式化

### DIFF
--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -61,6 +61,22 @@ if (process.platform === "win32") {
   await run("npm", ["install", "--package-lock-only"], rootDir);
 }
 
+// JSON.stringify 的输出与仓库 Prettier 风格不完全一致（如 manifest.json 的
+// 数组换行），不格式化会被预提交的 format:check 拦下。
+const prettierTargets = [...packagePaths, extensionManifestPath].map(
+  (filePath) => path.relative(rootDir, filePath),
+);
+
+if (process.platform === "win32") {
+  await run(
+    process.env.ComSpec ?? "cmd.exe",
+    ["/d", "/s", "/c", `npx prettier --write ${prettierTargets.join(" ")}`],
+    rootDir,
+  );
+} else {
+  await run("npx", ["prettier", "--write", ...prettierTargets], rootDir);
+}
+
 console.log(`Updated workspace version to ${nextVersion}`);
 
 function run(command, args, cwd) {


### PR DESCRIPTION
## Summary
- `scripts/release-version.mjs` 在改写版本号并刷新 lockfile 后，对其写入的 4 个 `package.json` 与 `extension/public/manifest.json` 统一执行 `npx prettier --write`（win32 走既有 `cmd /c` 模式）
- 背景：v1.2.3 release 时脚本输出的 `manifest.json` 不符合 Prettier 风格，被预提交 `format:check` 拦下，需要手工 `prettier --write` 补救

## Test plan
- [x] 幂等验证：在版本已是 1.2.3 的工作区跑 `npm run release:version -- 1.2.3`，prettier 步骤将 `JSON.stringify` 重写的 `manifest.json` 格式化回原样，最终 `git status` 除脚本本身外无任何变化，`format:check` 通过
- [x] 完整预提交序列：format:check / lint / typecheck / build / npm test 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)