### PR TITLE
feat: 新增 GC 暂停直方图与进程内存指标，定位事件循环停顿元凶

### DIFF
--- a/server/src/admin/metrics.ts
+++ b/server/src/admin/metrics.ts
@@ -1,4 +1,9 @@
-import { monitorEventLoopDelay } from "node:perf_hooks";
+import {
+  constants as perfHooksConstants,
+  monitorEventLoopDelay,
+  PerformanceObserver,
+  type PerformanceEntry,
+} from "node:perf_hooks";
 import type { RuntimeStore } from "../runtime-store.js";
 import type { RoomStore } from "../room-store.js";
 import { ROOM_EVENT_TYPES, type RoomEventType } from "../room-event-bus.js";
@@ -8,6 +13,22 @@ const DEFAULT_HISTOGRAM_BUCKETS_SECONDS = [
 ] as const;
 
 const NANOSECONDS_PER_SECOND = 1e9;
+
+const GC_KIND_NAMES: Readonly<Record<number, string>> = Object.freeze({
+  [perfHooksConstants.NODE_PERFORMANCE_GC_MAJOR]: "major",
+  [perfHooksConstants.NODE_PERFORMANCE_GC_MINOR]: "minor",
+  [perfHooksConstants.NODE_PERFORMANCE_GC_INCREMENTAL]: "incremental",
+  [perfHooksConstants.NODE_PERFORMANCE_GC_WEAKCB]: "weakcb",
+});
+
+function resolveGcKind(entry: PerformanceEntry): string {
+  const detail = (entry as PerformanceEntry & { detail?: { kind?: number } })
+    .detail;
+  return (
+    (typeof detail?.kind === "number" ? GC_KIND_NAMES[detail.kind] : null) ??
+    "unknown"
+  );
+}
 
 const CORE_EVENT_NAMES = [
   "room_created",
@@ -199,6 +220,21 @@ export function createMetricsCollector(options: {
   // the multi-hundred-millisecond stalls this gauge exists to expose.
   const eventLoopDelayMonitor = monitorEventLoopDelay({ resolution: 20 });
   eventLoopDelayMonitor.enable();
+  const nodejsGcDurationHistogram: HistogramMetric = {
+    help: "Duration of Node.js garbage collection pauses in seconds, grouped by GC kind",
+    buckets: DEFAULT_HISTOGRAM_BUCKETS_SECONDS,
+    samples: new Map(),
+  };
+  const gcObserver = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      observeHistogram(
+        nodejsGcDurationHistogram,
+        { kind: resolveGcKind(entry) },
+        entry.duration,
+      );
+    }
+  });
+  gcObserver.observe({ entryTypes: ["gc"] });
   const redisRoomEventBusPublishDurationHistogram: HistogramMetric = {
     help: "Duration of Redis room event bus publish operations in seconds",
     buckets: DEFAULT_HISTOGRAM_BUCKETS_SECONDS,
@@ -211,6 +247,12 @@ export function createMetricsCollector(options: {
 
   for (const messageType of RATE_LIMITED_MESSAGE_TYPES) {
     ensureCounterSample(rateLimitedCounter, { message_type: messageType });
+  }
+
+  // Pre-seed every GC kind so "no major GC happened" renders as an explicit
+  // zero-count series instead of an absent one.
+  for (const kindName of Object.values(GC_KIND_NAMES)) {
+    ensureHistogramSample(nodejsGcDurationHistogram, { kind: kindName });
   }
 
   // Pre-seed every room event type to 0 so dashboards can distinguish
@@ -251,6 +293,7 @@ export function createMetricsCollector(options: {
       keyword: undefined,
       includeExpired: false,
     });
+    const memory = process.memoryUsage();
     const eventSamples = Array.from(eventCounter.samples.values()).sort(
       (a, b) => (a.labels.event ?? "").localeCompare(b.labels.event ?? ""),
     );
@@ -292,6 +335,10 @@ export function createMetricsCollector(options: {
         metric: redisRoomStoreDurationHistogram,
       },
       {
+        name: "bili_syncplay_nodejs_gc_duration_seconds",
+        metric: nodejsGcDurationHistogram,
+      },
+      {
         name: "bili_syncplay_redis_room_event_bus_publish_duration_seconds",
         metric: redisRoomEventBusPublishDurationHistogram,
       },
@@ -331,6 +378,18 @@ export function createMetricsCollector(options: {
         eventLoopDelayMonitor.max / NANOSECONDS_PER_SECOND,
         { stat: "max" },
       ),
+      "# HELP bili_syncplay_nodejs_heap_used_bytes V8 heap currently in use, in bytes",
+      "# TYPE bili_syncplay_nodejs_heap_used_bytes gauge",
+      formatMetricLine("bili_syncplay_nodejs_heap_used_bytes", memory.heapUsed),
+      "# HELP bili_syncplay_nodejs_heap_total_bytes V8 heap currently reserved, in bytes",
+      "# TYPE bili_syncplay_nodejs_heap_total_bytes gauge",
+      formatMetricLine(
+        "bili_syncplay_nodejs_heap_total_bytes",
+        memory.heapTotal,
+      ),
+      "# HELP bili_syncplay_nodejs_process_rss_bytes Resident set size of the server process, in bytes",
+      "# TYPE bili_syncplay_nodejs_process_rss_bytes gauge",
+      formatMetricLine("bili_syncplay_nodejs_process_rss_bytes", memory.rss),
       "# HELP bili_syncplay_connections Current websocket connection count",
       "# TYPE bili_syncplay_connections gauge",
       formatMetricLine(

--- a/server/test/metrics.test.ts
+++ b/server/test/metrics.test.ts
@@ -155,6 +155,25 @@ test("metrics collector renders event counters, histograms, and redis failure co
       ),
     );
   }
+  for (const gauge of [
+    "bili_syncplay_nodejs_heap_used_bytes",
+    "bili_syncplay_nodejs_heap_total_bytes",
+    "bili_syncplay_nodejs_process_rss_bytes",
+  ]) {
+    const match = rendered.match(new RegExp(`^${gauge} (\\d+)$`, "m"));
+    assert.notEqual(match, null, gauge);
+    assert.equal(Number(match![1]) > 0, true, gauge);
+  }
+  // GC kinds are pre-seeded so "no major GC" is an explicit zero series.
+  for (const kind of ["major", "minor", "incremental", "weakcb"]) {
+    assert.match(
+      rendered,
+      new RegExp(
+        `^bili_syncplay_nodejs_gc_duration_seconds_count\\{kind="${kind}"\\} \\d+$`,
+        "m",
+      ),
+    );
+  }
   // Member-affecting drops are counted under their own event_type label so a
   // critical room_member_changed drop is never hidden behind high-frequency
   // room_state_updated drops.


### PR DESCRIPTION
## 背景

#167 的事件循环延迟指标部署后立即发现：每个抓取窗口内都有一次 0.6~0.95s 的事件循环停顿（`stat="max"` 持续 600-950ms，p50/p99 停留在 20ms 采样基线）。排查已排除：宿主机 CPU steal（vmstat st=0）、内存换页（swap 0B）、systemd CPUQuota（infinity）、60s 房间清理任务（47 次共 32ms）、Redis 慢查询（get/update_room 均值 1-2ms）。vmstat 抓到过一次"CPU 突发 + free 跳涨 25MB"的疑似 major GC 现场。本 PR 补齐实锤所需的最后两组指标。

## 改动

- **`bili_syncplay_nodejs_gc_duration_seconds{kind}` 直方图**：`PerformanceObserver("gc")` 监听 GC 暂停，按 `major` / `minor` / `incremental` / `weakcb` 分维（kind 集合来自 perf_hooks 常量，有界；未知值归入 `unknown`）。四种 kind 预置零值序列，"无 major GC"与"指标缺失"可区分。
- **进程内存三 gauge**：`nodejs_heap_used_bytes`、`nodejs_heap_total_bytes`、`process_rss_bytes`，每次抓取读 `process.memoryUsage()`。

## 判定方法（部署后）

GC major P99 曲线与 `eventloop_lag{stat="max"}` 逐根对齐 → 停顿元凶实锤为老年代 GC，随后依据 heap 锯齿形态决定 `--max-old-space-size` / `--max-semi-space-size` 的调整方向；若不对齐，则继续排查其它同步阻塞源。

## 测试

- 渲染断言：三个内存 gauge 输出正整数、GC 直方图四种 kind 的预置零值序列存在。
- `format:check` / `lint` / `typecheck` / `build` / `test` 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)