### PR TITLE
chore: release 1.2.4

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.2.3"
+    "@bili-syncplay/protocol": "1.2.4"
   },
   "devDependencies": {
     "@types/chrome": "^0.2.2",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "workspaces": [
         "packages/*",
         "server",
@@ -24,9 +24,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.2.3"
+        "@bili-syncplay/protocol": "1.2.4"
       },
       "devDependencies": {
         "@types/chrome": "^0.2.2",
@@ -1980,16 +1980,16 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "devDependencies": {
         "typescript": "^6.0.3"
       }
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.2.3",
+        "@bili-syncplay/protocol": "1.2.4",
         "ioredis": "^5.10.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.2.3",
+    "@bili-syncplay/protocol": "1.2.4",
     "ioredis": "^5.10.0",
     "ws": "^8.21.0"
   },


### PR DESCRIPTION
将工作区版本从 1.2.3 提升到 1.2.4（`npm run release:version -- 1.2.4`，package.json ×4、manifest.json、package-lock.json）。

## 自 v1.2.3 以来的变更

- **fix**: 运行阶段镜像删除基础镜像自带的 npm/corepack/yarn —— 修复 Docker 镜像全部 7 个 CVE（#156）；合并后需核对 Docker Hub 扫描归零
- **feat**: 服务端 WebSocket 心跳检测，回收半开死连接产生的幽灵成员房间（#157）
- **ci**: Redis 集成测试与 Firefox 构建纳入 CI + 修复多节点测试 protocolVersion 断言损坏（#158）
- **chore**: 依赖 minor 批量升级 + prettier 3.9 格式化（#159）
- **chore**: major 依赖升级——TypeScript 6 / ESLint 10 / esbuild 0.28 / @types/chrome 0.2 / globals 17（#160）

合并后在合并提交上打 `v1.2.4` tag，触发 Release（扩展 zip/xpi）与 Docker Release（GHCR + Docker Hub 双推送）workflow。

## 验证

`format:check` / `lint` / `typecheck` / `build` / `npm test` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)