### PR TITLE
feat: 房间管理页迁移到新控制台——列表筛选、抽屉详情与治理动作

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5703,6 +5703,7 @@
       "version": "1.2.4",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
+        "@bili-syncplay/protocol": "1.2.4",
         "@tanstack/react-query": "^5.101.2",
         "antd": "^6.5.1",
         "react": "^19.2.7",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -6,12 +6,15 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "pretypecheck": "npm --prefix ../protocol run build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "pretest": "npm --prefix ../protocol run build",
     "test": "vitest run",
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
+    "@bili-syncplay/protocol": "1.2.4",
     "@tanstack/react-query": "^5.101.2",
     "antd": "^6.5.1",
     "react": "^19.2.7",

--- a/packages/admin-ui/src/api/admin-api.ts
+++ b/packages/admin-ui/src/api/admin-api.ts
@@ -1,11 +1,16 @@
 import type { HttpClient } from "./http.js";
+import { toQueryString } from "./query-string.js";
 import type {
+  AdminActionResult,
   AdminLoginRequest,
   AdminLoginResult,
   AdminLogoutResult,
   AdminMeResult,
   AdminOverview,
   ReadyStatus,
+  RoomDetail,
+  RoomListQuery,
+  RoomListResult,
 } from "./types.js";
 
 export function createAdminApi(client: HttpClient) {
@@ -27,6 +32,52 @@ export function createAdminApi(client: HttpClient) {
     },
     getReady(): Promise<ReadyStatus> {
       return client.request("/readyz");
+    },
+    listRooms(query: RoomListQuery = {}): Promise<RoomListResult> {
+      return client.request(`/api/admin/rooms${toQueryString(query)}`);
+    },
+    getRoomDetail(roomCode: string): Promise<RoomDetail> {
+      return client.request(`/api/admin/rooms/${encodeURIComponent(roomCode)}`);
+    },
+    closeRoom(roomCode: string, reason?: string): Promise<AdminActionResult> {
+      return client.request(
+        `/api/admin/rooms/${encodeURIComponent(roomCode)}/close`,
+        { method: "POST", body: { reason: reason || undefined } },
+      );
+    },
+    expireRoom(roomCode: string, reason?: string): Promise<AdminActionResult> {
+      return client.request(
+        `/api/admin/rooms/${encodeURIComponent(roomCode)}/expire`,
+        { method: "POST", body: { reason: reason || undefined } },
+      );
+    },
+    clearRoomVideo(
+      roomCode: string,
+      reason?: string,
+    ): Promise<AdminActionResult> {
+      return client.request(
+        `/api/admin/rooms/${encodeURIComponent(roomCode)}/clear-video`,
+        { method: "POST", body: { reason: reason || undefined } },
+      );
+    },
+    kickMember(
+      roomCode: string,
+      memberId: string,
+      reason?: string,
+    ): Promise<AdminActionResult> {
+      return client.request(
+        `/api/admin/rooms/${encodeURIComponent(roomCode)}/members/${encodeURIComponent(memberId)}/kick`,
+        { method: "POST", body: { reason: reason || undefined } },
+      );
+    },
+    disconnectSession(
+      sessionId: string,
+      reason?: string,
+    ): Promise<AdminActionResult> {
+      return client.request(
+        `/api/admin/sessions/${encodeURIComponent(sessionId)}/disconnect`,
+        { method: "POST", body: { reason: reason || undefined } },
+      );
     },
   };
 }

--- a/packages/admin-ui/src/api/query-string.ts
+++ b/packages/admin-ui/src/api/query-string.ts
@@ -1,0 +1,13 @@
+export function toQueryString(
+  query: Record<string, string | number | boolean | undefined>,
+): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === "") {
+      continue;
+    }
+    params.set(key, String(value));
+  }
+  const serialized = params.toString();
+  return serialized ? `?${serialized}` : "";
+}

--- a/packages/admin-ui/src/api/types.ts
+++ b/packages/admin-ui/src/api/types.ts
@@ -1,3 +1,5 @@
+import type { PlaybackState, SharedVideo } from "@bili-syncplay/protocol";
+
 export type AdminRole = "viewer" | "operator" | "admin";
 
 export type AdminIdentity = {
@@ -97,3 +99,74 @@ export type ReadyStatus = {
     redis: string;
   };
 };
+
+export type RoomStatusFilter = "all" | "active" | "idle";
+export type RoomSortBy = "lastActiveAt" | "createdAt";
+export type SortOrder = "asc" | "desc";
+
+export type RoomListQuery = {
+  status?: RoomStatusFilter;
+  keyword?: string;
+  page?: number;
+  pageSize?: number;
+  sortBy?: RoomSortBy;
+  sortOrder?: SortOrder;
+  includeExpired?: boolean;
+};
+
+export type RoomSummary = {
+  instanceId?: string;
+  roomCode: string;
+  createdAt: number;
+  ownerMemberId: string | null;
+  ownerDisplayName: string | null;
+  lastActiveAt: number;
+  expiresAt: number | null;
+  sharedVideo: SharedVideo | null;
+  playback: PlaybackState | null;
+  memberCount: number;
+  isActive: boolean;
+  instanceIds: string[];
+};
+
+export type PaginationMeta = {
+  page: number;
+  pageSize: number;
+  total: number;
+};
+
+export type RoomListResult = {
+  items: RoomSummary[];
+  pagination: PaginationMeta;
+};
+
+export type RoomDetailMember = {
+  sessionId: string;
+  memberId: string;
+  instanceId?: string;
+  displayName: string;
+  joinedAt: number;
+  remoteAddress: string | null;
+  origin: string | null;
+};
+
+export type RuntimeEventRecord = {
+  id: string;
+  timestamp: string;
+  event: string;
+  roomCode: string | null;
+  sessionId: string | null;
+  remoteAddress: string | null;
+  origin: string | null;
+  result: string | null;
+  details: Record<string, unknown>;
+};
+
+export type RoomDetail = {
+  instanceId?: string;
+  room: RoomSummary;
+  members: RoomDetailMember[];
+  recentEvents: RuntimeEventRecord[];
+};
+
+export type AdminActionResult = Record<string, unknown>;

--- a/packages/admin-ui/src/app.tsx
+++ b/packages/admin-ui/src/app.tsx
@@ -11,6 +11,7 @@ import { NAV_ITEMS } from "./layout/nav-items.js";
 import { LoginPage } from "./pages/login-page.js";
 import { OverviewPage } from "./pages/overview/overview-page.js";
 import { PlaceholderPage } from "./pages/placeholder-page.js";
+import { RoomsPage } from "./pages/rooms/rooms-page.js";
 
 export function App() {
   const [queryClient] = useState(createQueryClient);
@@ -31,20 +32,23 @@ export function App() {
                 >
                   <Route index element={<Navigate to="/overview" replace />} />
                   <Route path="/overview" element={<OverviewPage />} />
-                  {NAV_ITEMS.filter((item) => item.path !== "/overview").map(
-                    (item) => (
-                      <Route
-                        key={item.path}
-                        path={item.path}
-                        element={
-                          <PlaceholderPage
-                            title={item.label}
-                            description={item.description}
-                          />
-                        }
-                      />
-                    ),
-                  )}
+                  <Route path="/rooms" element={<RoomsPage />} />
+                  <Route path="/rooms/:roomCode" element={<RoomsPage />} />
+                  {NAV_ITEMS.filter(
+                    (item) =>
+                      item.path !== "/overview" && item.path !== "/rooms",
+                  ).map((item) => (
+                    <Route
+                      key={item.path}
+                      path={item.path}
+                      element={
+                        <PlaceholderPage
+                          title={item.label}
+                          description={item.description}
+                        />
+                      }
+                    />
+                  ))}
                   <Route
                     path="*"
                     element={<Navigate to="/overview" replace />}

--- a/packages/admin-ui/src/lib/playback.ts
+++ b/packages/admin-ui/src/lib/playback.ts
@@ -1,0 +1,93 @@
+import type { PlaybackState } from "@bili-syncplay/protocol";
+
+// 超过该时长没有播放状态同步就视为陈旧，停止外推。
+export const PLAYBACK_STALE_AFTER_MS = 30_000;
+
+export function getPlaybackSyncedAt(
+  playback: PlaybackState | null,
+  lastActiveAt?: number,
+): number | null {
+  if (!playback) {
+    return null;
+  }
+  if (Number.isFinite(playback.serverTime)) {
+    return playback.serverTime;
+  }
+  if (Number.isFinite(playback.updatedAt)) {
+    return playback.updatedAt;
+  }
+  return typeof lastActiveAt === "number" && Number.isFinite(lastActiveAt)
+    ? lastActiveAt
+    : null;
+}
+
+export function isPlaybackStale(
+  playback: PlaybackState | null,
+  lastActiveAt?: number,
+  currentTime = Date.now(),
+): boolean {
+  const syncedAt = getPlaybackSyncedAt(playback, lastActiveAt);
+  return syncedAt !== null && currentTime - syncedAt > PLAYBACK_STALE_AFTER_MS;
+}
+
+/**
+ * 播放中且状态未陈旧时，按最近一次同步的位置 + 经过时间 × 倍速外推当前
+ * 位置；其余情况返回同步时的原始位置。
+ */
+export function getPlaybackDisplayPosition(
+  playback: PlaybackState | null,
+  lastActiveAt?: number,
+  currentTime = Date.now(),
+): number | null {
+  if (!playback) {
+    return null;
+  }
+  const basePosition = Number(playback.currentTime);
+  if (!Number.isFinite(basePosition)) {
+    return null;
+  }
+  const syncedAt = getPlaybackSyncedAt(playback, lastActiveAt);
+  if (
+    playback.playState !== "playing" ||
+    syncedAt === null ||
+    isPlaybackStale(playback, lastActiveAt, currentTime)
+  ) {
+    return basePosition;
+  }
+  const rate = Number(playback.playbackRate || 1);
+  const elapsedSeconds = Math.max(0, (currentTime - syncedAt) / 1000);
+  return basePosition + elapsedSeconds * rate;
+}
+
+const PLAY_STATE_LABELS: Record<string, string> = {
+  playing: "播放中",
+  paused: "已暂停",
+  buffering: "缓冲中",
+};
+
+export function getPlayStateLabel(playback: PlaybackState | null): string {
+  if (!playback) {
+    return "无播放状态";
+  }
+  return PLAY_STATE_LABELS[playback.playState] ?? playback.playState;
+}
+
+export function formatPlaybackPosition(
+  seconds: number | null | undefined,
+): string {
+  if (
+    seconds === null ||
+    seconds === undefined ||
+    !Number.isFinite(seconds) ||
+    seconds < 0
+  ) {
+    return "—";
+  }
+  const total = Math.floor(seconds);
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+  const mm = String(minutes).padStart(2, "0");
+  const ss = String(secs).padStart(2, "0");
+  return hours > 0 ? `${hours}:${mm}:${ss}` : `${minutes}:${ss}`;
+}

--- a/packages/admin-ui/src/lib/roles.ts
+++ b/packages/admin-ui/src/lib/roles.ts
@@ -1,0 +1,5 @@
+import type { AdminIdentity } from "../api/types.js";
+
+export function canManage(me: AdminIdentity | null): boolean {
+  return me !== null && (me.role === "operator" || me.role === "admin");
+}

--- a/packages/admin-ui/src/lib/use-now.ts
+++ b/packages/admin-ui/src/lib/use-now.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+/** 以 intervalMs 为周期返回当前时间戳；enabled 为 false 时停表不重渲染。 */
+export function useNow(intervalMs: number, enabled = true): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const handle = setInterval(() => {
+      setNow(Date.now());
+    }, intervalMs);
+    return () => {
+      clearInterval(handle);
+    };
+  }, [intervalMs, enabled]);
+
+  return now;
+}

--- a/packages/admin-ui/src/pages/rooms/playback-cell.tsx
+++ b/packages/admin-ui/src/pages/rooms/playback-cell.tsx
@@ -1,0 +1,49 @@
+import { Tag, Typography } from "antd";
+import type { RoomSummary } from "../../api/types.js";
+import {
+  formatPlaybackPosition,
+  getPlaybackDisplayPosition,
+  getPlayStateLabel,
+  isPlaybackStale,
+} from "../../lib/playback.js";
+import { useNow } from "../../lib/use-now.js";
+
+const STATE_COLORS: Record<string, string> = {
+  playing: "processing",
+  paused: "default",
+  buffering: "warning",
+};
+
+export function PlaybackCell({ room }: { room: RoomSummary }) {
+  const playing = room.playback?.playState === "playing";
+  // 只有播放中且状态未陈旧才需要每秒外推重绘。
+  const ticking = playing && !isPlaybackStale(room.playback, room.lastActiveAt);
+  const now = useNow(1_000, ticking);
+
+  if (!room.playback) {
+    return <Typography.Text type="secondary">—</Typography.Text>;
+  }
+
+  const position = getPlaybackDisplayPosition(
+    room.playback,
+    room.lastActiveAt,
+    now,
+  );
+  const stale = isPlaybackStale(room.playback, room.lastActiveAt, now);
+  const rate = room.playback.playbackRate;
+
+  return (
+    <span>
+      <Tag color={STATE_COLORS[room.playback.playState] ?? "default"}>
+        {getPlayStateLabel(room.playback)}
+      </Tag>
+      <Typography.Text>{formatPlaybackPosition(position)}</Typography.Text>
+      {rate !== 1 ? (
+        <Typography.Text type="secondary"> · {rate}x</Typography.Text>
+      ) : null}
+      {stale ? (
+        <Typography.Text type="warning"> · 同步已陈旧</Typography.Text>
+      ) : null}
+    </span>
+  );
+}

--- a/packages/admin-ui/src/pages/rooms/reason-modal.tsx
+++ b/packages/admin-ui/src/pages/rooms/reason-modal.tsx
@@ -1,0 +1,77 @@
+import { Alert, Input, Modal, Typography } from "antd";
+import { useState } from "react";
+
+export type PendingGovernanceAction = {
+  title: string;
+  description?: string;
+  danger?: boolean;
+  execute: (reason: string) => Promise<void>;
+};
+
+export function ReasonModal({
+  pending,
+  onClose,
+}: {
+  pending: PendingGovernanceAction | null;
+  onClose: () => void;
+}) {
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const close = () => {
+    setReason("");
+    setError("");
+    setSubmitting(false);
+    onClose();
+  };
+
+  const confirm = async () => {
+    if (!pending) {
+      return;
+    }
+    setSubmitting(true);
+    setError("");
+    try {
+      await pending.execute(reason.trim());
+      close();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "操作失败。");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={pending !== null}
+      title={pending?.title}
+      okText="确认执行"
+      okButtonProps={{ danger: pending?.danger, loading: submitting }}
+      cancelText="取消"
+      onOk={confirm}
+      onCancel={close}
+      destroyOnHidden
+    >
+      {pending?.description ? (
+        <Typography.Paragraph type="secondary">
+          {pending.description}
+        </Typography.Paragraph>
+      ) : null}
+      {error ? (
+        <Alert
+          type="error"
+          message={error}
+          showIcon
+          style={{ marginBottom: 12 }}
+        />
+      ) : null}
+      <Input.TextArea
+        rows={2}
+        placeholder="操作原因（可选，写入审计日志）"
+        value={reason}
+        onChange={(event) => setReason(event.target.value)}
+        maxLength={200}
+      />
+    </Modal>
+  );
+}

--- a/packages/admin-ui/src/pages/rooms/room-detail-drawer.tsx
+++ b/packages/admin-ui/src/pages/rooms/room-detail-drawer.tsx
@@ -1,0 +1,267 @@
+import {
+  Alert,
+  Button,
+  Descriptions,
+  Drawer,
+  Space,
+  Spin,
+  Table,
+  Tag,
+  Typography,
+} from "antd";
+import type {
+  RoomDetailMember,
+  RoomSummary,
+  RuntimeEventRecord,
+} from "../../api/types.js";
+import { formatDateTime } from "../../lib/format.js";
+import { PlaybackCell } from "./playback-cell.js";
+import { RoomStatusTag } from "./room-status-tag.js";
+import { useRoomDetailQuery } from "./rooms-queries.js";
+import type { PendingGovernanceAction } from "./reason-modal.js";
+import type { RoomGovernanceHandlers } from "./rooms-table.js";
+
+export type MemberGovernanceHandlers = {
+  kickMember: (
+    room: RoomSummary,
+    member: RoomDetailMember,
+  ) => PendingGovernanceAction;
+  disconnectSession: (
+    room: RoomSummary,
+    member: RoomDetailMember,
+  ) => PendingGovernanceAction;
+};
+
+export function RoomDetailDrawer({
+  roomCode,
+  autoRefresh,
+  manageable,
+  onClose,
+  onAction,
+  governance,
+  memberGovernance,
+}: {
+  roomCode: string | null;
+  autoRefresh: boolean;
+  manageable: boolean;
+  onClose: () => void;
+  onAction: (pending: PendingGovernanceAction) => void;
+  governance: RoomGovernanceHandlers;
+  memberGovernance: MemberGovernanceHandlers;
+}) {
+  const detailQuery = useRoomDetailQuery(roomCode, autoRefresh);
+  const detail = detailQuery.data;
+
+  return (
+    <Drawer
+      open={roomCode !== null}
+      onClose={onClose}
+      width={720}
+      title={`房间 ${roomCode ?? ""}`}
+    >
+      {detailQuery.isPending ? (
+        <div style={{ display: "flex", justifyContent: "center", padding: 48 }}>
+          <Spin />
+        </div>
+      ) : detailQuery.isError ? (
+        <Alert
+          type="error"
+          showIcon
+          message="房间详情加载失败"
+          description={
+            detailQuery.error instanceof Error
+              ? detailQuery.error.message
+              : "请求失败。"
+          }
+        />
+      ) : detail ? (
+        <Space direction="vertical" size={16} style={{ display: "flex" }}>
+          {manageable ? (
+            <Space wrap>
+              <Button
+                danger
+                size="small"
+                onClick={() => onAction(governance.closeRoom(detail.room))}
+              >
+                关闭房间
+              </Button>
+              <Button
+                size="small"
+                disabled={detail.room.isActive}
+                title={
+                  detail.room.isActive
+                    ? "房间仍有在线成员，仅空闲房间可提前过期"
+                    : undefined
+                }
+                onClick={() => onAction(governance.expireRoom(detail.room))}
+              >
+                提前过期
+              </Button>
+              <Button
+                size="small"
+                onClick={() => onAction(governance.clearRoomVideo(detail.room))}
+              >
+                清空共享视频
+              </Button>
+            </Space>
+          ) : null}
+
+          <Descriptions column={2} size="small" bordered>
+            <Descriptions.Item label="状态">
+              <RoomStatusTag room={detail.room} />
+            </Descriptions.Item>
+            <Descriptions.Item label="房主">
+              {detail.room.ownerDisplayName ?? "—"}
+            </Descriptions.Item>
+            <Descriptions.Item label="创建时间">
+              {formatDateTime(detail.room.createdAt)}
+            </Descriptions.Item>
+            <Descriptions.Item label="最近活跃">
+              {formatDateTime(detail.room.lastActiveAt)}
+            </Descriptions.Item>
+            <Descriptions.Item label="过期时间">
+              {detail.room.expiresAt === null
+                ? "不过期"
+                : formatDateTime(detail.room.expiresAt)}
+            </Descriptions.Item>
+            <Descriptions.Item label="所在节点">
+              {detail.room.instanceIds.length > 0
+                ? detail.room.instanceIds.join(", ")
+                : (detail.instanceId ?? "—")}
+            </Descriptions.Item>
+            <Descriptions.Item label="共享视频" span={2}>
+              {detail.room.sharedVideo ? (
+                <Typography.Link
+                  href={detail.room.sharedVideo.url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {detail.room.sharedVideo.title || detail.room.sharedVideo.url}
+                </Typography.Link>
+              ) : (
+                "未共享视频"
+              )}
+            </Descriptions.Item>
+            <Descriptions.Item label="播放状态" span={2}>
+              <PlaybackCell room={detail.room} />
+            </Descriptions.Item>
+          </Descriptions>
+
+          <Typography.Title level={5} style={{ margin: 0 }}>
+            在线成员（{detail.members.length}）
+          </Typography.Title>
+          <Table<RoomDetailMember>
+            size="small"
+            rowKey="sessionId"
+            pagination={false}
+            dataSource={detail.members}
+            locale={{ emptyText: "当前没有在线成员。" }}
+            columns={[
+              {
+                title: "成员",
+                dataIndex: "displayName",
+                render: (displayName: string, member) => (
+                  <>
+                    <Typography.Text strong>{displayName}</Typography.Text>
+                    {member.memberId === detail.room.ownerMemberId ? (
+                      <Tag color="blue" style={{ marginLeft: 8 }}>
+                        房主
+                      </Tag>
+                    ) : null}
+                    <br />
+                    <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                      {member.memberId}
+                    </Typography.Text>
+                  </>
+                ),
+              },
+              {
+                title: "加入时间",
+                dataIndex: "joinedAt",
+                render: (value: number) => formatDateTime(value),
+              },
+              {
+                title: "来源",
+                dataIndex: "remoteAddress",
+                render: (_value, member) => (
+                  <>
+                    {member.remoteAddress ?? "—"}
+                    <br />
+                    <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                      {member.origin ?? "—"}
+                    </Typography.Text>
+                  </>
+                ),
+              },
+              ...(manageable
+                ? [
+                    {
+                      title: "操作",
+                      key: "actions",
+                      render: (_value: unknown, member: RoomDetailMember) => (
+                        <Space>
+                          <Button
+                            size="small"
+                            danger
+                            onClick={() =>
+                              onAction(
+                                memberGovernance.kickMember(
+                                  detail.room,
+                                  member,
+                                ),
+                              )
+                            }
+                          >
+                            踢出
+                          </Button>
+                          <Button
+                            size="small"
+                            onClick={() =>
+                              onAction(
+                                memberGovernance.disconnectSession(
+                                  detail.room,
+                                  member,
+                                ),
+                              )
+                            }
+                          >
+                            断开会话
+                          </Button>
+                        </Space>
+                      ),
+                    },
+                  ]
+                : []),
+            ]}
+          />
+
+          <Typography.Title level={5} style={{ margin: 0 }}>
+            最近事件（{detail.recentEvents.length}）
+          </Typography.Title>
+          <Table<RuntimeEventRecord>
+            size="small"
+            rowKey="id"
+            pagination={false}
+            dataSource={detail.recentEvents}
+            locale={{ emptyText: "暂无事件。" }}
+            columns={[
+              {
+                title: "时间",
+                dataIndex: "timestamp",
+                width: 170,
+                render: (value: string) => formatDateTime(Date.parse(value)),
+              },
+              { title: "事件", dataIndex: "event" },
+              {
+                title: "结果",
+                dataIndex: "result",
+                render: (value: string | null) =>
+                  value ? <Tag>{value}</Tag> : "—",
+              },
+            ]}
+          />
+        </Space>
+      ) : null}
+    </Drawer>
+  );
+}

--- a/packages/admin-ui/src/pages/rooms/room-status-tag.tsx
+++ b/packages/admin-ui/src/pages/rooms/room-status-tag.tsx
@@ -1,0 +1,18 @@
+import { Tag } from "antd";
+import type { RoomSummary } from "../../api/types.js";
+
+export function RoomStatusTag({
+  room,
+  currentTime = Date.now(),
+}: {
+  room: RoomSummary;
+  currentTime?: number;
+}) {
+  if (room.isActive) {
+    return <Tag color="success">活跃 · {room.memberCount} 人</Tag>;
+  }
+  if (room.expiresAt !== null && room.expiresAt <= currentTime) {
+    return <Tag color="default">已过期</Tag>;
+  }
+  return <Tag color="warning">空闲</Tag>;
+}

--- a/packages/admin-ui/src/pages/rooms/rooms-filter.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-filter.tsx
@@ -1,0 +1,39 @@
+import { Checkbox, Input, Segmented, Space } from "antd";
+import type { RoomListQuery, RoomStatusFilter } from "../../api/types.js";
+
+export function RoomsFilter({
+  query,
+  onChange,
+}: {
+  query: RoomListQuery;
+  onChange: (patch: Partial<RoomListQuery>) => void;
+}) {
+  return (
+    <Space wrap>
+      <Input.Search
+        allowClear
+        placeholder="房间号 / 成员 / 视频标题 / URL，空格分隔多关键字"
+        defaultValue={query.keyword}
+        onSearch={(keyword) => onChange({ keyword: keyword.trim(), page: 1 })}
+        style={{ width: 360 }}
+      />
+      <Segmented<RoomStatusFilter>
+        value={query.status ?? "all"}
+        onChange={(status) => onChange({ status, page: 1 })}
+        options={[
+          { label: "全部", value: "all" },
+          { label: "活跃", value: "active" },
+          { label: "空闲", value: "idle" },
+        ]}
+      />
+      <Checkbox
+        checked={query.includeExpired ?? false}
+        onChange={(event) =>
+          onChange({ includeExpired: event.target.checked, page: 1 })
+        }
+      >
+        包含已过期
+      </Checkbox>
+    </Space>
+  );
+}

--- a/packages/admin-ui/src/pages/rooms/rooms-filter.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-filter.tsx
@@ -1,4 +1,5 @@
 import { Checkbox, Input, Segmented, Space } from "antd";
+import { useEffect, useState } from "react";
 import type { RoomListQuery, RoomStatusFilter } from "../../api/types.js";
 
 export function RoomsFilter({
@@ -8,12 +9,20 @@ export function RoomsFilter({
   query: RoomListQuery;
   onChange: (patch: Partial<RoomListQuery>) => void;
 }) {
+  // URL 是筛选状态的唯一来源；输入框保留本地草稿以便输入，
+  // 但路由带来的 keyword 变化（前进/后退、外部链接）必须回写。
+  const [keywordDraft, setKeywordDraft] = useState(query.keyword ?? "");
+  useEffect(() => {
+    setKeywordDraft(query.keyword ?? "");
+  }, [query.keyword]);
+
   return (
     <Space wrap>
       <Input.Search
         allowClear
         placeholder="房间号 / 成员 / 视频标题 / URL，空格分隔多关键字"
-        defaultValue={query.keyword}
+        value={keywordDraft}
+        onChange={(event) => setKeywordDraft(event.target.value)}
         onSearch={(keyword) => onChange({ keyword: keyword.trim(), page: 1 })}
         style={{ width: 360 }}
       />

--- a/packages/admin-ui/src/pages/rooms/rooms-page.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-page.tsx
@@ -1,6 +1,14 @@
 import { ReloadOutlined } from "@ant-design/icons";
 import { useQueryClient } from "@tanstack/react-query";
-import { App as AntdApp, Button, Card, Space, Switch, Typography } from "antd";
+import {
+  Alert,
+  App as AntdApp,
+  Button,
+  Card,
+  Space,
+  Switch,
+  Typography,
+} from "antd";
 import { useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type {
@@ -175,16 +183,34 @@ export function RoomsPage() {
         </Space>
       </Card>
 
-      <RoomsTable
-        data={roomsQuery.data}
-        loading={roomsQuery.isPending}
-        query={query}
-        manageable={manageable}
-        onQueryChange={updateQuery}
-        onOpenRoom={openRoom}
-        onAction={setPendingAction}
-        governance={governance}
-      />
+      {roomsQuery.isError ? (
+        <Alert
+          type="error"
+          showIcon
+          message="房间列表加载失败"
+          description={
+            roomsQuery.error instanceof Error
+              ? roomsQuery.error.message
+              : "请求失败。"
+          }
+          action={
+            <Button size="small" onClick={refreshNow}>
+              重试
+            </Button>
+          }
+        />
+      ) : (
+        <RoomsTable
+          data={roomsQuery.data}
+          loading={roomsQuery.isPending}
+          query={query}
+          manageable={manageable}
+          onQueryChange={updateQuery}
+          onOpenRoom={openRoom}
+          onAction={setPendingAction}
+          governance={governance}
+        />
+      )}
 
       <RoomDetailDrawer
         roomCode={roomCode}

--- a/packages/admin-ui/src/pages/rooms/rooms-page.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-page.tsx
@@ -1,0 +1,205 @@
+import { ReloadOutlined } from "@ant-design/icons";
+import { useQueryClient } from "@tanstack/react-query";
+import { App as AntdApp, Button, Card, Space, Switch, Typography } from "antd";
+import { useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import type {
+  RoomDetailMember,
+  RoomListQuery,
+  RoomSummary,
+} from "../../api/types.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { formatTime } from "../../lib/format.js";
+import { canManage } from "../../lib/roles.js";
+import { ReasonModal } from "./reason-modal.js";
+import type { PendingGovernanceAction } from "./reason-modal.js";
+import { RoomDetailDrawer } from "./room-detail-drawer.js";
+import { RoomsFilter } from "./rooms-filter.js";
+import { useRoomsQuery } from "./rooms-queries.js";
+import { RoomsTable } from "./rooms-table.js";
+
+export function queryFromSearchParams(params: URLSearchParams): RoomListQuery {
+  const status = params.get("status");
+  const sortBy = params.get("sortBy");
+  const page = Number(params.get("page"));
+  const pageSize = Number(params.get("pageSize"));
+  return {
+    status:
+      status === "active" || status === "idle" || status === "all"
+        ? status
+        : "all",
+    keyword: params.get("keyword") ?? undefined,
+    page: Number.isInteger(page) && page > 0 ? page : 1,
+    pageSize: Number.isInteger(pageSize) && pageSize > 0 ? pageSize : 20,
+    sortBy: sortBy === "createdAt" ? "createdAt" : "lastActiveAt",
+    sortOrder: params.get("sortOrder") === "asc" ? "asc" : "desc",
+    includeExpired: params.get("includeExpired") === "true",
+  };
+}
+
+const QUERY_DEFAULTS: Record<string, string> = {
+  status: "all",
+  keyword: "",
+  page: "1",
+  pageSize: "20",
+  sortBy: "lastActiveAt",
+  sortOrder: "desc",
+  includeExpired: "false",
+};
+
+export function RoomsPage() {
+  const { api, me } = useAuth();
+  const { message } = AntdApp.useApp();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const { roomCode: roomCodeParam } = useParams();
+  const roomCode = roomCodeParam ?? null;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const [pendingAction, setPendingAction] =
+    useState<PendingGovernanceAction | null>(null);
+
+  const query = queryFromSearchParams(searchParams);
+  const roomsQuery = useRoomsQuery(query, autoRefresh);
+  const manageable = canManage(me);
+
+  const updateQuery = (patch: Partial<RoomListQuery>) => {
+    const next = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(patch)) {
+      const serialized = value === undefined ? "" : String(value);
+      // 默认值不落 URL，保持地址干净可分享。
+      if (serialized === "" || serialized === QUERY_DEFAULTS[key]) {
+        next.delete(key);
+      } else {
+        next.set(key, serialized);
+      }
+    }
+    setSearchParams(next, { replace: true });
+  };
+
+  const openRoom = (code: string) => {
+    navigate({
+      pathname: `/rooms/${encodeURIComponent(code)}`,
+      search: searchParams.toString(),
+    });
+  };
+
+  const closeDrawer = () => {
+    navigate({ pathname: "/rooms", search: searchParams.toString() });
+  };
+
+  const refreshNow = () => {
+    void queryClient.invalidateQueries({ queryKey: ["rooms"] });
+    void queryClient.invalidateQueries({ queryKey: ["room"] });
+  };
+
+  const afterAction = async (successMessage: string) => {
+    message.success(successMessage);
+    await queryClient.invalidateQueries({ queryKey: ["rooms"] });
+    await queryClient.invalidateQueries({ queryKey: ["room"] });
+  };
+
+  const governance = {
+    closeRoom: (room: RoomSummary): PendingGovernanceAction => ({
+      title: `关闭房间 ${room.roomCode}`,
+      description: "关闭后房间立即解散，所有在线成员会被断开。",
+      danger: true,
+      execute: async (reason) => {
+        await api.closeRoom(room.roomCode, reason);
+        await afterAction(`房间 ${room.roomCode} 已关闭。`);
+      },
+    }),
+    expireRoom: (room: RoomSummary): PendingGovernanceAction => ({
+      title: `提前过期房间 ${room.roomCode}`,
+      description: "空闲房间将立即标记为过期，等待清理。",
+      execute: async (reason) => {
+        await api.expireRoom(room.roomCode, reason);
+        await afterAction(`房间 ${room.roomCode} 已提前过期。`);
+      },
+    }),
+    clearRoomVideo: (room: RoomSummary): PendingGovernanceAction => ({
+      title: `清空房间 ${room.roomCode} 的共享视频`,
+      description: "成员将回到未共享状态，不影响成员在线。",
+      execute: async (reason) => {
+        await api.clearRoomVideo(room.roomCode, reason);
+        await afterAction(`房间 ${room.roomCode} 的共享视频已清空。`);
+      },
+    }),
+  };
+
+  const memberGovernance = {
+    kickMember: (
+      room: RoomSummary,
+      member: RoomDetailMember,
+    ): PendingGovernanceAction => ({
+      title: `踢出成员 ${member.displayName}`,
+      description: `成员将被移出房间 ${room.roomCode} 并断开连接。`,
+      danger: true,
+      execute: async (reason) => {
+        await api.kickMember(room.roomCode, member.memberId, reason);
+        await afterAction(`成员 ${member.displayName} 已被踢出。`);
+      },
+    }),
+    disconnectSession: (
+      room: RoomSummary,
+      member: RoomDetailMember,
+    ): PendingGovernanceAction => ({
+      title: `断开会话 ${member.displayName}`,
+      description: "仅断开当前 WebSocket 连接，成员可重连回房间。",
+      execute: async (reason) => {
+        await api.disconnectSession(member.sessionId, reason);
+        await afterAction(`已断开 ${member.displayName} 的会话。`);
+      },
+    }),
+  };
+
+  return (
+    <Space direction="vertical" size={16} style={{ display: "flex" }}>
+      <Card>
+        <Space direction="vertical" size={12} style={{ display: "flex" }}>
+          <RoomsFilter query={query} onChange={updateQuery} />
+          <Space wrap>
+            <Switch
+              checked={autoRefresh}
+              onChange={setAutoRefresh}
+              checkedChildren="自动刷新"
+              unCheckedChildren="自动刷新已关"
+            />
+            <Button icon={<ReloadOutlined />} onClick={refreshNow}>
+              刷新
+            </Button>
+            <Typography.Text type="secondary">
+              更新于 {formatTime(roomsQuery.dataUpdatedAt)}
+            </Typography.Text>
+          </Space>
+        </Space>
+      </Card>
+
+      <RoomsTable
+        data={roomsQuery.data}
+        loading={roomsQuery.isPending}
+        query={query}
+        manageable={manageable}
+        onQueryChange={updateQuery}
+        onOpenRoom={openRoom}
+        onAction={setPendingAction}
+        governance={governance}
+      />
+
+      <RoomDetailDrawer
+        roomCode={roomCode}
+        autoRefresh={autoRefresh}
+        manageable={manageable}
+        onClose={closeDrawer}
+        onAction={setPendingAction}
+        governance={governance}
+        memberGovernance={memberGovernance}
+      />
+
+      <ReasonModal
+        pending={pendingAction}
+        onClose={() => setPendingAction(null)}
+      />
+    </Space>
+  );
+}

--- a/packages/admin-ui/src/pages/rooms/rooms-queries.ts
+++ b/packages/admin-ui/src/pages/rooms/rooms-queries.ts
@@ -1,0 +1,29 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useAuth } from "../../auth/auth-context.js";
+import type { RoomListQuery } from "../../api/types.js";
+
+export const ROOMS_REFRESH_MS = 15_000;
+
+export function useRoomsQuery(query: RoomListQuery, autoRefresh: boolean) {
+  const { api } = useAuth();
+  return useQuery({
+    queryKey: ["rooms", query],
+    queryFn: () => api.listRooms(query),
+    refetchInterval: autoRefresh ? ROOMS_REFRESH_MS : false,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useRoomDetailQuery(
+  roomCode: string | null,
+  autoRefresh: boolean,
+) {
+  const { api } = useAuth();
+  return useQuery({
+    queryKey: ["room", roomCode],
+    queryFn: () => api.getRoomDetail(roomCode ?? ""),
+    enabled: roomCode !== null,
+    refetchInterval: autoRefresh ? ROOMS_REFRESH_MS : false,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/packages/admin-ui/src/pages/rooms/rooms-queries.ts
+++ b/packages/admin-ui/src/pages/rooms/rooms-queries.ts
@@ -24,6 +24,7 @@ export function useRoomDetailQuery(
     queryFn: () => api.getRoomDetail(roomCode ?? ""),
     enabled: roomCode !== null,
     refetchInterval: autoRefresh ? ROOMS_REFRESH_MS : false,
-    placeholderData: keepPreviousData,
+    // 故意不用 keepPreviousData：切换房间瞬间若沿用上一个房间的 detail，
+    // 抽屉里的治理按钮会作用在错误的房间上，宁可显示加载态。
   });
 }

--- a/packages/admin-ui/src/pages/rooms/rooms-table.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-table.tsx
@@ -44,17 +44,33 @@ export function RoomsTable({
     sorter: SorterResult<RoomSummary> | SorterResult<RoomSummary>[],
   ) => {
     const activeSorter = Array.isArray(sorter) ? sorter[0] : sorter;
-    const sortBy: RoomSortBy =
-      activeSorter?.field === "createdAt" && activeSorter.order
+    // 纯翻页触发的 onChange 携带空 sorter，此时保留 URL 中的排序，
+    // 避免分享链接一翻页排序就被重置。
+    const hasSorter = Boolean(activeSorter?.order);
+    const sortBy: RoomSortBy = hasSorter
+      ? activeSorter?.field === "createdAt"
         ? "createdAt"
-        : "lastActiveAt";
+        : "lastActiveAt"
+      : (query.sortBy ?? "lastActiveAt");
+    const sortOrder = hasSorter
+      ? activeSorter?.order === "ascend"
+        ? "asc"
+        : "desc"
+      : (query.sortOrder ?? "desc");
     onQueryChange({
       page: pagination.current ?? 1,
       pageSize: pagination.pageSize ?? 20,
       sortBy,
-      sortOrder: activeSorter?.order === "ascend" ? "asc" : "desc",
+      sortOrder,
     });
   };
+
+  const controlledSortOrder = (column: RoomSortBy) =>
+    (query.sortBy ?? "lastActiveAt") === column
+      ? (query.sortOrder ?? "desc") === "asc"
+        ? ("ascend" as const)
+        : ("descend" as const)
+      : null;
 
   return (
     <Table<RoomSummary>
@@ -119,13 +135,14 @@ export function RoomsTable({
           title: "最近活跃",
           dataIndex: "lastActiveAt",
           sorter: true,
-          defaultSortOrder: query.sortBy === "lastActiveAt" ? undefined : null,
+          sortOrder: controlledSortOrder("lastActiveAt"),
           render: (value: number) => formatDateTime(value),
         },
         {
           title: "创建时间",
           dataIndex: "createdAt",
           sorter: true,
+          sortOrder: controlledSortOrder("createdAt"),
           render: (value: number) => formatDateTime(value),
         },
         {

--- a/packages/admin-ui/src/pages/rooms/rooms-table.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-table.tsx
@@ -1,0 +1,174 @@
+import { DownOutlined } from "@ant-design/icons";
+import { Button, Dropdown, Space, Table, Typography } from "antd";
+import type { TablePaginationConfig } from "antd";
+import type { SorterResult } from "antd/es/table/interface";
+import type {
+  RoomListQuery,
+  RoomListResult,
+  RoomSortBy,
+  RoomSummary,
+} from "../../api/types.js";
+import { formatDateTime } from "../../lib/format.js";
+import { PlaybackCell } from "./playback-cell.js";
+import { RoomStatusTag } from "./room-status-tag.js";
+import type { PendingGovernanceAction } from "./reason-modal.js";
+
+export type RoomGovernanceHandlers = {
+  closeRoom: (room: RoomSummary) => PendingGovernanceAction;
+  expireRoom: (room: RoomSummary) => PendingGovernanceAction;
+  clearRoomVideo: (room: RoomSummary) => PendingGovernanceAction;
+};
+
+export function RoomsTable({
+  data,
+  loading,
+  query,
+  manageable,
+  onQueryChange,
+  onOpenRoom,
+  onAction,
+  governance,
+}: {
+  data: RoomListResult | undefined;
+  loading: boolean;
+  query: RoomListQuery;
+  manageable: boolean;
+  onQueryChange: (patch: Partial<RoomListQuery>) => void;
+  onOpenRoom: (roomCode: string) => void;
+  onAction: (pending: PendingGovernanceAction) => void;
+  governance: RoomGovernanceHandlers;
+}) {
+  const handleTableChange = (
+    pagination: TablePaginationConfig,
+    _filters: unknown,
+    sorter: SorterResult<RoomSummary> | SorterResult<RoomSummary>[],
+  ) => {
+    const activeSorter = Array.isArray(sorter) ? sorter[0] : sorter;
+    const sortBy: RoomSortBy =
+      activeSorter?.field === "createdAt" && activeSorter.order
+        ? "createdAt"
+        : "lastActiveAt";
+    onQueryChange({
+      page: pagination.current ?? 1,
+      pageSize: pagination.pageSize ?? 20,
+      sortBy,
+      sortOrder: activeSorter?.order === "ascend" ? "asc" : "desc",
+    });
+  };
+
+  return (
+    <Table<RoomSummary>
+      size="middle"
+      rowKey="roomCode"
+      loading={loading}
+      dataSource={data?.items ?? []}
+      locale={{ emptyText: "没有符合条件的房间。" }}
+      onChange={handleTableChange}
+      pagination={{
+        current: query.page ?? 1,
+        pageSize: query.pageSize ?? 20,
+        total: data?.pagination.total ?? 0,
+        showSizeChanger: true,
+        showTotal: (total) => `共 ${total} 个房间`,
+      }}
+      columns={[
+        {
+          title: "房间",
+          dataIndex: "roomCode",
+          render: (roomCode: string, room) => (
+            <>
+              <Typography.Link onClick={() => onOpenRoom(roomCode)}>
+                <strong>{roomCode}</strong>
+              </Typography.Link>
+              <br />
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                {room.ownerDisplayName ?? "无房主"}
+              </Typography.Text>
+            </>
+          ),
+        },
+        {
+          title: "状态",
+          dataIndex: "isActive",
+          render: (_value, room) => <RoomStatusTag room={room} />,
+        },
+        {
+          title: "共享视频",
+          dataIndex: "sharedVideo",
+          render: (_value, room) =>
+            room.sharedVideo ? (
+              <Typography.Link
+                href={room.sharedVideo.url}
+                target="_blank"
+                rel="noreferrer"
+                ellipsis
+                style={{ maxWidth: 260, display: "inline-block" }}
+              >
+                {room.sharedVideo.title || room.sharedVideo.url}
+              </Typography.Link>
+            ) : (
+              <Typography.Text type="secondary">未共享视频</Typography.Text>
+            ),
+        },
+        {
+          title: "播放进度",
+          dataIndex: "playback",
+          render: (_value, room) => <PlaybackCell room={room} />,
+        },
+        {
+          title: "最近活跃",
+          dataIndex: "lastActiveAt",
+          sorter: true,
+          defaultSortOrder: query.sortBy === "lastActiveAt" ? undefined : null,
+          render: (value: number) => formatDateTime(value),
+        },
+        {
+          title: "创建时间",
+          dataIndex: "createdAt",
+          sorter: true,
+          render: (value: number) => formatDateTime(value),
+        },
+        {
+          title: "操作",
+          key: "actions",
+          render: (_value, room) => (
+            <Space>
+              <Button size="small" onClick={() => onOpenRoom(room.roomCode)}>
+                详情
+              </Button>
+              {manageable ? (
+                <Dropdown
+                  trigger={["click"]}
+                  menu={{
+                    items: [
+                      { key: "close", label: "关闭房间", danger: true },
+                      {
+                        key: "expire",
+                        label: "提前过期",
+                        disabled: room.isActive,
+                      },
+                      { key: "clear-video", label: "清空共享视频" },
+                    ],
+                    onClick: ({ key }) => {
+                      if (key === "close") {
+                        onAction(governance.closeRoom(room));
+                      } else if (key === "expire") {
+                        onAction(governance.expireRoom(room));
+                      } else if (key === "clear-video") {
+                        onAction(governance.clearRoomVideo(room));
+                      }
+                    },
+                  }}
+                >
+                  <Button size="small">
+                    治理 <DownOutlined />
+                  </Button>
+                </Dropdown>
+              ) : null}
+            </Space>
+          ),
+        },
+      ]}
+    />
+  );
+}

--- a/packages/admin-ui/test/app-layout.test.tsx
+++ b/packages/admin-ui/test/app-layout.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { AuthContext } from "../src/auth/auth-context.js";
 import type { AuthContextValue } from "../src/auth/auth-context.js";
 import { createAuthValue } from "./helpers.js";

--- a/packages/admin-ui/test/app-layout.test.tsx
+++ b/packages/admin-ui/test/app-layout.test.tsx
@@ -4,28 +4,17 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { AuthContext } from "../src/auth/auth-context.js";
 import type { AuthContextValue } from "../src/auth/auth-context.js";
+import { createAuthValue } from "./helpers.js";
 import { AppLayout } from "../src/layout/app-layout.js";
 
-function createAuthValue(
+function createLayoutAuthValue(
   overrides: Partial<AuthContextValue> = {},
 ): AuthContextValue {
-  return {
+  return createAuthValue({
     token: "token-1",
     me: { id: "admin-1", username: "ops", role: "operator" },
-    initializing: false,
-    meError: "",
-    api: {
-      login: vi.fn(),
-      logout: vi.fn(),
-      getMe: vi.fn(),
-      getOverview: vi.fn(),
-      getReady: vi.fn(),
-    },
-    signIn: vi.fn().mockResolvedValue(undefined),
-    signOut: vi.fn().mockResolvedValue(undefined),
-    retryLoadMe: vi.fn(),
     ...overrides,
-  };
+  });
 }
 
 function renderLayout(authValue: AuthContextValue) {
@@ -45,7 +34,7 @@ function renderLayout(authValue: AuthContextValue) {
 
 describe("AppLayout", () => {
   it("renders navigation, user info and the active page content", () => {
-    renderLayout(createAuthValue());
+    renderLayout(createLayoutAuthValue());
 
     for (const label of [
       "概览",
@@ -64,7 +53,7 @@ describe("AppLayout", () => {
 
   it("signs out and navigates to login", async () => {
     const user = userEvent.setup();
-    const authValue = createAuthValue();
+    const authValue = createLayoutAuthValue();
     renderLayout(authValue);
 
     await user.click(screen.getByRole("button", { name: /退\s*出/ }));

--- a/packages/admin-ui/test/helpers.tsx
+++ b/packages/admin-ui/test/helpers.tsx
@@ -1,0 +1,38 @@
+import { vi } from "vitest";
+import type { AuthContextValue } from "../src/auth/auth-context.js";
+
+export function createStubApi(
+  overrides: Partial<AuthContextValue["api"]> = {},
+): AuthContextValue["api"] {
+  return {
+    login: vi.fn(),
+    logout: vi.fn(),
+    getMe: vi.fn(),
+    getOverview: vi.fn(),
+    getReady: vi.fn(),
+    listRooms: vi.fn(),
+    getRoomDetail: vi.fn(),
+    closeRoom: vi.fn(),
+    expireRoom: vi.fn(),
+    clearRoomVideo: vi.fn(),
+    kickMember: vi.fn(),
+    disconnectSession: vi.fn(),
+    ...overrides,
+  };
+}
+
+export function createAuthValue(
+  overrides: Partial<AuthContextValue> = {},
+): AuthContextValue {
+  return {
+    token: "",
+    me: null,
+    initializing: false,
+    meError: "",
+    api: createStubApi(),
+    signIn: vi.fn().mockResolvedValue(undefined),
+    signOut: vi.fn().mockResolvedValue(undefined),
+    retryLoadMe: vi.fn(),
+    ...overrides,
+  };
+}

--- a/packages/admin-ui/test/login-page.test.tsx
+++ b/packages/admin-ui/test/login-page.test.tsx
@@ -5,29 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "../src/api/http.js";
 import { AuthContext } from "../src/auth/auth-context.js";
 import type { AuthContextValue } from "../src/auth/auth-context.js";
+import { createAuthValue } from "./helpers.js";
 import { LoginPage } from "../src/pages/login-page.js";
-
-function createAuthValue(
-  overrides: Partial<AuthContextValue> = {},
-): AuthContextValue {
-  return {
-    token: "",
-    me: null,
-    initializing: false,
-    meError: "",
-    api: {
-      login: vi.fn(),
-      logout: vi.fn(),
-      getMe: vi.fn(),
-      getOverview: vi.fn(),
-      getReady: vi.fn(),
-    },
-    signIn: vi.fn().mockResolvedValue(undefined),
-    signOut: vi.fn().mockResolvedValue(undefined),
-    retryLoadMe: vi.fn(),
-    ...overrides,
-  };
-}
 
 function renderLogin(authValue: AuthContextValue, initialEntry = "/login") {
   return render(

--- a/packages/admin-ui/test/overview-page.test.tsx
+++ b/packages/admin-ui/test/overview-page.test.tsx
@@ -5,6 +5,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { AdminOverview, ReadyStatus } from "../src/api/types.js";
 import { AuthContext } from "../src/auth/auth-context.js";
 import type { AuthContextValue } from "../src/auth/auth-context.js";
+import {
+  createAuthValue as createTestAuthValue,
+  createStubApi,
+} from "./helpers.js";
 import { OverviewPage } from "../src/pages/overview/overview-page.js";
 
 function createOverviewFixture(
@@ -69,23 +73,11 @@ const readyFixture: ReadyStatus = {
 };
 
 function createAuthValue(api: Partial<AuthContextValue["api"]>) {
-  return {
+  return createTestAuthValue({
     token: "token-1",
     me: { id: "admin-1", username: "ops", role: "admin" },
-    initializing: false,
-    meError: "",
-    api: {
-      login: vi.fn(),
-      logout: vi.fn(),
-      getMe: vi.fn(),
-      getOverview: vi.fn(),
-      getReady: vi.fn(),
-      ...api,
-    },
-    signIn: vi.fn(),
-    signOut: vi.fn(),
-    retryLoadMe: vi.fn(),
-  } as AuthContextValue;
+    api: createStubApi(api),
+  });
 }
 
 function renderOverview(authValue: AuthContextValue) {

--- a/packages/admin-ui/test/playback.test.ts
+++ b/packages/admin-ui/test/playback.test.ts
@@ -1,0 +1,103 @@
+import type { PlaybackState } from "@bili-syncplay/protocol";
+import { describe, expect, it } from "vitest";
+import {
+  PLAYBACK_STALE_AFTER_MS,
+  formatPlaybackPosition,
+  getPlaybackDisplayPosition,
+  getPlaybackSyncedAt,
+  getPlayStateLabel,
+  isPlaybackStale,
+} from "../src/lib/playback.js";
+
+const NOW = 1_800_000_000_000;
+
+function makePlayback(overrides: Partial<PlaybackState> = {}): PlaybackState {
+  return {
+    url: "https://www.bilibili.com/video/BV1xx411c7mD",
+    currentTime: 100,
+    playState: "playing",
+    playbackRate: 1,
+    updatedAt: NOW - 10_000,
+    serverTime: NOW - 10_000,
+    actorId: "member-1",
+    seq: 1,
+    ...overrides,
+  };
+}
+
+describe("getPlaybackSyncedAt", () => {
+  it("prefers serverTime, falls back to updatedAt then lastActiveAt", () => {
+    expect(getPlaybackSyncedAt(makePlayback({ serverTime: 111 }))).toBe(111);
+    expect(
+      getPlaybackSyncedAt(
+        makePlayback({
+          serverTime: Number.NaN,
+          updatedAt: 222,
+        }),
+      ),
+    ).toBe(222);
+    expect(
+      getPlaybackSyncedAt(
+        makePlayback({ serverTime: Number.NaN, updatedAt: Number.NaN }),
+        333,
+      ),
+    ).toBe(333);
+    expect(getPlaybackSyncedAt(null)).toBeNull();
+  });
+});
+
+describe("isPlaybackStale", () => {
+  it("becomes stale after the threshold", () => {
+    const playback = makePlayback({ serverTime: NOW - 10_000 });
+    expect(isPlaybackStale(playback, undefined, NOW)).toBe(false);
+    expect(
+      isPlaybackStale(
+        playback,
+        undefined,
+        NOW - 10_000 + PLAYBACK_STALE_AFTER_MS + 1,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("getPlaybackDisplayPosition", () => {
+  it("extrapolates while playing and fresh, honoring playback rate", () => {
+    const playback = makePlayback({
+      currentTime: 100,
+      playbackRate: 2,
+      serverTime: NOW - 10_000,
+    });
+    expect(getPlaybackDisplayPosition(playback, undefined, NOW)).toBe(120);
+  });
+
+  it("returns the base position when paused or stale", () => {
+    const paused = makePlayback({ playState: "paused", currentTime: 100 });
+    expect(getPlaybackDisplayPosition(paused, undefined, NOW)).toBe(100);
+
+    const stale = makePlayback({
+      currentTime: 100,
+      serverTime: NOW - PLAYBACK_STALE_AFTER_MS - 1_000,
+    });
+    expect(getPlaybackDisplayPosition(stale, undefined, NOW)).toBe(100);
+  });
+
+  it("returns null without playback state", () => {
+    expect(getPlaybackDisplayPosition(null)).toBeNull();
+  });
+});
+
+describe("formatPlaybackPosition / getPlayStateLabel", () => {
+  it("formats positions", () => {
+    expect(formatPlaybackPosition(65)).toBe("1:05");
+    expect(formatPlaybackPosition(3_661)).toBe("1:01:01");
+    expect(formatPlaybackPosition(null)).toBe("—");
+  });
+
+  it("labels play states", () => {
+    expect(getPlayStateLabel(makePlayback())).toBe("播放中");
+    expect(getPlayStateLabel(makePlayback({ playState: "paused" }))).toBe(
+      "已暂停",
+    );
+    expect(getPlayStateLabel(null)).toBe("无播放状态");
+  });
+});

--- a/packages/admin-ui/test/require-auth.test.tsx
+++ b/packages/admin-ui/test/require-auth.test.tsx
@@ -4,29 +4,8 @@ import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { AuthContext } from "../src/auth/auth-context.js";
 import type { AuthContextValue } from "../src/auth/auth-context.js";
+import { createAuthValue } from "./helpers.js";
 import { RequireAuth } from "../src/auth/require-auth.js";
-
-function createAuthValue(
-  overrides: Partial<AuthContextValue> = {},
-): AuthContextValue {
-  return {
-    token: "",
-    me: null,
-    initializing: false,
-    meError: "",
-    api: {
-      login: vi.fn(),
-      logout: vi.fn(),
-      getMe: vi.fn(),
-      getOverview: vi.fn(),
-      getReady: vi.fn(),
-    },
-    signIn: vi.fn().mockResolvedValue(undefined),
-    signOut: vi.fn().mockResolvedValue(undefined),
-    retryLoadMe: vi.fn(),
-    ...overrides,
-  };
-}
 
 function LoginProbe() {
   const location = useLocation();

--- a/packages/admin-ui/test/require-auth.test.tsx
+++ b/packages/admin-ui/test/require-auth.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { AuthContext } from "../src/auth/auth-context.js";
 import type { AuthContextValue } from "../src/auth/auth-context.js";
 import { createAuthValue } from "./helpers.js";

--- a/packages/admin-ui/test/rooms-page.test.tsx
+++ b/packages/admin-ui/test/rooms-page.test.tsx
@@ -1,0 +1,245 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { App as AntdApp } from "antd";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  RoomDetail,
+  RoomListResult,
+  RoomSummary,
+} from "../src/api/types.js";
+import { AuthContext } from "../src/auth/auth-context.js";
+import type { AuthContextValue } from "../src/auth/auth-context.js";
+import { RoomsPage } from "../src/pages/rooms/rooms-page.js";
+import { createAuthValue, createStubApi } from "./helpers.js";
+
+function makeRoom(overrides: Partial<RoomSummary> = {}): RoomSummary {
+  return {
+    roomCode: "ROOM1",
+    createdAt: Date.now() - 3_600_000,
+    ownerMemberId: "member-1",
+    ownerDisplayName: "阿伟",
+    lastActiveAt: Date.now() - 60_000,
+    expiresAt: null,
+    sharedVideo: {
+      videoId: "BV1xx411c7mD",
+      url: "https://www.bilibili.com/video/BV1xx411c7mD",
+      title: "测试视频",
+    },
+    playback: null,
+    memberCount: 2,
+    isActive: true,
+    instanceIds: ["node-a"],
+    ...overrides,
+  };
+}
+
+function makeListResult(items: RoomSummary[]): RoomListResult {
+  return {
+    items,
+    pagination: { page: 1, pageSize: 20, total: items.length },
+  };
+}
+
+function makeDetail(room: RoomSummary): RoomDetail {
+  return {
+    room,
+    members: [
+      {
+        sessionId: "session-1",
+        memberId: "member-1",
+        displayName: "阿伟",
+        joinedAt: Date.now() - 3_000_000,
+        remoteAddress: "1.2.3.4",
+        origin: "chrome-extension://abc",
+      },
+      {
+        sessionId: "session-2",
+        memberId: "member-2",
+        displayName: "小明",
+        joinedAt: Date.now() - 1_000_000,
+        remoteAddress: "5.6.7.8",
+        origin: "chrome-extension://def",
+      },
+    ],
+    recentEvents: [
+      {
+        id: "event-1",
+        timestamp: new Date().toISOString(),
+        event: "room_joined",
+        roomCode: room.roomCode,
+        sessionId: "session-2",
+        remoteAddress: "5.6.7.8",
+        origin: null,
+        result: "ok",
+        details: {},
+      },
+    ],
+  };
+}
+
+function renderRooms(authValue: AuthContextValue, initialEntry = "/rooms") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <AuthContext.Provider value={authValue}>
+      <QueryClientProvider client={queryClient}>
+        <AntdApp>
+          <MemoryRouter initialEntries={[initialEntry]}>
+            <Routes>
+              <Route path="/rooms" element={<RoomsPage />} />
+              <Route path="/rooms/:roomCode" element={<RoomsPage />} />
+            </Routes>
+          </MemoryRouter>
+        </AntdApp>
+      </QueryClientProvider>
+    </AuthContext.Provider>,
+  );
+}
+
+function createOperatorAuth(api: Partial<AuthContextValue["api"]>) {
+  return createAuthValue({
+    token: "token-1",
+    me: { id: "admin-1", username: "ops", role: "operator" },
+    api: createStubApi(api),
+  });
+}
+
+describe("RoomsPage", () => {
+  it("renders rooms with status, video and owner", async () => {
+    renderRooms(
+      createOperatorAuth({
+        listRooms: vi.fn().mockResolvedValue(
+          makeListResult([
+            makeRoom(),
+            makeRoom({
+              roomCode: "ROOM2",
+              isActive: false,
+              memberCount: 0,
+              sharedVideo: null,
+            }),
+          ]),
+        ),
+      }),
+    );
+
+    expect(await screen.findByText("ROOM1")).toBeTruthy();
+    expect(screen.getByText("活跃 · 2 人")).toBeTruthy();
+    // “空闲”同时出现在状态筛选器里。
+    expect(screen.getAllByText("空闲").length).toBeGreaterThan(1);
+    expect(screen.getByText("测试视频")).toBeTruthy();
+    expect(screen.getByText("未共享视频")).toBeTruthy();
+    expect(screen.getAllByText("阿伟").length).toBeGreaterThan(0);
+  });
+
+  it("passes URL search params through to the rooms query", async () => {
+    const listRooms = vi.fn().mockResolvedValue(makeListResult([]));
+    renderRooms(
+      createOperatorAuth({ listRooms }),
+      "/rooms?status=active&keyword=abc&includeExpired=true",
+    );
+
+    await waitFor(() => {
+      expect(listRooms).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "active",
+          keyword: "abc",
+          includeExpired: true,
+        }),
+      );
+    });
+  });
+
+  it("runs the close-room governance flow with a reason", async () => {
+    const closeRoom = vi.fn().mockResolvedValue({});
+    const user = userEvent.setup();
+    renderRooms(
+      createOperatorAuth({
+        listRooms: vi.fn().mockResolvedValue(makeListResult([makeRoom()])),
+        closeRoom,
+      }),
+    );
+
+    await user.click(await screen.findByRole("button", { name: /治\s*理/ }));
+    await user.click(await screen.findByText("关闭房间"));
+
+    const dialog = await screen.findByRole("dialog");
+    await user.type(
+      within(dialog).getByPlaceholderText(/操作原因/),
+      "违规内容",
+    );
+    await user.click(within(dialog).getByRole("button", { name: /确认执行/ }));
+
+    await waitFor(() => {
+      expect(closeRoom).toHaveBeenCalledWith("ROOM1", "违规内容");
+    });
+  });
+
+  it("disables early-expire for active rooms", async () => {
+    const user = userEvent.setup();
+    renderRooms(
+      createOperatorAuth({
+        listRooms: vi.fn().mockResolvedValue(makeListResult([makeRoom()])),
+      }),
+    );
+
+    await user.click(await screen.findByRole("button", { name: /治\s*理/ }));
+    const expireItem = await screen.findByText("提前过期");
+    expect(
+      expireItem.closest(
+        '[aria-disabled="true"], .ant-dropdown-menu-item-disabled',
+      ),
+    ).not.toBeNull();
+  });
+
+  it("hides governance actions for viewers", async () => {
+    renderRooms(
+      createAuthValue({
+        token: "token-1",
+        me: { id: "admin-2", username: "watcher", role: "viewer" },
+        api: createStubApi({
+          listRooms: vi.fn().mockResolvedValue(makeListResult([makeRoom()])),
+        }),
+      }),
+    );
+
+    expect(await screen.findByText("ROOM1")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /治\s*理/ })).toBeNull();
+  });
+
+  it("opens the detail drawer from the route and kicks a member", async () => {
+    const room = makeRoom();
+    const kickMember = vi.fn().mockResolvedValue({});
+    const user = userEvent.setup();
+    renderRooms(
+      createOperatorAuth({
+        listRooms: vi.fn().mockResolvedValue(makeListResult([room])),
+        getRoomDetail: vi.fn().mockResolvedValue(makeDetail(room)),
+        kickMember,
+      }),
+      "/rooms/ROOM1",
+    );
+
+    expect(await screen.findByText("小明")).toBeTruthy();
+    // “房主”同时是详情描述项的标签。
+    expect(screen.getAllByText("房主").length).toBeGreaterThan(1);
+    expect(screen.getByText("room_joined")).toBeTruthy();
+
+    const memberRow = screen.getByText("小明").closest("tr");
+    expect(memberRow).not.toBeNull();
+    await user.click(
+      within(memberRow as HTMLElement).getByRole("button", {
+        name: /踢\s*出/,
+      }),
+    );
+
+    // 抽屉与弹窗都是 role=dialog，直接用确认按钮定位。
+    await user.click(await screen.findByRole("button", { name: /确认执行/ }));
+
+    await waitFor(() => {
+      expect(kickMember).toHaveBeenCalledWith("ROOM1", "member-2", "");
+    });
+  });
+});

--- a/packages/admin-ui/test/rooms-page.test.tsx
+++ b/packages/admin-ui/test/rooms-page.test.tsx
@@ -11,6 +11,7 @@ import type {
 } from "../src/api/types.js";
 import { AuthContext } from "../src/auth/auth-context.js";
 import type { AuthContextValue } from "../src/auth/auth-context.js";
+import { RoomsFilter } from "../src/pages/rooms/rooms-filter.js";
 import { RoomsPage } from "../src/pages/rooms/rooms-page.js";
 import { createAuthValue, createStubApi } from "./helpers.js";
 
@@ -209,6 +210,78 @@ describe("RoomsPage", () => {
     expect(screen.queryByRole("button", { name: /治\s*理/ })).toBeNull();
   });
 
+  it("shows an error state with retry when the rooms request fails", async () => {
+    const listRooms = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("后端故障"))
+      .mockResolvedValue(makeListResult([makeRoom()]));
+    const user = userEvent.setup();
+    renderRooms(createOperatorAuth({ listRooms }));
+
+    expect(await screen.findByText("房间列表加载失败")).toBeTruthy();
+    expect(screen.getByText("后端故障")).toBeTruthy();
+    expect(screen.queryByText("没有符合条件的房间。")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: /重\s*试/ }));
+    expect(await screen.findByText("ROOM1")).toBeTruthy();
+  });
+
+  it("keeps URL sort when paginating", async () => {
+    const listRooms = vi.fn().mockResolvedValue({
+      items: [makeRoom()],
+      pagination: { page: 1, pageSize: 20, total: 45 },
+    });
+    const user = userEvent.setup();
+    renderRooms(
+      createOperatorAuth({ listRooms }),
+      "/rooms?sortBy=createdAt&sortOrder=asc",
+    );
+
+    expect(await screen.findByText("ROOM1")).toBeTruthy();
+    await user.click(screen.getByTitle("2"));
+
+    await waitFor(() => {
+      expect(listRooms).toHaveBeenCalledWith(
+        expect.objectContaining({
+          page: 2,
+          sortBy: "createdAt",
+          sortOrder: "asc",
+        }),
+      );
+    });
+  });
+
+  it("drops the previous room's detail while switching rooms", async () => {
+    const room1 = makeRoom();
+    const room2 = makeRoom({ roomCode: "ROOM2" });
+    const getRoomDetail = vi.fn((code: string) =>
+      code === "ROOM1"
+        ? Promise.resolve(makeDetail(room1))
+        : new Promise<never>(() => {}),
+    );
+    const user = userEvent.setup();
+    renderRooms(
+      createOperatorAuth({
+        listRooms: vi.fn().mockResolvedValue(makeListResult([room1, room2])),
+        getRoomDetail: getRoomDetail as never,
+      }),
+      "/rooms/ROOM1",
+    );
+
+    expect(await screen.findByText("小明")).toBeTruthy();
+
+    const room2Row = (await screen.findByText("ROOM2")).closest("tr");
+    await user.click(
+      within(room2Row as HTMLElement).getByRole("button", { name: /详\s*情/ }),
+    );
+
+    // ROOM2 的详情未返回前，不能继续展示 ROOM1 的成员，
+    // 否则抽屉里的治理按钮会作用在错误房间上。
+    await waitFor(() => {
+      expect(screen.queryByText("小明")).toBeNull();
+    });
+  });
+
   it("opens the detail drawer from the route and kicks a member", async () => {
     const room = makeRoom();
     const kickMember = vi.fn().mockResolvedValue({});
@@ -241,5 +314,19 @@ describe("RoomsPage", () => {
     await waitFor(() => {
       expect(kickMember).toHaveBeenCalledWith("ROOM1", "member-2", "");
     });
+  });
+});
+
+describe("RoomsFilter", () => {
+  it("syncs the keyword input when the routed query changes", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <RoomsFilter query={{ keyword: "abc" }} onChange={onChange} />,
+    );
+    const input = screen.getByPlaceholderText(/房间号/) as HTMLInputElement;
+    expect(input.value).toBe("abc");
+
+    rerender(<RoomsFilter query={{ keyword: "xyz" }} onChange={onChange} />);
+    expect(input.value).toBe("xyz");
   });
 });

--- a/packages/admin-ui/vite.config.ts
+++ b/packages/admin-ui/vite.config.ts
@@ -30,5 +30,8 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./test/setup.ts"],
+    // antd 组件交互测试（userEvent + 弹窗/下拉）在 CI 覆盖率插桩下
+    // 会超过默认 5s，放宽到 15s。
+    testTimeout: 15_000,
   },
 });


### PR DESCRIPTION
## Summary

管理后台重写第三阶段（承接 #171 脚手架、#174 概览页）。三个设计决策已与维护者确认：**实时性用轮询 + 播放进度前端外推**（SSE 的鉴权改造收益不成比例，留待确有需要时独立设计）、**详情用抽屉 + URL 同步**（消除旧 UI 来回跳转）、**批量操作留待后续小 PR**。

- **协议类型复用**：admin-ui 引入 `@bili-syncplay/protocol` 依赖，`SharedVideo` / `PlaybackState` 直接使用协议定义；新增房间列表 / 详情 / 五个治理动作的类型化端点
- **列表页**：关键字 / 状态 / 含过期筛选（URL 同步、默认值不落地址栏、可分享）、状态徽章（活跃·N 人 / 空闲 / 已过期）、共享视频链接、**实时播放进度**（沿用旧 UI 的 `serverTime` + 倍速外推公式，仅播放中且 30s 内有同步时每秒局部重绘该单元格）、服务端分页与排序
- **抽屉详情**（`/rooms/:code` 可刷新直达）：房间信息、在线成员（房主标记、IP/origin、踢出 / 断开会话）、房间最近 20 条事件
- **治理动作**：统一 reason 确认弹窗（写入审计日志）；`viewer` 角色隐藏全部动作；活跃房间禁用"提前过期"（与服务端语义一致）

## Test plan

- [x] 14 条新增测试：外推公式、列表渲染、URL 查询透传、关房 / 踢人完整流程、角色门控、过期禁用（admin-ui 共 47 条全绿）
- [x] 完整预提交序列：format:check / lint / typecheck / build / test 全部通过
- [x] 手动 E2E（真实服务端 + WS 客户端建真房间）：建房共享视频 → 管理端列表 / 详情形状与前端类型逐字段吻合 → 清空共享视频 → 关闭房间（带 reason）→ 活跃数归零
- [ ] 浏览器内可视化验证（部署后确认抽屉与进度外推的观感）

🤖 Generated with [Claude Code](https://claude.com/claude-code)