### PR TITLE
feat: 概览页迁移到新控制台（/admin-next），引入 TanStack Query 数据层

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "typescript-eslint": "^8.26.1"
       },
       "engines": {
-        "node": ">=22.5.0"
+        "node": ">=22.12.0"
       }
     },
     "extension": {
@@ -2362,6 +2362,32 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
+      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -5677,6 +5703,7 @@
       "version": "1.2.4",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
+        "@tanstack/react-query": "^5.101.2",
         "antd": "^6.5.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
+    "@tanstack/react-query": "^5.101.2",
     "antd": "^6.5.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/packages/admin-ui/src/api/admin-api.ts
+++ b/packages/admin-ui/src/api/admin-api.ts
@@ -4,6 +4,8 @@ import type {
   AdminLoginResult,
   AdminLogoutResult,
   AdminMeResult,
+  AdminOverview,
+  ReadyStatus,
 } from "./types.js";
 
 export function createAdminApi(client: HttpClient) {
@@ -19,6 +21,12 @@ export function createAdminApi(client: HttpClient) {
     },
     getMe(): Promise<AdminMeResult> {
       return client.request("/api/admin/me");
+    },
+    getOverview(): Promise<AdminOverview> {
+      return client.request("/api/admin/overview");
+    },
+    getReady(): Promise<ReadyStatus> {
+      return client.request("/readyz");
     },
   };
 }

--- a/packages/admin-ui/src/api/http.ts
+++ b/packages/admin-ui/src/api/http.ts
@@ -74,15 +74,17 @@ export function createHttpClient(options: HttpClientOptions): HttpClient {
         );
       }
 
-      if (!response.ok || payload?.ok !== true) {
-        throw new ApiError(
-          payload?.error?.code ?? "request_failed",
-          payload?.error?.message ?? "请求失败。",
-          response.status,
-        );
+      // 信封 ok:true 优先于 HTTP 状态码：/readyz 未就绪时返回 503 但
+      // 信封仍是 ok:true 的有效数据，调用方需要拿到 status 字段做降级展示。
+      if (payload?.ok === true) {
+        return payload.data as T;
       }
 
-      return payload.data as T;
+      throw new ApiError(
+        payload?.error?.code ?? "request_failed",
+        payload?.error?.message ?? "请求失败。",
+        response.status,
+      );
     },
   };
 }

--- a/packages/admin-ui/src/api/types.ts
+++ b/packages/admin-ui/src/api/types.ts
@@ -25,3 +25,75 @@ export type AdminMeResult = AdminIdentity & {
 export type AdminLogoutResult = {
   success: boolean;
 };
+
+export type OverviewEventCounts = {
+  room_created: number;
+  room_joined: number;
+  rate_limited: number;
+  ws_connection_rejected: number;
+};
+
+export type NodeHealth = "ok" | "stale" | "offline";
+
+export type OverviewNode = {
+  instanceId: string;
+  version: string;
+  startedAt: number;
+  lastHeartbeatAt: number;
+  staleAt: number;
+  expiresAt: number;
+  connectionCount: number;
+  activeRoomCount: number;
+  activeMemberCount: number;
+  health: NodeHealth;
+  currentRoomCount: number;
+  currentMemberCount: number;
+  roomCodes: string[];
+};
+
+export type AdminOverview = {
+  service: {
+    instanceId: string;
+    name: string;
+    version: string;
+    startedAt: number;
+    uptimeMs: number;
+  };
+  storage: {
+    provider: string;
+    redisConnected: boolean;
+  };
+  runtime: {
+    connectionCount: number;
+    activeRoomCount: number;
+    activeMemberCount: number;
+  };
+  rooms: {
+    totalNonExpired: number;
+    active: number;
+    idle: number;
+    orphanRuntimeCount: number;
+  };
+  nodes: {
+    total: number;
+    online: number;
+    stale: number;
+    offline: number;
+    items: OverviewNode[];
+  };
+  events: {
+    lastMinute: OverviewEventCounts;
+    lastHour: OverviewEventCounts;
+    lastDay: OverviewEventCounts;
+    totals: OverviewEventCounts;
+  };
+};
+
+export type ReadyStatus = {
+  status: "ready" | "not_ready";
+  checks: {
+    httpServer: string;
+    roomStore: string;
+    redis: string;
+  };
+};

--- a/packages/admin-ui/src/app.tsx
+++ b/packages/admin-ui/src/app.tsx
@@ -1,46 +1,59 @@
+import { QueryClientProvider } from "@tanstack/react-query";
 import { App as AntdApp, ConfigProvider } from "antd";
 import zhCN from "antd/locale/zh_CN";
+import { useState } from "react";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { AuthProvider } from "./auth/auth-context.js";
 import { RequireAuth } from "./auth/require-auth.js";
+import { createQueryClient } from "./data/query-client.js";
 import { AppLayout } from "./layout/app-layout.js";
 import { NAV_ITEMS } from "./layout/nav-items.js";
 import { LoginPage } from "./pages/login-page.js";
+import { OverviewPage } from "./pages/overview/overview-page.js";
 import { PlaceholderPage } from "./pages/placeholder-page.js";
 
 export function App() {
+  const [queryClient] = useState(createQueryClient);
   return (
     <ConfigProvider locale={zhCN}>
       <AntdApp>
-        <BrowserRouter basename="/admin-next">
-          <AuthProvider>
-            <Routes>
-              <Route path="/login" element={<LoginPage />} />
-              <Route
-                element={
-                  <RequireAuth>
-                    <AppLayout />
-                  </RequireAuth>
-                }
-              >
-                <Route index element={<Navigate to="/overview" replace />} />
-                {NAV_ITEMS.map((item) => (
-                  <Route
-                    key={item.path}
-                    path={item.path}
-                    element={
-                      <PlaceholderPage
-                        title={item.label}
-                        description={item.description}
+        <QueryClientProvider client={queryClient}>
+          <BrowserRouter basename="/admin-next">
+            <AuthProvider>
+              <Routes>
+                <Route path="/login" element={<LoginPage />} />
+                <Route
+                  element={
+                    <RequireAuth>
+                      <AppLayout />
+                    </RequireAuth>
+                  }
+                >
+                  <Route index element={<Navigate to="/overview" replace />} />
+                  <Route path="/overview" element={<OverviewPage />} />
+                  {NAV_ITEMS.filter((item) => item.path !== "/overview").map(
+                    (item) => (
+                      <Route
+                        key={item.path}
+                        path={item.path}
+                        element={
+                          <PlaceholderPage
+                            title={item.label}
+                            description={item.description}
+                          />
+                        }
                       />
-                    }
+                    ),
+                  )}
+                  <Route
+                    path="*"
+                    element={<Navigate to="/overview" replace />}
                   />
-                ))}
-                <Route path="*" element={<Navigate to="/overview" replace />} />
-              </Route>
-            </Routes>
-          </AuthProvider>
-        </BrowserRouter>
+                </Route>
+              </Routes>
+            </AuthProvider>
+          </BrowserRouter>
+        </QueryClientProvider>
       </AntdApp>
     </ConfigProvider>
   );

--- a/packages/admin-ui/src/data/query-client.ts
+++ b/packages/admin-ui/src/data/query-client.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        // 请求失败重试一次即可；401 由 http client 统一清会话，重试无意义。
+        retry: 1,
+        staleTime: 5_000,
+      },
+    },
+  });
+}

--- a/packages/admin-ui/src/lib/format.ts
+++ b/packages/admin-ui/src/lib/format.ts
@@ -1,0 +1,38 @@
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) {
+    return "—";
+  }
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const days = Math.floor(totalSeconds / 86_400);
+  const hours = Math.floor((totalSeconds % 86_400) / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (days > 0) {
+    return `${days} 天 ${hours} 小时`;
+  }
+  if (hours > 0) {
+    return `${hours} 小时 ${minutes} 分钟`;
+  }
+  if (minutes > 0) {
+    return `${minutes} 分钟 ${seconds} 秒`;
+  }
+  return `${seconds} 秒`;
+}
+
+export function formatDateTime(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return "—";
+  }
+
+  return new Date(value).toLocaleString("zh-CN", { hour12: false });
+}
+
+export function formatTime(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return "—";
+  }
+
+  return new Date(value).toLocaleTimeString("zh-CN", { hour12: false });
+}

--- a/packages/admin-ui/src/pages/overview/event-stats-table.tsx
+++ b/packages/admin-ui/src/pages/overview/event-stats-table.tsx
@@ -1,0 +1,56 @@
+import { Table, Typography } from "antd";
+import type { AdminOverview, OverviewEventCounts } from "../../api/types.js";
+
+type EventStatsRow = OverviewEventCounts & {
+  key: string;
+  window: string;
+};
+
+const WINDOW_LABELS: Array<[keyof AdminOverview["events"], string]> = [
+  ["lastMinute", "最近一分钟"],
+  ["lastHour", "最近一小时"],
+  ["lastDay", "最近一天"],
+  ["totals", "累计"],
+];
+
+function renderAttentionCount(value: number) {
+  if (value > 0) {
+    return <Typography.Text type="warning">{value}</Typography.Text>;
+  }
+  return value;
+}
+
+export function EventStatsTable({
+  events,
+}: {
+  events: AdminOverview["events"];
+}) {
+  const rows: EventStatsRow[] = WINDOW_LABELS.map(([key, label]) => ({
+    key,
+    window: label,
+    ...events[key],
+  }));
+
+  return (
+    <Table<EventStatsRow>
+      size="small"
+      pagination={false}
+      dataSource={rows}
+      columns={[
+        { title: "时间窗口", dataIndex: "window" },
+        { title: "创建房间", dataIndex: "room_created" },
+        { title: "加入房间", dataIndex: "room_joined" },
+        {
+          title: "限流",
+          dataIndex: "rate_limited",
+          render: renderAttentionCount,
+        },
+        {
+          title: "连接拒绝",
+          dataIndex: "ws_connection_rejected",
+          render: renderAttentionCount,
+        },
+      ]}
+    />
+  );
+}

--- a/packages/admin-ui/src/pages/overview/nodes-table.tsx
+++ b/packages/admin-ui/src/pages/overview/nodes-table.tsx
@@ -1,0 +1,55 @@
+import { Table, Tag, Typography } from "antd";
+import type { NodeHealth, OverviewNode } from "../../api/types.js";
+import { formatDateTime } from "../../lib/format.js";
+
+const HEALTH_PRESENTATION: Record<
+  NodeHealth,
+  { color: string; label: string }
+> = {
+  ok: { color: "success", label: "在线" },
+  stale: { color: "warning", label: "陈旧" },
+  offline: { color: "default", label: "离线" },
+};
+
+export function NodesTable({ nodes }: { nodes: OverviewNode[] }) {
+  return (
+    <Table<OverviewNode>
+      size="small"
+      pagination={false}
+      rowKey="instanceId"
+      dataSource={nodes}
+      locale={{ emptyText: "当前没有在线节点心跳或会话。" }}
+      columns={[
+        {
+          title: "节点",
+          dataIndex: "instanceId",
+          render: (instanceId: string, node) => (
+            <>
+              <Typography.Text strong>{instanceId}</Typography.Text>
+              <br />
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                {node.version || "unknown"}
+              </Typography.Text>
+            </>
+          ),
+        },
+        {
+          title: "状态",
+          dataIndex: "health",
+          render: (health: NodeHealth) => {
+            const presentation = HEALTH_PRESENTATION[health];
+            return <Tag color={presentation.color}>{presentation.label}</Tag>;
+          },
+        },
+        { title: "连接", dataIndex: "connectionCount" },
+        { title: "房间", dataIndex: "currentRoomCount" },
+        { title: "用户", dataIndex: "currentMemberCount" },
+        {
+          title: "最近心跳",
+          dataIndex: "lastHeartbeatAt",
+          render: (value: number) => formatDateTime(value),
+        },
+      ]}
+    />
+  );
+}

--- a/packages/admin-ui/src/pages/overview/overview-page.tsx
+++ b/packages/admin-ui/src/pages/overview/overview-page.tsx
@@ -1,0 +1,175 @@
+import { ReloadOutlined } from "@ant-design/icons";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Descriptions,
+  Row,
+  Space,
+  Spin,
+  Statistic,
+  Switch,
+  Tag,
+  Typography,
+} from "antd";
+import { useState } from "react";
+import { formatDuration, formatTime } from "../../lib/format.js";
+import { useOverviewQuery, useReadyQuery } from "./overview-queries.js";
+import { EventStatsTable } from "./event-stats-table.js";
+import { NodesTable } from "./nodes-table.js";
+
+export function OverviewPage() {
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const queryClient = useQueryClient();
+  const overviewQuery = useOverviewQuery(autoRefresh);
+  const readyQuery = useReadyQuery(autoRefresh);
+
+  const refreshNow = () => {
+    void queryClient.invalidateQueries({ queryKey: ["overview"] });
+    void queryClient.invalidateQueries({ queryKey: ["ready"] });
+  };
+
+  if (overviewQuery.isPending) {
+    return (
+      <div style={{ display: "flex", justifyContent: "center", padding: 48 }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (overviewQuery.isError) {
+    return (
+      <Alert
+        type="error"
+        showIcon
+        message="概览数据加载失败"
+        description={
+          overviewQuery.error instanceof Error
+            ? overviewQuery.error.message
+            : "请求失败。"
+        }
+        action={
+          <Button size="small" onClick={refreshNow}>
+            重试
+          </Button>
+        }
+      />
+    );
+  }
+
+  const overview = overviewQuery.data;
+  const ready = readyQuery.data;
+  const readyDegraded =
+    readyQuery.isError || (ready && ready.status !== "ready");
+
+  return (
+    <Space direction="vertical" size={16} style={{ display: "flex" }}>
+      {readyDegraded ? (
+        <Alert
+          type="warning"
+          showIcon
+          message={
+            readyQuery.isError
+              ? "readyz 检查失败，请检查服务与网络状态。"
+              : `readyz 状态为 ${ready?.status}，请检查存储与 Redis 连通性。`
+          }
+        />
+      ) : null}
+
+      <Space wrap>
+        <Switch
+          checked={autoRefresh}
+          onChange={setAutoRefresh}
+          checkedChildren="自动刷新"
+          unCheckedChildren="自动刷新已关"
+        />
+        <Button icon={<ReloadOutlined />} onClick={refreshNow}>
+          刷新
+        </Button>
+        <Typography.Text type="secondary">
+          更新于 {formatTime(overviewQuery.dataUpdatedAt)}
+        </Typography.Text>
+      </Space>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} sm={12} lg={6}>
+          <Card>
+            <Statistic
+              title="连接数"
+              value={overview.runtime.connectionCount}
+            />
+            <Typography.Text type="secondary">WebSocket</Typography.Text>
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card>
+            <Statistic
+              title="在线房间"
+              value={overview.runtime.activeRoomCount}
+            />
+            <Typography.Text type="secondary">
+              总计 {overview.rooms.totalNonExpired} 非过期
+            </Typography.Text>
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card>
+            <Statistic
+              title="在线成员"
+              value={overview.runtime.activeMemberCount}
+            />
+            <Typography.Text type="secondary">
+              空闲房间 {overview.rooms.idle}
+            </Typography.Text>
+          </Card>
+        </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card>
+            <Statistic
+              title="运行时长"
+              value={formatDuration(overview.service.uptimeMs)}
+            />
+            <Typography.Text type="secondary">
+              {overview.service.name} v{overview.service.version}
+            </Typography.Text>
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} lg={8}>
+          <Card title="存储">
+            <Descriptions column={1} size="small">
+              <Descriptions.Item label="提供方">
+                {overview.storage.provider}
+              </Descriptions.Item>
+              <Descriptions.Item label="Redis">
+                {overview.storage.redisConnected ? (
+                  <Tag color="success">已连接</Tag>
+                ) : (
+                  <Tag color="warning">未连接</Tag>
+                )}
+              </Descriptions.Item>
+              <Descriptions.Item label="roomStore">
+                {ready?.checks.roomStore ?? "—"}
+              </Descriptions.Item>
+            </Descriptions>
+          </Card>
+        </Col>
+        <Col xs={24} lg={16}>
+          <Card title="事件统计">
+            <EventStatsTable events={overview.events} />
+          </Card>
+        </Col>
+      </Row>
+
+      <Card
+        title={`节点（在线 ${overview.nodes.online} · 陈旧 ${overview.nodes.stale} · 离线 ${overview.nodes.offline}）`}
+      >
+        <NodesTable nodes={overview.nodes.items} />
+      </Card>
+    </Space>
+  );
+}

--- a/packages/admin-ui/src/pages/overview/overview-queries.ts
+++ b/packages/admin-ui/src/pages/overview/overview-queries.ts
@@ -1,0 +1,24 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useAuth } from "../../auth/auth-context.js";
+
+export const OVERVIEW_REFRESH_MS = 15_000;
+
+export function useOverviewQuery(autoRefresh: boolean) {
+  const { api } = useAuth();
+  return useQuery({
+    queryKey: ["overview"],
+    queryFn: () => api.getOverview(),
+    refetchInterval: autoRefresh ? OVERVIEW_REFRESH_MS : false,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useReadyQuery(autoRefresh: boolean) {
+  const { api } = useAuth();
+  return useQuery({
+    queryKey: ["ready"],
+    queryFn: () => api.getReady(),
+    refetchInterval: autoRefresh ? OVERVIEW_REFRESH_MS : false,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/packages/admin-ui/test/app-layout.test.tsx
+++ b/packages/admin-ui/test/app-layout.test.tsx
@@ -18,6 +18,8 @@ function createAuthValue(
       login: vi.fn(),
       logout: vi.fn(),
       getMe: vi.fn(),
+      getOverview: vi.fn(),
+      getReady: vi.fn(),
     },
     signIn: vi.fn().mockResolvedValue(undefined),
     signOut: vi.fn().mockResolvedValue(undefined),

--- a/packages/admin-ui/test/format.test.ts
+++ b/packages/admin-ui/test/format.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatDateTime,
+  formatDuration,
+  formatTime,
+} from "../src/lib/format.js";
+
+describe("formatDuration", () => {
+  it("formats each magnitude with two units", () => {
+    expect(formatDuration(5_000)).toBe("5 秒");
+    expect(formatDuration(3 * 60_000 + 20_000)).toBe("3 分钟 20 秒");
+    expect(formatDuration(2 * 3_600_000 + 5 * 60_000)).toBe("2 小时 5 分钟");
+    expect(formatDuration(3 * 86_400_000 + 4 * 3_600_000)).toBe("3 天 4 小时");
+  });
+
+  it("returns a dash for invalid input", () => {
+    expect(formatDuration(-1)).toBe("—");
+    expect(formatDuration(Number.NaN)).toBe("—");
+  });
+});
+
+describe("formatDateTime / formatTime", () => {
+  it("returns a dash for missing timestamps", () => {
+    expect(formatDateTime(undefined)).toBe("—");
+    expect(formatDateTime(0)).toBe("—");
+    expect(formatTime(null)).toBe("—");
+  });
+
+  it("formats valid timestamps", () => {
+    const timestamp = Date.UTC(2026, 0, 2, 3, 4, 5);
+    expect(formatDateTime(timestamp)).not.toBe("—");
+    expect(formatTime(timestamp)).not.toBe("—");
+  });
+});

--- a/packages/admin-ui/test/http.test.ts
+++ b/packages/admin-ui/test/http.test.ts
@@ -122,6 +122,20 @@ describe("createHttpClient", () => {
     expect(error.status).toBe(429);
   });
 
+  it("returns data when the envelope is ok despite a non-2xx status (readyz 503)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse(503, {
+        ok: true,
+        data: { status: "not_ready" },
+      }),
+    );
+    const client = createHttpClient({ getToken: () => "", fetchImpl });
+
+    const data = await client.request<{ status: string }>("/readyz");
+
+    expect(data).toEqual({ status: "not_ready" });
+  });
+
   it("falls back to request_failed for non-JSON failures", async () => {
     const fetchImpl = vi
       .fn()

--- a/packages/admin-ui/test/login-page.test.tsx
+++ b/packages/admin-ui/test/login-page.test.tsx
@@ -19,6 +19,8 @@ function createAuthValue(
       login: vi.fn(),
       logout: vi.fn(),
       getMe: vi.fn(),
+      getOverview: vi.fn(),
+      getReady: vi.fn(),
     },
     signIn: vi.fn().mockResolvedValue(undefined),
     signOut: vi.fn().mockResolvedValue(undefined),

--- a/packages/admin-ui/test/overview-page.test.tsx
+++ b/packages/admin-ui/test/overview-page.test.tsx
@@ -1,0 +1,175 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { AdminOverview, ReadyStatus } from "../src/api/types.js";
+import { AuthContext } from "../src/auth/auth-context.js";
+import type { AuthContextValue } from "../src/auth/auth-context.js";
+import { OverviewPage } from "../src/pages/overview/overview-page.js";
+
+function createOverviewFixture(
+  overrides: Partial<AdminOverview["events"]["lastHour"]> = {},
+): AdminOverview {
+  const counts = {
+    room_created: 3,
+    room_joined: 7,
+    rate_limited: 0,
+    ws_connection_rejected: 0,
+  };
+  return {
+    service: {
+      instanceId: "node-a",
+      name: "bili-syncplay-server",
+      version: "1.2.4",
+      startedAt: Date.now() - 3_600_000,
+      uptimeMs: 3_600_000,
+    },
+    storage: { provider: "redis", redisConnected: true },
+    runtime: {
+      connectionCount: 42,
+      activeRoomCount: 5,
+      activeMemberCount: 12,
+    },
+    rooms: { totalNonExpired: 9, active: 5, idle: 4, orphanRuntimeCount: 0 },
+    nodes: {
+      total: 1,
+      online: 1,
+      stale: 0,
+      offline: 0,
+      items: [
+        {
+          instanceId: "node-a",
+          version: "1.2.4",
+          startedAt: Date.now() - 3_600_000,
+          lastHeartbeatAt: Date.now(),
+          staleAt: Date.now() + 30_000,
+          expiresAt: Date.now() + 60_000,
+          connectionCount: 42,
+          activeRoomCount: 5,
+          activeMemberCount: 12,
+          health: "ok",
+          currentRoomCount: 5,
+          currentMemberCount: 12,
+          roomCodes: ["ROOM1"],
+        },
+      ],
+    },
+    events: {
+      lastMinute: { ...counts },
+      lastHour: { ...counts, ...overrides },
+      lastDay: { ...counts },
+      totals: { ...counts },
+    },
+  };
+}
+
+const readyFixture: ReadyStatus = {
+  status: "ready",
+  checks: { httpServer: "ok", roomStore: "ok", redis: "ok" },
+};
+
+function createAuthValue(api: Partial<AuthContextValue["api"]>) {
+  return {
+    token: "token-1",
+    me: { id: "admin-1", username: "ops", role: "admin" },
+    initializing: false,
+    meError: "",
+    api: {
+      login: vi.fn(),
+      logout: vi.fn(),
+      getMe: vi.fn(),
+      getOverview: vi.fn(),
+      getReady: vi.fn(),
+      ...api,
+    },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    retryLoadMe: vi.fn(),
+  } as AuthContextValue;
+}
+
+function renderOverview(authValue: AuthContextValue) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <AuthContext.Provider value={authValue}>
+      <QueryClientProvider client={queryClient}>
+        <OverviewPage />
+      </QueryClientProvider>
+    </AuthContext.Provider>,
+  );
+}
+
+describe("OverviewPage", () => {
+  it("renders metrics, storage, events and nodes from the API", async () => {
+    renderOverview(
+      createAuthValue({
+        getOverview: vi.fn().mockResolvedValue(createOverviewFixture()),
+        getReady: vi.fn().mockResolvedValue(readyFixture),
+      }),
+    );
+
+    // 连接数 42 同时出现在指标卡和节点表里。
+    expect((await screen.findAllByText("42")).length).toBeGreaterThan(0);
+    expect(screen.getByText("连接数")).toBeTruthy();
+    expect(screen.getByText("总计 9 非过期")).toBeTruthy();
+    expect(screen.getByText("已连接")).toBeTruthy();
+    expect(screen.getByText("node-a")).toBeTruthy();
+    expect(screen.getByText("最近一小时")).toBeTruthy();
+    expect(screen.queryByText(/readyz 状态为|readyz 检查失败/)).toBeNull();
+  });
+
+  it("shows a degradation banner when readyz is not ready", async () => {
+    renderOverview(
+      createAuthValue({
+        getOverview: vi.fn().mockResolvedValue(createOverviewFixture()),
+        getReady: vi.fn().mockResolvedValue({
+          status: "not_ready",
+          checks: { httpServer: "ok", roomStore: "error", redis: "error" },
+        } satisfies ReadyStatus),
+      }),
+    );
+
+    expect(await screen.findByText(/readyz 状态为 not_ready/)).toBeTruthy();
+  });
+
+  it("shows a retryable error state when the overview request fails", async () => {
+    const getOverview = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("网络错误"))
+      .mockResolvedValue(createOverviewFixture());
+    const user = userEvent.setup();
+    renderOverview(
+      createAuthValue({
+        getOverview,
+        getReady: vi.fn().mockResolvedValue(readyFixture),
+      }),
+    );
+
+    expect(await screen.findByText("概览数据加载失败")).toBeTruthy();
+    expect(screen.getByText("网络错误")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /重\s*试/ }));
+    expect(await screen.findByText("连接数")).toBeTruthy();
+  });
+
+  it("refetches when clicking manual refresh", async () => {
+    const getOverview = vi.fn().mockResolvedValue(createOverviewFixture());
+    const user = userEvent.setup();
+    renderOverview(
+      createAuthValue({
+        getOverview,
+        getReady: vi.fn().mockResolvedValue(readyFixture),
+      }),
+    );
+
+    expect(await screen.findByText("连接数")).toBeTruthy();
+    const callsBefore = getOverview.mock.calls.length;
+    await user.click(screen.getByRole("button", { name: /刷\s*新/ }));
+
+    await waitFor(() => {
+      expect(getOverview.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+  });
+});

--- a/packages/admin-ui/test/require-auth.test.tsx
+++ b/packages/admin-ui/test/require-auth.test.tsx
@@ -18,6 +18,8 @@ function createAuthValue(
       login: vi.fn(),
       logout: vi.fn(),
       getMe: vi.fn(),
+      getOverview: vi.fn(),
+      getReady: vi.fn(),
     },
     signIn: vi.fn().mockResolvedValue(undefined),
     signOut: vi.fn().mockResolvedValue(undefined),

--- a/packages/admin-ui/vite.config.ts
+++ b/packages/admin-ui/vite.config.ts
@@ -1,24 +1,30 @@
 import react from "@vitejs/plugin-react";
+import type { ProxyOptions } from "vite";
 import { defineConfig } from "vitest/config";
 
 const DEV_SERVER_TARGET = "http://localhost:8787";
+
+// 管理端写接口有同源 Origin 校验，代理时把 Origin 改写为目标源，
+// 否则 dev server（5173）发起的登录等 POST 会被拒绝。
+const devProxyEntry: ProxyOptions = {
+  target: DEV_SERVER_TARGET,
+  changeOrigin: true,
+  configure: (proxy) => {
+    proxy.on("proxyReq", (proxyReq) => {
+      proxyReq.setHeader("origin", DEV_SERVER_TARGET);
+    });
+  },
+};
 
 export default defineConfig({
   base: "/admin-next/",
   plugins: [react()],
   server: {
     proxy: {
-      "/api": {
-        target: DEV_SERVER_TARGET,
-        changeOrigin: true,
-        // 管理端写接口有同源 Origin 校验，代理时把 Origin 改写为目标源，
-        // 否则 dev server（5173）发起的登录等 POST 会被拒绝。
-        configure: (proxy) => {
-          proxy.on("proxyReq", (proxyReq) => {
-            proxyReq.setHeader("origin", DEV_SERVER_TARGET);
-          });
-        },
-      },
+      "/api": devProxyEntry,
+      // 健康检查在根路径，不代理的话 dev 模式下概览页会误报 readyz 降级。
+      "/readyz": devProxyEntry,
+      "/healthz": devProxyEntry,
     },
   },
   test: {


### PR DESCRIPTION
## Summary

管理后台重写第二阶段（承接 #171 的脚手架）。

**数据层设计**（已与维护者确认）：概览数据是跨集群按需计算的快照，服务端无推送基础设施，本阶段采用 TanStack Query 轮询——15s `refetchInterval`、页面隐藏自动暂停、窗口聚焦自动刷新、`keepPreviousData` 避免闪烁；SSE 推送留给房间页阶段独立设计（那里才有实时性收益）。

- **API client**：新增 `AdminOverview` / `ReadyStatus` 类型与 `getOverview` / `getReady` 端点
- **http client 语义修正**：信封 `ok:true` 优先于 HTTP 状态码。顺带修复旧 UI 存量问题——`/readyz` 未就绪时返回 503 但信封 `ok:true`，旧 client 见非 2xx 直接抛错，导致旧概览页的降级横幅永远展示不出来（整页先报错）
- **概览页**：readyz 降级横幅（仅异常显示）、4 指标卡、事件统计表（限流/连接拒绝非零时高亮）、存储状态、节点表（在线/陈旧/离线标签，旧 UI 隐藏离线节点，新版全部展示并打标）、自动刷新开关 + 手动刷新 + 最近更新时间

## Test plan

- [x] 9 条新增测试：概览页渲染 / 降级横幅 / 错误重试 / 手动刷新 / 格式化工具 / 信封优先语义（admin-ui 共 34 条全绿）
- [x] 完整预提交序列：format:check / lint / typecheck / build / test 全部通过
- [x] 手动 E2E（真实服务端 + 本地管理员账号）：登录 → `/api/admin/overview` 响应形状与前端类型逐字段吻合 → readyz → `/admin-next` 服务新构建产物
- [ ] 浏览器内可视化验证（部署后确认布局与刷新行为）

🤖 Generated with [Claude Code](https://claude.com/claude-code)