### PR TITLE
docs: 新增架构概览与协议参考，补齐多节点 runbook 英文版

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,12 +140,14 @@ Bili-SyncPlay/
 ## Documentation
 
 - [Documentation index](./docs/README.md)
+- [Architecture overview](./docs/architecture.md) — system parts, sync data flow, where new code belongs
 - [Development guide](./docs/development.md) — local commands, tests, benchmarks, code organization, troubleshooting, release packaging
 - [Server deployment guide](./docs/operations/deployment.md) — build, systemd, Nginx, TLS, update flow
 - [Multi-node deployment and global admin](./docs/operations/multi-node.md)
+- [Protocol reference](./docs/reference/protocol.md)
 - [Security environment variables](./docs/reference/security-env.md)
 - [Admin panel and API](./docs/reference/admin-api.md)
-- [Multi-node operations runbook](./docs/runbook/multi-node-operations.zh-CN.md)
+- [Multi-node operations runbook](./docs/runbook/multi-node-operations.md)
 - [Multi-node global admin migration](./docs/operations/multi-node-global-admin-migration.md)
 - [Privacy policy](./docs/legal/privacy.md)
 
@@ -204,7 +206,7 @@ Or use the repository's [`docker-compose.yml`](./docker-compose.yml), which incl
 Notes:
 
 - The container listens on `8787` (override with `PORT`), exposes `/healthz` and `/readyz`, and ships a built-in Docker `HEALTHCHECK`.
-- Configuration is entirely environment-variable based, identical to a bare-metal deployment: `ALLOWED_ORIGINS` (required for extensions to connect), Redis persistence (`ROOM_STORE_PROVIDER=redis` plus `REDIS_URL`; `REDIS_URL` alone keeps the in-memory store), admin panel variables (`ADMIN_USERNAME` / `ADMIN_PASSWORD_HASH` / `ADMIN_SESSION_SECRET`), and so on — see the [security environment variable reference](./docs/reference/security-env.md) and the [multi-node runbook](./docs/runbook/multi-node-operations.zh-CN.md).
+- Configuration is entirely environment-variable based, identical to a bare-metal deployment: `ALLOWED_ORIGINS` (required for extensions to connect), Redis persistence (`ROOM_STORE_PROVIDER=redis` plus `REDIS_URL`; `REDIS_URL` alone keeps the in-memory store), admin panel variables (`ADMIN_USERNAME` / `ADMIN_PASSWORD_HASH` / `ADMIN_SESSION_SECRET`), and so on — see the [security environment variable reference](./docs/reference/security-env.md) and the [multi-node runbook](./docs/runbook/multi-node-operations.md).
 - In production, terminate TLS at a reverse proxy so the extension connects over `wss://` (see the version matrix).
 - Build locally from the repository root: `docker build -t bili-syncplay-server .` (the image contains only the server; the extension is distributed separately).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -140,9 +140,11 @@ Bili-SyncPlay/
 ## 文档入口
 
 - [文档索引](./docs/README.md)
+- [架构概览](./docs/architecture.zh-CN.md)——系统组成、同步数据流、新代码放哪里
 - [开发指南](./docs/development.zh-CN.md)——本地命令、测试、基准压测、代码组织、故障排查、发布打包
 - [服务器部署指南](./docs/operations/deployment.zh-CN.md)——构建、systemd、Nginx、TLS、更新流程
 - [多节点部署与全局管理面](./docs/operations/multi-node.zh-CN.md)
+- [协议参考](./docs/reference/protocol.zh-CN.md)
 - [安全相关环境变量](./docs/reference/security-env.zh-CN.md)
 - [管理面板与 API](./docs/reference/admin-api.zh-CN.md)
 - [多节点运维 Runbook](./docs/runbook/multi-node-operations.zh-CN.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,18 +5,20 @@ This directory keeps project documentation that is useful after the first README
 
 ## Development / 开发
 
+- [Architecture overview](./architecture.md) / [架构概览](./architecture.zh-CN.md)
 - [Development guide](./development.md) / [开发指南](./development.zh-CN.md)
 
 ## Operations / 运维
 
 - [Server deployment guide](./operations/deployment.md) / [服务器部署指南](./operations/deployment.zh-CN.md)
 - [Multi-node deployment and global admin](./operations/multi-node.md) / [多节点部署与全局管理面](./operations/multi-node.zh-CN.md)
-- [Multi-node operations runbook](./runbook/multi-node-operations.zh-CN.md)
+- [Multi-node operations runbook](./runbook/multi-node-operations.md) / [多节点运维 Runbook](./runbook/multi-node-operations.zh-CN.md)
 - [Multi-node global admin migration](./operations/multi-node-global-admin-migration.md)
 - [多节点全局管理面迁移说明](./operations/multi-node-global-admin-migration.zh-CN.md)
 
 ## Reference / 参考
 
+- [Protocol reference](./reference/protocol.md) / [协议参考](./reference/protocol.zh-CN.md)
 - [Security environment variables](./reference/security-env.md) / [安全相关环境变量](./reference/security-env.zh-CN.md)
 - [Admin panel and API](./reference/admin-api.md) / [管理面板与 API](./reference/admin-api.zh-CN.md)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ Every store and bus has a `memory` and a `redis` provider behind the same interf
 
 ## Identity and State Lifetimes
 
-- A room is identified by `roomCode`; joining requires the `joinToken` from the invite (`roomCode:joinToken`), and every subsequent room message requires the session-bound `memberToken`, which is never persisted server-side across reconnects — it is re-issued on every successful join.
+- A room is identified by `roomCode`; joining requires the `joinToken` from the invite (`roomCode:joinToken`), and every subsequent room message requires the session-bound `memberToken` returned by join. A rejoin that presents a still-valid previous `memberToken` keeps its member identity and reuses that token; otherwise the server issues a new one. The extension intentionally discards its stored `memberToken` on disconnect, so it typically rejoins with a fresh token.
 - The extension splits persisted state by lifetime: `chrome.storage.session` holds room membership (cleared when the browser closes), `chrome.storage.local` holds `displayName` and `serverUrl`. Practical consequences are listed in the [development guide](./development.md#state-persistence).
 
 ## Where New Code Belongs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,90 @@
+# Architecture Overview
+
+[English](./architecture.md) | [简体中文](./architecture.zh-CN.md)
+
+This document orients contributors in the runtime architecture: what the moving parts are, how a playback change travels through the system, and where new code belongs. Module-boundary rules live in [CONTRIBUTING.md](../CONTRIBUTING.md); the wire protocol is specified in the [protocol reference](./reference/protocol.md).
+
+## System Parts
+
+| Part              | Location             | Runtime                                                                                 |
+| ----------------- | -------------------- | --------------------------------------------------------------------------------------- |
+| Browser extension | `extension/`         | MV3; service-worker background on Chrome/Edge, event-page background on Firefox 121+    |
+| Sync server       | `server/`            | Node.js WebSocket server plus admin panel; optional Redis for multi-node deployments    |
+| Protocol package  | `packages/protocol/` | Shared TypeScript types, type guards, and Bilibili URL normalization used by both sides |
+
+## Sync Data Flow
+
+```mermaid
+flowchart LR
+  page[Bilibili page<br/>content script] -->|chrome.runtime message| bg[Background worker]
+  bg -->|WebSocket ClientMessage| server[Sync server]
+  server -->|broadcast ServerMessage| bg2[Other members'<br/>background workers]
+  bg2 -->|chrome.runtime message| page2[Other members'<br/>content scripts]
+  page2 -->|apply state| video[Video player]
+```
+
+1. The content script detects playback changes (play, pause, seek, rate) on a supported Bilibili page.
+2. It sends the change to the background worker via `chrome.runtime` messaging.
+3. The background worker validates it, updates room state, and forwards it to the WebSocket server as a `playback:update`.
+4. The server stamps `serverTime`, persists room state, and broadcasts to all room members (across nodes via the Redis room event bus when configured).
+5. Receiving clients apply the playback state to their video player, correcting for clock offset.
+
+The reverse path (someone else's update arriving) flows server → background → content script, where reconcile logic decides whether to seek, change rate, or toggle play state. An NTP-style `sync:ping` / `sync:pong` exchange maintains the clock offset (see the [protocol reference](./reference/protocol.md#clock-synchronization)).
+
+## Extension
+
+Each entry area follows the same shape: `index.ts` is assembly-only, runtime state lives in a dedicated store, and behavior lives in named controllers.
+
+### Background (`extension/src/background/`)
+
+State lives in `state-store.ts`. Key controllers:
+
+| Controller                   | Responsibility                                         |
+| ---------------------------- | ------------------------------------------------------ |
+| `socket-controller.ts`       | WebSocket connection, reconnection, health checks      |
+| `room-session-controller.ts` | Room create / join / leave / state                     |
+| `share-controller.ts`        | Shared video and pending local shares                  |
+| `clock-controller.ts`        | NTP-style clock offset for playback sync               |
+| `tab-controller.ts`          | Bilibili tab tracking, shared vs. local page switching |
+| `message-controller.ts`      | Routes popup / content messages to handlers            |
+
+Supporting modules handle server-message dispatch (`server-message-controller.ts`), the popup connection (`popup-state-controller.ts`, `popup-bus.ts`), the server URL lifecycle (`server-url-controller.ts`), and persistence (`storage-manager.ts`).
+
+### Content script (`extension/src/content/`)
+
+State lives in `content-store.ts`. The main concerns are playback binding and broadcast (`playback-binding-controller.ts`, `playback-broadcast.ts`), applying and reconciling remote state (`room-state-apply-controller.ts`, `playback-reconcile.ts`, `soft-apply-controller.ts`), SPA navigation tracking (`navigation-controller.ts`), page-world bridging for player internals and festival pages (`page-bridge*.ts`, `festival-bridge.ts`), sharing (`share-controller.ts`, `auto-share-next-controller.ts`), and in-page toasts (`toast.ts`).
+
+### Popup (`extension/src/popup/`)
+
+Local UI state lives in `popup-store.ts`; template, refs/render, actions, and the background port connection are separate modules (`popup-template.ts`, `popup-render.ts`, `popup-actions.ts`, `popup-port.ts`).
+
+### Shared (`extension/src/shared/`)
+
+Cross-area helpers: normalized video URL handling (`url.ts`, wrapping the protocol package), extension-internal message contracts (`messages.ts`), i18n strings (`i18n.ts`), and storage helpers (`storage.ts`). Anything needed by more than one entry area belongs here, not redefined per entrypoint.
+
+## Server (`server/src/`)
+
+`app.ts` is runtime assembly only; `index.ts` (room node) and `global-admin-index.ts` (dedicated admin process) are the two entrypoints.
+
+| Layer               | Modules                                                                                            | Responsibility                                                      |
+| ------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Config              | `config/*`                                                                                         | Env / config-file parsing (the only place env vars are read)        |
+| Bootstrap           | `bootstrap/*`                                                                                      | Provider selection and dependency wiring                            |
+| Session handling    | `ws-session-handler.ts`, `message-handler.ts`, `rate-limit.ts`, `security.ts`, `origin.ts`         | Handshake checks, message validation, auth, rate limits             |
+| Room domain         | `room-service.ts`, `room-store.ts`, `playback-authority.ts`, `room-reaper.ts`                      | Room lifecycle, playback-state authority, expiry cleanup            |
+| Multi-node plumbing | `redis-*.ts`, `room-event-bus.ts`, `admin-command-bus.ts`, `runtime-store.ts`, `node-heartbeat.ts` | Redis-backed stores, cross-node fanout, command routing, heartbeats |
+| Admin               | `admin/*`, `admin-panel.ts`, `admin-session-store.ts`                                              | Admin panel UI, routes, sessions, events, audit logs                |
+
+Every store and bus has a `memory` and a `redis` provider behind the same interface; the [multi-node guide](./operations/multi-node.md) describes which providers must be enabled for a multi-node topology.
+
+## Identity and State Lifetimes
+
+- A room is identified by `roomCode`; joining requires the `joinToken` from the invite (`roomCode:joinToken`), and every subsequent room message requires the session-bound `memberToken`, which is never persisted server-side across reconnects — it is re-issued on every successful join.
+- The extension splits persisted state by lifetime: `chrome.storage.session` holds room membership (cleared when the browser closes), `chrome.storage.local` holds `displayName` and `serverUrl`. Practical consequences are listed in the [development guide](./development.md#state-persistence).
+
+## Where New Code Belongs
+
+- New behavior goes into an existing named module or a new controller — never into a growing `index.ts`.
+- New state goes behind the relevant store, not into a top-level mutable variable.
+- Protocol changes go through `packages/protocol` with the versioning checklist in [CONTRIBUTING.md](../CONTRIBUTING.md).
+- New server settings go through the config layer and must be documented in the [environment variable reference](./reference/security-env.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ Every store and bus has a `memory` and a `redis` provider behind the same interf
 
 ## Identity and State Lifetimes
 
-- A room is identified by `roomCode`; joining requires the `joinToken` from the invite (`roomCode:joinToken`), and every subsequent room message requires the session-bound `memberToken` returned by join. A rejoin that presents a still-valid previous `memberToken` keeps its member identity and reuses that token; otherwise the server issues a new one. The extension intentionally discards its stored `memberToken` on disconnect, so it typically rejoins with a fresh token.
+- A room is identified by `roomCode`; joining requires the `joinToken` from the invite (`roomCode:joinToken`), and every subsequent room message requires the session-bound `memberToken` returned by join. A rejoin that presents a still-valid previous `memberToken` keeps its member identity and reuses that token; otherwise the server issues a new one. The extension keeps its cached `memberToken` across automatic reconnects and presents it when rejoining; the token is cleared only on explicit leave or when the server tears down the session (e.g. an admin kick).
 - The extension splits persisted state by lifetime: `chrome.storage.session` holds room membership (cleared when the browser closes), `chrome.storage.local` holds `displayName` and `serverUrl`. Practical consequences are listed in the [development guide](./development.md#state-persistence).
 
 ## Where New Code Belongs

--- a/docs/architecture.zh-CN.md
+++ b/docs/architecture.zh-CN.md
@@ -79,7 +79,7 @@ flowchart LR
 
 ## 身份与状态生命周期
 
-- 房间由 `roomCode` 标识；加入需要邀请串（`roomCode:joinToken`）中的 `joinToken`，之后每条房间消息都需要会话绑定的 `memberToken`——它不会跨重连持久化，每次成功加入都会重新签发。
+- 房间由 `roomCode` 标识；加入需要邀请串（`roomCode:joinToken`）中的 `joinToken`，之后每条房间消息都需要加入时返回的会话绑定 `memberToken`。重连携带仍有效的旧 `memberToken` 时会保留原成员身份并复用该 token；否则服务端签发新 token。扩展会在断开连接时有意清除本地保存的 `memberToken`，因此重新加入时通常拿到新 token。
 - 扩展按生命周期拆分持久化状态：`chrome.storage.session` 保存房间成员信息（浏览器关闭即清除），`chrome.storage.local` 保存 `displayName` 与 `serverUrl`。实际影响见[开发指南](./development.zh-CN.md#状态持久化)。
 
 ## 新代码应该放在哪里

--- a/docs/architecture.zh-CN.md
+++ b/docs/architecture.zh-CN.md
@@ -1,0 +1,90 @@
+# 架构概览
+
+[English](./architecture.md) | [简体中文](./architecture.zh-CN.md)
+
+本文档帮助贡献者建立对运行时架构的整体认知：系统由哪些部分组成、一次播放变化如何在系统中流转、新代码应该放在哪里。模块边界规则见 [CONTRIBUTING.md](../CONTRIBUTING.md)；线上协议规范见[协议参考](./reference/protocol.zh-CN.md)。
+
+## 系统组成
+
+| 组成部分   | 位置                 | 运行时                                                                   |
+| ---------- | -------------------- | ------------------------------------------------------------------------ |
+| 浏览器扩展 | `extension/`         | MV3；Chrome/Edge 为 service worker 后台，Firefox 121+ 为 event page 后台 |
+| 同步服务端 | `server/`            | Node.js WebSocket 服务 + 管理后台；多节点部署时使用可选的 Redis          |
+| 协议包     | `packages/protocol/` | 两端共享的 TypeScript 类型、类型守卫和 Bilibili URL 归一化               |
+
+## 同步数据流
+
+```mermaid
+flowchart LR
+  page[Bilibili 页面<br/>content script] -->|chrome.runtime 消息| bg[Background worker]
+  bg -->|WebSocket ClientMessage| server[同步服务端]
+  server -->|广播 ServerMessage| bg2[其他成员的<br/>background worker]
+  bg2 -->|chrome.runtime 消息| page2[其他成员的<br/>content script]
+  page2 -->|应用状态| video[视频播放器]
+```
+
+1. content script 在受支持的 Bilibili 页面上检测播放变化（播放、暂停、跳转、倍速）。
+2. 通过 `chrome.runtime` 消息发送给 background worker。
+3. background worker 校验后更新房间状态，并以 `playback:update` 转发给 WebSocket 服务端。
+4. 服务端盖上 `serverTime`、持久化房间状态，并向所有房间成员广播（配置 Redis room event bus 时可跨节点）。
+5. 接收端把播放状态应用到自己的视频播放器上，并校正时钟偏移。
+
+反向路径（收到别人的更新）为 服务端 → background → content script，由 reconcile 逻辑决定是否 seek、调倍速或切换播放状态。NTP 式的 `sync:ping` / `sync:pong` 往返维护时钟偏移（见[协议参考](./reference/protocol.zh-CN.md#时钟同步)）。
+
+## 扩展端
+
+三个入口区域遵循同一套形态：`index.ts` 只负责装配，运行态收敛在专属 store，行为放在具名 controller 中。
+
+### Background（`extension/src/background/`）
+
+状态收敛在 `state-store.ts`。核心 controller：
+
+| Controller                   | 职责                                      |
+| ---------------------------- | ----------------------------------------- |
+| `socket-controller.ts`       | WebSocket 连接、重连、健康检查            |
+| `room-session-controller.ts` | 房间创建 / 加入 / 离开 / 状态             |
+| `share-controller.ts`        | 共享视频与待处理的本地分享                |
+| `clock-controller.ts`        | NTP 式时钟偏移，用于播放同步              |
+| `tab-controller.ts`          | Bilibili 标签页跟踪、共享页与本地页切换   |
+| `message-controller.ts`      | 把 popup / content 消息路由到对应 handler |
+
+辅助模块负责服务端消息分发（`server-message-controller.ts`）、popup 连接（`popup-state-controller.ts`、`popup-bus.ts`）、服务器地址生命周期（`server-url-controller.ts`）和持久化（`storage-manager.ts`）。
+
+### Content script（`extension/src/content/`）
+
+状态收敛在 `content-store.ts`。主要关注点：播放绑定与广播（`playback-binding-controller.ts`、`playback-broadcast.ts`）、远端状态应用与调和（`room-state-apply-controller.ts`、`playback-reconcile.ts`、`soft-apply-controller.ts`）、SPA 导航跟踪（`navigation-controller.ts`）、访问播放器内部与 festival 页面的页面世界桥接（`page-bridge*.ts`、`festival-bridge.ts`）、分享（`share-controller.ts`、`auto-share-next-controller.ts`）以及页内 toast（`toast.ts`）。
+
+### Popup（`extension/src/popup/`）
+
+本地 UI 状态收敛在 `popup-store.ts`；模板、refs/渲染、动作和 background 端口连接各自独立（`popup-template.ts`、`popup-render.ts`、`popup-actions.ts`、`popup-port.ts`）。
+
+### Shared（`extension/src/shared/`）
+
+跨区域 helper：归一化视频 URL 处理（`url.ts`，封装协议包）、扩展内部消息契约（`messages.ts`）、i18n 文案（`i18n.ts`）和存储 helper（`storage.ts`）。任何被多个入口区域使用的逻辑都应沉淀在这里，而不是各入口各写一份。
+
+## 服务端（`server/src/`）
+
+`app.ts` 只负责运行时装配；`index.ts`（Room Node）和 `global-admin-index.ts`（独立管理进程）是两个入口。
+
+| 层次       | 模块                                                                                               | 职责                                           |
+| ---------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| 配置       | `config/*`                                                                                         | 环境变量 / 配置文件解析（读取 env 的唯一位置） |
+| Bootstrap  | `bootstrap/*`                                                                                      | provider 选择与依赖装配                        |
+| 会话处理   | `ws-session-handler.ts`、`message-handler.ts`、`rate-limit.ts`、`security.ts`、`origin.ts`         | 握手检查、消息校验、鉴权、限流                 |
+| 房间领域   | `room-service.ts`、`room-store.ts`、`playback-authority.ts`、`room-reaper.ts`                      | 房间生命周期、播放状态权威、过期清理           |
+| 多节点管道 | `redis-*.ts`、`room-event-bus.ts`、`admin-command-bus.ts`、`runtime-store.ts`、`node-heartbeat.ts` | Redis 后端存储、跨节点广播、命令路由、心跳     |
+| 管理后台   | `admin/*`、`admin-panel.ts`、`admin-session-store.ts`                                              | 管理面板 UI、路由、会话、事件、审计日志        |
+
+每个 store 和 bus 都在同一接口后提供 `memory` 和 `redis` 两种实现；多节点拓扑需要启用哪些 provider 见[多节点部署指南](./operations/multi-node.zh-CN.md)。
+
+## 身份与状态生命周期
+
+- 房间由 `roomCode` 标识；加入需要邀请串（`roomCode:joinToken`）中的 `joinToken`，之后每条房间消息都需要会话绑定的 `memberToken`——它不会跨重连持久化，每次成功加入都会重新签发。
+- 扩展按生命周期拆分持久化状态：`chrome.storage.session` 保存房间成员信息（浏览器关闭即清除），`chrome.storage.local` 保存 `displayName` 与 `serverUrl`。实际影响见[开发指南](./development.zh-CN.md#状态持久化)。
+
+## 新代码应该放在哪里
+
+- 新行为放进已有具名模块或新建 controller——不要继续拉长 `index.ts`。
+- 新状态放进对应 store，不要新增顶层可变变量。
+- 协议变更走 `packages/protocol`，并遵循 [CONTRIBUTING.md](../CONTRIBUTING.md) 的版本清单。
+- 新服务端配置走 config 层，并同步补进[环境变量参考](./reference/security-env.zh-CN.md)。

--- a/docs/architecture.zh-CN.md
+++ b/docs/architecture.zh-CN.md
@@ -79,7 +79,7 @@ flowchart LR
 
 ## 身份与状态生命周期
 
-- 房间由 `roomCode` 标识；加入需要邀请串（`roomCode:joinToken`）中的 `joinToken`，之后每条房间消息都需要加入时返回的会话绑定 `memberToken`。重连携带仍有效的旧 `memberToken` 时会保留原成员身份并复用该 token；否则服务端签发新 token。扩展会在断开连接时有意清除本地保存的 `memberToken`，因此重新加入时通常拿到新 token。
+- 房间由 `roomCode` 标识；加入需要邀请串（`roomCode:joinToken`）中的 `joinToken`，之后每条房间消息都需要加入时返回的会话绑定 `memberToken`。重连携带仍有效的旧 `memberToken` 时会保留原成员身份并复用该 token；否则服务端签发新 token。扩展在自动重连时会保留缓存的 `memberToken` 并随重新加入一起发送；只有显式离开房间或服务端主动终止会话（如管理员踢人）时才会清除该 token。
 - 扩展按生命周期拆分持久化状态：`chrome.storage.session` 保存房间成员信息（浏览器关闭即清除），`chrome.storage.local` 保存 `displayName` 与 `serverUrl`。实际影响见[开发指南](./development.zh-CN.md#状态持久化)。
 
 ## 新代码应该放在哪里

--- a/docs/development.md
+++ b/docs/development.md
@@ -175,7 +175,7 @@ Redis integration test notes:
 
 ## Code Organization
 
-The repository follows a "thin entrypoint + named modules" structure.
+The repository follows a "thin entrypoint + named modules" structure. For the runtime view — system parts, sync data flow, and controller responsibilities — see the [architecture overview](./architecture.md).
 
 - `extension/src/background`
   - `index.ts` is assembly only

--- a/docs/development.md
+++ b/docs/development.md
@@ -241,7 +241,7 @@ Development notes:
 - `@bili-syncplay/server` depends on the built output of `@bili-syncplay/protocol`
 - for a clean local setup, prefer `npm run build` instead of building `server` alone
 - the extension does not keep a permanent socket by default; it connects when a room already exists in session state or when the user creates / joins a room
-- reconnecting into an existing room requires the stored `joinToken`; stale `memberToken` values are discarded on disconnect
+- reconnecting into an existing room requires the stored `joinToken`; the cached `memberToken` is sent along on automatic reconnect and is discarded only on explicit leave or an admin-initiated session teardown
 - if you change protocol types or message validation, rebuild both `packages/protocol` and `server`
 - the local server rejects extension connections unless `ALLOWED_ORIGINS` includes the current `chrome-extension://<extension-id>`
 - you can find the unpacked extension ID on `chrome://extensions`
@@ -271,7 +271,7 @@ Practical consequences:
 - the custom server URL survives browser restart
 - room session state and profile preferences are persisted independently, so a room-state write cannot leave `serverUrl` or `displayName` half-updated
 - the popup can reconnect into the current room only while the browser session still holds both `roomCode` and `joinToken`
-- `memberToken` is intentionally cleared on disconnect and re-issued after a successful rejoin
+- `memberToken` is kept across automatic reconnects and presented on rejoin; it is cleared on explicit leave or an admin-initiated session teardown, after which the next join receives a fresh token
 - if the persisted server URL becomes invalid, the extension keeps that value visible and stops auto reconnect until the URL is fixed
 - closing the browser does not restore the previous room automatically on the next launch
 

--- a/docs/development.zh-CN.md
+++ b/docs/development.zh-CN.md
@@ -175,7 +175,7 @@ Redis 集成测试说明：
 
 ## 代码组织约定
 
-仓库遵循“薄入口 + 具名模块”的组织方式。
+仓库遵循“薄入口 + 具名模块”的组织方式。运行时视角——系统组成、同步数据流与 controller 职责——见[架构概览](./architecture.zh-CN.md)。
 
 - `extension/src/background`
   - `index.ts` 只负责装配

--- a/docs/development.zh-CN.md
+++ b/docs/development.zh-CN.md
@@ -241,7 +241,7 @@ ws://localhost:8787
 - `@bili-syncplay/server` 依赖 `@bili-syncplay/protocol` 的构建产物
 - 对于全新本地环境，优先使用 `npm run build`，而不是单独构建 `server`
 - 扩展默认不会永久保持 socket 连接；只有在会话状态中已存在房间，或用户创建 / 加入房间时才会建立连接
-- 重新进入已有房间需要保存的 `joinToken`；断开连接后，旧的 `memberToken` 会被丢弃
+- 重新进入已有房间需要保存的 `joinToken`；自动重连会携带缓存的 `memberToken`，只有显式离开或管理端终止会话时才丢弃
 - 如果你修改了协议类型或消息校验，需要重新构建 `packages/protocol` 和 `server`
 - 本地服务器默认会拒绝扩展连接，除非 `ALLOWED_ORIGINS` 包含当前 `chrome-extension://<extension-id>`
 - 你可以在 `chrome://extensions` 中查看未打包扩展的 ID
@@ -271,7 +271,7 @@ Chrome 显示的扩展版本来自 `extension/dist/manifest.json`。
 - 自定义服务器地址会在浏览器重启后保留
 - 房间会话态与用户偏好会分别持久化，房间状态写入失败不会把 `serverUrl` 或 `displayName` 留在半更新状态
 - 只有在浏览器会话中仍保留 `roomCode` 和 `joinToken` 时，弹窗才能重新进入当前房间
-- `memberToken` 会在断开连接时被有意清除，并在重新加入成功后重新签发
+- `memberToken` 在自动重连时保留并随重新加入发送；显式离开或管理端终止会话时被清除，之后重新加入会拿到新 token
 - 如果持久化的服务器地址非法，扩展会保留原始值并停止自动重连，直到地址被修正
 - 关闭浏览器后，下次启动不会自动恢复之前的房间
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -82,7 +82,7 @@ The current server implementation:
 - supports `memory` and `redis` room storage providers
 - persists room base state when `ROOM_STORE_PROVIDER=redis`
 - requires `roomCode + joinToken` for room join and `memberToken` for room messages
-- reissues `memberToken` after reconnect or server restart
+- on rejoin, reuses a still-valid previous `memberToken` and issues a new one otherwise
 - keeps empty rooms until `EMPTY_ROOM_TTL_MS` expires instead of deleting them immediately
 - supports origin allowlists, connection throttling, message throttling, and structured security logs
 
@@ -503,7 +503,7 @@ If you run multiple room nodes, prefer a rolling restart instead of restarting e
 - With `ROOM_STORE_PROVIDER=redis`, room base state survives restart until it expires or is deleted.
 - Rooms are not deleted immediately when the last member leaves; the server writes `expiresAt` and retains the room until `EMPTY_ROOM_TTL_MS` elapses.
 - Room join requires both `roomCode` and `joinToken`; room messages require a valid `memberToken`.
-- `memberToken` is session-bound, never restored from persistence, and is re-issued after reconnect or restart.
+- `memberToken` is session-bound; a rejoin that presents a still-valid previous token reuses it, otherwise a new one is issued (the extension discards its stored token on disconnect, so it typically rejoins with a fresh token).
 - Handshake origin checks are deny-by-default unless you explicitly allow missing `Origin` in development.
 - `X-Forwarded-For` is ignored unless the socket peer matches `TRUSTED_PROXY_ADDRESSES`.
 - Health checks are available on both `GET /` and `GET /healthz`; readiness is `GET /readyz`.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -503,7 +503,7 @@ If you run multiple room nodes, prefer a rolling restart instead of restarting e
 - With `ROOM_STORE_PROVIDER=redis`, room base state survives restart until it expires or is deleted.
 - Rooms are not deleted immediately when the last member leaves; the server writes `expiresAt` and retains the room until `EMPTY_ROOM_TTL_MS` elapses.
 - Room join requires both `roomCode` and `joinToken`; room messages require a valid `memberToken`.
-- `memberToken` is session-bound; a rejoin that presents a still-valid previous token reuses it, otherwise a new one is issued (the extension discards its stored token on disconnect, so it typically rejoins with a fresh token).
+- `memberToken` is session-bound; a rejoin that presents a still-valid previous token reuses it, otherwise a new one is issued. The extension keeps its cached token across automatic reconnects and clears it only on explicit leave or an admin-initiated session teardown.
 - Handshake origin checks are deny-by-default unless you explicitly allow missing `Origin` in development.
 - `X-Forwarded-For` is ignored unless the socket peer matches `TRUSTED_PROXY_ADDRESSES`.
 - Health checks are available on both `GET /` and `GET /healthz`; readiness is `GET /readyz`.

--- a/docs/operations/deployment.zh-CN.md
+++ b/docs/operations/deployment.zh-CN.md
@@ -82,7 +82,7 @@ npm run build:release
 - 支持 `memory` 和 `redis` 两种房间存储实现
 - 当 `ROOM_STORE_PROVIDER=redis` 时会持久化房间基础状态
 - 房间加入需要 `roomCode + joinToken`，房间消息需要 `memberToken`
-- 服务重连或服务端重启后会重新签发 `memberToken`
+- 重连携带仍有效的旧 `memberToken` 时复用，否则重新签发
 - 最后一名成员离开后，房间不会立即删除，而是保留到 `EMPTY_ROOM_TTL_MS` 到期
 - 支持 Origin 白名单、连接限流、消息限流和结构化安全日志
 
@@ -503,7 +503,7 @@ sudo systemctl restart bili-syncplay-global-admin
 - 当 `ROOM_STORE_PROVIDER=redis` 时，房间基础状态会在重启后保留，直到过期或被删除。
 - 最后一名成员离开后，房间不会立刻删除；服务端会写入 `expiresAt`，并在 `EMPTY_ROOM_TTL_MS` 到期后清理。
 - 加入房间需要同时提供 `roomCode` 和 `joinToken`；发送房间消息需要有效的 `memberToken`。
-- `memberToken` 是会话态，不会从持久层恢复；重连或重启后都需要重新加入并重新签发。
+- `memberToken` 是会话态；重连携带仍有效的旧 token 时复用，否则重新签发（扩展会在断开连接时清除本地保存的 token，因此通常以新 token 重新加入）。
 - 握手阶段的 Origin 检查默认拒绝，除非你在开发环境中显式允许缺失 `Origin`。
 - 只有当 socket 对端命中 `TRUSTED_PROXY_ADDRESSES` 时才会读取 `X-Forwarded-For`。
 - 健康检查同时提供 `GET /` 与 `GET /healthz`；就绪检查为 `GET /readyz`。

--- a/docs/operations/deployment.zh-CN.md
+++ b/docs/operations/deployment.zh-CN.md
@@ -503,7 +503,7 @@ sudo systemctl restart bili-syncplay-global-admin
 - 当 `ROOM_STORE_PROVIDER=redis` 时，房间基础状态会在重启后保留，直到过期或被删除。
 - 最后一名成员离开后，房间不会立刻删除；服务端会写入 `expiresAt`，并在 `EMPTY_ROOM_TTL_MS` 到期后清理。
 - 加入房间需要同时提供 `roomCode` 和 `joinToken`；发送房间消息需要有效的 `memberToken`。
-- `memberToken` 是会话态；重连携带仍有效的旧 token 时复用，否则重新签发（扩展会在断开连接时清除本地保存的 token，因此通常以新 token 重新加入）。
+- `memberToken` 是会话态；重连携带仍有效的旧 token 时复用，否则重新签发。扩展在自动重连时保留缓存的 token，只有显式离开或管理端终止会话时才清除。
 - 握手阶段的 Origin 检查默认拒绝，除非你在开发环境中显式允许缺失 `Origin`。
 - 只有当 socket 对端命中 `TRUSTED_PROXY_ADDRESSES` 时才会读取 `X-Forwarded-For`。
 - 健康检查同时提供 `GET /` 与 `GET /healthz`；就绪检查为 `GET /readyz`。

--- a/docs/operations/multi-node.md
+++ b/docs/operations/multi-node.md
@@ -26,7 +26,7 @@ The server does not implement L4/L7 load balancing inside the application proces
 > If you are only doing local development or one-node deployment, you can stay on the single-node setup. The rest of this section is mainly for production multi-node rollout.
 
 For day-2 operations such as scaling, Redis incidents, admin credential rotation, and alert triage, see the
-[multi-node operations runbook](../runbook/multi-node-operations.zh-CN.md).
+[multi-node operations runbook](../runbook/multi-node-operations.md).
 
 ## Minimum required shared settings
 

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -18,19 +18,19 @@ Clients send `protocolVersion` inside the `room:create` / `room:join` payload; t
 
 ### `SharedVideo`
 
-| Field                 | Type      | Notes                       |
-| --------------------- | --------- | --------------------------- |
-| `videoId`             | `string`  | Normalized video identity   |
-| `url`                 | `string`  | Normalized video URL        |
-| `title`               | `string`  | Display title               |
-| `sharedByMemberId`    | `string?` | Member who shared the video |
-| `sharedByDisplayName` | `string?` | Display name of that member |
+| Field                 | Type      | Notes                                                                                                                                                                         |
+| --------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `videoId`             | `string`  | Normalized video identity                                                                                                                                                     |
+| `url`                 | `string`  | Share URL as sent by the sharer — accepted by the normalization helpers but not guaranteed pre-normalized (festival shares keep the raw page URL); normalize before comparing |
+| `title`               | `string`  | Display title                                                                                                                                                                 |
+| `sharedByMemberId`    | `string?` | Member who shared the video                                                                                                                                                   |
+| `sharedByDisplayName` | `string?` | Display name of that member                                                                                                                                                   |
 
 ### `PlaybackState`
 
 | Field           | Type                                        | Notes                                                                                                                                                                                   |
 | --------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `url`           | `string`                                    | Normalized URL the state applies to                                                                                                                                                     |
+| `url`           | `string`                                    | URL the state applies to; like `SharedVideo.url`, normalize before comparing                                                                                                            |
 | `currentTime`   | `number`                                    | Playback position in seconds                                                                                                                                                            |
 | `playState`     | `"playing" \| "paused" \| "buffering"`      | `PlaybackPlayState`                                                                                                                                                                     |
 | `syncIntent`    | `"explicit-seek" \| "explicit-ratechange"?` | Marks a state produced by an explicit seek / rate change (`PlaybackSyncIntent`)                                                                                                         |
@@ -66,11 +66,15 @@ Clients send `protocolVersion` inside the `room:create` / `room:join` payload; t
 | -------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `room:created`       | `{ roomCode, memberId, joinToken, memberToken, serverProtocolVersion? }` | Room created; carries the invite and session tokens                                                                                     |
 | `room:joined`        | `{ roomCode, memberId, memberToken, serverProtocolVersion? }`            | Join succeeded; returns the session `memberToken` (a rejoin with a still-valid previous token reuses it, otherwise a new one is issued) |
-| `room:state`         | `RoomState`                                                              | Full room snapshot (after join, on request, on change)                                                                                  |
-| `room:member-joined` | `{ roomCode, member: RoomMember }`                                       | A member joined                                                                                                                         |
-| `room:member-left`   | `{ roomCode, member: RoomMember }`                                       | A member left                                                                                                                           |
+| `room:state`         | `RoomState`                                                              | Full room snapshot (after join, on request, on shared-video / playback changes)                                                         |
+| `room:member-joined` | `{ roomCode, member: RoomMember }`                                       | Member joined (delta, sent to `protocolVersion >= 2` clients)                                                                           |
+| `room:member-left`   | `{ roomCode, member: RoomMember }`                                       | Member left (delta, sent to `protocolVersion >= 2` clients)                                                                             |
 | `error`              | `{ code: ErrorCode, message }`                                           | Request failed                                                                                                                          |
 | `sync:pong`          | `{ clientSendTime, serverReceiveTime, serverSendTime }`                  | Clock-offset probe response                                                                                                             |
+
+### Membership deltas
+
+Membership changes are version-gated (`MEMBER_DELTA_PROTOCOL_VERSION = 2` in `server/src/room-event-consumer.ts`): clients with `protocolVersion >= 2` receive `room:member-joined` / `room:member-left` deltas and must apply them to their member list — `room:state` is not re-broadcast for membership changes. Legacy clients (v1 or no version) receive a full `room:state` instead.
 
 ### Clock synchronization
 

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -1,0 +1,104 @@
+# Protocol Reference
+
+[English](./protocol.md) | [简体中文](./protocol.zh-CN.md)
+
+`@bili-syncplay/protocol` (`packages/protocol/`) is the single source of truth for the wire protocol between the extension and the server: message types, domain types, type guards, and Bilibili URL normalization. Always import through the package root; internal file layout is not part of the public surface. For the change process (versioning, compatibility windows, test checklist), see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Versioning
+
+| Constant                   | Location                                | Value | Meaning                                                      |
+| -------------------------- | --------------------------------------- | ----- | ------------------------------------------------------------ |
+| `PROTOCOL_VERSION`         | `packages/protocol/src/types/common.ts` | `3`   | Version sent by the extension in `room:create` / `room:join` |
+| `CURRENT_PROTOCOL_VERSION` | `server/src/messages.ts`                | `3`   | Version the server currently speaks                          |
+| `MIN_PROTOCOL_VERSION`     | `server/src/messages.ts`                | `1`   | Oldest client version the server still accepts               |
+
+Clients send `protocolVersion` inside the `room:create` / `room:join` payload; the server rejects clients below `MIN_PROTOCOL_VERSION` with the `unsupported_protocol_version` error code. Legacy clients that omit `protocolVersion` are treated according to the server's compatibility policy in `server/src/messages.ts`.
+
+## Domain Types
+
+### `SharedVideo`
+
+| Field                 | Type      | Notes                       |
+| --------------------- | --------- | --------------------------- |
+| `videoId`             | `string`  | Normalized video identity   |
+| `url`                 | `string`  | Normalized video URL        |
+| `title`               | `string`  | Display title               |
+| `sharedByMemberId`    | `string?` | Member who shared the video |
+| `sharedByDisplayName` | `string?` | Display name of that member |
+
+### `PlaybackState`
+
+| Field           | Type                                        | Notes                                                                                                                                                                                   |
+| --------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`           | `string`                                    | Normalized URL the state applies to                                                                                                                                                     |
+| `currentTime`   | `number`                                    | Playback position in seconds                                                                                                                                                            |
+| `playState`     | `"playing" \| "paused" \| "buffering"`      | `PlaybackPlayState`                                                                                                                                                                     |
+| `syncIntent`    | `"explicit-seek" \| "explicit-ratechange"?` | Marks a state produced by an explicit seek / rate change (`PlaybackSyncIntent`)                                                                                                         |
+| `userInitiated` | `boolean?`                                  | Hint that the transition came from an explicit user gesture rather than a buffer stall or remote-state application; receivers may skip flicker-defence debounces. Optional and additive |
+| `naturalEnd`    | `boolean?`                                  | Hint that this paused state came from the shared video reaching its natural end; receivers apply it but suppress the misleading "paused" toast. Optional and additive                   |
+| `playbackRate`  | `number`                                    | Playback rate                                                                                                                                                                           |
+| `updatedAt`     | `number`                                    | Sender timestamp (ms)                                                                                                                                                                   |
+| `serverTime`    | `number`                                    | Server timestamp stamped on relay (ms)                                                                                                                                                  |
+| `actorId`       | `string`                                    | Member who produced the state                                                                                                                                                           |
+| `seq`           | `number`                                    | Monotonic sequence number for ordering                                                                                                                                                  |
+
+### `RoomState` and `RoomMember`
+
+- `RoomMember`: `{ id: string; name: string }`
+- `RoomState`: `{ roomCode: RoomCode; sharedVideo: SharedVideo | null; playback: PlaybackState | null; members: RoomMember[] }`
+
+## Client Messages (`ClientMessage`)
+
+| Type              | Payload                                                                 | Auth          | Purpose                                        |
+| ----------------- | ----------------------------------------------------------------------- | ------------- | ---------------------------------------------- |
+| `room:create`     | `{ displayName?, protocolVersion? }?`                                   | —             | Create a room                                  |
+| `room:join`       | `{ roomCode, joinToken, memberToken?, displayName?, protocolVersion? }` | `joinToken`   | Join (or rejoin with a previous `memberToken`) |
+| `profile:update`  | `{ memberToken, displayName }`                                          | `memberToken` | Change display name                            |
+| `room:leave`      | `{ memberToken? }?`                                                     | `memberToken` | Leave the current room                         |
+| `video:share`     | `{ memberToken, video: SharedVideo, playback?: PlaybackState }`         | `memberToken` | Share / replace the room's shared video        |
+| `playback:update` | `{ memberToken, playback: PlaybackState }`                              | `memberToken` | Broadcast a playback state change              |
+| `sync:request`    | `{ memberToken }`                                                       | `memberToken` | Request the current room state                 |
+| `sync:ping`       | `{ clientSendTime }`                                                    | —             | Clock-offset probe                             |
+
+## Server Messages (`ServerMessage`)
+
+| Type                 | Payload                                                                  | Purpose                                                |
+| -------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------ |
+| `room:created`       | `{ roomCode, memberId, joinToken, memberToken, serverProtocolVersion? }` | Room created; carries the invite and session tokens    |
+| `room:joined`        | `{ roomCode, memberId, memberToken, serverProtocolVersion? }`            | Join succeeded; issues a fresh `memberToken`           |
+| `room:state`         | `RoomState`                                                              | Full room snapshot (after join, on request, on change) |
+| `room:member-joined` | `{ roomCode, member: RoomMember }`                                       | A member joined                                        |
+| `room:member-left`   | `{ roomCode, member: RoomMember }`                                       | A member left                                          |
+| `error`              | `{ code: ErrorCode, message }`                                           | Request failed                                         |
+| `sync:pong`          | `{ clientSendTime, serverReceiveTime, serverSendTime }`                  | Clock-offset probe response                            |
+
+### Clock synchronization
+
+`sync:ping` / `sync:pong` implement an NTP-style exchange: the client compares `clientSendTime`, `serverReceiveTime`, `serverSendTime`, and its own receive time to estimate the clock offset used when applying `PlaybackState.serverTime`. The extension's `clock-controller.ts` maintains this offset.
+
+## Error Codes (`ErrorCode`)
+
+`origin_not_allowed`, `room_not_found`, `join_token_invalid`, `member_token_invalid`, `not_in_room`, `rate_limited`, `invalid_message`, `payload_too_large`, `room_full`, `unsupported_protocol_version`, `internal_error`
+
+The developer-facing symptoms for the common codes are listed in the [troubleshooting section](../development.md#troubleshooting).
+
+## URL Normalization
+
+`parseBilibiliVideoRef(url)` parses a supported Bilibili page URL into `{ videoId, normalizedUrl }`; `normalizeBilibiliUrl(url)` returns just the normalized URL (or `null`). Only `www.bilibili.com` is accepted, with these path shapes:
+
+- `/video/<id>` (multi-part via `?p=`)
+- `/bangumi/play/<id>`
+- `/festival/<id>` (identity from `bvid` + `cid` query parameters)
+- `/list/watchlater` and `/medialist/play/watchlater` (require `bvid` in the query)
+
+All video-identity comparisons in the extension and server must go through these helpers instead of ad-hoc URL string handling.
+
+## Type Guards
+
+Every wire shape has a runtime guard exported from the package root, used by the server to validate inbound messages and by the extension to validate server frames:
+
+- `isClientMessage(value)` / `isServerMessage(value)` — top-level dispatch guards
+- Per-shape guards such as `isSharedVideo`, `isPlaybackState`, `isRoomState`, `isRoomMember`, `isErrorMessage`, `isClientHelloPayload`
+- Primitive guards such as `isRoomCode`, `isToken`, `isVideoId`, `isBilibiliUrl`, `isPlaybackPlayState`
+
+When adding or changing a message, update the corresponding guard and its accepted/rejected payload tests in the same change (see the checklist in [CONTRIBUTING.md](../../CONTRIBUTING.md)).

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -95,10 +95,11 @@ All video-identity comparisons in the extension and server must go through these
 
 ## Type Guards
 
-Every wire shape has a runtime guard exported from the package root, used by the server to validate inbound messages and by the extension to validate server frames:
+Runtime guards are exported from the package root. For wire validation, use the top-level guards:
 
-- `isClientMessage(value)` / `isServerMessage(value)` — top-level dispatch guards
-- Per-shape guards such as `isSharedVideo`, `isPlaybackState`, `isRoomState`, `isRoomMember`, `isErrorMessage`, `isClientHelloPayload`
-- Primitive guards such as `isRoomCode`, `isToken`, `isVideoId`, `isBilibiliUrl`, `isPlaybackPlayState`
+- `isClientMessage(value)` — the server validates inbound client frames with this
+- `isServerMessage(value)` — the extension validates server frames with this; `isRoomState(value)` covers a bare room snapshot
+
+The other exported guards (`isSharedVideo`, `isPlaybackState`, `isClientHelloPayload`, `isRoomMember`, `isErrorMessage`, and primitives such as `isRoomCode`, `isToken`, `isVideoId`, `isBilibiliUrl`, `isPlaybackPlayState`) exist to compose and test the message guards. Note that the exported `isSharedVideo` and `isPlaybackState` come from the client-message guard set and enforce client-payload limits — for example, `isSharedVideo` caps `sharedByMemberId` at 32 characters, while server-issued member ids are 36-character UUIDs — so a server-populated `room:state.sharedVideo` can legitimately fail them. Do not validate server frames with client-payload guards; `isServerMessage` / `isRoomState` internally apply the more lenient server-side shapes.
 
 When adding or changing a message, update the corresponding guard and its accepted/rejected payload tests in the same change (see the checklist in [CONTRIBUTING.md](../../CONTRIBUTING.md)).

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -62,15 +62,15 @@ Clients send `protocolVersion` inside the `room:create` / `room:join` payload; t
 
 ## Server Messages (`ServerMessage`)
 
-| Type                 | Payload                                                                  | Purpose                                                |
-| -------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------ |
-| `room:created`       | `{ roomCode, memberId, joinToken, memberToken, serverProtocolVersion? }` | Room created; carries the invite and session tokens    |
-| `room:joined`        | `{ roomCode, memberId, memberToken, serverProtocolVersion? }`            | Join succeeded; issues a fresh `memberToken`           |
-| `room:state`         | `RoomState`                                                              | Full room snapshot (after join, on request, on change) |
-| `room:member-joined` | `{ roomCode, member: RoomMember }`                                       | A member joined                                        |
-| `room:member-left`   | `{ roomCode, member: RoomMember }`                                       | A member left                                          |
-| `error`              | `{ code: ErrorCode, message }`                                           | Request failed                                         |
-| `sync:pong`          | `{ clientSendTime, serverReceiveTime, serverSendTime }`                  | Clock-offset probe response                            |
+| Type                 | Payload                                                                  | Purpose                                                                                                                                 |
+| -------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `room:created`       | `{ roomCode, memberId, joinToken, memberToken, serverProtocolVersion? }` | Room created; carries the invite and session tokens                                                                                     |
+| `room:joined`        | `{ roomCode, memberId, memberToken, serverProtocolVersion? }`            | Join succeeded; returns the session `memberToken` (a rejoin with a still-valid previous token reuses it, otherwise a new one is issued) |
+| `room:state`         | `RoomState`                                                              | Full room snapshot (after join, on request, on change)                                                                                  |
+| `room:member-joined` | `{ roomCode, member: RoomMember }`                                       | A member joined                                                                                                                         |
+| `room:member-left`   | `{ roomCode, member: RoomMember }`                                       | A member left                                                                                                                           |
+| `error`              | `{ code: ErrorCode, message }`                                           | Request failed                                                                                                                          |
+| `sync:pong`          | `{ clientSendTime, serverReceiveTime, serverSendTime }`                  | Clock-offset probe response                                                                                                             |
 
 ### Clock synchronization
 

--- a/docs/reference/protocol.zh-CN.md
+++ b/docs/reference/protocol.zh-CN.md
@@ -18,19 +18,19 @@
 
 ### `SharedVideo`
 
-| 字段                  | 类型      | 说明               |
-| --------------------- | --------- | ------------------ |
-| `videoId`             | `string`  | 归一化后的视频标识 |
-| `url`                 | `string`  | 归一化后的视频 URL |
-| `title`               | `string`  | 展示标题           |
-| `sharedByMemberId`    | `string?` | 分享者成员 ID      |
-| `sharedByDisplayName` | `string?` | 分享者昵称         |
+| 字段                  | 类型      | 说明                                                                                                              |
+| --------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
+| `videoId`             | `string`  | 归一化后的视频标识                                                                                                |
+| `url`                 | `string`  | 分享方发送的分享 URL——可被归一化 helper 接受，但不保证已归一化（festival 分享保留原始页面 URL）；比较前必须归一化 |
+| `title`               | `string`  | 展示标题                                                                                                          |
+| `sharedByMemberId`    | `string?` | 分享者成员 ID                                                                                                     |
+| `sharedByDisplayName` | `string?` | 分享者昵称                                                                                                        |
 
 ### `PlaybackState`
 
 | 字段            | 类型                                        | 说明                                                                                               |
 | --------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `url`           | `string`                                    | 该状态对应的归一化 URL                                                                             |
+| `url`           | `string`                                    | 该状态对应的 URL；与 `SharedVideo.url` 一样，比较前必须归一化                                      |
 | `currentTime`   | `number`                                    | 播放位置（秒）                                                                                     |
 | `playState`     | `"playing" \| "paused" \| "buffering"`      | `PlaybackPlayState`                                                                                |
 | `syncIntent`    | `"explicit-seek" \| "explicit-ratechange"?` | 标记由显式 seek / 倍速操作产生的状态（`PlaybackSyncIntent`）                                       |
@@ -66,11 +66,15 @@
 | -------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
 | `room:created`       | `{ roomCode, memberId, joinToken, memberToken, serverProtocolVersion? }` | 房间已创建，携带邀请与会话 token                                                      |
 | `room:joined`        | `{ roomCode, memberId, memberToken, serverProtocolVersion? }`            | 加入成功，返回本次会话的 `memberToken`（重连携带仍有效的旧 token 时复用，否则新签发） |
-| `room:state`         | `RoomState`                                                              | 房间完整快照（加入后、按请求、状态变化时）                                            |
-| `room:member-joined` | `{ roomCode, member: RoomMember }`                                       | 成员加入                                                                              |
-| `room:member-left`   | `{ roomCode, member: RoomMember }`                                       | 成员离开                                                                              |
+| `room:state`         | `RoomState`                                                              | 房间完整快照（加入后、按请求、共享视频/播放状态变化时）                               |
+| `room:member-joined` | `{ roomCode, member: RoomMember }`                                       | 成员加入（增量消息，发给 `protocolVersion >= 2` 客户端）                              |
+| `room:member-left`   | `{ roomCode, member: RoomMember }`                                       | 成员离开（增量消息，发给 `protocolVersion >= 2` 客户端）                              |
 | `error`              | `{ code: ErrorCode, message }`                                           | 请求失败                                                                              |
 | `sync:pong`          | `{ clientSendTime, serverReceiveTime, serverSendTime }`                  | 时钟偏移探测响应                                                                      |
+
+### 成员增量消息
+
+成员变更按协议版本分流（`server/src/room-event-consumer.ts` 中 `MEMBER_DELTA_PROTOCOL_VERSION = 2`）：`protocolVersion >= 2` 的客户端收到 `room:member-joined` / `room:member-left` 增量，必须据此维护成员列表——成员变更不会重新广播 `room:state`；旧客户端（v1 或未携带版本号）则收到完整 `room:state`。
 
 ### 时钟同步
 

--- a/docs/reference/protocol.zh-CN.md
+++ b/docs/reference/protocol.zh-CN.md
@@ -1,0 +1,104 @@
+# 协议参考
+
+[English](./protocol.md) | [简体中文](./protocol.zh-CN.md)
+
+`@bili-syncplay/protocol`（`packages/protocol/`）是扩展与服务端之间线上协议的单一可信来源：消息类型、领域类型、类型守卫和 Bilibili URL 归一化。请始终通过包根导入；内部文件布局不属于公开接口。变更流程（版本号、兼容窗口、测试清单）见 [CONTRIBUTING.md](../../CONTRIBUTING.md)。
+
+## 版本管理
+
+| 常量                       | 位置                                    | 当前值 | 含义                                              |
+| -------------------------- | --------------------------------------- | ------ | ------------------------------------------------- |
+| `PROTOCOL_VERSION`         | `packages/protocol/src/types/common.ts` | `3`    | 扩展在 `room:create` / `room:join` 中携带的版本号 |
+| `CURRENT_PROTOCOL_VERSION` | `server/src/messages.ts`                | `3`    | 服务端当前使用的版本                              |
+| `MIN_PROTOCOL_VERSION`     | `server/src/messages.ts`                | `1`    | 服务端仍接受的最老客户端版本                      |
+
+客户端在 `room:create` / `room:join` 的 payload 中携带 `protocolVersion`；低于 `MIN_PROTOCOL_VERSION` 的客户端会被以 `unsupported_protocol_version` 错误码拒绝。未携带 `protocolVersion` 的旧客户端按 `server/src/messages.ts` 中的兼容策略处理。
+
+## 领域类型
+
+### `SharedVideo`
+
+| 字段                  | 类型      | 说明               |
+| --------------------- | --------- | ------------------ |
+| `videoId`             | `string`  | 归一化后的视频标识 |
+| `url`                 | `string`  | 归一化后的视频 URL |
+| `title`               | `string`  | 展示标题           |
+| `sharedByMemberId`    | `string?` | 分享者成员 ID      |
+| `sharedByDisplayName` | `string?` | 分享者昵称         |
+
+### `PlaybackState`
+
+| 字段            | 类型                                        | 说明                                                                                               |
+| --------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `url`           | `string`                                    | 该状态对应的归一化 URL                                                                             |
+| `currentTime`   | `number`                                    | 播放位置（秒）                                                                                     |
+| `playState`     | `"playing" \| "paused" \| "buffering"`      | `PlaybackPlayState`                                                                                |
+| `syncIntent`    | `"explicit-seek" \| "explicit-ratechange"?` | 标记由显式 seek / 倍速操作产生的状态（`PlaybackSyncIntent`）                                       |
+| `userInitiated` | `boolean?`                                  | 提示该状态变化来自显式用户手势，而非缓冲卡顿或远端状态回放；接收方可跳过防闪烁防抖。可选、向后兼容 |
+| `naturalEnd`    | `boolean?`                                  | 提示该 paused 状态来自共享视频自然播完；接收方应用状态但不弹出误导性的"已暂停"提示。可选、向后兼容 |
+| `playbackRate`  | `number`                                    | 播放速率                                                                                           |
+| `updatedAt`     | `number`                                    | 发送方时间戳（毫秒）                                                                               |
+| `serverTime`    | `number`                                    | 服务端转发时盖的时间戳（毫秒）                                                                     |
+| `actorId`       | `string`                                    | 产生该状态的成员                                                                                   |
+| `seq`           | `number`                                    | 用于排序的单调递增序号                                                                             |
+
+### `RoomState` 与 `RoomMember`
+
+- `RoomMember`：`{ id: string; name: string }`
+- `RoomState`：`{ roomCode: RoomCode; sharedVideo: SharedVideo | null; playback: PlaybackState | null; members: RoomMember[] }`
+
+## 客户端消息（`ClientMessage`）
+
+| 类型              | Payload                                                                 | 鉴权          | 用途                                    |
+| ----------------- | ----------------------------------------------------------------------- | ------------- | --------------------------------------- |
+| `room:create`     | `{ displayName?, protocolVersion? }?`                                   | —             | 创建房间                                |
+| `room:join`       | `{ roomCode, joinToken, memberToken?, displayName?, protocolVersion? }` | `joinToken`   | 加入房间（带旧 `memberToken` 时为重连） |
+| `profile:update`  | `{ memberToken, displayName }`                                          | `memberToken` | 修改昵称                                |
+| `room:leave`      | `{ memberToken? }?`                                                     | `memberToken` | 离开当前房间                            |
+| `video:share`     | `{ memberToken, video: SharedVideo, playback?: PlaybackState }`         | `memberToken` | 分享 / 替换房间共享视频                 |
+| `playback:update` | `{ memberToken, playback: PlaybackState }`                              | `memberToken` | 广播播放状态变化                        |
+| `sync:request`    | `{ memberToken }`                                                       | `memberToken` | 请求当前房间状态                        |
+| `sync:ping`       | `{ clientSendTime }`                                                    | —             | 时钟偏移探测                            |
+
+## 服务端消息（`ServerMessage`）
+
+| 类型                 | Payload                                                                  | 用途                                       |
+| -------------------- | ------------------------------------------------------------------------ | ------------------------------------------ |
+| `room:created`       | `{ roomCode, memberId, joinToken, memberToken, serverProtocolVersion? }` | 房间已创建，携带邀请与会话 token           |
+| `room:joined`        | `{ roomCode, memberId, memberToken, serverProtocolVersion? }`            | 加入成功，签发新 `memberToken`             |
+| `room:state`         | `RoomState`                                                              | 房间完整快照（加入后、按请求、状态变化时） |
+| `room:member-joined` | `{ roomCode, member: RoomMember }`                                       | 成员加入                                   |
+| `room:member-left`   | `{ roomCode, member: RoomMember }`                                       | 成员离开                                   |
+| `error`              | `{ code: ErrorCode, message }`                                           | 请求失败                                   |
+| `sync:pong`          | `{ clientSendTime, serverReceiveTime, serverSendTime }`                  | 时钟偏移探测响应                           |
+
+### 时钟同步
+
+`sync:ping` / `sync:pong` 实现 NTP 式往返：客户端比较 `clientSendTime`、`serverReceiveTime`、`serverSendTime` 与自身接收时间，估算应用 `PlaybackState.serverTime` 时使用的时钟偏移。扩展端由 `clock-controller.ts` 维护该偏移。
+
+## 错误码（`ErrorCode`）
+
+`origin_not_allowed`、`room_not_found`、`join_token_invalid`、`member_token_invalid`、`not_in_room`、`rate_limited`、`invalid_message`、`payload_too_large`、`room_full`、`unsupported_protocol_version`、`internal_error`
+
+常见错误码对应的开发者侧现象见[故障排查](../development.zh-CN.md#故障排查)。
+
+## URL 归一化
+
+`parseBilibiliVideoRef(url)` 把受支持的 Bilibili 页面 URL 解析为 `{ videoId, normalizedUrl }`；`normalizeBilibiliUrl(url)` 只返回归一化 URL（无法解析时返回 `null`）。仅接受 `www.bilibili.com`，支持以下路径形态：
+
+- `/video/<id>`（多 P 通过 `?p=` 区分）
+- `/bangumi/play/<id>`
+- `/festival/<id>`（通过 query 中的 `bvid` + `cid` 确定身份）
+- `/list/watchlater` 与 `/medialist/play/watchlater`（要求 query 中带 `bvid`）
+
+扩展与服务端的所有视频身份比较都必须经过这些 helper，不允许各自手写 URL 字符串处理。
+
+## 类型守卫
+
+每种线上结构都有从包根导出的运行时守卫，服务端用于校验入站消息，扩展用于校验服务端帧：
+
+- `isClientMessage(value)` / `isServerMessage(value)`——顶层分发守卫
+- 结构级守卫，如 `isSharedVideo`、`isPlaybackState`、`isRoomState`、`isRoomMember`、`isErrorMessage`、`isClientHelloPayload`
+- 原语守卫，如 `isRoomCode`、`isToken`、`isVideoId`、`isBilibiliUrl`、`isPlaybackPlayState`
+
+新增或修改消息时，必须在同一变更中更新对应守卫及其接受/拒绝用例测试（见 [CONTRIBUTING.md](../../CONTRIBUTING.md) 的清单）。

--- a/docs/reference/protocol.zh-CN.md
+++ b/docs/reference/protocol.zh-CN.md
@@ -95,10 +95,11 @@
 
 ## 类型守卫
 
-每种线上结构都有从包根导出的运行时守卫，服务端用于校验入站消息，扩展用于校验服务端帧：
+运行时守卫从包根导出。线上校验请使用顶层守卫：
 
-- `isClientMessage(value)` / `isServerMessage(value)`——顶层分发守卫
-- 结构级守卫，如 `isSharedVideo`、`isPlaybackState`、`isRoomState`、`isRoomMember`、`isErrorMessage`、`isClientHelloPayload`
-- 原语守卫，如 `isRoomCode`、`isToken`、`isVideoId`、`isBilibiliUrl`、`isPlaybackPlayState`
+- `isClientMessage(value)`——服务端用它校验入站客户端帧
+- `isServerMessage(value)`——扩展用它校验服务端帧；单独的房间快照用 `isRoomState(value)`
+
+其余导出的守卫（`isSharedVideo`、`isPlaybackState`、`isClientHelloPayload`、`isRoomMember`、`isErrorMessage`，以及 `isRoomCode`、`isToken`、`isVideoId`、`isBilibiliUrl`、`isPlaybackPlayState` 等原语守卫）用于组合与测试上述消息守卫。注意：导出的 `isSharedVideo` 与 `isPlaybackState` 来自客户端消息守卫集，带有客户端 payload 限制——例如 `isSharedVideo` 把 `sharedByMemberId` 上限设为 32 字符，而服务端签发的成员 ID 是 36 字符 UUID——因此服务端填充的 `room:state.sharedVideo` 可能被它们合法地拒绝。不要用客户端 payload 守卫校验服务端帧；`isServerMessage` / `isRoomState` 内部使用更宽松的服务端结构。
 
 新增或修改消息时，必须在同一变更中更新对应守卫及其接受/拒绝用例测试（见 [CONTRIBUTING.md](../../CONTRIBUTING.md) 的清单）。

--- a/docs/reference/protocol.zh-CN.md
+++ b/docs/reference/protocol.zh-CN.md
@@ -62,15 +62,15 @@
 
 ## 服务端消息（`ServerMessage`）
 
-| 类型                 | Payload                                                                  | 用途                                       |
-| -------------------- | ------------------------------------------------------------------------ | ------------------------------------------ |
-| `room:created`       | `{ roomCode, memberId, joinToken, memberToken, serverProtocolVersion? }` | 房间已创建，携带邀请与会话 token           |
-| `room:joined`        | `{ roomCode, memberId, memberToken, serverProtocolVersion? }`            | 加入成功，签发新 `memberToken`             |
-| `room:state`         | `RoomState`                                                              | 房间完整快照（加入后、按请求、状态变化时） |
-| `room:member-joined` | `{ roomCode, member: RoomMember }`                                       | 成员加入                                   |
-| `room:member-left`   | `{ roomCode, member: RoomMember }`                                       | 成员离开                                   |
-| `error`              | `{ code: ErrorCode, message }`                                           | 请求失败                                   |
-| `sync:pong`          | `{ clientSendTime, serverReceiveTime, serverSendTime }`                  | 时钟偏移探测响应                           |
+| 类型                 | Payload                                                                  | 用途                                                                                  |
+| -------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `room:created`       | `{ roomCode, memberId, joinToken, memberToken, serverProtocolVersion? }` | 房间已创建，携带邀请与会话 token                                                      |
+| `room:joined`        | `{ roomCode, memberId, memberToken, serverProtocolVersion? }`            | 加入成功，返回本次会话的 `memberToken`（重连携带仍有效的旧 token 时复用，否则新签发） |
+| `room:state`         | `RoomState`                                                              | 房间完整快照（加入后、按请求、状态变化时）                                            |
+| `room:member-joined` | `{ roomCode, member: RoomMember }`                                       | 成员加入                                                                              |
+| `room:member-left`   | `{ roomCode, member: RoomMember }`                                       | 成员离开                                                                              |
+| `error`              | `{ code: ErrorCode, message }`                                           | 请求失败                                                                              |
+| `sync:pong`          | `{ clientSendTime, serverReceiveTime, serverSendTime }`                  | 时钟偏移探测响应                                                                      |
 
 ### 时钟同步
 

--- a/docs/runbook/multi-node-operations.md
+++ b/docs/runbook/multi-node-operations.md
@@ -1,0 +1,312 @@
+# Bili-SyncPlay Multi-Node Operations Runbook
+
+[English](./multi-node-operations.md) | [简体中文](./multi-node-operations.zh-CN.md)
+
+This document is written for day-to-day operations and on-call response. It covers scaling multiple room nodes, the dedicated global admin, Redis-backed shared control plane, Redis incidents, admin credential rotation, and triage for common alerts.
+
+## Scope
+
+- End users connect through a single entrypoint such as `wss://sync.example.com`.
+- Room nodes run `server/dist/index.js` and serve WebSocket traffic, `/healthz`, and `/readyz`.
+- The global admin runs `server/dist/global-admin-index.js` and serves `/admin` and `/api/admin/*`.
+- Redis backs persisted room base state, runtime indexes, event streams, audit streams, the room event bus, admin sessions, and the admin command bus.
+
+## Topology
+
+```mermaid
+flowchart LR
+  user[Browser extension users] --> edge[Edge / LB<br/>Nginx, HAProxy, ALB]
+  sre[SRE / operator] --> adminEdge[Admin edge / LB]
+  edge --> roomA[room-node-a<br/>server/dist/index.js]
+  edge --> roomB[room-node-b<br/>server/dist/index.js]
+  adminEdge --> globalAdmin[global-admin<br/>server/dist/global-admin-index.js]
+  roomA --> redis[(Redis)]
+  roomB --> redis
+  globalAdmin --> redis
+```
+
+Room nodes do not implement load balancing. The production edge layer must handle TLS termination, WebSocket reverse proxying, and connection distribution. WebSocket traffic is long-lived, so prefer `least_conn` at the edge, then plain round-robin; sticky routing is only an operational fallback during rollout, not a correctness requirement for multi-node deployments.
+
+## Baseline Configuration
+
+Every room node and the global admin should point at the same Redis and keep the following settings aligned:
+
+```bash
+REDIS_URL=redis://10.0.0.11:6379
+ROOM_STORE_PROVIDER=redis
+ADMIN_SESSION_STORE_PROVIDER=redis
+ADMIN_EVENT_STORE_PROVIDER=redis
+ADMIN_AUDIT_STORE_PROVIDER=redis
+RUNTIME_STORE_PROVIDER=redis
+ROOM_EVENT_BUS_PROVIDER=redis
+ADMIN_COMMAND_BUS_PROVIDER=redis
+NODE_HEARTBEAT_ENABLED=true
+```
+
+Every process must use a unique `INSTANCE_ID`. Room nodes listen on `PORT` with `GLOBAL_ADMIN_ENABLED=false`; the global admin listens on `GLOBAL_ADMIN_PORT` with `GLOBAL_ADMIN_ENABLED=true`.
+
+Production should also set these explicitly and keep them aligned:
+
+- `ALLOWED_ORIGINS`
+- `TRUSTED_PROXY_ADDRESSES`
+- `MAX_MEMBERS_PER_ROOM`
+- `MAX_MESSAGE_BYTES`
+- `ADMIN_USERNAME`
+- `ADMIN_PASSWORD_HASH`
+- `ADMIN_SESSION_SECRET`
+- `ADMIN_SESSION_TTL_MS`
+- `ADMIN_ROLE`
+
+## Common Verification Commands
+
+```bash
+# Redis connectivity
+redis-cli -u "$REDIS_URL" ping
+
+# Room node health checks
+curl -fsS http://10.0.0.11:8787/healthz
+curl -fsS http://10.0.0.11:8787/readyz
+
+# Global admin health checks
+curl -fsS http://10.0.0.11:8788/healthz
+curl -fsS http://10.0.0.11:8788/readyz
+
+# Prometheus text metrics
+curl -fsS http://10.0.0.11:8787/metrics
+
+# systemd logs
+sudo journalctl -u bili-syncplay-server -f
+sudo journalctl -u bili-syncplay-global-admin -f
+```
+
+If a dedicated metrics port is deployed, scrape `/metrics` from the address configured by `METRICS_PORT`.
+
+## Scaling Out a Room Node
+
+Goal: add a room node and let the edge layer start distributing new connections to it.
+
+1. Pick a unique instance name, for example `room-node-c`.
+2. Install Node.js 22, dependencies, and build artifacts on the new machine; the version should match the existing nodes.
+3. Configure the same `REDIS_URL`, providers, security, rate-limit, room-capacity, and admin auth settings as the existing nodes.
+4. Configure the unique settings:
+
+   ```bash
+   INSTANCE_ID=room-node-c
+   PORT=8787
+   GLOBAL_ADMIN_ENABLED=false
+   ```
+
+5. Start the service:
+
+   ```bash
+   sudo systemctl enable --now bili-syncplay-server
+   sudo systemctl status bili-syncplay-server
+   ```
+
+6. Add the new upstream at the edge layer, but start with a low weight or only a small share of canary traffic.
+7. Verify the new node:
+
+   ```bash
+   curl -fsS http://10.0.0.13:8787/readyz
+   curl -fsS http://10.0.0.13:8787/metrics
+   ```
+
+8. Log in to the global admin and confirm `room-node-c` appears in the overview with a continuously refreshing heartbeat.
+9. Create a test room with one client connected to an old node and another client connected to the new node, and verify shared video and playback state stay in sync across nodes.
+10. Observe for 10 to 15 minutes; once the error rate and Redis latency are stable, raise the edge-layer weight to its target value.
+
+Scale-out completion criteria:
+
+- `/readyz` returns 200.
+- The new node shows `health` as `ok` in the global admin overview.
+- `bili_syncplay_connections` grows in line with edge-layer distribution.
+- `bili_syncplay_redis_operation_failures_total` shows no sustained growth.
+
+## Scaling In or Safely Draining a Room Node
+
+Goal: stop accepting new connections, wait out or migrate existing rooms, then shut down a single node.
+
+1. Remove the target node from the edge upstream, or set its weight to 0.
+2. Keep the process running; do not stop the service immediately.
+3. Watch the connection count on the target node:
+
+   ```bash
+   curl -fsS http://10.0.0.12:8787/metrics | grep bili_syncplay_connections
+   ```
+
+4. Check in the global admin which rooms and sessions the node still carries.
+5. For rooms that still have active members, prefer asking users to reconnect briefly; reconnecting clients re-enter through the edge layer onto other nodes.
+6. If immediate migration is required, use the global admin to disconnect the sessions on the target node. Do not delete the rooms — room base state is retained in Redis and users can reconnect with `roomCode + joinToken`.
+7. Wait for `bili_syncplay_connections` to drop to 0, or confirm the remaining connections have been handled within the change window.
+8. Stop the target node:
+
+   ```bash
+   sudo systemctl stop bili-syncplay-server
+   ```
+
+9. Wait at least one `NODE_HEARTBEAT_TTL_MS` cycle and confirm the node disappears from the global admin or is marked as expired.
+10. Permanently remove the upstream from the edge configuration and reload the edge layer.
+
+Scale-in completion criteria:
+
+- The edge layer no longer forwards new connections to the target node.
+- `bili_syncplay_connections` on the target node is 0.
+- The global admin no longer shows the target node as healthy and active.
+- `/readyz` and cross-node sync on the remaining room nodes are normal.
+
+## Redis Incident Handling
+
+When the providers are configured as `redis`, Bili-SyncPlay does not transparently fail over to in-memory. Redis being unavailable at startup causes the affected process to fail to start; a Redis outage at runtime affects room persistence, runtime indexes, cross-node fanout, admin sessions, audit events, and admin commands.
+
+### Quick Triage
+
+```bash
+redis-cli -u "$REDIS_URL" ping
+curl -fsS http://10.0.0.11:8787/readyz
+curl -fsS http://10.0.0.11:8787/metrics | grep bili_syncplay_redis_operation_failures_total
+sudo journalctl -u bili-syncplay-server --since "15 min ago" | grep -E "redis|Redis|node_heartbeat_failed"
+```
+
+Also check the global admin overview:
+
+- Whether room node heartbeats have expired.
+- Whether the Redis-related providers are still `redis`.
+- Whether the room list, room detail, and event stream return errors or noticeable latency.
+
+### Prefer Restoring Redis
+
+1. Check the Redis process, disk, memory, network ACLs, and password.
+2. If you use managed Redis, complete the primary/replica or instance failover first and keep `REDIS_URL` pointing at an available instance.
+3. After Redis recovers, restart the affected processes:
+
+   ```bash
+   sudo systemctl restart bili-syncplay-server
+   sudo systemctl restart bili-syncplay-global-admin
+   ```
+
+4. Verify `/readyz`, the global admin overview, cross-node sync, and the Redis failure counters.
+
+### Emergency Downgrade to In-Memory
+
+Use this only when Redis cannot be restored in time and the business can accept temporarily running single-node or with weakened multi-node capabilities.
+
+Downgrade configuration:
+
+```bash
+ROOM_STORE_PROVIDER=memory
+ADMIN_SESSION_STORE_PROVIDER=memory
+ADMIN_EVENT_STORE_PROVIDER=memory
+ADMIN_AUDIT_STORE_PROVIDER=memory
+RUNTIME_STORE_PROVIDER=memory
+ROOM_EVENT_BUS_PROVIDER=memory
+ADMIN_COMMAND_BUS_PROVIDER=memory
+NODE_HEARTBEAT_ENABLED=false
+```
+
+Downgrade impact:
+
+- Rooms already stored in Redis are not read by in-memory nodes; users may need to recreate or rejoin rooms.
+- Room state, runtime sessions, admin sessions, events, and audit logs fall back to per-process local storage.
+- The global admin can only reliably manage the local state visible to its own process.
+- Cross-node room-state fanout and cross-node admin commands no longer have production semantics.
+- When multiple room nodes run in-memory simultaneously, the edge layer must enable sticky routing, or temporarily keep only one room node serving traffic.
+
+Downgrade steps:
+
+1. Declare emergency mode; freeze scaling operations and bulk admin actions.
+2. Keep only one room node at the edge layer, or turn on sticky routing and reduce change frequency.
+3. Change the room node and global admin environment variables to the in-memory configuration above.
+4. Restart the services:
+
+   ```bash
+   sudo systemctl restart bili-syncplay-server
+   sudo systemctl restart bili-syncplay-global-admin
+   ```
+
+5. Verify `/readyz`, admin login, creating a test room, and playback sync.
+6. Announce that old rooms may be unrecoverable and users need to recreate rooms or reconnect.
+
+### Recovering from In-Memory Back to Redis
+
+1. Confirm Redis is stable and `redis-cli -u "$REDIS_URL" ping` returns `PONG`.
+2. Switch the providers on every room node and the global admin back to `redis`, and restore `NODE_HEARTBEAT_ENABLED=true`.
+3. Start one room node and the global admin first; verify admin login, room creation, the event stream, and `/metrics`.
+4. Bring the remaining room nodes back one by one, adding one upstream at a time.
+5. Watch `bili_syncplay_redis_operation_failures_total` and Redis latency for at least 15 minutes.
+
+## Admin Credential Rotation
+
+Goal: change the admin password, and rotate the session secret at the same time when existing tokens must be invalidated.
+
+1. Generate the new password hash. `sha256:<hex>` and `scrypt:<salt>:<base64url>` are supported; the quick command in the [security environment variable reference](../reference/security-env.md) uses `sha256`:
+
+   ```bash
+   node -e "const { createHash } = require('node:crypto'); console.log('sha256:' + createHash('sha256').update(process.argv[1]).digest('hex'));" 'new-admin-password'
+   ```
+
+2. Store the new `ADMIN_PASSWORD_HASH` in your secret system or deployment configuration.
+3. To force all existing admin tokens to expire, also generate and distribute a new `ADMIN_SESSION_SECRET`:
+
+   ```bash
+   node -e "console.log(require('node:crypto').randomBytes(32).toString('base64url'))"
+   ```
+
+4. Update every room node and the global admin together. In multi-node deployments these admin auth settings must stay identical.
+5. Rolling restart:
+
+   ```bash
+   sudo systemctl restart bili-syncplay-server
+   sudo systemctl restart bili-syncplay-global-admin
+   ```
+
+6. Open `/admin` and log in with the new password.
+7. Run read-only verification: check the overview, room list, events, and audit logs.
+8. For the minimal write verification, use a test room to avoid touching production rooms by accident.
+9. Confirm the old password can no longer log in; if `ADMIN_SESSION_SECRET` was rotated, confirm old pages require a fresh login after refresh.
+
+## Global Admin Restart
+
+The global admin carries no WebSocket room traffic and can be rolling-restarted independently.
+
+```bash
+sudo systemctl restart bili-syncplay-global-admin
+curl -fsS http://10.0.0.11:8788/readyz
+```
+
+With `ADMIN_SESSION_STORE_PROVIDER=redis` and an unchanged `ADMIN_SESSION_SECRET`, existing admin sessions keep working; with `memory` or a rotated secret, admins need to log in again.
+
+## Common Alerts and Triage
+
+| Alert or symptom                                                  | Key metrics / signals                                                                  | Check first                                                           | Direction                                                                      |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Abnormal drop in WebSocket connections                            | `bili_syncplay_connections`                                                            | Edge upstreams, room node `/readyz`, process logs                     | Restore the node or remove the unhealthy node from the LB                      |
+| Abnormal drop in active rooms                                     | `bili_syncplay_active_rooms`, `bili_syncplay_rooms_non_expired`                        | Redis connectivity, room expiry settings, restart history             | Restore Redis; confirm `ROOM_STORE_PROVIDER` was not switched to memory        |
+| Redis operation failures                                          | `bili_syncplay_redis_operation_failures_total`                                         | Redis process, network, ACLs, password, slow queries                  | Restore Redis first; downgrade to in-memory only if necessary                  |
+| Elevated Redis runtime store latency                              | `bili_syncplay_redis_runtime_store_duration_seconds_bucket`                            | Redis CPU, memory, network RTT, command queueing                      | Scale Redis or reduce edge-layer traffic                                       |
+| Redis room event bus publish latency or failures                  | `bili_syncplay_redis_room_event_bus_publish_duration_seconds_bucket`, failure counters | Redis pub/sub connectivity, network jitter, room node logs            | Restore Redis and the network; verify cross-node playback sync                 |
+| Increase in rejected connections                                  | `bili_syncplay_ws_connection_rejected_total`, structured `origin_not_allowed` logs     | `ALLOWED_ORIGINS`, whether the edge rewrites `Origin`                 | Fix the origin allowlist or the reverse-proxy configuration                    |
+| Increase in rate limiting                                         | `bili_syncplay_rate_limited_total`                                                     | Source IPs, real IP forwarding at the edge, `TRUSTED_PROXY_ADDRESSES` | Tune the limits or fix the proxy address configuration                         |
+| Elevated message handling latency                                 | `bili_syncplay_message_handler_duration_seconds_bucket`                                | Node CPU, Redis latency, room member counts, errors in logs           | Rate-limit, scale room nodes, investigate slow Redis                           |
+| Global admin missing a node, or a node shown as expired           | Global admin overview, `node_heartbeat_failed` logs                                    | `NODE_HEARTBEAT_ENABLED`, `INSTANCE_ID`, Redis runtime store          | Fix the heartbeat configuration or the Redis runtime store                     |
+| Admin login failures or frequent re-login prompts                 | `/api/admin/auth/login` responses, audit logs                                          | Whether `ADMIN_PASSWORD_HASH` / `ADMIN_SESSION_SECRET` are consistent | Align the admin auth settings and restart                                      |
+| Cross-node room actions fail, e.g. kick or close room returns 502 | Audit logs, `ADMIN_COMMAND_BUS_PROVIDER`, target node heartbeat                        | Admin command bus, target `INSTANCE_ID`, Redis                        | Restore the Redis command bus or perform the action locally on the target node |
+
+When troubleshooting, check these together first:
+
+```bash
+curl -fsS http://<room-node>:8787/metrics
+curl -fsS http://<room-node>:8787/readyz
+curl -fsS http://<global-admin>:8788/readyz
+sudo journalctl -u bili-syncplay-server --since "30 min ago"
+sudo journalctl -u bili-syncplay-global-admin --since "30 min ago"
+```
+
+## Post-Change Regression Checklist
+
+- Creating a room, joining a room, sharing a video, and play / pause / seek sync all work.
+- At least two clients connected through different room nodes still stay in sync.
+- `/healthz`, `/readyz`, and `/metrics` are reachable on every node.
+- The global admin allows login and shows the overview, rooms, events, and audit logs.
+- `disconnect session`, `kick member`, and `close room` behave as expected on a test room.
+- `bili_syncplay_redis_operation_failures_total` shows no sustained growth.
+- The edge-layer upstream list matches the nodes actually online.

--- a/docs/runbook/multi-node-operations.md
+++ b/docs/runbook/multi-node-operations.md
@@ -45,6 +45,8 @@ NODE_HEARTBEAT_ENABLED=true
 
 Every process must use a unique `INSTANCE_ID`. Room nodes listen on `PORT` with `GLOBAL_ADMIN_ENABLED=false`; the global admin listens on `GLOBAL_ADMIN_PORT` with `GLOBAL_ADMIN_ENABLED=true`.
 
+If `REDIS_NAMESPACE` is set, it prefixes every Redis key and channel (rooms, runtime indexes, event streams, room event bus, admin command bus), so it must be identical on every room node and the global admin; leaving it unset everywhere means all nodes share the default `bsp` prefix. Mixed namespaces split the cluster — the global admin stops seeing rooms and heartbeats, and cross-node fanout and admin commands silently fail.
+
 Production should also set these explicitly and keep them aligned:
 
 - `ALLOWED_ORIGINS`
@@ -75,9 +77,11 @@ curl -fsS http://10.0.0.11:8788/readyz
 curl -fsS http://10.0.0.11:8787/metrics
 
 # systemd logs
-sudo journalctl -u bili-syncplay-server -f
+sudo journalctl -u bili-syncplay-room-node-a -f
 sudo journalctl -u bili-syncplay-global-admin -f
 ```
+
+The examples use the per-node systemd unit names from the [deployment guide](../operations/deployment.md) (`bili-syncplay-room-node-a`, `bili-syncplay-room-node-b`, …); substitute the unit of the node you are operating on.
 
 If a dedicated metrics port is deployed, scrape `/metrics` from the address configured by `METRICS_PORT`.
 
@@ -99,8 +103,8 @@ Goal: add a room node and let the edge layer start distributing new connections 
 5. Start the service:
 
    ```bash
-   sudo systemctl enable --now bili-syncplay-server
-   sudo systemctl status bili-syncplay-server
+   sudo systemctl enable --now bili-syncplay-room-node-c
+   sudo systemctl status bili-syncplay-room-node-c
    ```
 
 6. Add the new upstream at the edge layer, but start with a low weight or only a small share of canary traffic.
@@ -141,7 +145,7 @@ Goal: stop accepting new connections, wait out or migrate existing rooms, then s
 8. Stop the target node:
 
    ```bash
-   sudo systemctl stop bili-syncplay-server
+   sudo systemctl stop bili-syncplay-room-node-b
    ```
 
 9. Wait at least one `NODE_HEARTBEAT_TTL_MS` cycle and confirm the node disappears from the global admin or is marked as expired.
@@ -164,7 +168,7 @@ When the providers are configured as `redis`, Bili-SyncPlay does not transparent
 redis-cli -u "$REDIS_URL" ping
 curl -fsS http://10.0.0.11:8787/readyz
 curl -fsS http://10.0.0.11:8787/metrics | grep bili_syncplay_redis_operation_failures_total
-sudo journalctl -u bili-syncplay-server --since "15 min ago" | grep -E "redis|Redis|node_heartbeat_failed"
+sudo journalctl -u bili-syncplay-room-node-a --since "15 min ago" | grep -E "redis|Redis|node_heartbeat_failed"
 ```
 
 Also check the global admin overview:
@@ -180,7 +184,7 @@ Also check the global admin overview:
 3. After Redis recovers, restart the affected processes:
 
    ```bash
-   sudo systemctl restart bili-syncplay-server
+   sudo systemctl restart bili-syncplay-room-node-a   # repeat for every room node
    sudo systemctl restart bili-syncplay-global-admin
    ```
 
@@ -219,7 +223,7 @@ Downgrade steps:
 4. Restart the services:
 
    ```bash
-   sudo systemctl restart bili-syncplay-server
+   sudo systemctl restart bili-syncplay-room-node-a   # repeat for every room node
    sudo systemctl restart bili-syncplay-global-admin
    ```
 
@@ -255,7 +259,7 @@ Goal: change the admin password, and rotate the session secret at the same time 
 5. Rolling restart:
 
    ```bash
-   sudo systemctl restart bili-syncplay-server
+   sudo systemctl restart bili-syncplay-room-node-a   # repeat for every room node
    sudo systemctl restart bili-syncplay-global-admin
    ```
 
@@ -297,7 +301,7 @@ When troubleshooting, check these together first:
 curl -fsS http://<room-node>:8787/metrics
 curl -fsS http://<room-node>:8787/readyz
 curl -fsS http://<global-admin>:8788/readyz
-sudo journalctl -u bili-syncplay-server --since "30 min ago"
+sudo journalctl -u bili-syncplay-room-node-a --since "30 min ago"
 sudo journalctl -u bili-syncplay-global-admin --since "30 min ago"
 ```
 

--- a/docs/runbook/multi-node-operations.zh-CN.md
+++ b/docs/runbook/multi-node-operations.zh-CN.md
@@ -1,5 +1,7 @@
 # Bili-SyncPlay 多节点运维 Runbook
 
+[English](./multi-node-operations.md) | [简体中文](./multi-node-operations.zh-CN.md)
+
 本文档面向日常运维和应急值班，覆盖多 Room Node、独立 Global Admin 与 Redis
 共享控制面的扩容、缩容、Redis 故障、管理员口令轮换和常见告警定位。
 

--- a/docs/runbook/multi-node-operations.zh-CN.md
+++ b/docs/runbook/multi-node-operations.zh-CN.md
@@ -51,6 +51,8 @@ NODE_HEARTBEAT_ENABLED=true
 `GLOBAL_ADMIN_ENABLED=false`；Global Admin 使用 `GLOBAL_ADMIN_PORT`，并设置
 `GLOBAL_ADMIN_ENABLED=true`。
 
+如果设置了 `REDIS_NAMESPACE`，它会作为所有 Redis 键和频道（房间、运行时索引、事件流、房间事件总线、管理命令总线）的前缀，因此所有 Room Node 与 Global Admin 必须使用同一个值；全部不设置时共同使用默认前缀 `bsp`。命名空间不一致会把集群分裂——表现为 Global Admin 看不到房间和心跳、跨节点广播与管理命令静默失效。
+
 生产环境还应显式配置并保持一致：
 
 - `ALLOWED_ORIGINS`
@@ -81,9 +83,11 @@ curl -fsS http://10.0.0.11:8788/readyz
 curl -fsS http://10.0.0.11:8787/metrics
 
 # systemd 日志
-sudo journalctl -u bili-syncplay-server -f
+sudo journalctl -u bili-syncplay-room-node-a -f
 sudo journalctl -u bili-syncplay-global-admin -f
 ```
+
+示例中的 systemd 单元名沿用[部署指南](../operations/deployment.zh-CN.md)的按节点命名方案（`bili-syncplay-room-node-a`、`bili-syncplay-room-node-b`……），实际操作时替换为目标节点对应的单元名。
 
 如果部署了独立指标端口，使用 `METRICS_PORT` 对应地址抓取 `/metrics`。
 
@@ -106,8 +110,8 @@ sudo journalctl -u bili-syncplay-global-admin -f
 5. 启动服务：
 
    ```bash
-   sudo systemctl enable --now bili-syncplay-server
-   sudo systemctl status bili-syncplay-server
+   sudo systemctl enable --now bili-syncplay-room-node-c
+   sudo systemctl status bili-syncplay-room-node-c
    ```
 
 6. 在入口层加入新 upstream，但先设置较低权重或仅灰度少量流量。
@@ -148,7 +152,7 @@ sudo journalctl -u bili-syncplay-global-admin -f
 8. 停止目标节点：
 
    ```bash
-   sudo systemctl stop bili-syncplay-server
+   sudo systemctl stop bili-syncplay-room-node-b
    ```
 
 9. 等待至少一个 `NODE_HEARTBEAT_TTL_MS` 周期，确认 Global Admin 中目标节点消失或标记为过期。
@@ -172,7 +176,7 @@ Redis 在启动阶段不可用会导致相关进程启动失败；运行中 Redi
 redis-cli -u "$REDIS_URL" ping
 curl -fsS http://10.0.0.11:8787/readyz
 curl -fsS http://10.0.0.11:8787/metrics | grep bili_syncplay_redis_operation_failures_total
-sudo journalctl -u bili-syncplay-server --since "15 min ago" | grep -E "redis|Redis|node_heartbeat_failed"
+sudo journalctl -u bili-syncplay-room-node-a --since "15 min ago" | grep -E "redis|Redis|node_heartbeat_failed"
 ```
 
 同时检查 Global Admin 概览：
@@ -188,7 +192,7 @@ sudo journalctl -u bili-syncplay-server --since "15 min ago" | grep -E "redis|Re
 3. Redis 恢复后重启受影响进程：
 
    ```bash
-   sudo systemctl restart bili-syncplay-server
+   sudo systemctl restart bili-syncplay-room-node-a   # 每个 Room Node 依次执行
    sudo systemctl restart bili-syncplay-global-admin
    ```
 
@@ -227,7 +231,7 @@ NODE_HEARTBEAT_ENABLED=false
 4. 重启服务：
 
    ```bash
-   sudo systemctl restart bili-syncplay-server
+   sudo systemctl restart bili-syncplay-room-node-a   # 每个 Room Node 依次执行
    sudo systemctl restart bili-syncplay-global-admin
    ```
 
@@ -265,7 +269,7 @@ NODE_HEARTBEAT_ENABLED=false
 5. 滚动重启：
 
    ```bash
-   sudo systemctl restart bili-syncplay-server
+   sudo systemctl restart bili-syncplay-room-node-a   # 每个 Room Node 依次执行
    sudo systemctl restart bili-syncplay-global-admin
    ```
 
@@ -307,7 +311,7 @@ curl -fsS http://10.0.0.11:8788/readyz
 curl -fsS http://<room-node>:8787/metrics
 curl -fsS http://<room-node>:8787/readyz
 curl -fsS http://<global-admin>:8788/readyz
-sudo journalctl -u bili-syncplay-server --since "30 min ago"
+sudo journalctl -u bili-syncplay-room-node-a --since "30 min ago"
 sudo journalctl -u bili-syncplay-global-admin --since "30 min ago"
 ```
 


### PR DESCRIPTION
## 背景

#163 拆分 README 后的文档盘点确认了三个缺口：缺少面向人类贡献者的架构文档、协议无参考文档（消息一览只能读源码）、多节点运维 runbook 是全仓唯一没有英文版的文档。本 PR 补齐这三项。

## 变更

| 新文档 | 内容 |
| --- | --- |
| `docs/architecture(.zh-CN).md` | 系统组成、同步数据流（mermaid 图 + 正反向路径）、background/content/popup/shared 与服务端六层的模块职责表、身份与状态生命周期、新代码归属指引 |
| `docs/reference/protocol(.zh-CN).md` | 协议版本常量（PROTOCOL_VERSION=3 / MIN=1）、SharedVideo 与 PlaybackState 字段表、8 条 ClientMessage 与 7 条 ServerMessage 消息表（含鉴权要求）、11 个错误码、时钟同步、URL 归一化路径形态、类型守卫清单 |
| `docs/runbook/multi-node-operations.md` | 中文 runbook（320 行）的完整英文版：扩缩容、Redis 故障处理与降级/恢复、口令轮换、告警定位表、回归清单 |

配套更新：

- `docs/README.md` 索引与两份根 README 的文档节加入新文档
- 英文 README / multi-node.md 中指向中文 runbook 的链接改为英文版；中文 runbook 补语言切换行
- 开发指南"代码组织"一节增加指向架构概览的交叉引用

## 事实核对

- 架构文档的模块清单与 `extension/src/*`、`server/src/*` 实际目录逐一核对
- 协议参考内容从 `packages/protocol/src`（types/guards/video-ref）与 `server/src/messages.ts` 逐项抽取，含 PlaybackState 可选字段（`userInitiated` / `naturalEnd`）的语义注释
- runbook 英文版为逐节对照翻译，命令与指标名保持原样

## 验证

- `npm run format:check` / `npm run lint` / `npm run typecheck` / `npm run build` / `npm test`（477 通过，0 失败）
- 全部改动文件的相对链接存在性校验通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)