### PR TITLE
feat: 服务端 WebSocket 心跳检测，回收半开死连接产生的幽灵成员房间

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,6 +842,8 @@ The server accepts the following environment variables. Safe defaults are built 
 - `MAX_MEMBERS_PER_ROOM`: room member cap
 - `MAX_MESSAGE_BYTES`: WebSocket message size cap in bytes
 - `INVALID_MESSAGE_CLOSE_THRESHOLD`: number of invalid messages before disconnect
+- `WS_HEARTBEAT_ENABLED`: enables server-side WebSocket ping/pong liveness checks that terminate half-open dead connections (ghost members); defaults to `true`
+- `WS_HEARTBEAT_INTERVAL_MS`: WebSocket heartbeat ping interval in milliseconds; a connection is terminated after two consecutive missed pongs; defaults to `30000`
 - `ROOM_STORE_PROVIDER`: `memory` or `redis`
 - `EMPTY_ROOM_TTL_MS`: how long an empty room is retained before deletion
 - `ROOM_CLEANUP_INTERVAL_MS`: how often the server deletes expired rooms

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -842,6 +842,8 @@ node server/dist/global-admin-index.js
 - `MAX_MEMBERS_PER_ROOM`：房间成员上限
 - `MAX_MESSAGE_BYTES`：WebSocket 消息字节上限
 - `INVALID_MESSAGE_CLOSE_THRESHOLD`：在断开连接前允许的无效消息次数
+- `WS_HEARTBEAT_ENABLED`：是否开启服务端 WebSocket ping/pong 存活检测，用于清理半开死连接（幽灵成员）；默认 `true`
+- `WS_HEARTBEAT_INTERVAL_MS`：WebSocket 心跳 ping 间隔（毫秒），连续 2 次未收到 pong 即断开；默认 `30000`
 - `ROOM_STORE_PROVIDER`：`memory` 或 `redis`
 - `EMPTY_ROOM_TTL_MS`：空房保留时长，超时后删除
 - `ROOM_CLEANUP_INTERVAL_MS`：服务端扫描并清理过期房间的周期

--- a/server/src/admin/config-service.ts
+++ b/server/src/admin/config-service.ts
@@ -35,6 +35,8 @@ export function createAdminConfigService(options: {
           maxMessageBytes: options.securityConfig.maxMessageBytes,
           invalidMessageCloseThreshold:
             options.securityConfig.invalidMessageCloseThreshold,
+          wsHeartbeatEnabled: options.securityConfig.wsHeartbeatEnabled,
+          wsHeartbeatIntervalMs: options.securityConfig.wsHeartbeatIntervalMs,
           rateLimits: options.securityConfig.rateLimits,
         },
         admin: options.adminConfig

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -18,6 +18,7 @@ import { createRoomEventConsumer } from "./room-event-consumer.js";
 import { type RoomStore } from "./room-store.js";
 import { createRoomReaper } from "./room-reaper.js";
 import { createRoomService } from "./room-service.js";
+import { createWsHeartbeat } from "./ws-heartbeat.js";
 import type { RoomEventBusMessage } from "./room-event-bus.js";
 import { type RuntimeStore } from "./runtime-store.js";
 import { hasAttachedSocket } from "./types.js";
@@ -293,6 +294,12 @@ export async function createSyncServer(
     maxPayload: securityConfig.maxMessageBytes,
   });
   const pendingSessionCleanup = new Set<Promise<void>>();
+  const wsHeartbeat = createWsHeartbeat({
+    enabled: securityConfig.wsHeartbeatEnabled,
+    intervalMs: securityConfig.wsHeartbeatIntervalMs,
+    logEvent,
+  });
+  wsHeartbeat.start();
 
   httpServer.on(
     "upgrade",
@@ -309,6 +316,7 @@ export async function createSyncServer(
       messageHandler,
       logEvent,
       pendingSessionCleanup,
+      wsHeartbeat,
     }),
   );
 
@@ -361,6 +369,12 @@ export async function createSyncServer(
           {
             name: "stop_runtime_index_reaper",
             run: () => runtimeIndexReaper.stop(),
+          },
+          {
+            name: "stop_ws_heartbeat",
+            run: () => {
+              wsHeartbeat.stop();
+            },
           },
           {
             name: "terminate_ws_clients",

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -210,6 +210,8 @@ export function getDefaultSecurityConfig(): SecurityConfig {
     maxMembersPerRoom: 8,
     maxMessageBytes: 8 * 1024,
     invalidMessageCloseThreshold: 3,
+    wsHeartbeatEnabled: true,
+    wsHeartbeatIntervalMs: 30_000,
     rateLimits: {
       roomCreatePerMinute: 3,
       roomJoinPerMinute: 10,

--- a/server/src/config/runtime-config-schema.ts
+++ b/server/src/config/runtime-config-schema.ts
@@ -283,14 +283,25 @@ export function setConfigValue(
   current[path[path.length - 1]!] = value;
 }
 
-function assertFiniteNumber(scope: string, value: unknown): number | undefined {
+function assertInteger(scope: string, value: unknown): number | undefined {
   if (value === undefined) {
     return undefined;
   }
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    throw new Error(`Config field "${scope}" must be a finite number.`);
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(`Config field "${scope}" must be an integer.`);
   }
   return value;
+}
+
+function assertPositiveInteger(
+  scope: string,
+  value: unknown,
+): number | undefined {
+  const parsedValue = assertInteger(scope, value);
+  if (parsedValue !== undefined && parsedValue <= 0) {
+    throw new Error(`Config field "${scope}" must be greater than 0.`);
+  }
+  return parsedValue;
 }
 
 function assertBoolean(scope: string, value: unknown): boolean | undefined {
@@ -336,13 +347,26 @@ export function parseConfigFileFieldValue(
 ): unknown {
   switch (field.kind) {
     case "integer":
+      return assertInteger(scope, value);
     case "positiveInteger":
-      return assertFiniteNumber(scope, value);
+      return assertPositiveInteger(scope, value);
     case "boolean":
       return assertBoolean(scope, value);
     case "string":
-    case "enum":
       return assertString(scope, value);
+    case "enum": {
+      const parsedValue = assertString(scope, value);
+      if (
+        parsedValue !== undefined &&
+        field.enumValues &&
+        !field.enumValues.includes(parsedValue)
+      ) {
+        throw new Error(
+          `Config field "${scope}" must be one of ${field.enumValues.join(", ")}.`,
+        );
+      }
+      return parsedValue;
+    }
     case "stringArray":
       return assertStringArray(scope, value);
   }

--- a/server/src/config/runtime-config-schema.ts
+++ b/server/src/config/runtime-config-schema.ts
@@ -95,6 +95,16 @@ export const SERVER_CONFIG_FIELDS = [
     "positiveInteger",
   ),
   createField(
+    ["security", "wsHeartbeatEnabled"],
+    "WS_HEARTBEAT_ENABLED",
+    "boolean",
+  ),
+  createField(
+    ["security", "wsHeartbeatIntervalMs"],
+    "WS_HEARTBEAT_INTERVAL_MS",
+    "positiveInteger",
+  ),
+  createField(
     ["security", "rateLimits", "roomCreatePerMinute"],
     "RATE_LIMIT_ROOM_CREATE_PER_MINUTE",
     "positiveInteger",

--- a/server/src/config/runtime-config.ts
+++ b/server/src/config/runtime-config.ts
@@ -39,6 +39,8 @@ type SecurityConfigFile = {
   maxMembersPerRoom?: number;
   maxMessageBytes?: number;
   invalidMessageCloseThreshold?: number;
+  wsHeartbeatEnabled?: boolean;
+  wsHeartbeatIntervalMs?: number;
   rateLimits?: {
     roomCreatePerMinute?: number;
     roomJoinPerMinute?: number;

--- a/server/src/node-heartbeat.ts
+++ b/server/src/node-heartbeat.ts
@@ -1,3 +1,4 @@
+import { clampTimerIntervalMs } from "./timers.js";
 import type { LogEvent, ClusterNodeStatus } from "./types.js";
 import type { RuntimeStore } from "./runtime-store.js";
 
@@ -69,7 +70,7 @@ export function createNodeHeartbeat(options: {
       scheduleBeat();
       timer = setInterval(() => {
         scheduleBeat();
-      }, options.intervalMs);
+      }, clampTimerIntervalMs(options.intervalMs));
       timer.unref?.();
     },
     async beat() {

--- a/server/src/room-reaper.ts
+++ b/server/src/room-reaper.ts
@@ -1,3 +1,4 @@
+import { clampTimerIntervalMs } from "./timers.js";
 import type { LogEvent } from "./types.js";
 
 export type RoomReaper = {
@@ -35,7 +36,7 @@ export function createRoomReaper(options: {
 
   const intervalId = setInterval(() => {
     void runNow();
-  }, options.intervalMs);
+  }, clampTimerIntervalMs(options.intervalMs));
 
   return {
     stop() {

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -1,3 +1,4 @@
+import { clampTimerIntervalMs } from "./timers.js";
 import type { LogEvent } from "./types.js";
 import type { RuntimeStore } from "./runtime-store.js";
 
@@ -94,7 +95,7 @@ export function createRuntimeIndexReaper(options: {
       }
       timer = setInterval(() => {
         scheduleSweep();
-      }, options.intervalMs);
+      }, clampTimerIntervalMs(options.intervalMs));
       timer.unref?.();
     },
     async sweep() {

--- a/server/src/timers.ts
+++ b/server/src/timers.ts
@@ -1,0 +1,7 @@
+// Node timers store the delay as a signed 32-bit integer; anything larger
+// overflows and fires after ~1ms, turning a long interval into a hot loop.
+export const MAX_TIMER_INTERVAL_MS = 2_147_483_647;
+
+export function clampTimerIntervalMs(intervalMs: number): number {
+  return Math.min(intervalMs, MAX_TIMER_INTERVAL_MS);
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -149,6 +149,8 @@ export type SecurityConfig = {
   maxMembersPerRoom: number;
   maxMessageBytes: number;
   invalidMessageCloseThreshold: number;
+  wsHeartbeatEnabled: boolean;
+  wsHeartbeatIntervalMs: number;
   rateLimits: {
     roomCreatePerMinute: number;
     roomJoinPerMinute: number;

--- a/server/src/ws-heartbeat.ts
+++ b/server/src/ws-heartbeat.ts
@@ -1,6 +1,6 @@
 import type { LogEvent, Session } from "./types.js";
 
-export const WS_HEARTBEAT_MISSED_PONG_THRESHOLD = 2;
+const MISSED_PONG_THRESHOLD = 2;
 
 export type HeartbeatSocket = {
   readyState?: number;
@@ -20,11 +20,8 @@ export type WsHeartbeat = {
 export function createWsHeartbeat(options: {
   enabled: boolean;
   intervalMs: number;
-  missedPongThreshold?: number;
   logEvent: LogEvent;
 }): WsHeartbeat {
-  const missedPongThreshold =
-    options.missedPongThreshold ?? WS_HEARTBEAT_MISSED_PONG_THRESHOLD;
   const tracked = new Map<
     HeartbeatSocket,
     { session: Session; missedPongs: number }
@@ -57,33 +54,45 @@ export function createWsHeartbeat(options: {
   function sweepNow(): number {
     let terminatedCount = 0;
     for (const [socket, entry] of tracked) {
-      if (entry.missedPongs >= missedPongThreshold) {
-        // Half-open TCP connections never emit "close" on their own, so this
-        // terminate() is what finally triggers the existing close-path cleanup
-        // (leaveRoom, session unregister, room expiry scheduling).
-        tracked.delete(socket);
-        options.logEvent("ws_heartbeat_timeout_terminated", {
+      // Per-socket guard: sweepNow runs inside a bare setInterval, so an
+      // exception here would otherwise crash the process and skip the
+      // remaining sockets in this sweep.
+      try {
+        if (entry.missedPongs >= MISSED_PONG_THRESHOLD) {
+          // Half-open TCP connections never emit "close" on their own, so this
+          // terminate() is what finally triggers the existing close-path
+          // cleanup (leaveRoom, session unregister, room expiry scheduling).
+          tracked.delete(socket);
+          options.logEvent("ws_heartbeat_timeout_terminated", {
+            sessionId: entry.session.id,
+            roomCode: entry.session.roomCode,
+            memberId: entry.session.memberId,
+            remoteAddress: entry.session.remoteAddress,
+            origin: entry.session.origin,
+            missedPongs: entry.missedPongs,
+            result: "terminated",
+          });
+          socket.terminate();
+          terminatedCount += 1;
+          continue;
+        }
+
+        entry.missedPongs += 1;
+        if (isSocketOpen(socket)) {
+          try {
+            socket.ping?.();
+          } catch {
+            // A socket racing into CLOSING/CLOSED state may reject the ping;
+            // the pending close event will untrack it.
+          }
+        }
+      } catch (error) {
+        options.logEvent("ws_heartbeat_sweep_failed", {
           sessionId: entry.session.id,
           roomCode: entry.session.roomCode,
-          memberId: entry.session.memberId,
-          remoteAddress: entry.session.remoteAddress,
-          origin: entry.session.origin,
-          missedPongs: entry.missedPongs,
-          result: "terminated",
+          result: "error",
+          error: error instanceof Error ? error.message : String(error),
         });
-        socket.terminate();
-        terminatedCount += 1;
-        continue;
-      }
-
-      entry.missedPongs += 1;
-      if (isSocketOpen(socket)) {
-        try {
-          socket.ping?.();
-        } catch {
-          // A socket racing into CLOSING/CLOSED state may reject the ping;
-          // the pending close event will untrack it.
-        }
       }
     }
     return terminatedCount;

--- a/server/src/ws-heartbeat.ts
+++ b/server/src/ws-heartbeat.ts
@@ -62,7 +62,9 @@ export function createWsHeartbeat(options: {
           // Half-open TCP connections never emit "close" on their own, so this
           // terminate() is what finally triggers the existing close-path
           // cleanup (leaveRoom, session unregister, room expiry scheduling).
-          tracked.delete(socket);
+          // Untrack only after terminate() succeeds: if it throws, the entry
+          // stays tracked and the next sweep retries, so the ghost is never
+          // silently abandoned.
           options.logEvent("ws_heartbeat_timeout_terminated", {
             sessionId: entry.session.id,
             roomCode: entry.session.roomCode,
@@ -73,6 +75,7 @@ export function createWsHeartbeat(options: {
             result: "terminated",
           });
           socket.terminate();
+          tracked.delete(socket);
           terminatedCount += 1;
           continue;
         }

--- a/server/src/ws-heartbeat.ts
+++ b/server/src/ws-heartbeat.ts
@@ -1,0 +1,111 @@
+import type { LogEvent, Session } from "./types.js";
+
+export const WS_HEARTBEAT_MISSED_PONG_THRESHOLD = 2;
+
+export type HeartbeatSocket = {
+  readyState?: number;
+  OPEN?: number;
+  ping?: () => void;
+  terminate: () => void;
+  on: (event: "pong" | "close", listener: () => void) => unknown;
+};
+
+export type WsHeartbeat = {
+  track: (socket: HeartbeatSocket, session: Session) => void;
+  sweepNow: () => number;
+  start: () => void;
+  stop: () => void;
+};
+
+export function createWsHeartbeat(options: {
+  enabled: boolean;
+  intervalMs: number;
+  missedPongThreshold?: number;
+  logEvent: LogEvent;
+}): WsHeartbeat {
+  const missedPongThreshold =
+    options.missedPongThreshold ?? WS_HEARTBEAT_MISSED_PONG_THRESHOLD;
+  const tracked = new Map<
+    HeartbeatSocket,
+    { session: Session; missedPongs: number }
+  >();
+  let timer: NodeJS.Timeout | null = null;
+
+  function track(socket: HeartbeatSocket, session: Session): void {
+    if (!options.enabled) {
+      return;
+    }
+    tracked.set(socket, { session, missedPongs: 0 });
+    socket.on("pong", () => {
+      const entry = tracked.get(socket);
+      if (entry) {
+        entry.missedPongs = 0;
+      }
+    });
+    socket.on("close", () => {
+      tracked.delete(socket);
+    });
+  }
+
+  function isSocketOpen(socket: HeartbeatSocket): boolean {
+    if (socket.readyState === undefined || socket.OPEN === undefined) {
+      return true;
+    }
+    return socket.readyState === socket.OPEN;
+  }
+
+  function sweepNow(): number {
+    let terminatedCount = 0;
+    for (const [socket, entry] of tracked) {
+      if (entry.missedPongs >= missedPongThreshold) {
+        // Half-open TCP connections never emit "close" on their own, so this
+        // terminate() is what finally triggers the existing close-path cleanup
+        // (leaveRoom, session unregister, room expiry scheduling).
+        tracked.delete(socket);
+        options.logEvent("ws_heartbeat_timeout_terminated", {
+          sessionId: entry.session.id,
+          roomCode: entry.session.roomCode,
+          memberId: entry.session.memberId,
+          remoteAddress: entry.session.remoteAddress,
+          origin: entry.session.origin,
+          missedPongs: entry.missedPongs,
+          result: "terminated",
+        });
+        socket.terminate();
+        terminatedCount += 1;
+        continue;
+      }
+
+      entry.missedPongs += 1;
+      if (isSocketOpen(socket)) {
+        try {
+          socket.ping?.();
+        } catch {
+          // A socket racing into CLOSING/CLOSED state may reject the ping;
+          // the pending close event will untrack it.
+        }
+      }
+    }
+    return terminatedCount;
+  }
+
+  return {
+    track,
+    sweepNow,
+    start() {
+      if (!options.enabled || timer) {
+        return;
+      }
+      timer = setInterval(() => {
+        sweepNow();
+      }, options.intervalMs);
+      timer.unref?.();
+    },
+    stop() {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/server/src/ws-heartbeat.ts
+++ b/server/src/ws-heartbeat.ts
@@ -1,3 +1,4 @@
+import { clampTimerIntervalMs } from "./timers.js";
 import type { LogEvent, Session } from "./types.js";
 
 const MISSED_PONG_THRESHOLD = 2;
@@ -110,7 +111,7 @@ export function createWsHeartbeat(options: {
       }
       timer = setInterval(() => {
         sweepNow();
-      }, options.intervalMs);
+      }, clampTimerIntervalMs(options.intervalMs));
       timer.unref?.();
     },
     stop() {

--- a/server/src/ws-session-handler.ts
+++ b/server/src/ws-session-handler.ts
@@ -189,6 +189,7 @@ export function createWsConnectionHandler(args: {
   logEvent: LogEvent;
   pendingSessionCleanup: Set<Promise<void>>;
   messageQueueDrainTimeoutMs?: number;
+  wsHeartbeat?: { track: (socket: WebSocket, session: Session) => void };
 }): (socket: WebSocket, request: IncomingMessage) => void {
   const drainTimeoutMs = args.messageQueueDrainTimeoutMs ?? 10_000;
   return (socket, request) => {
@@ -217,6 +218,7 @@ export function createWsConnectionHandler(args: {
 
     args.securityPolicy.incrementConnectionCount(session.remoteAddress);
     args.runtimeStore.registerSession(session);
+    args.wsHeartbeat?.track(socket, session);
     args.logEvent("ws_connection_accepted", {
       sessionId: session.id,
       remoteAddress: session.remoteAddress,

--- a/server/src/ws-session-handler.ts
+++ b/server/src/ws-session-handler.ts
@@ -17,6 +17,7 @@ import {
   INVALID_JSON_MESSAGE,
 } from "./messages.js";
 import type { RuntimeStore } from "./runtime-store.js";
+import type { WsHeartbeat } from "./ws-heartbeat.js";
 
 const CLOSE_CODE_POLICY_VIOLATION = 1008;
 
@@ -189,7 +190,7 @@ export function createWsConnectionHandler(args: {
   logEvent: LogEvent;
   pendingSessionCleanup: Set<Promise<void>>;
   messageQueueDrainTimeoutMs?: number;
-  wsHeartbeat?: { track: (socket: WebSocket, session: Session) => void };
+  wsHeartbeat?: Pick<WsHeartbeat, "track">;
 }): (socket: WebSocket, request: IncomingMessage) => void {
   const drainTimeoutMs = args.messageQueueDrainTimeoutMs ?? 10_000;
   return (socket, request) => {

--- a/server/test/config-env.test.ts
+++ b/server/test/config-env.test.ts
@@ -26,6 +26,19 @@ test("security config reads overrides and keeps defaults for missing values", ()
   assert.deepEqual(config.trustedProxyAddresses, ["127.0.0.1", "198.51.100.7"]);
   assert.equal(config.rateLimits.syncPingBurst, 5);
   assert.equal(config.maxMembersPerRoom, 8);
+  assert.equal(config.wsHeartbeatEnabled, true);
+  assert.equal(config.wsHeartbeatIntervalMs, 30_000);
+});
+
+test("security config reads ws heartbeat overrides", () => {
+  const config = loadSecurityConfig({
+    ALLOWED_ORIGINS: "https://a.example",
+    WS_HEARTBEAT_ENABLED: "false",
+    WS_HEARTBEAT_INTERVAL_MS: "10000",
+  });
+
+  assert.equal(config.wsHeartbeatEnabled, false);
+  assert.equal(config.wsHeartbeatIntervalMs, 10_000);
 });
 
 test("persistence config validates provider and trims string env values", () => {

--- a/server/test/runtime-config.test.ts
+++ b/server/test/runtime-config.test.ts
@@ -335,6 +335,63 @@ test("runtime config reports invalid config field types", async () => {
   });
 });
 
+test("runtime config rejects non-positive positiveInteger fields from config file", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeFile(
+      join(tempDir, "server.config.json"),
+      JSON.stringify({
+        security: {
+          wsHeartbeatIntervalMs: 0,
+        },
+      }),
+      "utf8",
+    );
+
+    await assert.rejects(
+      () => loadRuntimeConfig({}, { cwd: tempDir }),
+      /security\.wsHeartbeatIntervalMs.*greater than 0/,
+    );
+  });
+});
+
+test("runtime config rejects fractional integer fields from config file", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeFile(
+      join(tempDir, "server.config.json"),
+      JSON.stringify({
+        security: {
+          wsHeartbeatIntervalMs: 0.5,
+        },
+      }),
+      "utf8",
+    );
+
+    await assert.rejects(
+      () => loadRuntimeConfig({}, { cwd: tempDir }),
+      /security\.wsHeartbeatIntervalMs.*must be an integer/,
+    );
+  });
+});
+
+test("runtime config rejects unknown enum values from config file", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeFile(
+      join(tempDir, "server.config.json"),
+      JSON.stringify({
+        persistence: {
+          provider: "postgres",
+        },
+      }),
+      "utf8",
+    );
+
+    await assert.rejects(
+      () => loadRuntimeConfig({}, { cwd: tempDir }),
+      /persistence\.provider.*must be one of memory, redis/,
+    );
+  });
+});
+
 test("redisNamespace is loaded from config file and passable through env override", async () => {
   await withTempDir(async (tempDir) => {
     await writeFile(

--- a/server/test/timers.test.ts
+++ b/server/test/timers.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { clampTimerIntervalMs, MAX_TIMER_INTERVAL_MS } from "../src/timers.js";
+
+test("clampTimerIntervalMs passes through intervals within the 32-bit timer range", () => {
+  assert.equal(clampTimerIntervalMs(30_000), 30_000);
+  assert.equal(
+    clampTimerIntervalMs(MAX_TIMER_INTERVAL_MS),
+    MAX_TIMER_INTERVAL_MS,
+  );
+});
+
+test("clampTimerIntervalMs clamps intervals that would overflow Node timers", () => {
+  assert.equal(
+    clampTimerIntervalMs(MAX_TIMER_INTERVAL_MS + 1),
+    MAX_TIMER_INTERVAL_MS,
+  );
+  assert.equal(clampTimerIntervalMs(2_592_000_000), MAX_TIMER_INTERVAL_MS);
+});

--- a/server/test/ws-heartbeat.test.ts
+++ b/server/test/ws-heartbeat.test.ts
@@ -160,13 +160,17 @@ test("ws heartbeat does not ping sockets that are no longer open", () => {
   assert.equal(socket.pingCount, 0);
 });
 
-test("ws heartbeat sweep survives a terminate() throw and still processes remaining sockets", () => {
+test("ws heartbeat sweep survives a terminate() throw, keeps the socket tracked, and retries", () => {
   const { heartbeat, events } = createHeartbeatHarness();
-  const throwingSocket = createFakeSocket({
-    terminate() {
+  let failTerminate = true;
+  const throwingSocket = createFakeSocket();
+  throwingSocket.terminate = () => {
+    if (failTerminate) {
       throw new Error("stream already destroyed");
-    },
-  });
+    }
+    throwingSocket.terminated = true;
+    throwingSocket.emit("close");
+  };
   const healthySocket = createFakeSocket();
   heartbeat.track(throwingSocket, createSession("session-throwing"));
   heartbeat.track(healthySocket, createSession("session-healthy"));
@@ -175,15 +179,24 @@ test("ws heartbeat sweep survives a terminate() throw and still processes remain
   healthySocket.emit("pong");
   heartbeat.sweepNow();
   healthySocket.emit("pong");
-  const terminated = heartbeat.sweepNow();
 
-  assert.equal(terminated, 0);
+  // 3rd sweep: threshold reached, terminate throws — the sweep must not
+  // crash, the healthy socket must still be pinged, and the failed socket
+  // must stay tracked instead of being silently abandoned.
+  assert.equal(heartbeat.sweepNow(), 0);
+  healthySocket.emit("pong");
   const failure = events.find((e) => e.event === "ws_heartbeat_sweep_failed");
   assert.ok(failure);
   assert.equal(failure.data.sessionId, "session-throwing");
   assert.equal(failure.data.error, "stream already destroyed");
+  assert.equal(throwingSocket.terminated, false);
   assert.equal(healthySocket.pingCount, 3);
   assert.equal(healthySocket.terminated, false);
+
+  // 4th sweep retries the terminate; once it succeeds the ghost is reaped.
+  failTerminate = false;
+  assert.equal(heartbeat.sweepNow(), 1);
+  assert.equal(throwingSocket.terminated, true);
 });
 
 test("ws heartbeat tracks nothing when disabled", () => {

--- a/server/test/ws-heartbeat.test.ts
+++ b/server/test/ws-heartbeat.test.ts
@@ -160,6 +160,32 @@ test("ws heartbeat does not ping sockets that are no longer open", () => {
   assert.equal(socket.pingCount, 0);
 });
 
+test("ws heartbeat sweep survives a terminate() throw and still processes remaining sockets", () => {
+  const { heartbeat, events } = createHeartbeatHarness();
+  const throwingSocket = createFakeSocket({
+    terminate() {
+      throw new Error("stream already destroyed");
+    },
+  });
+  const healthySocket = createFakeSocket();
+  heartbeat.track(throwingSocket, createSession("session-throwing"));
+  heartbeat.track(healthySocket, createSession("session-healthy"));
+
+  heartbeat.sweepNow();
+  healthySocket.emit("pong");
+  heartbeat.sweepNow();
+  healthySocket.emit("pong");
+  const terminated = heartbeat.sweepNow();
+
+  assert.equal(terminated, 0);
+  const failure = events.find((e) => e.event === "ws_heartbeat_sweep_failed");
+  assert.ok(failure);
+  assert.equal(failure.data.sessionId, "session-throwing");
+  assert.equal(failure.data.error, "stream already destroyed");
+  assert.equal(healthySocket.pingCount, 3);
+  assert.equal(healthySocket.terminated, false);
+});
+
 test("ws heartbeat tracks nothing when disabled", () => {
   const { heartbeat, events } = createHeartbeatHarness({ enabled: false });
   const socket = createFakeSocket();

--- a/server/test/ws-heartbeat.test.ts
+++ b/server/test/ws-heartbeat.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createWsHeartbeat,
+  type HeartbeatSocket,
+} from "../src/ws-heartbeat.js";
+import type { LogEvent, Session } from "../src/types.js";
+
+type FakeSocket = HeartbeatSocket & {
+  pingCount: number;
+  terminated: boolean;
+  emit: (event: "pong" | "close") => void;
+};
+
+function createFakeSocket(
+  overrides: Partial<HeartbeatSocket> = {},
+): FakeSocket {
+  const listeners = new Map<"pong" | "close", Array<() => void>>();
+  const socket: FakeSocket = {
+    readyState: 1,
+    OPEN: 1,
+    pingCount: 0,
+    terminated: false,
+    ping() {
+      socket.pingCount += 1;
+    },
+    terminate() {
+      socket.terminated = true;
+      socket.emit("close");
+    },
+    on(event, listener) {
+      const bucket = listeners.get(event) ?? [];
+      bucket.push(listener);
+      listeners.set(event, bucket);
+      return socket;
+    },
+    emit(event) {
+      for (const listener of listeners.get(event) ?? []) {
+        listener();
+      }
+    },
+    ...overrides,
+  };
+  return socket;
+}
+
+function createSession(id: string, roomCode: string | null = null): Session {
+  return {
+    id,
+    connectionState: "attached",
+    socket: {
+      readyState: 1,
+      OPEN: 1,
+      send() {},
+      close() {},
+      terminate() {},
+    } as Session["socket"],
+    instanceId: "test-node",
+    remoteAddress: null,
+    origin: null,
+    roomCode,
+    memberId: null,
+    memberToken: null,
+    displayName: id,
+    joinedAt: null,
+    invalidMessageCount: 0,
+    rateLimitState: {
+      roomCreate: { windowStart: 0, count: 0 },
+      roomJoin: { windowStart: 0, count: 0 },
+      videoShare: { windowStart: 0, count: 0 },
+      playbackUpdate: { tokens: 0, lastRefillAt: 0 },
+      syncRequest: { windowStart: 0, count: 0 },
+      syncPing: { tokens: 0, lastRefillAt: 0 },
+    },
+  };
+}
+
+function createHeartbeatHarness(options?: { enabled?: boolean }) {
+  const events: Array<{ event: string; data: Record<string, unknown> }> = [];
+  const logEvent: LogEvent = (event, data) => {
+    events.push({ event, data });
+  };
+  const heartbeat = createWsHeartbeat({
+    enabled: options?.enabled ?? true,
+    intervalMs: 30_000,
+    logEvent,
+  });
+  return { heartbeat, events };
+}
+
+test("ws heartbeat pings tracked sockets and keeps responsive ones alive", () => {
+  const { heartbeat, events } = createHeartbeatHarness();
+  const socket = createFakeSocket();
+  heartbeat.track(socket, createSession("session-1"));
+
+  for (let sweep = 0; sweep < 5; sweep += 1) {
+    const terminated = heartbeat.sweepNow();
+    assert.equal(terminated, 0);
+    socket.emit("pong");
+  }
+
+  assert.equal(socket.pingCount, 5);
+  assert.equal(socket.terminated, false);
+  assert.equal(events.length, 0);
+});
+
+test("ws heartbeat terminates a socket after two consecutive missed pongs", () => {
+  const { heartbeat, events } = createHeartbeatHarness();
+  const socket = createFakeSocket();
+  heartbeat.track(socket, createSession("session-1", "ROOM01"));
+
+  assert.equal(heartbeat.sweepNow(), 0);
+  assert.equal(heartbeat.sweepNow(), 0);
+  assert.equal(socket.terminated, false);
+
+  assert.equal(heartbeat.sweepNow(), 1);
+  assert.equal(socket.terminated, true);
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.event, "ws_heartbeat_timeout_terminated");
+  assert.equal(events[0]?.data.sessionId, "session-1");
+  assert.equal(events[0]?.data.roomCode, "ROOM01");
+  assert.equal(events[0]?.data.missedPongs, 2);
+});
+
+test("ws heartbeat resets the miss counter when a late pong arrives", () => {
+  const { heartbeat } = createHeartbeatHarness();
+  const socket = createFakeSocket();
+  heartbeat.track(socket, createSession("session-1"));
+
+  assert.equal(heartbeat.sweepNow(), 0);
+  assert.equal(heartbeat.sweepNow(), 0);
+  socket.emit("pong");
+
+  assert.equal(heartbeat.sweepNow(), 0);
+  assert.equal(heartbeat.sweepNow(), 0);
+  assert.equal(socket.terminated, false);
+});
+
+test("ws heartbeat stops tracking sockets that close normally", () => {
+  const { heartbeat } = createHeartbeatHarness();
+  const socket = createFakeSocket();
+  heartbeat.track(socket, createSession("session-1"));
+
+  assert.equal(heartbeat.sweepNow(), 0);
+  socket.emit("close");
+
+  for (let sweep = 0; sweep < 3; sweep += 1) {
+    assert.equal(heartbeat.sweepNow(), 0);
+  }
+  assert.equal(socket.pingCount, 1);
+  assert.equal(socket.terminated, false);
+});
+
+test("ws heartbeat does not ping sockets that are no longer open", () => {
+  const { heartbeat } = createHeartbeatHarness();
+  const socket = createFakeSocket({ readyState: 3 });
+  heartbeat.track(socket, createSession("session-1"));
+
+  assert.equal(heartbeat.sweepNow(), 0);
+  assert.equal(socket.pingCount, 0);
+});
+
+test("ws heartbeat tracks nothing when disabled", () => {
+  const { heartbeat, events } = createHeartbeatHarness({ enabled: false });
+  const socket = createFakeSocket();
+  heartbeat.track(socket, createSession("session-1"));
+
+  for (let sweep = 0; sweep < 4; sweep += 1) {
+    assert.equal(heartbeat.sweepNow(), 0);
+  }
+  assert.equal(socket.pingCount, 0);
+  assert.equal(socket.terminated, false);
+  assert.equal(events.length, 0);
+});


### PR DESCRIPTION
## Summary
- **问题**：服务端移除房间成员完全依赖 socket `close` 事件。客户端断电/休眠/网络路径中断等不发 TCP FIN 的场景下 `close` 永不触发，成员永久滞留；房间因始终非空拿不到 `expiresAt`，reaper 永远不会回收——即管理面板中"暂停五六天仍有 1 名成员"的房间。暂停房间没有任何服务端写入（`sync:pong` 仅被动应答），TCP 层也永远发现不了对端已死。
- **修复**：新增 `server/src/ws-heartbeat.ts`，按 `WS_HEARTBEAT_INTERVAL_MS`（默认 30s）向所有连接发协议层 ping，连续 2 次未收到 pong 即 `terminate()`，触发既有 close 清理链路（`cleanupSessionAfterClose → leaveRoom → 空房调度过期 → reaper 回收`），下游逻辑零改动。
- **扩展端零改动**：浏览器网络栈自动应答协议层 ping（不经扩展 JS，也不受 MV3 service worker 挂起影响），无需发扩展新版。
- 新配置 `WS_HEARTBEAT_ENABLED` / `WS_HEARTBEAT_INTERVAL_MS` 走 server config 层 schema（env 解析、config 文件、管理面板配置摘要同步支持），并更新中英 README 环境变量文档。
- 误杀容忍：阈值为连续 2 次 miss（约 60–90s 无响应才断开），短暂网络抖动不受影响；被误断的真实客户端会走扩展既有的自动重连 + `memberToken` 重入房间路径。
- 部署后存量幽灵连接会在心跳首轮扫描中被清理，无需手动处理。

## Test plan
- [x] 新增 `server/test/ws-heartbeat.test.ts`（6 例）：响应 pong 保活、连续 2 次 miss 后 terminate 并记录事件、迟到 pong 重置计数、正常 close 停止追踪、非 OPEN socket 不发 ping、disabled 时不追踪
- [x] `server/test/config-env.test.ts` 补默认值与 env 覆盖解析断言
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test`（477 例全绿）

🤖 Generated with [Claude Code](https://claude.com/claude-code)