### PR TITLE
feat: /metrics 支持可选 METRICS_TOKEN Bearer 鉴权

### DIFF
--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -114,7 +114,7 @@ Implemented endpoints:
 - `POST /api/admin/rooms/:roomCode/members/:memberId/kick`
 - `POST /api/admin/sessions/:sessionId/disconnect`
 
-`GET /metrics` is served on the main service port by default and can be moved to a dedicated port with `METRICS_PORT` (see [Security Environment Variables](./security-env.md)).
+`GET /metrics` is served on the main service port by default and can be moved to a dedicated port with `METRICS_PORT`; setting `METRICS_TOKEN` additionally requires scrapes to send `Authorization: Bearer <token>` (see [Security Environment Variables](./security-env.md)).
 
 Authentication model:
 

--- a/docs/reference/admin-api.zh-CN.md
+++ b/docs/reference/admin-api.zh-CN.md
@@ -114,7 +114,7 @@ node -e "const { createHash } = require('node:crypto'); const password = 'secret
 - `POST /api/admin/rooms/:roomCode/members/:memberId/kick`
 - `POST /api/admin/sessions/:sessionId/disconnect`
 
-`GET /metrics` 默认在主服务端口上提供，也可以通过 `METRICS_PORT` 挪到独立端口（见[安全相关环境变量](./security-env.zh-CN.md)）。
+`GET /metrics` 默认在主服务端口上提供，也可以通过 `METRICS_PORT` 挪到独立端口；设置 `METRICS_TOKEN` 后抓取请求还需携带 `Authorization: Bearer <token>`（见[安全相关环境变量](./security-env.zh-CN.md)）。
 
 鉴权方式：
 

--- a/docs/reference/security-env.md
+++ b/docs/reference/security-env.md
@@ -9,6 +9,7 @@ The server accepts the following environment variables. Safe defaults are built 
 - `BILI_SYNCPLAY_CONFIG`: optional path to a JSON config file; when unset, the server looks for `server.config.json` in the current working directory
 - `PORT`: HTTP/WebSocket listen port for a room node; defaults to `8787`
 - `METRICS_PORT`: optional dedicated port for `GET /metrics`; when unset, metrics are served on the main service port; must not collide with `PORT` or `GLOBAL_ADMIN_PORT`
+- `METRICS_TOKEN`: optional static bearer token guarding `GET /metrics` (both the main-port route and the `METRICS_PORT` server); when set, scrapes must send `Authorization: Bearer <token>` or receive `401`; when unset, the endpoint stays open; `/healthz` and `/readyz` are never affected. Configure Prometheus via `authorization.credentials_file`
 - `LOG_LEVEL`: log level, one of `debug`, `info`, `warn`, `error`; defaults to `info`
 - `INSTANCE_ID`: identifier for the current server process (e.g. `room-node-a`), shown in the admin overview, room detail, and audit logs; must be unique per process in multi-node deployments; defaults to `instance-1`
 

--- a/docs/reference/security-env.zh-CN.md
+++ b/docs/reference/security-env.zh-CN.md
@@ -9,6 +9,7 @@
 - `BILI_SYNCPLAY_CONFIG`：可选的 JSON 配置文件路径；未设置时会优先查找当前工作目录下的 `server.config.json`
 - `PORT`：Room Node 的 HTTP/WebSocket 监听端口；默认 `8787`
 - `METRICS_PORT`：可选的 `GET /metrics` 独立端口；未设置时 metrics 在主服务端口上提供；不能与 `PORT` 或 `GLOBAL_ADMIN_PORT` 冲突
+- `METRICS_TOKEN`：可选的 `GET /metrics` 静态 Bearer token（主端口路由和 `METRICS_PORT` 独立端口都会校验）；设置后抓取请求必须携带 `Authorization: Bearer <token>`，否则返回 `401`；未设置时端点保持开放；`/healthz` 与 `/readyz` 不受影响。Prometheus 侧通过 `authorization.credentials_file` 配置
 - `LOG_LEVEL`：日志级别，可选 `debug`、`info`、`warn`、`error`；默认 `info`
 - `INSTANCE_ID`：当前服务进程的标识（如 `room-node-a`），会出现在后台概览、房间详情和审计日志中；多节点部署时每个进程必须唯一；默认 `instance-1`
 

--- a/server/src/admin/router-types.ts
+++ b/server/src/admin/router-types.ts
@@ -14,6 +14,7 @@ import type {
 export type AdminRouterOptions = {
   getConfigSummary: () => unknown;
   getMetrics: () => Promise<string>;
+  metricsToken?: string;
   authService?: AdminAuthService;
   roomStoreReady: () => Promise<boolean>;
   getOverview: () => Promise<unknown>;

--- a/server/src/admin/routes/system-routes.ts
+++ b/server/src/admin/routes/system-routes.ts
@@ -1,3 +1,7 @@
+import {
+  isMetricsRequestAuthorized,
+  sendMetricsUnauthorized,
+} from "../../metrics-auth.js";
 import { sendOk } from "../response.js";
 import type { AdminRouteHandler } from "../router-types.js";
 
@@ -8,6 +12,10 @@ export const handleSystemRoutes: AdminRouteHandler = async ({
   options,
 }) => {
   if (request.method === "GET" && pathname === "/metrics") {
+    if (!isMetricsRequestAuthorized(request, options.metricsToken)) {
+      sendMetricsUnauthorized(response);
+      return true;
+    }
     response.writeHead(200, {
       "content-type": "text/plain; version=0.0.4; charset=utf-8",
     });

--- a/server/src/bootstrap/admin-http-bootstrap.ts
+++ b/server/src/bootstrap/admin-http-bootstrap.ts
@@ -117,6 +117,7 @@ export async function createSharedAdminHttpBootstrap(args: {
     : createServer(
         createMetricsRequestHandler({
           getMetrics: () => args.metricsCollector.render(),
+          metricsToken: args.securityConfig.metricsToken,
         }),
       );
   runtimeIndexReaper.start();

--- a/server/src/bootstrap/admin-services.ts
+++ b/server/src/bootstrap/admin-services.ts
@@ -174,6 +174,7 @@ export function createAdminServices(args: {
     const adminRouter = createAdminRouter({
       getConfigSummary: () => configService.getSummary(),
       getMetrics: () => metricsService.render(),
+      metricsToken: args.securityConfig.metricsToken,
       authService,
       roomStoreReady: () => args.roomStore.isReady(),
       getOverview: () => overviewService.getOverview(),

--- a/server/src/bootstrap/metrics-handler.ts
+++ b/server/src/bootstrap/metrics-handler.ts
@@ -1,7 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  isMetricsRequestAuthorized,
+  sendMetricsUnauthorized,
+} from "../metrics-auth.js";
 
 export function createMetricsRequestHandler(args: {
   getMetrics: () => Promise<string> | string;
+  metricsToken?: string;
 }) {
   return async (
     request: IncomingMessage,
@@ -32,6 +37,10 @@ export function createMetricsRequestHandler(args: {
           },
         }),
       );
+      return;
+    }
+    if (!isMetricsRequestAuthorized(request, args.metricsToken)) {
+      sendMetricsUnauthorized(response);
       return;
     }
     try {

--- a/server/src/config/runtime-config-schema.ts
+++ b/server/src/config/runtime-config-schema.ts
@@ -99,6 +99,7 @@ export const SERVER_CONFIG_FIELDS = [
     "WS_HEARTBEAT_INTERVAL_MS",
     "positiveInteger",
   ),
+  createField(["security", "metricsToken"], "METRICS_TOKEN", "string"),
   createField(
     ["security", "rateLimits", "roomCreatePerMinute"],
     "RATE_LIMIT_ROOM_CREATE_PER_MINUTE",

--- a/server/src/metrics-auth.ts
+++ b/server/src/metrics-auth.ts
@@ -1,0 +1,48 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+function sha256(value: string): Buffer {
+  return createHash("sha256").update(value).digest();
+}
+
+/**
+ * Guards `/metrics` scrapes with an optional static bearer token
+ * (`METRICS_TOKEN`). Health probes (`/healthz`, `/readyz`) intentionally stay
+ * open, so this must only be applied to the metrics route itself.
+ */
+export function isMetricsRequestAuthorized(
+  request: Pick<IncomingMessage, "headers">,
+  metricsToken: string | undefined,
+): boolean {
+  if (metricsToken === undefined || metricsToken.length === 0) {
+    // Token not configured — preserve the historical open-endpoint behavior.
+    return true;
+  }
+  const header = request.headers.authorization;
+  if (typeof header !== "string") {
+    return false;
+  }
+  const presentedToken = /^Bearer\s+(.+)$/i.exec(header)?.[1];
+  if (presentedToken === undefined) {
+    return false;
+  }
+  // Hashing both sides collapses length differences so timingSafeEqual is
+  // applicable and the comparison stays constant-time for any input.
+  return timingSafeEqual(sha256(presentedToken), sha256(metricsToken));
+}
+
+export function sendMetricsUnauthorized(response: ServerResponse): void {
+  response.writeHead(401, {
+    "content-type": "application/json",
+    "www-authenticate": 'Bearer realm="metrics"',
+  });
+  response.end(
+    JSON.stringify({
+      ok: false,
+      error: {
+        code: "unauthorized",
+        message: "Unauthorized.",
+      },
+    }),
+  );
+}

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -151,6 +151,7 @@ export type SecurityConfig = {
   invalidMessageCloseThreshold: number;
   wsHeartbeatEnabled: boolean;
   wsHeartbeatIntervalMs: number;
+  metricsToken?: string;
   rateLimits: {
     roomCreatePerMinute: number;
     roomJoinPerMinute: number;

--- a/server/test/config-env.test.ts
+++ b/server/test/config-env.test.ts
@@ -41,6 +41,19 @@ test("security config reads ws heartbeat overrides", () => {
   assert.equal(config.wsHeartbeatIntervalMs, 10_000);
 });
 
+test("security config reads the optional metrics token", () => {
+  const withToken = loadSecurityConfig({
+    ALLOWED_ORIGINS: "https://a.example",
+    METRICS_TOKEN: " scrape-token-1 ",
+  });
+  assert.equal(withToken.metricsToken, "scrape-token-1");
+
+  const withoutToken = loadSecurityConfig({
+    ALLOWED_ORIGINS: "https://a.example",
+  });
+  assert.equal(withoutToken.metricsToken, undefined);
+});
+
 test("persistence config validates provider and trims string env values", () => {
   const config = loadPersistenceConfig({
     ROOM_STORE_PROVIDER: "redis",

--- a/server/test/metrics-token.test.ts
+++ b/server/test/metrics-token.test.ts
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  createSyncServer,
+  getDefaultPersistenceConfig,
+  getDefaultSecurityConfig,
+} from "../src/app.js";
+import { createMetricsRequestHandler } from "../src/bootstrap/metrics-handler.js";
+import { isMetricsRequestAuthorized } from "../src/metrics-auth.js";
+
+const ALLOWED_ORIGIN = "chrome-extension://allowed-extension";
+
+test("metrics auth allows every request when no token is configured", () => {
+  assert.equal(isMetricsRequestAuthorized({ headers: {} }, undefined), true);
+  assert.equal(isMetricsRequestAuthorized({ headers: {} }, ""), true);
+});
+
+test("metrics auth requires a matching bearer token when configured", () => {
+  const token = "scrape-token-1";
+  assert.equal(
+    isMetricsRequestAuthorized(
+      { headers: { authorization: `Bearer ${token}` } },
+      token,
+    ),
+    true,
+  );
+  assert.equal(
+    isMetricsRequestAuthorized(
+      { headers: { authorization: `bearer ${token}` } },
+      token,
+    ),
+    true,
+  );
+  assert.equal(isMetricsRequestAuthorized({ headers: {} }, token), false);
+  assert.equal(
+    isMetricsRequestAuthorized(
+      { headers: { authorization: "Bearer wrong-token" } },
+      token,
+    ),
+    false,
+  );
+  // Length mismatch must not throw (timingSafeEqual compares digests).
+  assert.equal(
+    isMetricsRequestAuthorized(
+      { headers: { authorization: "Bearer x" } },
+      token,
+    ),
+    false,
+  );
+  assert.equal(
+    isMetricsRequestAuthorized({ headers: { authorization: token } }, token),
+    false,
+  );
+});
+
+function createFakeResponse() {
+  const state = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: "",
+  };
+  const response = {
+    writeHead(statusCode: number, headers?: Record<string, string>) {
+      state.statusCode = statusCode;
+      state.headers = headers ?? {};
+      return response;
+    },
+    end(body?: string) {
+      state.body = body ?? "";
+    },
+  };
+  return { response: response as unknown as ServerResponse, state };
+}
+
+test("dedicated metrics port handler enforces the configured token", async () => {
+  const handler = createMetricsRequestHandler({
+    getMetrics: () => "metric_line 1\n",
+    metricsToken: "scrape-token-1",
+  });
+
+  const unauthorized = createFakeResponse();
+  await handler(
+    { url: "/metrics", method: "GET", headers: {} } as IncomingMessage,
+    unauthorized.response,
+  );
+  assert.equal(unauthorized.state.statusCode, 401);
+  assert.equal(
+    unauthorized.state.headers["www-authenticate"],
+    'Bearer realm="metrics"',
+  );
+
+  const authorized = createFakeResponse();
+  await handler(
+    {
+      url: "/metrics",
+      method: "GET",
+      headers: { authorization: "Bearer scrape-token-1" },
+    } as IncomingMessage,
+    authorized.response,
+  );
+  assert.equal(authorized.state.statusCode, 200);
+  assert.equal(authorized.state.body, "metric_line 1\n");
+});
+
+test("main-port /metrics enforces the token while health probes stay open", async () => {
+  const server = await createSyncServer(
+    {
+      ...getDefaultSecurityConfig(),
+      allowedOrigins: [ALLOWED_ORIGIN],
+      metricsToken: "scrape-token-1",
+    },
+    getDefaultPersistenceConfig(),
+    { serviceVersion: "0.0.0-test" },
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    server.httpServer.listen(0, "127.0.0.1", () => resolve());
+    server.httpServer.once("error", reject);
+  });
+  const address = server.httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to determine test server address.");
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    const missingToken = await fetch(`${baseUrl}/metrics`);
+    assert.equal(missingToken.status, 401);
+    assert.equal(
+      missingToken.headers.get("www-authenticate"),
+      'Bearer realm="metrics"',
+    );
+
+    const wrongToken = await fetch(`${baseUrl}/metrics`, {
+      headers: { authorization: "Bearer wrong-token" },
+    });
+    assert.equal(wrongToken.status, 401);
+
+    const authorized = await fetch(`${baseUrl}/metrics`, {
+      headers: { authorization: "Bearer scrape-token-1" },
+    });
+    assert.equal(authorized.status, 200);
+    const body = await authorized.text();
+    assert.equal(body.includes("bili_syncplay_connections"), true);
+
+    // LB probes must keep working without credentials.
+    const healthz = await fetch(`${baseUrl}/healthz`);
+    assert.equal(healthz.status, 200);
+    const readyz = await fetch(`${baseUrl}/readyz`);
+    assert.equal(readyz.status, 200);
+  } finally {
+    await server.close();
+  }
+});
+
+test("main-port /metrics stays open when no token is configured", async () => {
+  const server = await createSyncServer(
+    {
+      ...getDefaultSecurityConfig(),
+      allowedOrigins: [ALLOWED_ORIGIN],
+    },
+    getDefaultPersistenceConfig(),
+    { serviceVersion: "0.0.0-test" },
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    server.httpServer.listen(0, "127.0.0.1", () => resolve());
+    server.httpServer.once("error", reject);
+  });
+  const address = server.httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to determine test server address.");
+  }
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${address.port}/metrics`);
+    assert.equal(response.status, 200);
+    const body = await response.text();
+    assert.equal(body.includes("bili_syncplay_connections"), true);
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
## 背景

`https://sync.skyarkplay.com/metrics` 当前公网无鉴权可访问，泄露房间数、连接数、事件量等运营信息。参考讨论结论：采用可选静态 Bearer token 方案（保留公网 curl / 外部 Prometheus 的使用方式），`METRICS_PORT` 内网隔离可另行叠加。

## 改动

- **新增 `METRICS_TOKEN`**（env 或 `server.config.json` 的 `security.metricsToken`）：设置后 `GET /metrics` 必须携带 `Authorization: Bearer <token>`，否则返回 `401` + `WWW-Authenticate: Bearer realm="metrics"`；**未设置时保持现有开放行为，向后完全兼容**。
- **两条服务路径全覆盖**：主端口路由（`system-routes.ts`）与 `METRICS_PORT` 独立端口（`metrics-handler.ts`）都做校验；token 挂在 `SecurityConfig` 上经既有管道传递，room node 与 global admin 入口同时生效，无新增穿层参数。
- **校验实现**：集中在新模块 `server/src/metrics-auth.ts`，双方 sha256 摘要后 `timingSafeEqual` 比较——长度不一致不抛错、比较恒定耗时；`Bearer` 前缀大小写不敏感。
- **不受影响的面**：`/healthz`、`/readyz` 探活保持开放（LB 依赖）；admin config summary 是显式字段白名单，token 不会出现在后台配置摘要里。
- **文档**：`docs/reference/security-env` 与 `admin-api`（中英双语）补充 `METRICS_TOKEN` 说明，含 Prometheus `authorization.credentials_file` 提示。

## 测试

- helper 单元：未配置直通、正确/错误/缺失/畸形 header、长度不匹配不抛错、大小写不敏感。
- 独立端口 handler：401（含 WWW-Authenticate 断言）与 200。
- 主端口整链路（真实 `createSyncServer`）：缺 token 401、错 token 401、正确 token 200、`/healthz`、`/readyz` 免鉴权、未配置 token 时保持开放。
- config 层：`METRICS_TOKEN` env 解析与 trim、未设置为 undefined。
- 已运行 `format:check`、`lint`、`typecheck`、`build`、`test` 全部通过。

## 运维接入

```bash
# 服务端
METRICS_TOKEN=<random-token> node server/dist/index.js

# 手动验证
curl -H "Authorization: Bearer <random-token>" https://sync.skyarkplay.com/metrics
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)