### PR TITLE
fix: prevent spurious room pause broadcasts

### DIFF
--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -38,7 +38,7 @@ const REMOTE_FOLLOW_PLAYING_WINDOW_MS = 3000;
 const PROGRAMMATIC_APPLY_WINDOW_MS = 700;
 const USER_GESTURE_GRACE_MS = 1200;
 const BUFFER_SIGNAL_WINDOW_MS = 300;
-const BUFFER_PAUSE_UPGRADE_MS = 1500;
+const UNCONFIRMED_PAUSE_RECOVERY_MS = 1500;
 const REMOTE_PAUSE_DEBOUNCE_MS = 250;
 const FESTIVAL_SNAPSHOT_TTL_MS = 1200;
 const NAVIGATION_WATCH_INTERVAL_MS = 400;
@@ -108,7 +108,6 @@ const syncController = createSyncController({
   remoteFollowPlayingWindowMs: REMOTE_FOLLOW_PLAYING_WINDOW_MS,
   programmaticApplyWindowMs: PROGRAMMATIC_APPLY_WINDOW_MS,
   userGestureGraceMs: USER_GESTURE_GRACE_MS,
-  bufferPauseUpgradeMs: BUFFER_PAUSE_UPGRADE_MS,
   remotePauseDebounceMs: REMOTE_PAUSE_DEBOUNCE_MS,
   nextSeq: () => seq++,
   markBroadcastAt: (at) => {
@@ -132,7 +131,7 @@ const playbackBindingController = createPlaybackBindingController({
   userGestureGraceMs: USER_GESTURE_GRACE_MS,
   initialRoomStatePauseHoldMs: INITIAL_ROOM_STATE_PAUSE_HOLD_MS,
   bufferSignalWindowMs: BUFFER_SIGNAL_WINDOW_MS,
-  bufferPauseUpgradeMs: BUFFER_PAUSE_UPGRADE_MS,
+  unconfirmedPauseRecoveryMs: UNCONFIRMED_PAUSE_RECOVERY_MS,
   getSharedVideo: () => shareController.getSharedVideo(),
   hasRecentRemoteStopIntent: (currentVideoUrl) =>
     syncController.hasRecentRemoteStopIntent(currentVideoUrl),

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -35,11 +35,10 @@ export function createPlaybackBindingController(args: {
    */
   bufferSignalWindowMs: number;
   /**
-   * Maximum duration to keep reporting a buffer-induced pause as
-   * `buffering` to peers before re-broadcasting it as `paused`. Bounds the
-   * worst-case desync if a buffer stall turns into a real stop.
+   * Delay before trying to resume a pause that lacks explicit in-player intent.
+   * Such pauses never gain authority to stop the room.
    */
-  bufferPauseUpgradeMs: number;
+  unconfirmedPauseRecoveryMs: number;
   getSharedVideo: () => SharedVideo | null;
   hasRecentRemoteStopIntent: (currentVideoUrl: string) => boolean;
   normalizeUrl: (url: string | undefined | null) => string | null;
@@ -60,10 +59,13 @@ export function createPlaybackBindingController(args: {
   getNow?: () => number;
 }): PlaybackBindingController {
   let videoBindingTimer: number | null = null;
-  let pauseBufferUpgradeTimerId: number | null = null;
+  let unconfirmedPauseRecoveryTimerId: number | null = null;
   let sharerEndedFlushTimerId: number | null = null;
   const nowOf = () => args.getNow?.() ?? Date.now();
-  const scheduleUpgradeTimer = (cb: () => void, ms: number): number | null => {
+  const scheduleControllerTimer = (
+    cb: () => void,
+    ms: number,
+  ): number | null => {
     if (
       typeof globalThis.window !== "undefined" &&
       typeof globalThis.window.setTimeout === "function"
@@ -75,7 +77,7 @@ export function createPlaybackBindingController(args: {
     }
     return null;
   };
-  const cancelUpgradeTimer = (id: number): void => {
+  const cancelControllerTimer = (id: number): void => {
     if (
       typeof globalThis.window !== "undefined" &&
       typeof globalThis.window.clearTimeout === "function"
@@ -87,22 +89,22 @@ export function createPlaybackBindingController(args: {
       globalThis.clearTimeout(id);
     }
   };
-  const clearBufferUpgradeTimer = () => {
-    if (pauseBufferUpgradeTimerId !== null) {
-      cancelUpgradeTimer(pauseBufferUpgradeTimerId);
-      pauseBufferUpgradeTimerId = null;
+  const clearUnconfirmedPauseRecoveryTimer = () => {
+    if (unconfirmedPauseRecoveryTimerId !== null) {
+      cancelControllerTimer(unconfirmedPauseRecoveryTimerId);
+      unconfirmedPauseRecoveryTimerId = null;
     }
   };
   const clearSharerEndedFlushTimer = () => {
     if (sharerEndedFlushTimerId !== null) {
-      cancelUpgradeTimer(sharerEndedFlushTimerId);
+      cancelControllerTimer(sharerEndedFlushTimerId);
       sharerEndedFlushTimerId = null;
     }
   };
   const clearActivePauseClassification = () => {
     args.runtimeState.pauseStartedAt = 0;
     args.runtimeState.pauseClassifiedAsBuffer = false;
-    clearBufferUpgradeTimer();
+    clearUnconfirmedPauseRecoveryTimer();
   };
   const hasRecentUserGesture = () =>
     nowOf() - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs;
@@ -114,16 +116,17 @@ export function createPlaybackBindingController(args: {
   const hasRecentUserGestureInPlayer = () =>
     nowOf() - args.runtimeState.lastUserGestureInPlayerAt <
     args.userGestureGraceMs;
+  const hasFreshInPlayerGesture = () =>
+    hasRecentUserGestureInPlayer() &&
+    args.runtimeState.lastUserGestureInPlayerAt >
+      args.runtimeState.lastForcedPauseAt;
   // A FRESH in-player play intent: an in-player gesture that also postdates the
   // last forced pause. While the page bridge resolves, the unconfirmed-context
   // hold force-pauses (updating `lastForcedPauseAt`); the SAME click that
   // triggered that pause must not then authorize the delayed `play`/`playing`
   // once the bridge resolves — only a gesture made AFTER the forced pause counts
   // as a new play intent (mirrors `shouldPreRecordNonSharedExplicitPlay`).
-  const hasFreshInPlayerPlayIntent = () =>
-    hasRecentUserGestureInPlayer() &&
-    args.runtimeState.lastUserGestureInPlayerAt >
-      args.runtimeState.lastForcedPauseAt;
+  const hasFreshInPlayerPlayIntent = () => hasFreshInPlayerGesture();
   const getRecentExplicitSeekWithoutNewGestureAt = (): number | null => {
     const explicitAction = args.runtimeState.lastExplicitUserAction;
     if (
@@ -151,10 +154,13 @@ export function createPlaybackBindingController(args: {
     }
   }
 
-  function rememberExplicitPlaybackAction(playState: "playing" | "paused") {
+  function rememberExplicitPlaybackAction(
+    playState: "playing" | "paused",
+    gestureAt = args.runtimeState.lastUserGestureAt,
+  ) {
     if (
-      nowOf() - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs &&
-      args.runtimeState.lastUserGestureAt > args.runtimeState.lastForcedPauseAt
+      nowOf() - gestureAt < args.userGestureGraceMs &&
+      gestureAt > args.runtimeState.lastForcedPauseAt
     ) {
       args.runtimeState.lastExplicitPlaybackAction = {
         playState,
@@ -163,10 +169,13 @@ export function createPlaybackBindingController(args: {
     }
   }
 
-  function rememberExplicitUserAction(kind: ExplicitUserActionKind) {
+  function rememberExplicitUserAction(
+    kind: ExplicitUserActionKind,
+    gestureAt = args.runtimeState.lastUserGestureAt,
+  ) {
     if (
-      nowOf() - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs &&
-      args.runtimeState.lastUserGestureAt > args.runtimeState.lastForcedPauseAt
+      nowOf() - gestureAt < args.userGestureGraceMs &&
+      gestureAt > args.runtimeState.lastForcedPauseAt
     ) {
       if (
         kind === "play" &&
@@ -348,7 +357,7 @@ export function createPlaybackBindingController(args: {
       nowOf() + args.initialRoomStatePauseHoldMs;
     args.runtimeState.sharerEndedSuppressionArmedAt = nowOf();
     clearSharerEndedFlushTimer();
-    sharerEndedFlushTimerId = scheduleUpgradeTimer(() => {
+    sharerEndedFlushTimerId = scheduleControllerTimer(() => {
       sharerEndedFlushTimerId = null;
       flushSharerEndedSuppressionIfTerminal(armedUrl);
     }, args.initialRoomStatePauseHoldMs);
@@ -830,7 +839,13 @@ export function createPlaybackBindingController(args: {
         if (video.ended && armSharerSharedVideoEndSuppression()) {
           return;
         }
-        if (hasRecentUserGesture()) {
+        // A seek can pause the element as part of the same progress-bar drag.
+        // It is only a real pause intent when a distinct, newer in-player
+        // gesture follows that seek.
+        const userInitiatedPause =
+          hasFreshInPlayerGesture() &&
+          getRecentExplicitSeekWithoutNewGestureAt() === null;
+        if (userInitiatedPause) {
           args.cancelActiveSoftApply(video, "pause");
         }
         const now = nowOf();
@@ -838,10 +853,6 @@ export function createPlaybackBindingController(args: {
           args.runtimeState.lastBufferSignalAt > 0 &&
           now - args.runtimeState.lastBufferSignalAt <
             args.bufferSignalWindowMs;
-        const userInitiatedPause =
-          hasRecentUserGesture() &&
-          args.runtimeState.lastUserGestureAt >
-            args.runtimeState.lastForcedPauseAt;
         // When applying a remote `paused`, we hard-seek then call `video.pause()`.
         // The seek trips a `waiting` event milliseconds before the `pause`, so the
         // buffer-signal window will look "fresh" even though no real stall occurred.
@@ -860,28 +871,51 @@ export function createPlaybackBindingController(args: {
           now < args.runtimeState.programmaticApplyUntil &&
           normalizedSharedUrl !== null &&
           normalizedSharedUrl === programmaticSignature.url;
-        const bufferInduced =
-          !insideProgrammaticPausedWindow &&
-          recentBufferSignal &&
-          !userInitiatedPause;
+        // A DOM `pause` without a fresh in-player gesture is not authoritative:
+        // Bilibili can briefly pause while rebuilding the player, switching
+        // quality, or recovering from a stall without firing `waiting` first.
+        // Treat every such pause as local/transient. It never gains authority
+        // to stop the room; after a short grace period we instead try to restore
+        // the room's non-paused intent locally. Known buffer pauses have already
+        // emitted `waiting`/`stalled` and recover through the same path.
+        const unconfirmedPause =
+          !insideProgrammaticPausedWindow && !userInitiatedPause;
         args.runtimeState.pauseStartedAt = now;
-        args.runtimeState.pauseClassifiedAsBuffer = bufferInduced;
-        clearBufferUpgradeTimer();
-        if (bufferInduced) {
-          pauseBufferUpgradeTimerId = scheduleUpgradeTimer(() => {
-            pauseBufferUpgradeTimerId = null;
-            if (!video.paused) {
+        args.runtimeState.pauseClassifiedAsBuffer = unconfirmedPause;
+        clearUnconfirmedPauseRecoveryTimer();
+        if (unconfirmedPause) {
+          const classifiedPauseStartedAt = now;
+          unconfirmedPauseRecoveryTimerId = scheduleControllerTimer(() => {
+            unconfirmedPauseRecoveryTimerId = null;
+            if (
+              !video.paused ||
+              !args.runtimeState.pauseClassifiedAsBuffer ||
+              args.runtimeState.pauseStartedAt !== classifiedPauseStartedAt
+            ) {
               return;
             }
-            args.runtimeState.pauseClassifiedAsBuffer = false;
-            args.debugLog(
-              `Buffer-pause upgraded to paused after ${args.bufferPauseUpgradeMs}ms, re-broadcasting`,
-            );
-            void args.broadcastPlayback(video, "pause");
-          }, args.bufferPauseUpgradeMs);
+            if (args.runtimeState.intendedPlayState !== "paused") {
+              args.debugLog(
+                `Unconfirmed local pause persisted for ${args.unconfirmedPauseRecoveryMs}ms, restoring room playback`,
+              );
+              void video.play().catch(() => {
+                args.debugLog(
+                  "Failed to restore playback after unconfirmed pause",
+                );
+              });
+            }
+          }, args.unconfirmedPauseRecoveryMs);
         }
-        rememberExplicitPlaybackAction("paused");
-        rememberExplicitUserAction("pause");
+        if (userInitiatedPause) {
+          rememberExplicitPlaybackAction(
+            "paused",
+            args.runtimeState.lastUserGestureInPlayerAt,
+          );
+          rememberExplicitUserAction(
+            "pause",
+            args.runtimeState.lastUserGestureInPlayerAt,
+          );
+        }
         // Deauthorize the non-shared video the user paused — UNLESS this `pause`
         // is the natural end of the video (the browser fires `pause` immediately
         // before `ended`). At a natural end the player is about to autoplay the
@@ -892,12 +926,19 @@ export function createPlaybackBindingController(args: {
         // make that classification fail and let the next episode autoplay, so keep
         // it until the navigation reset replaces it.
         if (
+          userInitiatedPause &&
           !video.ended &&
           currentVideo &&
           args.normalizeUrl(currentVideo.url) ===
             args.runtimeState.explicitNonSharedPlaybackUrl
         ) {
           args.runtimeState.explicitNonSharedPlaybackUrl = null;
+        }
+        if (unconfirmedPause) {
+          args.debugLog(
+            `Deferred unconfirmed local pause (recentBufferSignal=${recentBufferSignal})`,
+          );
+          return;
         }
         scheduleBroadcast(video, "pause", 120);
       },
@@ -1009,7 +1050,7 @@ export function createPlaybackBindingController(args: {
         window.clearInterval(videoBindingTimer);
         videoBindingTimer = null;
       }
-      clearBufferUpgradeTimer();
+      clearUnconfirmedPauseRecoveryTimer();
       clearSharerEndedFlushTimer();
     },
   };

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -209,16 +209,17 @@ export interface ContentRuntimeState {
   /**
    * Timestamp when the local video most recently transitioned to `paused`.
    * Reset to 0 once playback resumes. Together with
-   * [[pauseClassifiedAsBuffer]] this powers the "buffer-pause → buffering"
-   * remote broadcast classification and its upgrade-to-`paused` timeout.
+   * [[pauseClassifiedAsBuffer]] this identifies the active unconfirmed pause
+   * and prevents a stale recovery timer from acting in a new context.
    */
   pauseStartedAt: number;
   /**
-   * Whether the active pause is currently classified as buffer-induced. Set
-   * on the `pause` event when a `waiting`/`stalled` signal occurred very
-   * recently and no fresh user gesture preceded the pause; cleared on
-   * resume. The broadcast layer reports `buffering` instead of `paused`
-   * while this flag is on and within the upgrade threshold.
+   * Whether the active pause is currently unconfirmed. Set on a `pause` event
+   * when no fresh in-player gesture proves explicit user intent (including,
+   * but not limited to, pauses preceded by `waiting`/`stalled`); cleared on
+   * resume. The binding suppresses the paused broadcast and attempts to restore
+   * room playback locally; any incidental broadcasts remain `buffering`, never
+   * `paused`, while this flag is on.
    */
   pauseClassifiedAsBuffer: boolean;
   /**
@@ -249,6 +250,8 @@ export function resetUserGestureState(state: ContentRuntimeState): void {
   state.suppressedLocalEndPauseUrl = null;
   state.suppressedLocalEndPauseUntil = 0;
   state.nonSharerAutoplayHoldUrl = null;
+  state.pauseStartedAt = 0;
+  state.pauseClassifiedAsBuffer = false;
 }
 
 export function createContentRuntimeState(): ContentRuntimeState {

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -73,12 +73,6 @@ export function createSyncController(args: {
   programmaticApplyWindowMs: number;
   userGestureGraceMs: number;
   /**
-   * Window during which a buffer-induced pause is broadcast as `buffering`
-   * instead of `paused`. After this elapses the binding layer re-broadcasts
-   * as `paused`.
-   */
-  bufferPauseUpgradeMs: number;
-  /**
    * Delay before applying a remote `paused` room state, to absorb the
    * "pause→play within ~1s" flicker emitted by peers experiencing buffer
    * stalls. Set to 0 to disable.
@@ -259,6 +253,8 @@ export function createSyncController(args: {
     args.runtimeState.intendedPlaybackRate = 1;
     args.runtimeState.lastNonSharedGuardUrl = null;
     args.runtimeState.lastExplicitPlaybackAction = null;
+    args.runtimeState.pauseStartedAt = 0;
+    args.runtimeState.pauseClassifiedAsBuffer = false;
     // Preserve the user's authorization to keep watching a non-shared local video
     // they manually started when this reset is a remote shared-url switch and they
     // are STILL on that very video. Otherwise the periodic non-shared load-pause
@@ -688,9 +684,7 @@ export function createSyncController(args: {
     if (
       basePlayState === "paused" &&
       args.runtimeState.pauseClassifiedAsBuffer &&
-      args.runtimeState.pauseStartedAt > 0 &&
-      argsForBroadcast.now - args.runtimeState.pauseStartedAt <
-        args.bufferPauseUpgradeMs
+      args.runtimeState.pauseStartedAt > 0
     ) {
       return "buffering";
     }

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -1,12 +1,28 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { SharedVideo } from "@bili-syncplay/protocol";
-import { createContentRuntimeState } from "../src/content/runtime-state";
+import {
+  createContentRuntimeState,
+  resetUserGestureState,
+} from "../src/content/runtime-state";
 import { createPlaybackBindingController } from "../src/content/playback-binding-controller";
 import { createRoomStateController } from "../src/content/room-state-controller";
 import { createToastCoordinatorState } from "../src/content/toast";
 
 type ListenerMap = Map<string, EventListener>;
+
+test("resetting gesture state invalidates an unconfirmed pause", () => {
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 5_000;
+  runtimeState.lastUserGestureInPlayerAt = 5_000;
+  runtimeState.pauseStartedAt = 5_100;
+  runtimeState.pauseClassifiedAsBuffer = true;
+
+  resetUserGestureState(runtimeState);
+
+  assert.equal(runtimeState.pauseStartedAt, 0);
+  assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
+});
 
 function installDomStub() {
   const originalDocument = globalThis.document;
@@ -103,6 +119,7 @@ test("playback binding controller cancels active soft apply on pause and seek", 
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();
   runtimeState.lastUserGestureAt = 1_000;
+  runtimeState.lastUserGestureInPlayerAt = 1_000;
   const reasons: string[] = [];
 
   const controller = createPlaybackBindingController({
@@ -427,7 +444,7 @@ test("playback binding controller keeps hydration guard after direct room switch
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => ({
       videoId: "BVnew:p1",
       url: currentUrl,
@@ -569,7 +586,7 @@ test("playback binding controller reapplies pause hold for unstable identity aft
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => ({
       videoId: "/festival/demo",
       url: "https://www.bilibili.com/festival/demo",
@@ -638,7 +655,7 @@ test("playback binding controller reapplies pause hold for unstable room shared 
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => ({
       videoId: "ep1231523",
       url: "https://www.bilibili.com/bangumi/play/ep1231523",
@@ -1931,6 +1948,8 @@ test("playback binding controller preserves the explicit non-shared authorizatio
     );
 
     // A genuine manual mid-video pause (not ended) still deauthorizes it.
+    runtimeState.lastUserGestureAt = 19_950;
+    runtimeState.lastUserGestureInPlayerAt = 19_950;
     (dom.video as { ended?: boolean }).ended = false;
     dom.listeners.get("pause")?.(new Event("pause"));
     await Promise.resolve();
@@ -2244,7 +2263,7 @@ test("playback binding controller holds a non-sharer at the shared video natural
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => ({
       videoId: "BVshared:p1",
       url: "https://www.bilibili.com/video/BVshared?p=1",
@@ -2319,7 +2338,7 @@ test("playback binding controller does not pause the sharer at the shared video 
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => ({
       videoId: "BVshared:p1",
       url: "https://www.bilibili.com/video/BVshared?p=1",
@@ -2383,7 +2402,7 @@ test("playback binding controller does not pause a non-sharer before the shared 
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => ({
       videoId: "BVshared:p1",
       url: "https://www.bilibili.com/video/BVshared?p=1",
@@ -2449,7 +2468,7 @@ test("playback binding controller re-pauses non-sharer multi-part autoplay after
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => ({
       videoId: "BVshared:p1",
       url: "https://www.bilibili.com/video/BVshared?p=1",
@@ -2517,7 +2536,7 @@ test("playback binding controller classifies pause as buffer when waiting fired 
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => null,
     hasRecentRemoteStopIntent: () => false,
     normalizeUrl: (url) => url ?? null,
@@ -2552,6 +2571,7 @@ test("playback binding controller treats pause as user-initiated when fresh gest
   const runtimeState = createContentRuntimeState();
   let now = 5_000;
   runtimeState.lastUserGestureAt = 4_950; // fresh gesture
+  runtimeState.lastUserGestureInPlayerAt = 4_950;
   runtimeState.lastForcedPauseAt = 0;
 
   const controller = createPlaybackBindingController({
@@ -2560,7 +2580,7 @@ test("playback binding controller treats pause as user-initiated when fresh gest
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => null,
     hasRecentRemoteStopIntent: () => false,
     normalizeUrl: (url) => url ?? null,
@@ -2585,12 +2605,72 @@ test("playback binding controller treats pause as user-initiated when fresh gest
 
     assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
     assert.equal(runtimeState.pauseStartedAt, 5_120);
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "pause",
+      at: 5_120,
+    });
   } finally {
     dom.restore();
   }
 });
 
-test("playback binding controller clears buffer-pause classification on resume", () => {
+test("playback binding controller defers a seek-triggered pause from the same player gesture", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  let now = 5_000;
+  runtimeState.lastUserGestureAt = 4_950;
+  runtimeState.lastUserGestureInPlayerAt = 4_950;
+  const broadcasts: string[] = [];
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    unconfirmedPauseRecoveryMs: 1_500,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async (_video, eventSource) => {
+      broadcasts.push(eventSource ?? "manual");
+    },
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("seeking")?.(new Event("seeking"));
+    await Promise.resolve();
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "seek",
+      at: 5_000,
+    });
+
+    broadcasts.length = 0;
+    now = 5_100;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+    await Promise.resolve();
+
+    assert.deepEqual(broadcasts, []);
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "seek",
+      at: 5_000,
+    });
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller clears unconfirmed-pause classification on resume", () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();
   runtimeState.lastUserGestureAt = 0;
@@ -2602,7 +2682,7 @@ test("playback binding controller clears buffer-pause classification on resume",
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => null,
     hasRecentRemoteStopIntent: () => false,
     normalizeUrl: (url) => url ?? null,
@@ -2667,7 +2747,7 @@ test("playback binding controller does not classify pause as buffer-induced insi
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => ({
       videoId: "BV1xx411c7mD:p1",
       url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
@@ -2696,7 +2776,7 @@ test("playback binding controller does not classify pause as buffer-induced insi
 
     assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
     assert.equal(runtimeState.pauseStartedAt, 5_120);
-    // No buffer-pause upgrade timer should have been armed.
+    // No unconfirmed-pause recovery timer should have been armed.
     assert.equal(
       scheduledTimers.some((t) => t.ms === 1_500),
       false,
@@ -2726,7 +2806,7 @@ test("playback binding controller still classifies pause as buffer-induced when 
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => ({
       videoId: "BV1xx411c7mD:p1",
       url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
@@ -2757,12 +2837,17 @@ test("playback binding controller still classifies pause as buffer-induced when 
   }
 });
 
-test("playback binding controller re-broadcasts paused after buffer-pause upgrade threshold", async () => {
+test("playback binding controller never broadcasts an unconfirmed pause and restores local playback", async () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();
+  // The player pauses internally without any user gesture at all.
   runtimeState.lastUserGestureAt = 0;
+  runtimeState.lastUserGestureInPlayerAt = 0;
+  runtimeState.intendedPlayState = "playing";
   let now = 5_000;
   const broadcasts: string[] = [];
+  let playCalls = 0;
+  const originalPlay = dom.video.play;
   const originalSetTimeout = globalThis.window.setTimeout;
   const scheduledTimers: Array<{ cb: () => void; ms: number }> = [];
   globalThis.window.setTimeout = ((callback: TimerHandler, ms?: number) => {
@@ -2771,6 +2856,10 @@ test("playback binding controller re-broadcasts paused after buffer-pause upgrad
     }
     return scheduledTimers.length;
   }) as typeof globalThis.window.setTimeout;
+  dom.video.play = () => {
+    playCalls += 1;
+    return Promise.resolve();
+  };
 
   const controller = createPlaybackBindingController({
     runtimeState,
@@ -2778,7 +2867,7 @@ test("playback binding controller re-broadcasts paused after buffer-pause upgrad
     userGestureGraceMs: 1_200,
     initialRoomStatePauseHoldMs: 3_000,
     bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
+    unconfirmedPauseRecoveryMs: 1_500,
     getSharedVideo: () => null,
     hasRecentRemoteStopIntent: () => false,
     normalizeUrl: (url) => url ?? null,
@@ -2796,26 +2885,137 @@ test("playback binding controller re-broadcasts paused after buffer-pause upgrad
 
   try {
     controller.attachPlaybackListeners();
-    dom.listeners.get("waiting")?.(new Event("waiting"));
     now = 5_100;
     dom.video.paused = true;
     dom.listeners.get("pause")?.(new Event("pause"));
 
     await Promise.resolve();
-    // Initial broadcasts from pause + 120ms followup (captured but not fired here)
-    assert.equal(broadcasts.includes("pause"), true);
+    assert.deepEqual(broadcasts, []);
     assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
-    const upgradeTimer = scheduledTimers.find((t) => t.ms === 1_500);
-    assert.notEqual(upgradeTimer, undefined);
+    assert.equal(runtimeState.lastExplicitUserAction, null);
+    const recoveryTimer = scheduledTimers.find((t) => t.ms === 1_500);
+    assert.notEqual(recoveryTimer, undefined);
 
-    // Fire the upgrade timer: video still paused, should re-broadcast and clear classification
+    // A persistent player-internal pause must still not stop the room. Restore
+    // the intended room playback locally instead.
     now = 6_600;
     broadcasts.length = 0;
-    upgradeTimer?.cb();
+    recoveryTimer?.cb();
     await Promise.resolve();
 
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
+    assert.deepEqual(broadcasts, []);
+    assert.equal(playCalls, 1);
+  } finally {
+    dom.video.play = originalPlay;
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.restore();
+  }
+});
+
+test("playback binding controller cancels unconfirmed-pause recovery when playback resumes", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  let now = 5_000;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalClearTimeout = globalThis.window.clearTimeout;
+  const clearedTimers: number[] = [];
+  globalThis.window.setTimeout = ((callback: TimerHandler, ms?: number) => {
+    assert.equal(typeof callback, "function");
+    return ms === 1_500 ? 7 : 8;
+  }) as typeof globalThis.window.setTimeout;
+  globalThis.window.clearTimeout = ((id?: number) => {
+    if (id !== undefined) {
+      clearedTimers.push(id);
+    }
+  }) as typeof globalThis.window.clearTimeout;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    unconfirmedPauseRecoveryMs: 1_500,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
+
+    now = 5_200;
+    dom.video.paused = false;
+    dom.listeners.get("playing")?.(new Event("playing"));
+
     assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
-    assert.equal(broadcasts.includes("pause"), true);
+    assert.equal(runtimeState.pauseStartedAt, 0);
+    assert.deepEqual(clearedTimers, [7]);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    globalThis.window.clearTimeout = originalClearTimeout;
+    dom.restore();
+  }
+});
+
+test("playback binding controller ignores unconfirmed-pause recovery invalidated by navigation", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  let upgradeCallback: (() => void) | null = null;
+  const broadcasts: string[] = [];
+  const originalSetTimeout = globalThis.window.setTimeout;
+  globalThis.window.setTimeout = ((callback: TimerHandler, ms?: number) => {
+    if (typeof callback === "function" && ms === 1_500) {
+      upgradeCallback = callback as () => void;
+    }
+    return 1;
+  }) as typeof globalThis.window.setTimeout;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    unconfirmedPauseRecoveryMs: 1_500,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async (_video, eventSource) => {
+      broadcasts.push(eventSource ?? "manual");
+    },
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 5_000,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+    assert.notEqual(upgradeCallback, null);
+
+    resetUserGestureState(runtimeState);
+    upgradeCallback?.();
+    await Promise.resolve();
+
+    assert.deepEqual(broadcasts, []);
   } finally {
     globalThis.window.setTimeout = originalSetTimeout;
     dom.restore();

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -58,7 +58,6 @@ function createControllerHarness() {
     remoteFollowPlayingWindowMs: 3_000,
     programmaticApplyWindowMs: 700,
     userGestureGraceMs: 300,
-    bufferPauseUpgradeMs: 1_500,
     remotePauseDebounceMs: 0,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
@@ -1553,7 +1552,7 @@ test("sync controller releases sharer end-of-video marker once the resolved url 
   assert.equal(harness.runtimeState.sharerEndedSuppressionUntil, 0);
 });
 
-test("sync controller broadcasts buffering when active pause is classified as buffer", async () => {
+test("sync controller broadcasts buffering while a pause lacks user intent", async () => {
   const harness = createControllerHarness();
   const sharedVideo = {
     videoId: "BV1xx411c7mD",
@@ -1589,7 +1588,6 @@ test("sync controller broadcasts buffering when active pause is classified as bu
     remoteFollowPlayingWindowMs: 3_000,
     programmaticApplyWindowMs: 700,
     userGestureGraceMs: 300,
-    bufferPauseUpgradeMs: 1_500,
     remotePauseDebounceMs: 0,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
@@ -1617,7 +1615,7 @@ test("sync controller broadcasts buffering when active pause is classified as bu
   assert.equal(payload.playState, "buffering");
 });
 
-test("sync controller broadcasts paused once buffer-pause upgrade window elapses", async () => {
+test("sync controller keeps an unconfirmed pause as buffering after the recovery delay", async () => {
   const harness = createControllerHarness();
   const sharedVideo = {
     videoId: "BV1xx411c7mD",
@@ -1653,11 +1651,10 @@ test("sync controller broadcasts paused once buffer-pause upgrade window elapses
     remoteFollowPlayingWindowMs: 3_000,
     programmaticApplyWindowMs: 700,
     userGestureGraceMs: 300,
-    bufferPauseUpgradeMs: 1_500,
     remotePauseDebounceMs: 0,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
-    getNow: () => 21_700, // 1700ms after pauseStartedAt, past upgrade threshold
+    getNow: () => 21_700, // 1700ms after pauseStartedAt, past recovery delay
     debugLog: (message) => harness.debugLogs.push(message),
     shouldLogHeartbeat: () => true,
     runtimeSendMessage: async (message) => {
@@ -1678,7 +1675,7 @@ test("sync controller broadcasts paused once buffer-pause upgrade window elapses
   const payload = (
     harness.runtimeMessages[0] as { payload: { playState: string } }
   ).payload;
-  assert.equal(payload.playState, "paused");
+  assert.equal(payload.playState, "buffering");
 });
 
 test("sync controller suppresses local end-pause broadcasts from non-sharer autoplay guard", async () => {
@@ -1764,7 +1761,6 @@ test("sync controller tags broadcast with userInitiated:true on a fresh user pau
     remoteFollowPlayingWindowMs: 3_000,
     programmaticApplyWindowMs: 700,
     userGestureGraceMs: 300,
-    bufferPauseUpgradeMs: 1_500,
     remotePauseDebounceMs: 0,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
@@ -1833,7 +1829,6 @@ test("sync controller omits userInitiated when a pause is buffer-induced", async
     remoteFollowPlayingWindowMs: 3_000,
     programmaticApplyWindowMs: 700,
     userGestureGraceMs: 300,
-    bufferPauseUpgradeMs: 1_500,
     remotePauseDebounceMs: 0,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
@@ -1864,7 +1859,7 @@ test("sync controller omits userInitiated when a pause is buffer-induced", async
   assert.equal(payload.userInitiated, undefined);
 });
 
-test("sync controller omits userInitiated on buffer-pause upgrade re-broadcast", async () => {
+test("sync controller omits userInitiated when paused broadcast has no fresh gesture", async () => {
   const harness = createControllerHarness();
   const sharedVideo = {
     videoId: "BV1xx411c7mD",
@@ -1882,7 +1877,7 @@ test("sync controller omits userInitiated on buffer-pause upgrade re-broadcast",
   harness.runtimeState.localMemberId = "local-member";
   harness.runtimeState.intendedPlayState = "paused";
   harness.runtimeState.pauseStartedAt = 20_000;
-  harness.runtimeState.pauseClassifiedAsBuffer = false; // already upgraded
+  harness.runtimeState.pauseClassifiedAsBuffer = false;
   // Original gesture, if any, is way past the gesture grace window — the
   // re-broadcast must not be mistaken for a fresh user pause.
   harness.runtimeState.lastExplicitUserAction = {
@@ -1907,7 +1902,6 @@ test("sync controller omits userInitiated on buffer-pause upgrade re-broadcast",
     remoteFollowPlayingWindowMs: 3_000,
     programmaticApplyWindowMs: 700,
     userGestureGraceMs: 300,
-    bufferPauseUpgradeMs: 1_500,
     remotePauseDebounceMs: 0,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
@@ -1948,6 +1942,8 @@ test("sync controller keeps non-shared authorization on reset while still on tha
   });
   harness.runtimeState.explicitNonSharedPlaybackUrl = localUrl;
   harness.runtimeState.nonSharerAutoplayHoldUrl = localUrl;
+  harness.runtimeState.pauseStartedAt = 20_000;
+  harness.runtimeState.pauseClassifiedAsBuffer = true;
 
   // A remote member switches the room's shared video while the user is still
   // watching their manually-started local video. Its authorization must survive,
@@ -1955,6 +1951,8 @@ test("sync controller keeps non-shared authorization on reset while still on tha
   harness.controller.resetPlaybackSyncState("shared url changed");
 
   assert.equal(harness.runtimeState.explicitNonSharedPlaybackUrl, localUrl);
+  assert.equal(harness.runtimeState.pauseStartedAt, 0);
+  assert.equal(harness.runtimeState.pauseClassifiedAsBuffer, false);
 });
 
 test("sync controller clears non-shared authorization on reset when no longer on that video", () => {
@@ -2091,7 +2089,6 @@ test("programmatic apply signature stores the normalized url for mismatched (fes
     remoteFollowPlayingWindowMs: 3_000,
     programmaticApplyWindowMs: 700,
     userGestureGraceMs: 300,
-    bufferPauseUpgradeMs: 1_500,
     remotePauseDebounceMs: 0,
     nextSeq: () => 1,
     markBroadcastAt: () => {},


### PR DESCRIPTION
## Summary

- require a fresh in-player gesture before a local `pause` can stop the room
- keep unconfirmed player pauses classified as buffering and suppress their paused broadcast
- restore local playback after a short delay when the room still intends to play
- clear pause classification during playback and navigation resets
- add regression coverage for gesture-free pauses, seek-triggered pauses, recovery cancellation, and stale timers

## Root cause

The content script treated every HTML media `pause` event as authoritative and scheduled a room playback update even when no user gesture existed. Bilibili player internals can pause the media element while rebuilding the player, switching quality, or recovering from a stall. Buffer-classified pauses were also upgraded to `paused` after a timeout, so a transient local pause could eventually stop the entire room.

## User impact

Player-internal pauses no longer repeatedly pause every member in the room. Normal pause actions made inside the Bilibili player, including pointer/touch controls and Space/K, still propagate to the room.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test` (protocol 77 passed; extension 489 passed; server suite passed with Redis-only tests skipped when `REDIS_URL` is not configured)

Local dependencies were synchronized with `npm ci` before running the final validation; no dependency or lockfile changes are included.