### PR TITLE
feat: 补齐延迟尖峰排查所需指标——room store 直方图、事件循环延迟、15ms 桶

### DIFF
--- a/server/src/admin/metrics.ts
+++ b/server/src/admin/metrics.ts
@@ -1,10 +1,13 @@
+import { monitorEventLoopDelay } from "node:perf_hooks";
 import type { RuntimeStore } from "../runtime-store.js";
 import type { RoomStore } from "../room-store.js";
 import { ROOM_EVENT_TYPES, type RoomEventType } from "../room-event-bus.js";
 
 const DEFAULT_HISTOGRAM_BUCKETS_SECONDS = [
-  0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
+  0.001, 0.005, 0.01, 0.015, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
 ] as const;
+
+const NANOSECONDS_PER_SECOND = 1e9;
 
 const CORE_EVENT_NAMES = [
   "room_created",
@@ -66,6 +69,11 @@ export type MetricsCollector = {
     durationMs: number,
   ) => void;
   observeRedisRuntimeStoreFailure: (operation: string) => void;
+  observeRedisRoomStoreDuration: (
+    operation: string,
+    durationMs: number,
+  ) => void;
+  observeRedisRoomStoreFailure: (operation: string) => void;
   observeRedisRoomEventBusPublishDuration: (durationMs: number) => void;
   observeRedisRoomEventBusPublishFailure: () => void;
   recordRoomEventPublishDropped: (eventType: RoomEventType) => void;
@@ -182,6 +190,15 @@ export function createMetricsCollector(options: {
     buckets: DEFAULT_HISTOGRAM_BUCKETS_SECONDS,
     samples: new Map(),
   };
+  const redisRoomStoreDurationHistogram: HistogramMetric = {
+    help: "Duration of Redis room store operations in seconds",
+    buckets: DEFAULT_HISTOGRAM_BUCKETS_SECONDS,
+    samples: new Map(),
+  };
+  // 20ms sampling resolution keeps overhead negligible while still catching
+  // the multi-hundred-millisecond stalls this gauge exists to expose.
+  const eventLoopDelayMonitor = monitorEventLoopDelay({ resolution: 20 });
+  eventLoopDelayMonitor.enable();
   const redisRoomEventBusPublishDurationHistogram: HistogramMetric = {
     help: "Duration of Redis room event bus publish operations in seconds",
     buckets: DEFAULT_HISTOGRAM_BUCKETS_SECONDS,
@@ -271,6 +288,10 @@ export function createMetricsCollector(options: {
         metric: redisRuntimeStoreDurationHistogram,
       },
       {
+        name: "bili_syncplay_redis_room_store_duration_seconds",
+        metric: redisRoomStoreDurationHistogram,
+      },
+      {
         name: "bili_syncplay_redis_room_event_bus_publish_duration_seconds",
         metric: redisRoomEventBusPublishDurationHistogram,
       },
@@ -287,6 +308,28 @@ export function createMetricsCollector(options: {
       formatMetricLine(
         "bili_syncplay_process_start_time_seconds",
         processStartTimeSeconds,
+      ),
+      "# HELP bili_syncplay_nodejs_eventloop_lag_seconds Event loop delay since the previous scrape, in seconds",
+      "# TYPE bili_syncplay_nodejs_eventloop_lag_seconds gauge",
+      formatMetricLine(
+        "bili_syncplay_nodejs_eventloop_lag_seconds",
+        eventLoopDelayMonitor.mean / NANOSECONDS_PER_SECOND,
+        { stat: "mean" },
+      ),
+      formatMetricLine(
+        "bili_syncplay_nodejs_eventloop_lag_seconds",
+        eventLoopDelayMonitor.percentile(50) / NANOSECONDS_PER_SECOND,
+        { stat: "p50" },
+      ),
+      formatMetricLine(
+        "bili_syncplay_nodejs_eventloop_lag_seconds",
+        eventLoopDelayMonitor.percentile(99) / NANOSECONDS_PER_SECOND,
+        { stat: "p99" },
+      ),
+      formatMetricLine(
+        "bili_syncplay_nodejs_eventloop_lag_seconds",
+        eventLoopDelayMonitor.max / NANOSECONDS_PER_SECOND,
+        { stat: "max" },
       ),
       "# HELP bili_syncplay_connections Current websocket connection count",
       "# TYPE bili_syncplay_connections gauge",
@@ -370,6 +413,10 @@ export function createMetricsCollector(options: {
       ),
     ];
 
+    // Each scrape reports the delay distribution observed since the previous
+    // scrape, so a stall shows up exactly once instead of decaying slowly.
+    eventLoopDelayMonitor.reset();
+
     for (const { name, metric } of histogramMetrics) {
       lines.push(`# HELP ${name} ${metric.help}`);
       lines.push(`# TYPE ${name} histogram`);
@@ -437,6 +484,19 @@ export function createMetricsCollector(options: {
     observeRedisRuntimeStoreFailure(operation) {
       incrementCounter(redisFailureCounter, {
         component: "runtime_store",
+        operation,
+      });
+    },
+    observeRedisRoomStoreDuration(operation, durationMs) {
+      observeHistogram(
+        redisRoomStoreDurationHistogram,
+        { operation },
+        durationMs,
+      );
+    },
+    observeRedisRoomStoreFailure(operation) {
+      incrementCounter(redisFailureCounter, {
+        component: "room_store",
         operation,
       });
     },

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -34,6 +34,7 @@ import {
   type RoomEventBusMessage,
 } from "../room-event-bus.js";
 import { createInMemoryRoomStore, type RoomStore } from "../room-store.js";
+import { instrumentRoomStore } from "../room-store-instrumentation.js";
 import {
   createInMemoryRuntimeStore,
   type RuntimeStore,
@@ -238,7 +239,7 @@ export async function createServerBootstrapContext(
   const serviceVersion =
     dependencies.serviceVersion ?? (await resolveServiceVersion());
   const now = dependencies.now ?? Date.now;
-  const roomStore =
+  const rawRoomStore =
     dependencies.roomStore ??
     (persistenceConfig.provider === "redis"
       ? await createRedisRoomStore(persistenceConfig.redisUrl, {
@@ -246,11 +247,18 @@ export async function createServerBootstrapContext(
         })
       : createInMemoryRoomStore({ now }));
   const localRuntimeStore = createInMemoryRuntimeStore(now);
+  // The collector polls countRooms on every scrape; give it the raw store so
+  // scrape-driven reads stay out of the room store operation histogram.
   const metricsCollector = createMetricsCollector({
     runtimeStore: localRuntimeStore,
-    roomStore,
+    roomStore: rawRoomStore,
     serviceVersion,
   });
+  const roomStore =
+    persistenceConfig.provider === "redis" &&
+    dependencies.roomStore === undefined
+      ? instrumentRoomStore(rawRoomStore, metricsCollector)
+      : rawRoomStore;
   const runtimeStorePendingOperationLogger =
     options.loggingHooks?.onRuntimeStorePendingOperationError;
 

--- a/server/src/room-store-instrumentation.ts
+++ b/server/src/room-store-instrumentation.ts
@@ -1,0 +1,53 @@
+import type { MetricsCollector } from "./admin/metrics.js";
+import type { RoomStore } from "./room-store.js";
+
+type RoomStoreMetricsCollector = Pick<
+  MetricsCollector,
+  "observeRedisRoomStoreDuration" | "observeRedisRoomStoreFailure"
+>;
+
+/**
+ * Wraps a RoomStore so every operation reports a duration histogram sample
+ * (and a failure counter on throw). Applied to the Redis-backed store only —
+ * the in-memory store is synchronous and would just add noise.
+ */
+export function instrumentRoomStore(
+  roomStore: RoomStore,
+  metricsCollector: RoomStoreMetricsCollector,
+): RoomStore {
+  function measure<Args extends unknown[], Result>(
+    operation: string,
+    run: (...args: Args) => Promise<Result>,
+  ): (...args: Args) => Promise<Result> {
+    return async (...args: Args): Promise<Result> => {
+      const startedAt = performance.now();
+      try {
+        return await run(...args);
+      } catch (error) {
+        metricsCollector.observeRedisRoomStoreFailure(operation);
+        throw error;
+      } finally {
+        metricsCollector.observeRedisRoomStoreDuration(
+          operation,
+          performance.now() - startedAt,
+        );
+      }
+    };
+  }
+
+  return {
+    createRoom: measure("create_room", (input) => roomStore.createRoom(input)),
+    getRoom: measure("get_room", (code) => roomStore.getRoom(code)),
+    saveRoom: measure("save_room", (room) => roomStore.saveRoom(room)),
+    updateRoom: measure("update_room", (code, expectedVersion, patch) =>
+      roomStore.updateRoom(code, expectedVersion, patch),
+    ),
+    deleteRoom: measure("delete_room", (code) => roomStore.deleteRoom(code)),
+    deleteExpiredRooms: measure("delete_expired_rooms", (now) =>
+      roomStore.deleteExpiredRooms(now),
+    ),
+    listRooms: measure("list_rooms", (query) => roomStore.listRooms(query)),
+    countRooms: measure("count_rooms", (query) => roomStore.countRooms(query)),
+    isReady: measure("is_ready", () => roomStore.isReady()),
+  };
+}

--- a/server/src/room-store-instrumentation.ts
+++ b/server/src/room-store-instrumentation.ts
@@ -35,7 +35,7 @@ export function instrumentRoomStore(
     };
   }
 
-  return {
+  const instrumented: RoomStore = {
     createRoom: measure("create_room", (input) => roomStore.createRoom(input)),
     getRoom: measure("get_room", (code) => roomStore.getRoom(code)),
     saveRoom: measure("save_room", (room) => roomStore.saveRoom(room)),
@@ -50,4 +50,16 @@ export function instrumentRoomStore(
     countRooms: measure("count_rooms", (query) => roomStore.countRooms(query)),
     isReady: measure("is_ready", () => roomStore.isReady()),
   };
+
+  // The Redis-backed store carries a close() hook outside the RoomStore
+  // contract, and shutdown probes for it structurally (hasClose) — it must
+  // survive wrapping or server.close() would leak the Redis connection.
+  const underlying = roomStore as RoomStore & {
+    close?: () => Promise<void>;
+  };
+  if (typeof underlying.close === "function") {
+    const close = underlying.close.bind(underlying);
+    return Object.assign(instrumented, { close });
+  }
+  return instrumented;
 }

--- a/server/test/metrics.test.ts
+++ b/server/test/metrics.test.ts
@@ -47,6 +47,8 @@ test("metrics collector renders event counters, histograms, and redis failure co
   metrics.observeMessageHandlerDuration("room:join", 12);
   metrics.observeRedisRuntimeStoreDuration("register_session", 8);
   metrics.observeRedisRuntimeStoreFailure("register_session");
+  metrics.observeRedisRoomStoreDuration("update_room", 6);
+  metrics.observeRedisRoomStoreFailure("update_room");
   metrics.observeRedisRoomEventBusPublishDuration(5);
   metrics.observeRedisRoomEventBusPublishFailure();
   metrics.recordRoomEventPublishDropped("room_member_changed");
@@ -125,6 +127,34 @@ test("metrics collector renders event counters, histograms, and redis failure co
     ),
     true,
   );
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_redis_room_store_duration_seconds_count{operation="update_room"} 1',
+    ),
+    true,
+  );
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_redis_operation_failures_total{component="room_store",operation="update_room"} 1',
+    ),
+    true,
+  );
+  // The 15ms bucket fills the 10–25ms gap where playback:update P95 lives.
+  assert.equal(
+    rendered.includes(
+      'bili_syncplay_message_handler_duration_seconds_bucket{le="0.015",message_type="room:join"}',
+    ),
+    true,
+  );
+  for (const stat of ["mean", "p50", "p99", "max"]) {
+    assert.match(
+      rendered,
+      new RegExp(
+        `^bili_syncplay_nodejs_eventloop_lag_seconds\\{stat="${stat}"\\} `,
+        "m",
+      ),
+    );
+  }
   // Member-affecting drops are counted under their own event_type label so a
   // critical room_member_changed drop is never hidden behind high-frequency
   // room_state_updated drops.

--- a/server/test/room-store-instrumentation.test.ts
+++ b/server/test/room-store-instrumentation.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createInMemoryRoomStore } from "../src/room-store.js";
+import { instrumentRoomStore } from "../src/room-store-instrumentation.js";
+
+function createRecorder() {
+  const durations: Array<{ operation: string; durationMs: number }> = [];
+  const failures: string[] = [];
+  return {
+    durations,
+    failures,
+    collector: {
+      observeRedisRoomStoreDuration(operation: string, durationMs: number) {
+        durations.push({ operation, durationMs });
+      },
+      observeRedisRoomStoreFailure(operation: string) {
+        failures.push(operation);
+      },
+    },
+  };
+}
+
+test("instrumented room store records a duration sample per operation", async () => {
+  const recorder = createRecorder();
+  const store = instrumentRoomStore(
+    createInMemoryRoomStore({ now: () => 0 }),
+    recorder.collector,
+  );
+
+  const room = await store.createRoom({
+    code: "ROOM01",
+    joinToken: "join-token-1",
+    createdAt: 0,
+    ownerMemberId: "member-1",
+    ownerDisplayName: "Alice",
+  });
+  const fetched = await store.getRoom(room.code);
+  const missing = await store.getRoom("NOPE01");
+  await store.countRooms({ keyword: undefined, includeExpired: true });
+
+  assert.equal(fetched?.code, room.code);
+  assert.equal(missing, null);
+  assert.deepEqual(
+    recorder.durations.map((entry) => entry.operation),
+    ["create_room", "get_room", "get_room", "count_rooms"],
+  );
+  assert.equal(
+    recorder.durations.every((entry) => entry.durationMs >= 0),
+    true,
+  );
+  assert.deepEqual(recorder.failures, []);
+});
+
+test("instrumented room store counts failures and still records duration", async () => {
+  const recorder = createRecorder();
+  const store = instrumentRoomStore(
+    {
+      ...createInMemoryRoomStore({ now: () => 0 }),
+      async updateRoom() {
+        throw new Error("redis unavailable");
+      },
+    },
+    recorder.collector,
+  );
+
+  await assert.rejects(
+    store.updateRoom("ROOM01", 1, { expiresAt: null }),
+    /redis unavailable/,
+  );
+
+  assert.deepEqual(recorder.failures, ["update_room"]);
+  assert.deepEqual(
+    recorder.durations.map((entry) => entry.operation),
+    ["update_room"],
+  );
+});

--- a/server/test/room-store-instrumentation.test.ts
+++ b/server/test/room-store-instrumentation.test.ts
@@ -74,3 +74,34 @@ test("instrumented room store counts failures and still records duration", async
     ["update_room"],
   );
 });
+
+test("instrumented room store preserves the underlying close hook", async () => {
+  const recorder = createRecorder();
+  let closed = 0;
+  const store = instrumentRoomStore(
+    {
+      ...createInMemoryRoomStore({ now: () => 0 }),
+      async close() {
+        closed += 1;
+      },
+    } as never,
+    recorder.collector,
+  );
+
+  // Shutdown probes structurally ("close" in store) — the hook must survive
+  // wrapping and forward to the underlying store without being instrumented.
+  assert.equal("close" in store, true);
+  await (store as { close?: () => Promise<void> }).close?.();
+  assert.equal(closed, 1);
+  assert.deepEqual(recorder.durations, []);
+});
+
+test("instrumented room store adds no close hook when the underlying store has none", () => {
+  const recorder = createRecorder();
+  const store = instrumentRoomStore(
+    createInMemoryRoomStore({ now: () => 0 }),
+    recorder.collector,
+  );
+
+  assert.equal("close" in store, false);
+});


### PR DESCRIPTION
## 背景

排查线上消息处理 P95 尖峰（`video:share` / `room:join` 偶发 0.5–1s，Redis runtime store 每日约两个固定时间窗出现孤立尖峰）时确认了三个观测缺口，导致"Redis 真慢 / Node 事件循环被卡 / 房间持久化层慢"三种情况无法区分。

## 改动

1. **room store 操作直方图**：新增 `instrumentRoomStore` 装饰器（`server/src/room-store-instrumentation.ts`），对 Redis provider 的 `RoomStore` 全部九个操作输出 `bili_syncplay_redis_room_store_duration_seconds{operation}`，失败计入 `bili_syncplay_redis_operation_failures_total{component="room_store"}`。`room:join`/`video:share` 的耗时大头（`getRoom`/`updateRoom`）从此可见。内存 provider 和测试注入的 store 不包装；metrics collector 自身每次抓取的 `countRooms` 轮询走原始 store，不污染直方图。
2. **事件循环延迟 gauge**：`bili_syncplay_nodejs_eventloop_lag_seconds{stat="mean"|"p50"|"p99"|"max"}`，基于 `monitorEventLoopDelay`（20ms 采样分辨率），每次抓取后 reset——每根停顿在面板上恰好出现一次，不会慢慢衰减。消息处理直方图和 Redis 直方图同时升高时，看这条曲线即可判定是否为 Node 侧停顿。
3. **15ms 直方图桶**：所有直方图在 10ms 与 25ms 之间补 `0.015` 桶，`playback:update` P95 常驻区间的插值精度翻倍。已有序列不受影响（Prometheus 对新增 le 标签透明）。

## 测试

- `room-store-instrumentation.test.ts`：逐操作计时（含 get_room 命中/未命中）、抛错时失败计数且仍记录耗时。
- `metrics.test.ts`：room store 直方图与 failures 渲染、eventloop lag 四条 stat 序列、`le="0.015"` 桶存在性。
- `format:check` / `lint` / `typecheck` / `build` / `test` 全部通过。

## 部署后用法

尖峰复现时三张图并排：消息处理 P95、`redis_room_store` P95、`nodejs_eventloop_lag_seconds{stat="max"}`——事件循环同步隆起 → Node/宿主机停顿；只有 room store 隆起 → Redis 持久化层；均不隆起而消息处理隆起 → 应用逻辑路径。配合 `redis-cli slowlog get` 与 `systemctl list-timers` 对 11:30 / 23:00 两个复现窗口收口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)