### PR TITLE
fix: support CORS for split admin deployments

### DIFF
--- a/docs/operations/multi-node-global-admin-migration.md
+++ b/docs/operations/multi-node-global-admin-migration.md
@@ -136,7 +136,7 @@ Room node setting:
 Global admin setting:
 
 - `GLOBAL_ADMIN_ENABLED=true`
-- optional `GLOBAL_ADMIN_API_BASE_URL` if the UI and API origins differ
+- optional `GLOBAL_ADMIN_API_BASE_URL` if the UI and API origins differ; add the UI origin to `ALLOWED_ORIGINS`
 
 Verify:
 

--- a/docs/operations/multi-node-global-admin-migration.zh-CN.md
+++ b/docs/operations/multi-node-global-admin-migration.zh-CN.md
@@ -139,7 +139,7 @@ Room Node：
 Global Admin：
 
 - `GLOBAL_ADMIN_ENABLED=true`
-- 如 UI 与 API 域名分离，可补 `GLOBAL_ADMIN_API_BASE_URL`
+- 如 UI 与 API 域名分离，可补 `GLOBAL_ADMIN_API_BASE_URL`，并把 UI 的 Origin 加入 `ALLOWED_ORIGINS`
 
 验证：
 

--- a/docs/operations/multi-node.md
+++ b/docs/operations/multi-node.md
@@ -67,7 +67,7 @@ GLOBAL_ADMIN_ENABLED=true \
 node server/dist/global-admin-index.js
 ```
 
-If the admin UI should talk to a separate API origin, set `GLOBAL_ADMIN_API_BASE_URL=https://admin.example.com`.
+If the admin UI should talk to a separate API origin, set `GLOBAL_ADMIN_API_BASE_URL=https://admin.example.com` and add the UI origin to `ALLOWED_ORIGINS`. The admin API only returns CORS headers for same-origin requests and origins explicitly included in that allowlist.
 
 ## Node role configuration matrix
 

--- a/docs/operations/multi-node.zh-CN.md
+++ b/docs/operations/multi-node.zh-CN.md
@@ -67,7 +67,7 @@ GLOBAL_ADMIN_ENABLED=true \
 node server/dist/global-admin-index.js
 ```
 
-如果管理 UI 需要请求一个独立 API 域名，可设置 `GLOBAL_ADMIN_API_BASE_URL=https://admin.example.com`。
+如果管理 UI 需要请求一个独立 API 域名，可设置 `GLOBAL_ADMIN_API_BASE_URL=https://admin.example.com`，并把 UI 的 Origin 加入 `ALLOWED_ORIGINS`。管理 API 只会为同源请求和显式列入该白名单的 Origin 返回 CORS 响应头。
 
 ## 节点角色配置矩阵
 

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -114,6 +114,8 @@ Implemented endpoints:
 - `POST /api/admin/rooms/:roomCode/members/:memberId/kick`
 - `POST /api/admin/sessions/:sessionId/disconnect`
 
+Every `/api/admin/*` endpoint accepts CORS preflights for `GET`, `POST`, and `OPTIONS`, with `authorization` and `content-type` request headers. The server reflects the exact request origin only when it is same-origin or explicitly included in `ALLOWED_ORIGINS`; wildcard origins are not used. When `GLOBAL_ADMIN_API_BASE_URL` points to a separate API origin, add the admin UI origin to that allowlist.
+
 `GET /metrics` is served on the main service port by default and can be moved to a dedicated port with `METRICS_PORT`; setting `METRICS_TOKEN` additionally requires scrapes to send `Authorization: Bearer <token>` (see [Security Environment Variables](./security-env.md)).
 
 Authentication model:

--- a/docs/reference/admin-api.md
+++ b/docs/reference/admin-api.md
@@ -114,7 +114,7 @@ Implemented endpoints:
 - `POST /api/admin/rooms/:roomCode/members/:memberId/kick`
 - `POST /api/admin/sessions/:sessionId/disconnect`
 
-Every `/api/admin/*` endpoint accepts CORS preflights for `GET`, `POST`, and `OPTIONS`, with `authorization` and `content-type` request headers. The server reflects the exact request origin only when it is same-origin or explicitly included in `ALLOWED_ORIGINS`; wildcard origins are not used. When `GLOBAL_ADMIN_API_BASE_URL` points to a separate API origin, add the admin UI origin to that allowlist.
+Every `/api/admin/*` endpoint accepts CORS preflights for `GET`, `POST`, and `OPTIONS`, with `authorization` and `content-type` request headers. The admin UI-facing `/healthz` and `/readyz` endpoints use the same origin policy and accept `GET` and `OPTIONS`. The server reflects the exact request origin only when it is same-origin or explicitly included in `ALLOWED_ORIGINS`; wildcard origins are not used. When `GLOBAL_ADMIN_API_BASE_URL` points to a separate API origin, add the admin UI origin to that allowlist.
 
 `GET /metrics` is served on the main service port by default and can be moved to a dedicated port with `METRICS_PORT`; setting `METRICS_TOKEN` additionally requires scrapes to send `Authorization: Bearer <token>` (see [Security Environment Variables](./security-env.md)).
 

--- a/docs/reference/admin-api.zh-CN.md
+++ b/docs/reference/admin-api.zh-CN.md
@@ -114,6 +114,8 @@ node -e "const { createHash } = require('node:crypto'); const password = 'secret
 - `POST /api/admin/rooms/:roomCode/members/:memberId/kick`
 - `POST /api/admin/sessions/:sessionId/disconnect`
 
+所有 `/api/admin/*` 接口都支持 `GET`、`POST`、`OPTIONS` 的 CORS 预检，并允许 `authorization` 与 `content-type` 请求头。只有请求 Origin 与 API 同源或被显式列入 `ALLOWED_ORIGINS` 时，服务端才会原样返回该 Origin，不使用通配符。`GLOBAL_ADMIN_API_BASE_URL` 指向独立 API 域名时，需把管理 UI 的 Origin 加入该白名单。
+
 `GET /metrics` 默认在主服务端口上提供，也可以通过 `METRICS_PORT` 挪到独立端口；设置 `METRICS_TOKEN` 后抓取请求还需携带 `Authorization: Bearer <token>`（见[安全相关环境变量](./security-env.zh-CN.md)）。
 
 鉴权方式：

--- a/docs/reference/admin-api.zh-CN.md
+++ b/docs/reference/admin-api.zh-CN.md
@@ -114,7 +114,7 @@ node -e "const { createHash } = require('node:crypto'); const password = 'secret
 - `POST /api/admin/rooms/:roomCode/members/:memberId/kick`
 - `POST /api/admin/sessions/:sessionId/disconnect`
 
-所有 `/api/admin/*` 接口都支持 `GET`、`POST`、`OPTIONS` 的 CORS 预检，并允许 `authorization` 与 `content-type` 请求头。只有请求 Origin 与 API 同源或被显式列入 `ALLOWED_ORIGINS` 时，服务端才会原样返回该 Origin，不使用通配符。`GLOBAL_ADMIN_API_BASE_URL` 指向独立 API 域名时，需把管理 UI 的 Origin 加入该白名单。
+所有 `/api/admin/*` 接口都支持 `GET`、`POST`、`OPTIONS` 的 CORS 预检，并允许 `authorization` 与 `content-type` 请求头。管理 UI 会访问的 `/healthz` 与 `/readyz` 使用相同的来源策略，并支持 `GET` 和 `OPTIONS`。只有请求 Origin 与 API 同源或被显式列入 `ALLOWED_ORIGINS` 时，服务端才会原样返回该 Origin，不使用通配符。`GLOBAL_ADMIN_API_BASE_URL` 指向独立 API 域名时，需把管理 UI 的 Origin 加入该白名单。
 
 `GET /metrics` 默认在主服务端口上提供，也可以通过 `METRICS_PORT` 挪到独立端口；设置 `METRICS_TOKEN` 后抓取请求还需携带 `Authorization: Bearer <token>`（见[安全相关环境变量](./security-env.zh-CN.md)）。
 

--- a/docs/reference/security-env.md
+++ b/docs/reference/security-env.md
@@ -15,7 +15,7 @@ The server accepts the following environment variables. Safe defaults are built 
 
 ## Origin and Connection Security
 
-- `ALLOWED_ORIGINS`: comma-separated WebSocket `Origin` allowlist; when empty, the server rejects all explicit `Origin` values by default
+- `ALLOWED_ORIGINS`: comma-separated `Origin` allowlist for WebSocket connections and cross-origin admin API requests; when empty, the server rejects all explicit cross-origin values by default
 - `ALLOW_MISSING_ORIGIN_IN_DEV`: allow missing `Origin` headers when set to `true`; defaults to `false`
 - `ALLOW_ANY_FIREFOX_EXTENSION_ORIGIN`: when `true`, accept any well-formed `moz-extension://<uuid>` origin; Firefox assigns a random per-install UUID that a public/shared server cannot enumerate in `ALLOWED_ORIGINS`. Still rejects web-page origins (a page can never present a `moz-extension://` origin) and does not replace room/member-token auth; defaults to `false`
 - `TRUSTED_PROXY_ADDRESSES`: comma-separated proxy socket IP allowlist; only requests arriving from these proxies can use `X-Forwarded-For`; defaults to empty
@@ -70,7 +70,7 @@ All three of `ADMIN_USERNAME`, `ADMIN_PASSWORD_HASH`, and `ADMIN_SESSION_SECRET`
 - `ROOM_EVENT_BUS_PROVIDER`: cross-node room event fanout, `none`, `memory`, or `redis`; defaults to `redis` when `RUNTIME_STORE_PROVIDER=redis`, otherwise `memory`
 - `ADMIN_COMMAND_BUS_PROVIDER`: cross-node admin command routing, `none`, `memory`, or `redis`; defaults to `redis` when `RUNTIME_STORE_PROVIDER=redis`, otherwise `memory`
 - `GLOBAL_ADMIN_ENABLED`: when `false`, a room node keeps `/`, `/healthz`, `/readyz`, but disables `/admin` and `/api/admin/*`; defaults to `true`
-- `GLOBAL_ADMIN_API_BASE_URL`: optional admin UI API base URL override, for serving the admin UI and admin API from different origins
+- `GLOBAL_ADMIN_API_BASE_URL`: optional admin UI API base URL override, for serving the admin UI and admin API from different origins; add the UI origin to `ALLOWED_ORIGINS` when using this mode
 - `GLOBAL_ADMIN_PORT`: HTTP port for `server/dist/global-admin-index.js`; defaults to `PORT`, or `8788` when `PORT` is also unset
 - `NODE_HEARTBEAT_ENABLED`: enables node heartbeat reporting to the shared runtime store; defaults to `false`
 - `NODE_HEARTBEAT_INTERVAL_MS`: heartbeat interval in milliseconds; defaults to `15000`

--- a/docs/reference/security-env.md
+++ b/docs/reference/security-env.md
@@ -15,7 +15,7 @@ The server accepts the following environment variables. Safe defaults are built 
 
 ## Origin and Connection Security
 
-- `ALLOWED_ORIGINS`: comma-separated `Origin` allowlist for WebSocket connections and cross-origin admin API requests; when empty, the server rejects all explicit cross-origin values by default
+- `ALLOWED_ORIGINS`: comma-separated `Origin` allowlist for WebSocket connections and cross-origin admin UI requests; when empty, the server rejects all explicit cross-origin values by default
 - `ALLOW_MISSING_ORIGIN_IN_DEV`: allow missing `Origin` headers when set to `true`; defaults to `false`
 - `ALLOW_ANY_FIREFOX_EXTENSION_ORIGIN`: when `true`, accept any well-formed `moz-extension://<uuid>` origin; Firefox assigns a random per-install UUID that a public/shared server cannot enumerate in `ALLOWED_ORIGINS`. Still rejects web-page origins (a page can never present a `moz-extension://` origin) and does not replace room/member-token auth; defaults to `false`
 - `TRUSTED_PROXY_ADDRESSES`: comma-separated proxy socket IP allowlist; only requests arriving from these proxies can use `X-Forwarded-For`; defaults to empty

--- a/docs/reference/security-env.zh-CN.md
+++ b/docs/reference/security-env.zh-CN.md
@@ -15,7 +15,7 @@
 
 ## Origin 与连接安全
 
-- `ALLOWED_ORIGINS`：逗号分隔的 WebSocket `Origin` 白名单；为空时服务器默认拒绝所有显式 `Origin`
+- `ALLOWED_ORIGINS`：逗号分隔的 `Origin` 白名单，用于 WebSocket 连接和跨域管理 API 请求；为空时服务器默认拒绝所有显式跨域 Origin
 - `ALLOW_MISSING_ORIGIN_IN_DEV`：设为 `true` 时允许缺失 `Origin` 头；默认 `false`
 - `ALLOW_ANY_FIREFOX_EXTENSION_ORIGIN`：设为 `true` 时接受任意格式正确的 `moz-extension://<uuid>` Origin；Firefox 每个安装随机分配 UUID，公共/共享服务端无法逐一枚举进 `ALLOWED_ORIGINS`。仍会拒绝网页 Origin（网页永远无法呈现 `moz-extension://` Origin），且不替代房间/成员 token 鉴权；默认 `false`
 - `TRUSTED_PROXY_ADDRESSES`：逗号分隔的受信代理 socket IP 列表；只有来自这些代理的请求才会使用 `X-Forwarded-For`；默认为空
@@ -70,7 +70,7 @@
 - `ROOM_EVENT_BUS_PROVIDER`：跨节点房间事件广播，`none`、`memory` 或 `redis`；当 `RUNTIME_STORE_PROVIDER=redis` 时默认跟随 `redis`，否则默认 `memory`
 - `ADMIN_COMMAND_BUS_PROVIDER`：跨节点管理命令路由，`none`、`memory` 或 `redis`；当 `RUNTIME_STORE_PROVIDER=redis` 时默认跟随 `redis`，否则默认 `memory`
 - `GLOBAL_ADMIN_ENABLED`：设为 `false` 时，Room Node 保留 `/`、`/healthz`、`/readyz`，但关闭 `/admin` 与 `/api/admin/*`；默认 `true`
-- `GLOBAL_ADMIN_API_BASE_URL`：可选的管理 UI API 基址覆盖项，用于管理 UI 与管理 API 分属不同域名的场景
+- `GLOBAL_ADMIN_API_BASE_URL`：可选的管理 UI API 基址覆盖项，用于管理 UI 与管理 API 分属不同域名的场景；使用该模式时需把 UI 的 Origin 加入 `ALLOWED_ORIGINS`
 - `GLOBAL_ADMIN_PORT`：`server/dist/global-admin-index.js` 使用的 HTTP 端口；默认取 `PORT`，`PORT` 也未设置时为 `8788`
 - `NODE_HEARTBEAT_ENABLED`：是否向共享运行时存储上报节点心跳；默认 `false`
 - `NODE_HEARTBEAT_INTERVAL_MS`：节点心跳间隔，单位毫秒；默认 `15000`

--- a/docs/reference/security-env.zh-CN.md
+++ b/docs/reference/security-env.zh-CN.md
@@ -15,7 +15,7 @@
 
 ## Origin 与连接安全
 
-- `ALLOWED_ORIGINS`：逗号分隔的 `Origin` 白名单，用于 WebSocket 连接和跨域管理 API 请求；为空时服务器默认拒绝所有显式跨域 Origin
+- `ALLOWED_ORIGINS`：逗号分隔的 `Origin` 白名单，用于 WebSocket 连接和跨域管理 UI 请求；为空时服务器默认拒绝所有显式跨域 Origin
 - `ALLOW_MISSING_ORIGIN_IN_DEV`：设为 `true` 时允许缺失 `Origin` 头；默认 `false`
 - `ALLOW_ANY_FIREFOX_EXTENSION_ORIGIN`：设为 `true` 时接受任意格式正确的 `moz-extension://<uuid>` Origin；Firefox 每个安装随机分配 UUID，公共/共享服务端无法逐一枚举进 `ALLOWED_ORIGINS`。仍会拒绝网页 Origin（网页永远无法呈现 `moz-extension://` Origin），且不替代房间/成员 token 鉴权；默认 `false`
 - `TRUSTED_PROXY_ADDRESSES`：逗号分隔的受信代理 socket IP 列表；只有来自这些代理的请求才会使用 `X-Forwarded-For`；默认为空

--- a/server/src/admin/csrf.ts
+++ b/server/src/admin/csrf.ts
@@ -48,6 +48,20 @@ export function evaluateAdminWriteOrigin(
   return { ok: false, reason: "origin_not_allowed" };
 }
 
+export function setAdminCorsResponseHeaders(
+  request: IncomingMessage,
+  response: ServerResponse,
+  policy: AdminWriteOriginPolicy,
+): void {
+  response.setHeader("vary", "origin");
+
+  const result = evaluateAdminWriteOrigin(request, policy);
+  const origin = request.headers.origin;
+  if (result.ok && typeof origin === "string") {
+    response.setHeader("access-control-allow-origin", origin);
+  }
+}
+
 export function requireAdminWriteOrigin(
   request: IncomingMessage,
   response: ServerResponse,

--- a/server/src/admin/router.ts
+++ b/server/src/admin/router.ts
@@ -1,6 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { AdminActionError } from "./action-service.js";
-import { requireAdminWriteOrigin } from "./csrf.js";
+import {
+  requireAdminWriteOrigin,
+  setAdminCorsResponseHeaders,
+} from "./csrf.js";
 import {
   getBearerToken,
   getPathSegments,
@@ -96,6 +99,30 @@ export function createAdminRouter(options: AdminRouterOptions) {
       const segments = getPathSegments(request);
 
       try {
+        if (pathname.startsWith("/api/admin/")) {
+          setAdminCorsResponseHeaders(
+            request,
+            response,
+            options.writeOriginPolicy,
+          );
+          if (request.method === "OPTIONS") {
+            if (!requireWriteOrigin(request, response)) {
+              return true;
+            }
+            response.setHeader(
+              "access-control-allow-methods",
+              "GET, POST, OPTIONS",
+            );
+            response.setHeader(
+              "access-control-allow-headers",
+              "authorization, content-type",
+            );
+            response.writeHead(204);
+            response.end();
+            return true;
+          }
+        }
+
         for (const routeHandler of routeHandlers) {
           if (
             await routeHandler({

--- a/server/src/admin/router.ts
+++ b/server/src/admin/router.ts
@@ -30,6 +30,16 @@ function forbidden(response: ServerResponse): void {
   sendError(response, 403, "forbidden", FORBIDDEN_MESSAGE);
 }
 
+function getAdminCorsAllowedMethods(pathname: string): string | null {
+  if (pathname.startsWith("/api/admin/")) {
+    return "GET, POST, OPTIONS";
+  }
+  if (pathname === "/healthz" || pathname === "/readyz") {
+    return "GET, OPTIONS";
+  }
+  return null;
+}
+
 export function createAdminRouter(options: AdminRouterOptions) {
   const roleRank: Record<AdminRole, number> = {
     viewer: 1,
@@ -99,7 +109,8 @@ export function createAdminRouter(options: AdminRouterOptions) {
       const segments = getPathSegments(request);
 
       try {
-        if (pathname.startsWith("/api/admin/")) {
+        const corsAllowedMethods = getAdminCorsAllowedMethods(pathname);
+        if (corsAllowedMethods) {
           setAdminCorsResponseHeaders(
             request,
             response,
@@ -111,7 +122,7 @@ export function createAdminRouter(options: AdminRouterOptions) {
             }
             response.setHeader(
               "access-control-allow-methods",
-              "GET, POST, OPTIONS",
+              corsAllowedMethods,
             );
             response.setHeader(
               "access-control-allow-headers",

--- a/server/test/admin-backend.test.ts
+++ b/server/test/admin-backend.test.ts
@@ -455,6 +455,108 @@ test("admin endpoints support auth, overview, rooms, and events without breaking
   }
 });
 
+test("admin API supports CORS preflights and responses for allowed origins", async () => {
+  const server = await startAdminServer();
+
+  try {
+    const loginPreflight = await fetch(
+      `${server.httpBaseUrl}/api/admin/auth/login`,
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: ALLOWED_ORIGIN,
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers": "content-type",
+        },
+      },
+    );
+    assert.equal(loginPreflight.status, 204);
+    assert.equal(
+      loginPreflight.headers.get("access-control-allow-origin"),
+      ALLOWED_ORIGIN,
+    );
+    assert.equal(
+      loginPreflight.headers.get("access-control-allow-methods"),
+      "GET, POST, OPTIONS",
+    );
+    assert.equal(
+      loginPreflight.headers.get("access-control-allow-headers"),
+      "authorization, content-type",
+    );
+    assert.equal(loginPreflight.headers.get("vary"), "origin");
+
+    const loginResponse = await fetch(
+      `${server.httpBaseUrl}/api/admin/auth/login`,
+      {
+        method: "POST",
+        headers: {
+          Origin: ALLOWED_ORIGIN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "admin",
+          password: "secret-123",
+        }),
+      },
+    );
+    assert.equal(loginResponse.status, 200);
+    assert.equal(
+      loginResponse.headers.get("access-control-allow-origin"),
+      ALLOWED_ORIGIN,
+    );
+    assert.equal(loginResponse.headers.get("vary"), "origin");
+    const loginPayload = (await loginResponse.json()) as {
+      data: { token: string };
+    };
+
+    const mePreflight = await fetch(`${server.httpBaseUrl}/api/admin/me`, {
+      method: "OPTIONS",
+      headers: {
+        Origin: ALLOWED_ORIGIN,
+        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Headers": "authorization",
+      },
+    });
+    assert.equal(mePreflight.status, 204);
+    assert.equal(
+      mePreflight.headers.get("access-control-allow-origin"),
+      ALLOWED_ORIGIN,
+    );
+
+    const meResponse = await fetch(`${server.httpBaseUrl}/api/admin/me`, {
+      headers: {
+        Origin: ALLOWED_ORIGIN,
+        Authorization: `Bearer ${loginPayload.data.token}`,
+      },
+    });
+    assert.equal(meResponse.status, 200);
+    assert.equal(
+      meResponse.headers.get("access-control-allow-origin"),
+      ALLOWED_ORIGIN,
+    );
+
+    const deniedPreflight = await fetch(
+      `${server.httpBaseUrl}/api/admin/auth/login`,
+      {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://not-allowed.example.com",
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers": "content-type",
+        },
+      },
+    );
+    assert.equal(deniedPreflight.status, 403);
+    assert.equal(
+      deniedPreflight.headers.get("access-control-allow-origin"),
+      null,
+    );
+    assert.equal(deniedPreflight.headers.get("vary"), "origin");
+  } finally {
+    await server.close();
+  }
+});
+
 test("admin overview falls back to server package version", async () => {
   const packageJson = JSON.parse(
     await readFile(new URL("../package.json", import.meta.url), "utf8"),

--- a/server/test/admin-backend.test.ts
+++ b/server/test/admin-backend.test.ts
@@ -455,7 +455,7 @@ test("admin endpoints support auth, overview, rooms, and events without breaking
   }
 });
 
-test("admin API supports CORS preflights and responses for allowed origins", async () => {
+test("admin UI endpoints support CORS preflights and responses for allowed origins", async () => {
   const server = await startAdminServer();
 
   try {
@@ -534,6 +534,42 @@ test("admin API supports CORS preflights and responses for allowed origins", asy
       meResponse.headers.get("access-control-allow-origin"),
       ALLOWED_ORIGIN,
     );
+
+    for (const path of ["/healthz", "/readyz"]) {
+      const probePreflight = await fetch(`${server.httpBaseUrl}${path}`, {
+        method: "OPTIONS",
+        headers: {
+          Origin: ALLOWED_ORIGIN,
+          "Access-Control-Request-Method": "GET",
+          "Access-Control-Request-Headers": "authorization",
+        },
+      });
+      assert.equal(probePreflight.status, 204);
+      assert.equal(
+        probePreflight.headers.get("access-control-allow-origin"),
+        ALLOWED_ORIGIN,
+      );
+      assert.equal(
+        probePreflight.headers.get("access-control-allow-methods"),
+        "GET, OPTIONS",
+      );
+      assert.equal(
+        probePreflight.headers.get("access-control-allow-headers"),
+        "authorization, content-type",
+      );
+
+      const probeResponse = await fetch(`${server.httpBaseUrl}${path}`, {
+        headers: {
+          Origin: ALLOWED_ORIGIN,
+          Authorization: `Bearer ${loginPayload.data.token}`,
+        },
+      });
+      assert.equal(probeResponse.status, 200);
+      assert.equal(
+        probeResponse.headers.get("access-control-allow-origin"),
+        ALLOWED_ORIGIN,
+      );
+    }
 
     const deniedPreflight = await fetch(
       `${server.httpBaseUrl}/api/admin/auth/login`,


### PR DESCRIPTION
## Summary
- add strict CORS preflight handling for `/api/admin/*` using the existing same-origin and `ALLOWED_ORIGINS` policy
- reflect allowed origins on actual admin API responses so login and bearer-authenticated requests work across origins
- document split UI/API configuration and add regression coverage for allowed and denied origins

Fixes #172

## Test plan
- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`