### PR TITLE
docs: README Docker Hub 镜像地址占位符替换为 sky1wu

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,10 @@ After login, the current UI includes:
 
 The server is also published as a container image on every `v*` release tag:
 
-- `ghcr.io/sky1wu/bili-syncplay-server`
-- `docker.io/sky1wu/bili-syncplay-server` (mirror)
+- `ghcr.io/sky1wu/bili-syncplay-server` ([GHCR package page](https://github.com/sky1wu/Bili-SyncPlay/pkgs/container/bili-syncplay-server))
+- `docker.io/sky1wu/bili-syncplay-server` ([Docker Hub page](https://hub.docker.com/r/sky1wu/bili-syncplay-server), mirror)
+
+These are `docker pull` references, not web URLs — to browse in a browser, use the linked pages.
 
 Image tags: `latest`, `<major>.<minor>`, and the full version (e.g. `1.2.2`). Both `linux/amd64` and `linux/arm64` are supported.
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ After login, the current UI includes:
 The server is also published as a container image on every `v*` release tag:
 
 - `ghcr.io/sky1wu/bili-syncplay-server`
-- `docker.io/<dockerhub-username>/bili-syncplay-server` (mirror)
+- `docker.io/sky1wu/bili-syncplay-server` (mirror)
 
 Image tags: `latest`, `<major>.<minor>`, and the full version (e.g. `1.2.2`). Both `linux/amd64` and `linux/arm64` are supported.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -247,8 +247,10 @@ node -e "const { createHash } = require('node:crypto'); const password = 'secret
 
 服务端在每个 `v*` release tag 上同步发布容器镜像：
 
-- `ghcr.io/sky1wu/bili-syncplay-server`
-- `docker.io/sky1wu/bili-syncplay-server`（镜像仓库）
+- `ghcr.io/sky1wu/bili-syncplay-server`（[GHCR package 页面](https://github.com/sky1wu/Bili-SyncPlay/pkgs/container/bili-syncplay-server)）
+- `docker.io/sky1wu/bili-syncplay-server`（[Docker Hub 页面](https://hub.docker.com/r/sky1wu/bili-syncplay-server)，镜像仓库）
+
+以上是 `docker pull` 用的镜像引用，不是网页地址——浏览器访问请用括号里的链接。
 
 镜像 tag 包括 `latest`、`<major>.<minor>` 和完整版本号（如 `1.2.2`），支持 `linux/amd64` 与 `linux/arm64` 双架构。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -248,7 +248,7 @@ node -e "const { createHash } = require('node:crypto'); const password = 'secret
 服务端在每个 `v*` release tag 上同步发布容器镜像：
 
 - `ghcr.io/sky1wu/bili-syncplay-server`
-- `docker.io/<dockerhub-username>/bili-syncplay-server`（镜像仓库）
+- `docker.io/sky1wu/bili-syncplay-server`（镜像仓库）
 
 镜像 tag 包括 `latest`、`<major>.<minor>` 和完整版本号（如 `1.2.2`），支持 `linux/amd64` 与 `linux/arm64` 双架构。
 


### PR DESCRIPTION
## Summary
- 中英 README 的 Docker 部署章节中 `docker.io/<dockerhub-username>/bili-syncplay-server` 占位符替换为实际地址 `docker.io/sky1wu/bili-syncplay-server`（v1.2.3 首个镜像已发布）

## Test plan
- [x] 纯文档改动；完整预提交序列全绿（477 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)