### PR TITLE
feat: 指标增强——rate_limited 按消息类型分维、会话协议版本计数、build_info 与进程启动时间

### DIFF
--- a/server/src/admin/metrics.ts
+++ b/server/src/admin/metrics.ts
@@ -13,6 +13,17 @@ const CORE_EVENT_NAMES = [
   "rate_limited",
 ] as const;
 
+// Every message type guarded by a rate limiter in the message handler.
+// Pre-seeded to 0 so dashboards can tell "never limited" from "not emitted".
+const RATE_LIMITED_MESSAGE_TYPES = [
+  "room:create",
+  "room:join",
+  "video:share",
+  "playback:update",
+  "sync:request",
+  "sync:ping",
+] as const;
+
 export type MonitoredMessageType =
   "video:share" | "playback:update" | "room:join" | "room:leave";
 
@@ -44,6 +55,8 @@ type CounterMetric = {
 export type MetricsCollector = {
   bindRuntimeStore: (runtimeStore: RuntimeStore) => void;
   recordEvent: (event: string) => void;
+  recordRateLimited: (messageType: string) => void;
+  recordSessionProtocolVersion: (protocolVersion: string) => void;
   observeMessageHandlerDuration: (
     messageType: MonitoredMessageType,
     durationMs: number,
@@ -134,10 +147,21 @@ function ensureHistogramSample(
 export function createMetricsCollector(options: {
   runtimeStore: RuntimeStore;
   roomStore: RoomStore;
+  serviceVersion?: string;
 }): MetricsCollector {
   let runtimeStore = options.runtimeStore;
+  const serviceVersion = options.serviceVersion ?? "unknown";
+  const processStartTimeSeconds = (Date.now() - process.uptime() * 1000) / 1000;
   const eventCounter: CounterMetric = {
     help: "Total structured log events grouped by event name",
+    samples: new Map(),
+  };
+  const rateLimitedCounter: CounterMetric = {
+    help: "Total rate_limited events grouped by client message type",
+    samples: new Map(),
+  };
+  const sessionProtocolVersionCounter: CounterMetric = {
+    help: "Total accepted sessions grouped by first negotiated protocol version",
     samples: new Map(),
   };
   const redisFailureCounter: CounterMetric = {
@@ -166,6 +190,10 @@ export function createMetricsCollector(options: {
 
   for (const eventName of CORE_EVENT_NAMES) {
     ensureCounterSample(eventCounter, { event: eventName });
+  }
+
+  for (const messageType of RATE_LIMITED_MESSAGE_TYPES) {
+    ensureCounterSample(rateLimitedCounter, { message_type: messageType });
   }
 
   // Pre-seed every room event type to 0 so dashboards can distinguish
@@ -221,6 +249,18 @@ export function createMetricsCollector(options: {
     ).sort((a, b) =>
       (a.labels.event_type ?? "").localeCompare(b.labels.event_type ?? ""),
     );
+    const rateLimitedSamples = Array.from(
+      rateLimitedCounter.samples.values(),
+    ).sort((a, b) =>
+      (a.labels.message_type ?? "").localeCompare(b.labels.message_type ?? ""),
+    );
+    const sessionProtocolVersionSamples = Array.from(
+      sessionProtocolVersionCounter.samples.values(),
+    ).sort((a, b) =>
+      (a.labels.protocol_version ?? "").localeCompare(
+        b.labels.protocol_version ?? "",
+      ),
+    );
     const histogramMetrics = [
       {
         name: "bili_syncplay_message_handler_duration_seconds",
@@ -237,6 +277,17 @@ export function createMetricsCollector(options: {
     ] as const;
 
     const lines = [
+      "# HELP bili_syncplay_build_info Build metadata; constant 1 labelled with the service version",
+      "# TYPE bili_syncplay_build_info gauge",
+      formatMetricLine("bili_syncplay_build_info", 1, {
+        version: serviceVersion,
+      }),
+      "# HELP bili_syncplay_process_start_time_seconds Unix time the server process started, in seconds",
+      "# TYPE bili_syncplay_process_start_time_seconds gauge",
+      formatMetricLine(
+        "bili_syncplay_process_start_time_seconds",
+        processStartTimeSeconds,
+      ),
       "# HELP bili_syncplay_connections Current websocket connection count",
       "# TYPE bili_syncplay_connections gauge",
       formatMetricLine(
@@ -281,11 +332,23 @@ export function createMetricsCollector(options: {
           event: "ws_connection_rejected",
         }).value,
       ),
-      "# HELP bili_syncplay_rate_limited_total Total rate_limited events",
+      "# HELP bili_syncplay_rate_limited_total Total rate_limited events grouped by client message type",
       "# TYPE bili_syncplay_rate_limited_total counter",
-      formatMetricLine(
-        "bili_syncplay_rate_limited_total",
-        ensureCounterSample(eventCounter, { event: "rate_limited" }).value,
+      ...rateLimitedSamples.map((sample) =>
+        formatMetricLine(
+          "bili_syncplay_rate_limited_total",
+          sample.value,
+          sample.labels,
+        ),
+      ),
+      "# HELP bili_syncplay_session_protocol_versions_total Total accepted sessions grouped by first negotiated protocol version",
+      "# TYPE bili_syncplay_session_protocol_versions_total counter",
+      ...sessionProtocolVersionSamples.map((sample) =>
+        formatMetricLine(
+          "bili_syncplay_session_protocol_versions_total",
+          sample.value,
+          sample.labels,
+        ),
       ),
       "# HELP bili_syncplay_redis_operation_failures_total Total Redis metric-instrumented operation failures",
       "# TYPE bili_syncplay_redis_operation_failures_total counter",
@@ -349,6 +412,14 @@ export function createMetricsCollector(options: {
     recordEvent(event) {
       incrementCounter(eventCounter, { event });
     },
+    recordRateLimited(messageType) {
+      incrementCounter(rateLimitedCounter, { message_type: messageType });
+    },
+    recordSessionProtocolVersion(protocolVersion) {
+      incrementCounter(sessionProtocolVersionCounter, {
+        protocol_version: protocolVersion,
+      });
+    },
     observeMessageHandlerDuration(messageType, durationMs) {
       observeHistogram(
         messageDurationHistogram,
@@ -394,6 +465,7 @@ export function createMetricsCollector(options: {
 export function createMetricsService(options: {
   runtimeStore: RuntimeStore;
   roomStore: RoomStore;
+  serviceVersion?: string;
 }) {
   return createMetricsCollector(options);
 }

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -249,6 +249,7 @@ export async function createServerBootstrapContext(
   const metricsCollector = createMetricsCollector({
     runtimeStore: localRuntimeStore,
     roomStore,
+    serviceVersion,
   });
   const runtimeStorePendingOperationLogger =
     options.loggingHooks?.onRuntimeStorePendingOperationError;

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -100,7 +100,10 @@ export function createMessageHandler(options: {
   instanceId: string;
   metricsCollector?: Pick<
     MetricsCollector,
-    "observeMessageHandlerDuration" | "recordRoomEventPublishDropped"
+    | "observeMessageHandlerDuration"
+    | "recordRoomEventPublishDropped"
+    | "recordRateLimited"
+    | "recordSessionProtocolVersion"
   >;
   maxPendingPublishes?: number;
   backpressureWaitMs?: number;
@@ -384,6 +387,7 @@ export function createMessageHandler(options: {
     session: Session,
     messageType: string,
   ): void {
+    metricsCollector?.recordRateLimited(messageType);
     logEvent("rate_limited", {
       sessionId: session.id,
       roomCode: session.roomCode,
@@ -416,6 +420,9 @@ export function createMessageHandler(options: {
   ): boolean {
     if (clientVersion === undefined) {
       // Old extension without protocolVersion — compatible baseline, log deprecation
+      if (session.protocolVersion === undefined) {
+        metricsCollector?.recordSessionProtocolVersion("legacy");
+      }
       session.protocolVersion = MIN_PROTOCOL_VERSION;
       logEvent("protocol_version_missing", {
         sessionId: session.id,
@@ -441,6 +448,12 @@ export function createMessageHandler(options: {
         minVersion: MIN_PROTOCOL_VERSION,
       });
       return false;
+    }
+    // Count each session once, at its first accepted handshake, so the
+    // per-version series tracks connected-client population rather than
+    // room:create/room:join message volume.
+    if (session.protocolVersion === undefined) {
+      metricsCollector?.recordSessionProtocolVersion(String(clientVersion));
     }
     session.protocolVersion = clientVersion;
     return true;

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -451,9 +451,16 @@ export function createMessageHandler(options: {
     }
     // Count each session once, at its first accepted handshake, so the
     // per-version series tracks connected-client population rather than
-    // room:create/room:join message volume.
+    // room:create/room:join message volume. The label set must stay bounded
+    // even though clients control the value: anything above the server's
+    // current version collapses into a single "future" bucket so a hostile
+    // client cannot mint unbounded Prometheus series.
     if (session.protocolVersion === undefined) {
-      metricsCollector?.recordSessionProtocolVersion(String(clientVersion));
+      metricsCollector?.recordSessionProtocolVersion(
+        clientVersion <= CURRENT_PROTOCOL_VERSION
+          ? String(clientVersion)
+          : "future",
+      );
     }
     session.protocolVersion = clientVersion;
     return true;

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -648,6 +648,9 @@ test("message handler records monitored duration metrics for critical room paths
       observeMessageHandlerDuration(messageType) {
         observedTypes.push(messageType);
       },
+      recordRoomEventPublishDropped() {},
+      recordRateLimited() {},
+      recordSessionProtocolVersion() {},
     },
   });
 
@@ -706,6 +709,145 @@ test("message handler records monitored duration metrics for critical room paths
     "playback:update",
     "room:leave",
   ]);
+});
+
+test("message handler records rate-limited messages with their message type", async () => {
+  const rateLimitedTypes: string[] = [];
+  const session = createSession("pinger");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent() {},
+    send() {},
+    sendError() {},
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+    now: () => 0,
+    metricsCollector: {
+      observeMessageHandlerDuration() {},
+      recordRoomEventPublishDropped() {},
+      recordRateLimited(messageType) {
+        rateLimitedTypes.push(messageType);
+      },
+      recordSessionProtocolVersion() {},
+    },
+  });
+
+  // syncPingBurst is 2 with a frozen clock, so the third ping is limited.
+  for (let index = 0; index < 3; index += 1) {
+    await handler.handleClientMessage(session, {
+      type: "sync:ping",
+      payload: { clientSendTime: 1 },
+    });
+  }
+
+  assert.deepEqual(rateLimitedTypes, ["sync:ping"]);
+});
+
+test("message handler records the negotiated protocol version once per session", async () => {
+  const recordedVersions: string[] = [];
+  const session = createSession("versioned-member");
+  const legacySession = createSession("legacy-member");
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession(currentSession) {
+        currentSession.roomCode = "ROOM01";
+        currentSession.memberId = "member-1";
+        currentSession.memberToken = "member-token-1";
+        return {
+          room: { code: "ROOM01" },
+          memberToken: "member-token-1",
+        };
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        return {
+          roomCode: "ROOM01",
+          sharedVideo: null,
+          playback: null,
+          members: [{ id: "member-1", name: "Alice" }],
+        };
+      },
+    },
+    logEvent() {},
+    send() {},
+    sendError() {},
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+    metricsCollector: {
+      observeMessageHandlerDuration() {},
+      recordRoomEventPublishDropped() {},
+      recordRateLimited() {},
+      recordSessionProtocolVersion(protocolVersion) {
+        recordedVersions.push(protocolVersion);
+      },
+    },
+  });
+
+  const joinPayload = {
+    roomCode: "ROOM01",
+    joinToken: "join-token-1",
+    displayName: "Alice",
+    protocolVersion: 2,
+  };
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: joinPayload,
+  });
+  // Re-joining with the same session must not double-count it.
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: joinPayload,
+  });
+  await handler.handleClientMessage(legacySession, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      displayName: "Bob",
+    },
+  });
+
+  assert.deepEqual(recordedVersions, ["2", "legacy"]);
 });
 
 test("message handler accepts room:create without protocolVersion (legacy client)", async () => {
@@ -1587,6 +1729,8 @@ test("publish backpressure drops new events when wait deadline elapses", async (
       recordRoomEventPublishDropped(eventType) {
         droppedMetricTypes.push(eventType);
       },
+      recordRateLimited() {},
+      recordSessionProtocolVersion() {},
     },
   });
 

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -771,6 +771,7 @@ test("message handler records the negotiated protocol version once per session",
   const recordedVersions: string[] = [];
   const session = createSession("versioned-member");
   const legacySession = createSession("legacy-member");
+  const futureSession = createSession("future-member");
 
   const handler = createMessageHandler({
     config: CONFIG,
@@ -846,8 +847,19 @@ test("message handler records the negotiated protocol version once per session",
       displayName: "Bob",
     },
   });
+  // Client-supplied versions above the server's current version must collapse
+  // into one bucket so hostile clients cannot mint unbounded label values.
+  await handler.handleClientMessage(futureSession, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      displayName: "Mallory",
+      protocolVersion: 9999,
+    },
+  });
 
-  assert.deepEqual(recordedVersions, ["2", "legacy"]);
+  assert.deepEqual(recordedVersions, ["2", "legacy", "future"]);
 });
 
 test("message handler accepts room:create without protocolVersion (legacy client)", async () => {

--- a/server/test/metrics.test.ts
+++ b/server/test/metrics.test.ts
@@ -12,6 +12,7 @@ test("metrics collector renders event counters, histograms, and redis failure co
         return 2;
       },
     } as never,
+    serviceVersion: "9.9.9-test",
   });
 
   runtimeStore.registerSession({
@@ -39,6 +40,10 @@ test("metrics collector renders event counters, histograms, and redis failure co
   runtimeStore.markSessionJoinedRoom("session-1", "ROOM01");
 
   metrics.recordEvent("room_created");
+  metrics.recordRateLimited("sync:request");
+  metrics.recordRateLimited("sync:request");
+  metrics.recordSessionProtocolVersion("2");
+  metrics.recordSessionProtocolVersion("legacy");
   metrics.observeMessageHandlerDuration("room:join", 12);
   metrics.observeRedisRuntimeStoreDuration("register_session", 8);
   metrics.observeRedisRuntimeStoreFailure("register_session");
@@ -52,6 +57,40 @@ test("metrics collector renders event counters, histograms, and redis failure co
   assert.equal(rendered.includes("bili_syncplay_connections 1"), true);
   assert.equal(rendered.includes("bili_syncplay_active_rooms 1"), true);
   assert.equal(rendered.includes("bili_syncplay_rooms_non_expired 2"), true);
+  assert.equal(
+    rendered.includes('bili_syncplay_build_info{version="9.9.9-test"} 1'),
+    true,
+  );
+  const startTimeMatch = rendered.match(
+    /^bili_syncplay_process_start_time_seconds (\d+(?:\.\d+)?)$/m,
+  );
+  assert.notEqual(startTimeMatch, null);
+  assert.equal(Number(startTimeMatch![1]) > 0, true);
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_rate_limited_total{message_type="sync:request"} 2',
+    ),
+    true,
+  );
+  // Pre-seeded to 0 so "never limited" is distinguishable from "metric absent".
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_rate_limited_total{message_type="playback:update"} 0',
+    ),
+    true,
+  );
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_session_protocol_versions_total{protocol_version="2"} 1',
+    ),
+    true,
+  );
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_session_protocol_versions_total{protocol_version="legacy"} 1',
+    ),
+    true,
+  );
   assert.equal(
     rendered.includes('bili_syncplay_events_total{event="room_created"} 1'),
     true,


### PR DESCRIPTION
## 背景

线上 `/metrics` 显示 `rate_limited` 已累计 31 万+（超过 `playback_update_applied` 的 24.5 万），但该计数器没有任何维度，无法定位来源。结合代码考古：用户量最大的 Edge 端仍停留在 v1.1.2，而该版本携带 sync:request 重试风暴 bug（加入初始状态为 paused 的房间后每 150ms 重试 hydrate，撞上 6 次/10 秒限流；#148 已修复但仅进入 v1.2.2+）。当前指标无法验证这一假说，也无法在 Edge 新版过审后观察旧客户端退场。

## 改动

- **`bili_syncplay_rate_limited_total` 增加 `message_type` 标签**：在 `handleRateLimitedMessage` 处按消息类型计数，六种受限消息类型预置为 0。原无标签序列被labeled序列取代（PromQL 按名称查询不受影响，runbook 中引用的指标名不变）。
- **新增 `bili_syncplay_session_protocol_versions_total{protocol_version}`**：每个会话首次通过协议版本握手时计数一次（重复 join 不重复计数）；v1.1.2 上报 `2`，当前版本 `3`，未携带版本字段的记 `legacy`。用于绘制旧版本会话占比衰减曲线，判断何时可提高 `MIN_PROTOCOL_VERSION`。
- **新增 `bili_syncplay_build_info{version} 1` 与 `bili_syncplay_process_start_time_seconds`**：版本号复用 bootstrap 已有的 `resolveServiceVersion()`；用于区分"计数器因重启归零"与"流量真实下降"，并把指标变化关联到发版。

## 测试

- `server/test/metrics.test.ts`：新增 labeled `rate_limited_total`（含预置 0 断言）、`session_protocol_versions_total`、`build_info`、`process_start_time_seconds` 渲染断言。
- `server/test/message-handler.test.ts`：新增两个回归用例——sync:ping 第三次触发限流时按消息类型记录；协议版本每会话仅记一次（含 legacy 路径），并更新既有 stub。
- 已运行 `format:check`、`lint`、`typecheck`、`build`、`test`（477 通过）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)