### PR TITLE
ci: 补齐 Redis 集成测试与 Firefox 构建的 CI 覆盖

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,40 @@ jobs:
       - name: Build Firefox extension target
         run: npm run build:extension:firefox
 
+  redis-integration:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build protocol package
+        run: npm run build -w @bili-syncplay/protocol
+
+      - name: Run server tests against Redis
+        run: npm run test:server:redis
+        env:
+          REDIS_URL: redis://127.0.0.1:6379
+
   benchmark-baseline:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Run tests with coverage
         run: npm run coverage
 
+      - name: Build Firefox extension target
+        run: npm run build:extension:firefox
+
   benchmark-baseline:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Useful command matrix:
 - `npm test`: run audit gate tests plus repository-wide protocol, server, and extension tests
 - `npm run audit`: run the dependency audit gate, failing on unallowlisted `high` or `critical` vulnerabilities
 - `npm run test:audit-gate`: run unit tests for the dependency audit gate
-- `npm run test:server:redis`: run the explicit Redis regression entry point for server persistence
+- `npm run test:server:redis`: run the explicit Redis regression entry point for server persistence (requires `REDIS_URL`; CI runs it in a dedicated job with a Redis service container)
 
 Development constraints:
 

--- a/server/test/multi-node-admin-actions.test.ts
+++ b/server/test/multi-node-admin-actions.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import {
   closeClient,
   connectClient,
@@ -30,7 +31,7 @@ test("global admin executes cross-node kick_member and disconnect_session action
     owner.send(
       JSON.stringify({
         type: "room:create",
-        payload: { displayName: "Alice" },
+        payload: { displayName: "Alice", protocolVersion: PROTOCOL_VERSION },
       }),
     );
     const created = await ownerCollector.next("room:created");
@@ -43,6 +44,7 @@ test("global admin executes cross-node kick_member and disconnect_session action
           roomCode: (created.payload as { roomCode: string }).roomCode,
           joinToken: (created.payload as { joinToken: string }).joinToken,
           displayName: "Bob",
+          protocolVersion: PROTOCOL_VERSION,
         },
       }),
     );
@@ -86,10 +88,10 @@ test("global admin executes cross-node kick_member and disconnect_session action
     assert.equal(kickResponse.status, 200);
     await waitForCondition(() => joiner.readyState === joiner.CLOSED);
 
-    const ownerAfterKick = await ownerCollector.next("room:state");
+    const ownerSawKick = await ownerCollector.next("room:member-left");
     assert.equal(
-      (ownerAfterKick.payload as { members: Array<unknown> }).members.length,
-      1,
+      (ownerSawKick.payload as { member: { id: string } }).member.id,
+      bob?.memberId,
     );
 
     const kickedReconnect = await connectClient(nodeB.wsUrl);

--- a/server/test/multi-node-room-broadcast.test.ts
+++ b/server/test/multi-node-room-broadcast.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import {
   closeClient,
   connectClient,
@@ -26,7 +27,7 @@ test("cross-node room broadcasts sync join, shared video, playback updates, and 
     owner.send(
       JSON.stringify({
         type: "room:create",
-        payload: { displayName: "Alice" },
+        payload: { displayName: "Alice", protocolVersion: PROTOCOL_VERSION },
       }),
     );
     const created = await ownerCollector.next("room:created");
@@ -39,6 +40,7 @@ test("cross-node room broadcasts sync join, shared video, playback updates, and 
           roomCode: (created.payload as { roomCode: string }).roomCode,
           joinToken: (created.payload as { joinToken: string }).joinToken,
           displayName: "Bob",
+          protocolVersion: PROTOCOL_VERSION,
         },
       }),
     );

--- a/server/test/runtime-lifecycle.test.ts
+++ b/server/test/runtime-lifecycle.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { once } from "node:events";
 import test from "node:test";
 import { WebSocket, type RawData } from "ws";
+import { PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import { EventEmitter } from "node:events";
 import {
   cleanupSessionAfterClose,
@@ -404,7 +405,10 @@ test("profile updates are reflected in redis-backed room state views", async (t)
       owner.send(
         JSON.stringify({
           type: "room:create",
-          payload: { displayName: "Guest-123" },
+          payload: {
+            displayName: "Guest-123",
+            protocolVersion: PROTOCOL_VERSION,
+          },
         }),
       );
       const created = await ownerCollector.next("room:created");
@@ -419,6 +423,7 @@ test("profile updates are reflected in redis-backed room state views", async (t)
             roomCode,
             joinToken,
             displayName: "Bob",
+            protocolVersion: PROTOCOL_VERSION,
           },
         }),
       );


### PR DESCRIPTION
## 背景

CI 此前存在两个覆盖缺口：

1. **Redis 门控测试从不在 CI 运行**——服务端 38 个依赖 `REDIS_URL` 的测试（多节点广播、跨节点管理动作、集群 runtime 镜像等）在 CI 和本地默认流程中都被跳过，多节点路径完全无 CI 保护。
2. **Firefox 目标不在 CI 构建**——`build:extension:firefox` 只在发版打包时执行，破坏 Firefox 构建的改动要到发版当天才暴露。

## 缺口 1 的实际代价：一处存在已久的测试损坏

本地起 Redis 实跑门控测试后立即暴露 3 个失败（`multi-node-room-broadcast`、`multi-node-admin-actions`、`runtime-lifecycle` 的 profile 用例），签名一致：等待 `room:member-joined` 超时。

根因：协议 v2 引入成员增量事件后，未声明 `protocolVersion` 的会话按 v1 旧客户端处理，只收全量 `room:state` 兜底。这三个测试的客户端从未发送 `protocolVersion`，等增量事件必然超时——而且测试本身就是按 v2+ 语义写的（`multi-node-room-broadcast` 还断言成员离开后**不再**收到全量 `room:state`）。因为 CI 从不跑这些测试，损坏一直未被发现。**跨节点广播链路本身经验证工作正常，属测试过时，非产品缺陷。**

## 变更

- **test**: 三个多节点测试的 `room:create` / `room:join` payload 补发 `protocolVersion`（与 `admin-backend`、`e2e-smoke` 等在跑测试一致）；kick 后 owner 改为断言 `room:member-left` 增量事件。已审计全部等待成员增量消息的测试点位，无同类遗漏。
- **ci**: verify job 在 coverage 后追加 `build:extension:firefox`。
- **ci**: 新增 `redis-integration` job——`redis:7-alpine` service（带健康检查）+ 构建 protocol + `npm run test:server:redis`，370 个服务端测试零跳过执行。README 命令矩阵同步说明。

## 验证

- 本地 Redis（8.0.2）实跑 `test:server:redis`：370/370 通过、0 跳过
- `format:check` / `lint` / `typecheck` / `build` / `npm test`（477 通过）全绿
- `build:extension:firefox` 本地构建通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)