### PR TITLE
fix: 运行阶段镜像删除基础镜像自带的 npm/corepack/yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,11 @@ COPY --from=builder /app/server/dist server/dist
 # 服务端按 dist/../admin-ui 解析管理面板静态资源。
 COPY server/admin-ui server/admin-ui
 
+# 运行阶段直接以 node 启动，用不到 npm/corepack/yarn；删除基础镜像自带的
+# npm CLI，消除其 vendored 依赖（sigstore/tar/picomatch 等）触发的漏洞扫描报告。
+RUN rm -rf /usr/local/lib/node_modules /usr/local/bin/npm /usr/local/bin/npx \
+  /usr/local/bin/corepack /usr/local/bin/yarn /usr/local/bin/yarnpkg /opt/yarn*
+
 USER node
 EXPOSE 8787
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \


### PR DESCRIPTION
## Summary
- Docker Hub 对 v1.2.3 镜像报告 7 个 CVE：`picomatch`、`sigstore`、`tar`、`brace-expansion`、`@sigstore/core`、`ip-address`
- 已核实：这 5 个包**均不在**服务端生产 `node_modules`（仅 20 个包：ws、ioredis 及其依赖）里，全部来自 `node:22-alpine` 基础镜像自带 npm CLI（`/usr/local/lib/node_modules/npm`）的 vendored 依赖
- 运行阶段 CMD 直接 `node server/dist/index.js` 启动，不需要任何包管理器；在 `USER node` 之前删除 npm/npx/corepack/yarn 及 `/usr/local/lib/node_modules`，消除漏洞报告面（顺带减小镜像体积）
- builder 阶段不受影响（仍用 npm 安装与构建）

## Test plan
- [x] 生产依赖核实：按运行阶段 COPY 清单生成的 node_modules 中逐一确认 5 个涉事包不存在
- [x] 完整预提交序列：format:check / lint / typecheck / build / npm test（477 passed）
- [x] 真实 `docker build` 由本 PR 的 Docker Release build-only 任务验证
- [ ] 合并 + 发新 tag 后，确认 Docker Hub 扫描归零

🤖 Generated with [Claude Code](https://claude.com/claude-code)