### PR TITLE
feat: 运行事件与审计日志页迁移到新控制台

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5706,6 +5706,7 @@
         "@bili-syncplay/protocol": "1.2.4",
         "@tanstack/react-query": "^5.101.2",
         "antd": "^6.5.1",
+        "dayjs": "^1.11.21",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router-dom": "^7.18.1"

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -17,6 +17,7 @@
     "@bili-syncplay/protocol": "1.2.4",
     "@tanstack/react-query": "^5.101.2",
     "antd": "^6.5.1",
+    "dayjs": "^1.11.21",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.18.1"

--- a/packages/admin-ui/src/api/admin-api.ts
+++ b/packages/admin-ui/src/api/admin-api.ts
@@ -7,6 +7,10 @@ import type {
   AdminLogoutResult,
   AdminMeResult,
   AdminOverview,
+  AuditLogListResult,
+  AuditLogQuery,
+  EventListQuery,
+  EventListResult,
   ReadyStatus,
   RoomDetail,
   RoomListQuery,
@@ -69,6 +73,12 @@ export function createAdminApi(client: HttpClient) {
         `/api/admin/rooms/${encodeURIComponent(roomCode)}/members/${encodeURIComponent(memberId)}/kick`,
         { method: "POST", body: { reason: reason || undefined } },
       );
+    },
+    listEvents(query: EventListQuery = {}): Promise<EventListResult> {
+      return client.request(`/api/admin/events${toQueryString(query)}`);
+    },
+    listAuditLogs(query: AuditLogQuery = {}): Promise<AuditLogListResult> {
+      return client.request(`/api/admin/audit-logs${toQueryString(query)}`);
     },
     disconnectSession(
       sessionId: string,

--- a/packages/admin-ui/src/api/types.ts
+++ b/packages/admin-ui/src/api/types.ts
@@ -170,3 +170,74 @@ export type RoomDetail = {
 };
 
 export type AdminActionResult = Record<string, unknown>;
+
+export type ListPaginationMeta = {
+  page: number;
+  pageSize: number;
+};
+
+export type EventListQuery = {
+  event?: string;
+  roomCode?: string;
+  sessionId?: string;
+  remoteAddress?: string;
+  origin?: string;
+  result?: string;
+  includeSystem?: boolean;
+  from?: number;
+  to?: number;
+  page?: number;
+  pageSize?: number;
+};
+
+export type EventListResult = {
+  items: RuntimeEventRecord[];
+  total: number;
+  pagination: ListPaginationMeta;
+};
+
+export type AuditTargetType =
+  "room" | "session" | "member" | "config" | "block";
+export type AuditResult = "ok" | "rejected" | "error";
+
+export type AuditActor = {
+  adminId: string;
+  username: string;
+  role: AdminRole;
+};
+
+export type AuditLogRecord = {
+  id: string;
+  timestamp: string;
+  actor: AuditActor;
+  action: string;
+  targetType: AuditTargetType;
+  targetId: string;
+  request: Record<string, unknown>;
+  result: AuditResult;
+  reason?: string;
+  instanceId?: string;
+  targetInstanceId?: string;
+  executorInstanceId?: string;
+  commandRequestId?: string;
+  commandStatus?: "ok" | "not_found" | "stale_target" | "error";
+  commandCode?: string;
+};
+
+export type AuditLogQuery = {
+  actor?: string;
+  action?: string;
+  targetId?: string;
+  targetType?: AuditTargetType;
+  result?: AuditResult;
+  from?: number;
+  to?: number;
+  page?: number;
+  pageSize?: number;
+};
+
+export type AuditLogListResult = {
+  items: AuditLogRecord[];
+  total: number;
+  pagination: ListPaginationMeta;
+};

--- a/packages/admin-ui/src/app.tsx
+++ b/packages/admin-ui/src/app.tsx
@@ -9,6 +9,8 @@ import { createQueryClient } from "./data/query-client.js";
 import { AppLayout } from "./layout/app-layout.js";
 import { NAV_ITEMS } from "./layout/nav-items.js";
 import { LoginPage } from "./pages/login-page.js";
+import { AuditLogsPage } from "./pages/audit/audit-page.js";
+import { EventsPage } from "./pages/events/events-page.js";
 import { OverviewPage } from "./pages/overview/overview-page.js";
 import { PlaceholderPage } from "./pages/placeholder-page.js";
 import { RoomsPage } from "./pages/rooms/rooms-page.js";
@@ -34,21 +36,22 @@ export function App() {
                   <Route path="/overview" element={<OverviewPage />} />
                   <Route path="/rooms" element={<RoomsPage />} />
                   <Route path="/rooms/:roomCode" element={<RoomsPage />} />
-                  {NAV_ITEMS.filter(
-                    (item) =>
-                      item.path !== "/overview" && item.path !== "/rooms",
-                  ).map((item) => (
-                    <Route
-                      key={item.path}
-                      path={item.path}
-                      element={
-                        <PlaceholderPage
-                          title={item.label}
-                          description={item.description}
-                        />
-                      }
-                    />
-                  ))}
+                  <Route path="/events" element={<EventsPage />} />
+                  <Route path="/audit-logs" element={<AuditLogsPage />} />
+                  {NAV_ITEMS.filter((item) => item.path === "/config").map(
+                    (item) => (
+                      <Route
+                        key={item.path}
+                        path={item.path}
+                        element={
+                          <PlaceholderPage
+                            title={item.label}
+                            description={item.description}
+                          />
+                        }
+                      />
+                    ),
+                  )}
                   <Route
                     path="*"
                     element={<Navigate to="/overview" replace />}

--- a/packages/admin-ui/src/components/json-modal.tsx
+++ b/packages/admin-ui/src/components/json-modal.tsx
@@ -1,0 +1,27 @@
+import { Modal, Typography } from "antd";
+
+export function JsonModal({
+  title,
+  value,
+  onClose,
+}: {
+  title: string;
+  value: unknown;
+  onClose: () => void;
+}) {
+  return (
+    <Modal
+      open={value !== null}
+      title={title}
+      footer={null}
+      onCancel={onClose}
+      width={640}
+    >
+      <Typography.Paragraph>
+        <pre style={{ maxHeight: 480, overflow: "auto", margin: 0 }}>
+          {JSON.stringify(value, null, 2)}
+        </pre>
+      </Typography.Paragraph>
+    </Modal>
+  );
+}

--- a/packages/admin-ui/src/components/result-badge.tsx
+++ b/packages/admin-ui/src/components/result-badge.tsx
@@ -1,0 +1,18 @@
+import { Tag } from "antd";
+
+const RESULT_PRESENTATION: Record<string, { color: string; label: string }> = {
+  ok: { color: "success", label: "成功" },
+  rejected: { color: "warning", label: "已拒绝" },
+  error: { color: "error", label: "错误" },
+};
+
+export function ResultBadge({ result }: { result: string | null }) {
+  if (!result) {
+    return <span>—</span>;
+  }
+  const presentation = RESULT_PRESENTATION[result];
+  if (!presentation) {
+    return <Tag>{result}</Tag>;
+  }
+  return <Tag color={presentation.color}>{presentation.label}</Tag>;
+}

--- a/packages/admin-ui/src/lib/url-query.ts
+++ b/packages/admin-ui/src/lib/url-query.ts
@@ -1,0 +1,46 @@
+import { useSearchParams } from "react-router-dom";
+
+export type UrlQueryPatch = Record<
+  string,
+  string | number | boolean | undefined
+>;
+
+/**
+ * 以 URL 查询串为筛选状态的唯一来源：patch 里等于默认值或为空的键
+ * 从地址栏移除，保持链接干净可分享。
+ */
+export function useUrlQueryState(defaults: Record<string, string>) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const updateQuery = (patch: UrlQueryPatch) => {
+    const next = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(patch)) {
+      const serialized = value === undefined ? "" : String(value);
+      if (serialized === "" || serialized === defaults[key]) {
+        next.delete(key);
+      } else {
+        next.set(key, serialized);
+      }
+    }
+    setSearchParams(next, { replace: true });
+  };
+
+  return { searchParams, updateQuery };
+}
+
+export function readPositiveInt(
+  params: URLSearchParams,
+  key: string,
+  fallback: number,
+): number {
+  const value = Number(params.get(key));
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+export function readTimestamp(
+  params: URLSearchParams,
+  key: string,
+): number | undefined {
+  const value = Number(params.get(key));
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}

--- a/packages/admin-ui/src/pages/audit/audit-page.tsx
+++ b/packages/admin-ui/src/pages/audit/audit-page.tsx
@@ -1,0 +1,353 @@
+import { ReloadOutlined } from "@ant-design/icons";
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  Alert,
+  Button,
+  Card,
+  DatePicker,
+  Input,
+  Select,
+  Space,
+  Switch,
+  Table,
+  Tag,
+  Typography,
+} from "antd";
+import dayjs from "dayjs";
+import { useEffect, useState } from "react";
+import type {
+  AuditLogQuery,
+  AuditLogRecord,
+  AuditResult,
+  AuditTargetType,
+} from "../../api/types.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { JsonModal } from "../../components/json-modal.js";
+import { ResultBadge } from "../../components/result-badge.js";
+import { formatDateTime, formatTime } from "../../lib/format.js";
+import {
+  readPositiveInt,
+  readTimestamp,
+  useUrlQueryState,
+} from "../../lib/url-query.js";
+
+const AUDIT_REFRESH_MS = 15_000;
+
+const QUERY_DEFAULTS: Record<string, string> = {
+  page: "1",
+  pageSize: "20",
+};
+
+// 管理动作的中文标签；未收录的动作原样展示。
+const ACTION_LABELS: Record<string, string> = {
+  close_room: "关闭房间",
+  expire_room: "提前过期",
+  clear_room_video: "清空共享视频",
+  kick_member: "踢出成员",
+  disconnect_session: "断开会话",
+};
+
+const TARGET_TYPE_LABELS: Record<AuditTargetType, string> = {
+  room: "房间",
+  session: "会话",
+  member: "成员",
+  config: "配置",
+  block: "封禁",
+};
+
+function queryFromSearchParams(params: URLSearchParams): AuditLogQuery {
+  const targetType = params.get("targetType");
+  const result = params.get("result");
+  return {
+    actor: params.get("actor") ?? undefined,
+    action: params.get("action") ?? undefined,
+    targetId: params.get("targetId") ?? undefined,
+    targetType:
+      targetType && targetType in TARGET_TYPE_LABELS
+        ? (targetType as AuditTargetType)
+        : undefined,
+    result:
+      result === "ok" || result === "rejected" || result === "error"
+        ? result
+        : undefined,
+    from: readTimestamp(params, "from"),
+    to: readTimestamp(params, "to"),
+    page: readPositiveInt(params, "page", 1),
+    pageSize: readPositiveInt(params, "pageSize", 20),
+  };
+}
+
+function AuditFilter({
+  query,
+  onChange,
+}: {
+  query: AuditLogQuery;
+  onChange: (
+    patch: Record<string, string | number | boolean | undefined>,
+  ) => void;
+}) {
+  const [drafts, setDrafts] = useState({
+    actor: query.actor ?? "",
+    action: query.action ?? "",
+    targetId: query.targetId ?? "",
+  });
+
+  useEffect(() => {
+    setDrafts({
+      actor: query.actor ?? "",
+      action: query.action ?? "",
+      targetId: query.targetId ?? "",
+    });
+  }, [query.actor, query.action, query.targetId]);
+
+  const submit = () => {
+    onChange({
+      actor: drafts.actor.trim(),
+      action: drafts.action.trim(),
+      targetId: drafts.targetId.trim(),
+      page: 1,
+    });
+  };
+
+  return (
+    <Space wrap>
+      {(
+        [
+          ["actor", "操作人"],
+          ["action", "动作"],
+          ["targetId", "目标 ID"],
+        ] as const
+      ).map(([key, label]) => (
+        <Input
+          key={key}
+          allowClear
+          placeholder={label}
+          value={drafts[key]}
+          onChange={(event) =>
+            setDrafts((prev) => ({ ...prev, [key]: event.target.value }))
+          }
+          onPressEnter={submit}
+          style={{ width: 160 }}
+        />
+      ))}
+      <Select<AuditTargetType | "">
+        value={query.targetType ?? ""}
+        style={{ width: 140 }}
+        onChange={(value) => onChange({ targetType: value, page: 1 })}
+        options={[
+          { value: "", label: "全部目标类型" },
+          ...Object.entries(TARGET_TYPE_LABELS).map(([value, label]) => ({
+            value,
+            label,
+          })),
+        ]}
+      />
+      <Select<AuditResult | "">
+        value={query.result ?? ""}
+        style={{ width: 120 }}
+        onChange={(value) => onChange({ result: value, page: 1 })}
+        options={[
+          { value: "", label: "全部结果" },
+          { value: "ok", label: "成功" },
+          { value: "rejected", label: "已拒绝" },
+          { value: "error", label: "错误" },
+        ]}
+      />
+      <DatePicker.RangePicker
+        showTime
+        value={[
+          query.from ? dayjs(query.from) : null,
+          query.to ? dayjs(query.to) : null,
+        ]}
+        onChange={(range) =>
+          onChange({
+            from: range?.[0]?.valueOf(),
+            to: range?.[1]?.valueOf(),
+            page: 1,
+          })
+        }
+      />
+      <Button type="primary" onClick={submit}>
+        查询
+      </Button>
+    </Space>
+  );
+}
+
+export function AuditLogsPage() {
+  const { api } = useAuth();
+  const queryClient = useQueryClient();
+  const { searchParams, updateQuery } = useUrlQueryState(QUERY_DEFAULTS);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const [requestValue, setRequestValue] = useState<unknown>(null);
+
+  const query = queryFromSearchParams(searchParams);
+  const auditQuery = useQuery({
+    queryKey: ["audit-logs", query],
+    queryFn: () => api.listAuditLogs(query),
+    refetchInterval: autoRefresh ? AUDIT_REFRESH_MS : false,
+    placeholderData: keepPreviousData,
+  });
+
+  const refreshNow = () => {
+    void queryClient.invalidateQueries({ queryKey: ["audit-logs"] });
+  };
+
+  return (
+    <Space direction="vertical" size={16} style={{ display: "flex" }}>
+      <Card>
+        <Space direction="vertical" size={12} style={{ display: "flex" }}>
+          <AuditFilter query={query} onChange={updateQuery} />
+          <Space wrap>
+            <Switch
+              checked={autoRefresh}
+              onChange={setAutoRefresh}
+              checkedChildren="自动刷新"
+              unCheckedChildren="自动刷新已关"
+            />
+            <Button icon={<ReloadOutlined />} onClick={refreshNow}>
+              刷新
+            </Button>
+            <Typography.Text type="secondary">
+              更新于 {formatTime(auditQuery.dataUpdatedAt)}
+            </Typography.Text>
+          </Space>
+        </Space>
+      </Card>
+
+      {auditQuery.isError ? (
+        <Alert
+          type="error"
+          showIcon
+          message="审计日志加载失败"
+          description={
+            auditQuery.error instanceof Error
+              ? auditQuery.error.message
+              : "请求失败。"
+          }
+          action={
+            <Button size="small" onClick={refreshNow}>
+              重试
+            </Button>
+          }
+        />
+      ) : (
+        <Table<AuditLogRecord>
+          size="middle"
+          rowKey="id"
+          loading={auditQuery.isPending}
+          dataSource={auditQuery.data?.items ?? []}
+          locale={{ emptyText: "没有匹配的审计记录。" }}
+          onChange={(pagination) =>
+            updateQuery({
+              page: pagination.current ?? 1,
+              pageSize: pagination.pageSize ?? 20,
+            })
+          }
+          pagination={{
+            current: query.page ?? 1,
+            pageSize: query.pageSize ?? 20,
+            total: auditQuery.data?.total ?? 0,
+            showSizeChanger: true,
+            showTotal: (total) => `共 ${total} 条记录`,
+          }}
+          columns={[
+            {
+              title: "时间",
+              dataIndex: "timestamp",
+              width: 180,
+              render: (value: string) => formatDateTime(Date.parse(value)),
+            },
+            {
+              title: "操作人",
+              dataIndex: "actor",
+              render: (_value, item) => (
+                <>
+                  <Typography.Text strong>
+                    {item.actor.username}
+                  </Typography.Text>
+                  <br />
+                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                    {item.actor.role}
+                  </Typography.Text>
+                </>
+              ),
+            },
+            {
+              title: "动作",
+              dataIndex: "action",
+              render: (action: string) => (
+                <>
+                  <Tag>{action}</Tag>
+                  {ACTION_LABELS[action] ? (
+                    <Typography.Text type="secondary">
+                      {ACTION_LABELS[action]}
+                    </Typography.Text>
+                  ) : null}
+                </>
+              ),
+            },
+            {
+              title: "目标",
+              dataIndex: "targetId",
+              render: (_value, item) => (
+                <>
+                  <Tag color="blue">
+                    {TARGET_TYPE_LABELS[item.targetType] ?? item.targetType}
+                  </Tag>
+                  <Typography.Text code>{item.targetId}</Typography.Text>
+                </>
+              ),
+            },
+            {
+              title: "结果",
+              dataIndex: "result",
+              render: (value: AuditResult) => <ResultBadge result={value} />,
+            },
+            {
+              title: "原因",
+              dataIndex: "reason",
+              render: (_value, item) => {
+                // 成功动作的 reason 被服务端记录在 request.reason 里，
+                // 顶层 reason 字段仅部分路径写入，这里做回退取值。
+                const reason =
+                  item.reason ??
+                  (typeof item.request.reason === "string"
+                    ? item.request.reason
+                    : undefined);
+                return reason ? (
+                  reason
+                ) : (
+                  <Typography.Text type="secondary">未填写</Typography.Text>
+                );
+              },
+            },
+            {
+              title: "请求",
+              key: "request",
+              render: (_value, item) => (
+                <Button
+                  size="small"
+                  type="link"
+                  onClick={() => setRequestValue(item.request)}
+                >
+                  JSON
+                </Button>
+              ),
+            },
+          ]}
+        />
+      )}
+
+      <JsonModal
+        title="审计请求参数"
+        value={requestValue}
+        onClose={() => setRequestValue(null)}
+      />
+    </Space>
+  );
+}

--- a/packages/admin-ui/src/pages/events/event-labels.ts
+++ b/packages/admin-ui/src/pages/events/event-labels.ts
@@ -1,0 +1,29 @@
+// 常见事件名的中文标签；未收录的事件原样展示事件名。
+export const EVENT_LABELS: Record<string, string> = {
+  room_created: "创建房间",
+  room_joined: "加入房间",
+  room_left: "离开房间",
+  room_restored: "房间恢复",
+  room_persisted: "房间持久化",
+  room_expired_deleted: "过期清理",
+  room_expiry_scheduled: "计划过期",
+  video_shared: "共享视频",
+  playback_update_applied: "播放状态更新",
+  playback_update_ignored: "播放更新被忽略",
+  playback_update_deduplicated: "播放更新去重",
+  rate_limited: "触发限流",
+  ws_connection_rejected: "连接被拒",
+  auth_failed: "认证失败",
+  invalid_message: "非法消息",
+  protocol_version_missing: "协议版本缺失",
+  protocol_version_rejected: "协议版本被拒",
+  admin_room_closed: "管理端关闭房间",
+  admin_room_expired: "管理端提前过期",
+  admin_room_video_cleared: "管理端清空视频",
+  admin_member_kicked: "管理端踢出成员",
+  admin_session_disconnected: "管理端断开会话",
+};
+
+export function getEventLabel(event: string): string | null {
+  return EVENT_LABELS[event] ?? null;
+}

--- a/packages/admin-ui/src/pages/events/events-page.tsx
+++ b/packages/admin-ui/src/pages/events/events-page.tsx
@@ -1,0 +1,315 @@
+import { ReloadOutlined } from "@ant-design/icons";
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  Alert,
+  Button,
+  Card,
+  Checkbox,
+  DatePicker,
+  Input,
+  Space,
+  Switch,
+  Table,
+  Tag,
+  Typography,
+} from "antd";
+import dayjs from "dayjs";
+import { useEffect, useState } from "react";
+import type { EventListQuery, RuntimeEventRecord } from "../../api/types.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { JsonModal } from "../../components/json-modal.js";
+import { ResultBadge } from "../../components/result-badge.js";
+import { formatDateTime, formatTime } from "../../lib/format.js";
+import {
+  readPositiveInt,
+  readTimestamp,
+  useUrlQueryState,
+} from "../../lib/url-query.js";
+import { getEventLabel } from "./event-labels.js";
+
+const EVENTS_REFRESH_MS = 15_000;
+
+const QUERY_DEFAULTS: Record<string, string> = {
+  page: "1",
+  pageSize: "20",
+  includeSystem: "false",
+};
+
+function queryFromSearchParams(params: URLSearchParams): EventListQuery {
+  return {
+    event: params.get("event") ?? undefined,
+    roomCode: params.get("roomCode") ?? undefined,
+    sessionId: params.get("sessionId") ?? undefined,
+    remoteAddress: params.get("remoteAddress") ?? undefined,
+    origin: params.get("origin") ?? undefined,
+    result: params.get("result") ?? undefined,
+    includeSystem: params.get("includeSystem") === "true",
+    from: readTimestamp(params, "from"),
+    to: readTimestamp(params, "to"),
+    page: readPositiveInt(params, "page", 1),
+    pageSize: readPositiveInt(params, "pageSize", 20),
+  };
+}
+
+type TextFilterKey =
+  "event" | "roomCode" | "sessionId" | "remoteAddress" | "origin" | "result";
+
+const TEXT_FILTERS: Array<{ key: TextFilterKey; label: string }> = [
+  { key: "event", label: "事件名" },
+  { key: "roomCode", label: "房间号" },
+  { key: "sessionId", label: "会话 ID" },
+  { key: "remoteAddress", label: "远端地址" },
+  { key: "origin", label: "来源" },
+  { key: "result", label: "结果" },
+];
+
+function EventsFilter({
+  query,
+  onChange,
+}: {
+  query: EventListQuery;
+  onChange: (
+    patch: Record<string, string | number | boolean | undefined>,
+  ) => void;
+}) {
+  const [drafts, setDrafts] = useState<Record<TextFilterKey, string>>({
+    event: query.event ?? "",
+    roomCode: query.roomCode ?? "",
+    sessionId: query.sessionId ?? "",
+    remoteAddress: query.remoteAddress ?? "",
+    origin: query.origin ?? "",
+    result: query.result ?? "",
+  });
+
+  // URL 是状态源：前进/后退等路由变化要回写输入框。
+  useEffect(() => {
+    setDrafts({
+      event: query.event ?? "",
+      roomCode: query.roomCode ?? "",
+      sessionId: query.sessionId ?? "",
+      remoteAddress: query.remoteAddress ?? "",
+      origin: query.origin ?? "",
+      result: query.result ?? "",
+    });
+  }, [
+    query.event,
+    query.roomCode,
+    query.sessionId,
+    query.remoteAddress,
+    query.origin,
+    query.result,
+  ]);
+
+  const submit = () => {
+    onChange({
+      ...Object.fromEntries(
+        Object.entries(drafts).map(([key, value]) => [key, value.trim()]),
+      ),
+      page: 1,
+    });
+  };
+
+  return (
+    <Space direction="vertical" size={12} style={{ display: "flex" }}>
+      <Space wrap>
+        {TEXT_FILTERS.map(({ key, label }) => (
+          <Input
+            key={key}
+            allowClear
+            placeholder={label}
+            value={drafts[key]}
+            onChange={(event) =>
+              setDrafts((prev) => ({ ...prev, [key]: event.target.value }))
+            }
+            onPressEnter={submit}
+            style={{ width: 160 }}
+          />
+        ))}
+      </Space>
+      <Space wrap>
+        <DatePicker.RangePicker
+          showTime
+          value={[
+            query.from ? dayjs(query.from) : null,
+            query.to ? dayjs(query.to) : null,
+          ]}
+          onChange={(range) =>
+            onChange({
+              from: range?.[0]?.valueOf(),
+              to: range?.[1]?.valueOf(),
+              page: 1,
+            })
+          }
+        />
+        <Checkbox
+          checked={query.includeSystem ?? false}
+          onChange={(event) =>
+            onChange({ includeSystem: event.target.checked, page: 1 })
+          }
+        >
+          含系统事件
+        </Checkbox>
+        <Button type="primary" onClick={submit}>
+          查询
+        </Button>
+      </Space>
+    </Space>
+  );
+}
+
+export function EventsPage() {
+  const { api } = useAuth();
+  const queryClient = useQueryClient();
+  const { searchParams, updateQuery } = useUrlQueryState(QUERY_DEFAULTS);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const [detailsValue, setDetailsValue] = useState<unknown>(null);
+
+  const query = queryFromSearchParams(searchParams);
+  const eventsQuery = useQuery({
+    queryKey: ["events", query],
+    queryFn: () => api.listEvents(query),
+    refetchInterval: autoRefresh ? EVENTS_REFRESH_MS : false,
+    placeholderData: keepPreviousData,
+  });
+
+  const refreshNow = () => {
+    void queryClient.invalidateQueries({ queryKey: ["events"] });
+  };
+
+  return (
+    <Space direction="vertical" size={16} style={{ display: "flex" }}>
+      <Card>
+        <Space direction="vertical" size={12} style={{ display: "flex" }}>
+          <EventsFilter query={query} onChange={updateQuery} />
+          <Space wrap>
+            <Switch
+              checked={autoRefresh}
+              onChange={setAutoRefresh}
+              checkedChildren="自动刷新"
+              unCheckedChildren="自动刷新已关"
+            />
+            <Button icon={<ReloadOutlined />} onClick={refreshNow}>
+              刷新
+            </Button>
+            <Typography.Text type="secondary">
+              更新于 {formatTime(eventsQuery.dataUpdatedAt)}
+            </Typography.Text>
+          </Space>
+        </Space>
+      </Card>
+
+      {eventsQuery.isError ? (
+        <Alert
+          type="error"
+          showIcon
+          message="运行事件加载失败"
+          description={
+            eventsQuery.error instanceof Error
+              ? eventsQuery.error.message
+              : "请求失败。"
+          }
+          action={
+            <Button size="small" onClick={refreshNow}>
+              重试
+            </Button>
+          }
+        />
+      ) : (
+        <Table<RuntimeEventRecord>
+          size="middle"
+          rowKey="id"
+          loading={eventsQuery.isPending}
+          dataSource={eventsQuery.data?.items ?? []}
+          locale={{ emptyText: "没有匹配的事件。" }}
+          onChange={(pagination) =>
+            updateQuery({
+              page: pagination.current ?? 1,
+              pageSize: pagination.pageSize ?? 20,
+            })
+          }
+          pagination={{
+            current: query.page ?? 1,
+            pageSize: query.pageSize ?? 20,
+            total: eventsQuery.data?.total ?? 0,
+            showSizeChanger: true,
+            showTotal: (total) => `共 ${total} 条事件`,
+          }}
+          columns={[
+            {
+              title: "时间",
+              dataIndex: "timestamp",
+              width: 180,
+              render: (value: string) => formatDateTime(Date.parse(value)),
+            },
+            {
+              title: "事件",
+              dataIndex: "event",
+              render: (event: string) => {
+                const label = getEventLabel(event);
+                return (
+                  <>
+                    <Tag>{event}</Tag>
+                    {label ? (
+                      <Typography.Text type="secondary">
+                        {label}
+                      </Typography.Text>
+                    ) : null}
+                  </>
+                );
+              },
+            },
+            {
+              title: "房间",
+              dataIndex: "roomCode",
+              render: (value: string | null) => value ?? "—",
+            },
+            {
+              title: "来源",
+              dataIndex: "remoteAddress",
+              render: (_value, item) => (
+                <>
+                  {item.remoteAddress ?? "—"}
+                  <br />
+                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                    {item.origin ?? "—"}
+                  </Typography.Text>
+                </>
+              ),
+            },
+            {
+              title: "结果",
+              dataIndex: "result",
+              render: (value: string | null) => <ResultBadge result={value} />,
+            },
+            {
+              title: "详情",
+              key: "details",
+              render: (_value, item) =>
+                Object.keys(item.details ?? {}).length > 0 ? (
+                  <Button
+                    size="small"
+                    type="link"
+                    onClick={() => setDetailsValue(item.details)}
+                  >
+                    JSON
+                  </Button>
+                ) : (
+                  "—"
+                ),
+            },
+          ]}
+        />
+      )}
+
+      <JsonModal
+        title="事件详情"
+        value={detailsValue}
+        onClose={() => setDetailsValue(null)}
+      />
+    </Space>
+  );
+}

--- a/packages/admin-ui/test/app-layout.test.tsx
+++ b/packages/admin-ui/test/app-layout.test.tsx
@@ -52,7 +52,7 @@ describe("AppLayout", () => {
   });
 
   it("signs out and navigates to login", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     const authValue = createLayoutAuthValue();
     renderLayout(authValue);
 

--- a/packages/admin-ui/test/audit-page.test.tsx
+++ b/packages/admin-ui/test/audit-page.test.tsx
@@ -113,7 +113,7 @@ describe("AuditLogsPage", () => {
   });
 
   it("opens the request JSON modal", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderAudit(
       createAuth({
         listAuditLogs: vi
@@ -131,7 +131,7 @@ describe("AuditLogsPage", () => {
       .fn()
       .mockRejectedValueOnce(new Error("审计存储不可用"))
       .mockResolvedValue(makeResult([makeAuditRecord()]));
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderAudit(createAuth({ listAuditLogs }));
 
     expect(await screen.findByText("审计日志加载失败")).toBeTruthy();

--- a/packages/admin-ui/test/audit-page.test.tsx
+++ b/packages/admin-ui/test/audit-page.test.tsx
@@ -1,0 +1,141 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import type { AuditLogListResult, AuditLogRecord } from "../src/api/types.js";
+import { AuthContext } from "../src/auth/auth-context.js";
+import type { AuthContextValue } from "../src/auth/auth-context.js";
+import { AuditLogsPage } from "../src/pages/audit/audit-page.js";
+import { createAuthValue, createStubApi } from "./helpers.js";
+
+function makeAuditRecord(
+  overrides: Partial<AuditLogRecord> = {},
+): AuditLogRecord {
+  return {
+    id: "audit-1",
+    timestamp: new Date().toISOString(),
+    actor: { adminId: "admin-1", username: "ops", role: "operator" },
+    action: "close_room",
+    targetType: "room",
+    targetId: "ROOM1",
+    request: { reason: "违规内容" },
+    result: "ok",
+    reason: "违规内容",
+    ...overrides,
+  };
+}
+
+function makeResult(items: AuditLogRecord[]): AuditLogListResult {
+  return { items, total: items.length, pagination: { page: 1, pageSize: 20 } };
+}
+
+function renderAudit(
+  authValue: AuthContextValue,
+  initialEntry = "/audit-logs",
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <AuthContext.Provider value={authValue}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route path="/audit-logs" element={<AuditLogsPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </AuthContext.Provider>,
+  );
+}
+
+function createAuth(api: Partial<AuthContextValue["api"]>) {
+  return createAuthValue({
+    token: "token-1",
+    me: { id: "admin-1", username: "ops", role: "admin" },
+    api: createStubApi(api),
+  });
+}
+
+describe("AuditLogsPage", () => {
+  it("renders audit records with actor, action label, target and reason", async () => {
+    renderAudit(
+      createAuth({
+        listAuditLogs: vi
+          .fn()
+          .mockResolvedValue(makeResult([makeAuditRecord()])),
+      }),
+    );
+
+    expect(await screen.findByText("close_room")).toBeTruthy();
+    expect(screen.getByText("关闭房间")).toBeTruthy();
+    expect(screen.getByText("ops")).toBeTruthy();
+    expect(screen.getByText("ROOM1")).toBeTruthy();
+    expect(screen.getByText("成功")).toBeTruthy();
+    expect(screen.getAllByText("违规内容").length).toBeGreaterThan(0);
+  });
+
+  it("falls back to request.reason when the top-level reason is absent", async () => {
+    renderAudit(
+      createAuth({
+        listAuditLogs: vi.fn().mockResolvedValue(
+          makeResult([
+            makeAuditRecord({
+              reason: undefined,
+              request: { reason: "深夜清理空闲房间" },
+            }),
+          ]),
+        ),
+      }),
+    );
+
+    expect(await screen.findByText("深夜清理空闲房间")).toBeTruthy();
+    expect(screen.queryByText("未填写")).toBeNull();
+  });
+
+  it("passes URL filters through to the audit query", async () => {
+    const listAuditLogs = vi.fn().mockResolvedValue(makeResult([]));
+    renderAudit(
+      createAuth({ listAuditLogs }),
+      "/audit-logs?actor=ops&targetType=room&result=rejected",
+    );
+
+    await waitFor(() => {
+      expect(listAuditLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actor: "ops",
+          targetType: "room",
+          result: "rejected",
+        }),
+      );
+    });
+  });
+
+  it("opens the request JSON modal", async () => {
+    const user = userEvent.setup();
+    renderAudit(
+      createAuth({
+        listAuditLogs: vi
+          .fn()
+          .mockResolvedValue(makeResult([makeAuditRecord()])),
+      }),
+    );
+
+    await user.click(await screen.findByRole("button", { name: "JSON" }));
+    expect(await screen.findByText(/"reason"/)).toBeTruthy();
+  });
+
+  it("shows an error state with retry on failure", async () => {
+    const listAuditLogs = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("审计存储不可用"))
+      .mockResolvedValue(makeResult([makeAuditRecord()]));
+    const user = userEvent.setup();
+    renderAudit(createAuth({ listAuditLogs }));
+
+    expect(await screen.findByText("审计日志加载失败")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: /重\s*试/ }));
+    expect(await screen.findByText("close_room")).toBeTruthy();
+  });
+});

--- a/packages/admin-ui/test/events-page.test.tsx
+++ b/packages/admin-ui/test/events-page.test.tsx
@@ -1,0 +1,132 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import type { EventListResult, RuntimeEventRecord } from "../src/api/types.js";
+import { AuthContext } from "../src/auth/auth-context.js";
+import type { AuthContextValue } from "../src/auth/auth-context.js";
+import { EventsPage } from "../src/pages/events/events-page.js";
+import { createAuthValue, createStubApi } from "./helpers.js";
+
+function makeEvent(
+  overrides: Partial<RuntimeEventRecord> = {},
+): RuntimeEventRecord {
+  return {
+    id: "event-1",
+    timestamp: new Date().toISOString(),
+    event: "rate_limited",
+    roomCode: "ROOM1",
+    sessionId: "session-1",
+    remoteAddress: "1.2.3.4",
+    origin: "chrome-extension://abc",
+    result: "rejected",
+    details: { limit: "playback:update" },
+    ...overrides,
+  };
+}
+
+function makeResult(items: RuntimeEventRecord[]): EventListResult {
+  return { items, total: items.length, pagination: { page: 1, pageSize: 20 } };
+}
+
+function renderEvents(authValue: AuthContextValue, initialEntry = "/events") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <AuthContext.Provider value={authValue}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <Routes>
+            <Route path="/events" element={<EventsPage />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </AuthContext.Provider>,
+  );
+}
+
+function createAuth(api: Partial<AuthContextValue["api"]>) {
+  return createAuthValue({
+    token: "token-1",
+    me: { id: "admin-1", username: "ops", role: "admin" },
+    api: createStubApi(api),
+  });
+}
+
+describe("EventsPage", () => {
+  it("renders events with labels, result badge and details entry", async () => {
+    renderEvents(
+      createAuth({
+        listEvents: vi.fn().mockResolvedValue(makeResult([makeEvent()])),
+      }),
+    );
+
+    expect(await screen.findByText("rate_limited")).toBeTruthy();
+    expect(screen.getByText("触发限流")).toBeTruthy();
+    expect(screen.getByText("已拒绝")).toBeTruthy();
+    expect(screen.getByText("ROOM1")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "JSON" })).toBeTruthy();
+  });
+
+  it("passes URL filters through to the events query", async () => {
+    const listEvents = vi.fn().mockResolvedValue(makeResult([]));
+    renderEvents(
+      createAuth({ listEvents }),
+      "/events?event=rate_limited&roomCode=R1&includeSystem=true&from=1000&to=2000",
+    );
+
+    await waitFor(() => {
+      expect(listEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "rate_limited",
+          roomCode: "R1",
+          includeSystem: true,
+          from: 1000,
+          to: 2000,
+        }),
+      );
+    });
+  });
+
+  it("submits text filters and resets the page", async () => {
+    const listEvents = vi.fn().mockResolvedValue(makeResult([]));
+    const user = userEvent.setup();
+    renderEvents(createAuth({ listEvents }), "/events?page=3");
+
+    await user.type(screen.getByPlaceholderText("事件名"), "room_created");
+    await user.click(screen.getByRole("button", { name: /查\s*询/ }));
+
+    await waitFor(() => {
+      expect(listEvents).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "room_created", page: 1 }),
+      );
+    });
+  });
+
+  it("opens the details JSON modal", async () => {
+    const user = userEvent.setup();
+    renderEvents(
+      createAuth({
+        listEvents: vi.fn().mockResolvedValue(makeResult([makeEvent()])),
+      }),
+    );
+
+    await user.click(await screen.findByRole("button", { name: "JSON" }));
+    expect(await screen.findByText(/playback:update/)).toBeTruthy();
+  });
+
+  it("shows an error state with retry on failure", async () => {
+    const listEvents = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("事件存储不可用"))
+      .mockResolvedValue(makeResult([makeEvent()]));
+    const user = userEvent.setup();
+    renderEvents(createAuth({ listEvents }));
+
+    expect(await screen.findByText("运行事件加载失败")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: /重\s*试/ }));
+    expect(await screen.findByText("rate_limited")).toBeTruthy();
+  });
+});

--- a/packages/admin-ui/test/events-page.test.tsx
+++ b/packages/admin-ui/test/events-page.test.tsx
@@ -92,7 +92,7 @@ describe("EventsPage", () => {
 
   it("submits text filters and resets the page", async () => {
     const listEvents = vi.fn().mockResolvedValue(makeResult([]));
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderEvents(createAuth({ listEvents }), "/events?page=3");
 
     await user.type(screen.getByPlaceholderText("事件名"), "room_created");
@@ -106,7 +106,7 @@ describe("EventsPage", () => {
   });
 
   it("opens the details JSON modal", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderEvents(
       createAuth({
         listEvents: vi.fn().mockResolvedValue(makeResult([makeEvent()])),
@@ -122,7 +122,7 @@ describe("EventsPage", () => {
       .fn()
       .mockRejectedValueOnce(new Error("事件存储不可用"))
       .mockResolvedValue(makeResult([makeEvent()]));
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderEvents(createAuth({ listEvents }));
 
     expect(await screen.findByText("运行事件加载失败")).toBeTruthy();

--- a/packages/admin-ui/test/helpers.tsx
+++ b/packages/admin-ui/test/helpers.tsx
@@ -12,6 +12,8 @@ export function createStubApi(
     getReady: vi.fn(),
     listRooms: vi.fn(),
     getRoomDetail: vi.fn(),
+    listEvents: vi.fn(),
+    listAuditLogs: vi.fn(),
     closeRoom: vi.fn(),
     expireRoom: vi.fn(),
     clearRoomVideo: vi.fn(),

--- a/packages/admin-ui/test/login-page.test.tsx
+++ b/packages/admin-ui/test/login-page.test.tsx
@@ -23,7 +23,7 @@ function renderLogin(authValue: AuthContextValue, initialEntry = "/login") {
 
 describe("LoginPage", () => {
   it("submits trimmed credentials and navigates to overview", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     const authValue = createAuthValue();
     renderLogin(authValue);
 
@@ -38,7 +38,7 @@ describe("LoginPage", () => {
   });
 
   it("shows the error message when sign-in fails", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     const authValue = createAuthValue({
       signIn: vi.fn().mockRejectedValue(new Error("用户名或密码错误。")),
     });
@@ -52,7 +52,7 @@ describe("LoginPage", () => {
   });
 
   it("maps invalid_credentials to a friendly Chinese message", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     const authValue = createAuthValue({
       signIn: vi
         .fn()

--- a/packages/admin-ui/test/overview-page.test.tsx
+++ b/packages/admin-ui/test/overview-page.test.tsx
@@ -131,7 +131,7 @@ describe("OverviewPage", () => {
       .fn()
       .mockRejectedValueOnce(new Error("网络错误"))
       .mockResolvedValue(createOverviewFixture());
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderOverview(
       createAuthValue({
         getOverview,
@@ -148,7 +148,7 @@ describe("OverviewPage", () => {
 
   it("refetches when clicking manual refresh", async () => {
     const getOverview = vi.fn().mockResolvedValue(createOverviewFixture());
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderOverview(
       createAuthValue({
         getOverview,

--- a/packages/admin-ui/test/require-auth.test.tsx
+++ b/packages/admin-ui/test/require-auth.test.tsx
@@ -46,7 +46,7 @@ describe("RequireAuth", () => {
   });
 
   it("shows a retryable error instead of dropping the session on meError", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     const authValue = createAuthValue({
       token: "token-1",
       meError: "服务暂时不可用",

--- a/packages/admin-ui/test/rooms-page.test.tsx
+++ b/packages/admin-ui/test/rooms-page.test.tsx
@@ -155,7 +155,7 @@ describe("RoomsPage", () => {
 
   it("runs the close-room governance flow with a reason", async () => {
     const closeRoom = vi.fn().mockResolvedValue({});
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderRooms(
       createOperatorAuth({
         listRooms: vi.fn().mockResolvedValue(makeListResult([makeRoom()])),
@@ -179,7 +179,7 @@ describe("RoomsPage", () => {
   });
 
   it("disables early-expire for active rooms", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderRooms(
       createOperatorAuth({
         listRooms: vi.fn().mockResolvedValue(makeListResult([makeRoom()])),
@@ -215,7 +215,7 @@ describe("RoomsPage", () => {
       .fn()
       .mockRejectedValueOnce(new Error("后端故障"))
       .mockResolvedValue(makeListResult([makeRoom()]));
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderRooms(createOperatorAuth({ listRooms }));
 
     expect(await screen.findByText("房间列表加载失败")).toBeTruthy();
@@ -231,7 +231,7 @@ describe("RoomsPage", () => {
       items: [makeRoom()],
       pagination: { page: 1, pageSize: 20, total: 45 },
     });
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderRooms(
       createOperatorAuth({ listRooms }),
       "/rooms?sortBy=createdAt&sortOrder=asc",
@@ -259,7 +259,7 @@ describe("RoomsPage", () => {
         ? Promise.resolve(makeDetail(room1))
         : new Promise<never>(() => {}),
     );
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderRooms(
       createOperatorAuth({
         listRooms: vi.fn().mockResolvedValue(makeListResult([room1, room2])),
@@ -285,7 +285,7 @@ describe("RoomsPage", () => {
   it("opens the detail drawer from the route and kicks a member", async () => {
     const room = makeRoom();
     const kickMember = vi.fn().mockResolvedValue({});
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderRooms(
       createOperatorAuth({
         listRooms: vi.fn().mockResolvedValue(makeListResult([room])),

--- a/packages/admin-ui/vite.config.ts
+++ b/packages/admin-ui/vite.config.ts
@@ -30,8 +30,9 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./test/setup.ts"],
-    // antd 组件交互测试（userEvent + 弹窗/下拉）在 CI 覆盖率插桩下
-    // 会超过默认 5s，放宽到 15s。
-    testTimeout: 15_000,
+    // antd 组件交互测试（userEvent + 弹窗/下拉）在 CI 覆盖率插桩 +
+    // 多 worker 争抢下明显变慢，放宽超时作为兜底；主要提速手段是
+    // 测试里 userEvent.setup({ delay: null }) 关闭逐键延迟。
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Summary

管理后台重写第四阶段（承接 #171 / #174 / #175）。两页沿用房间页沉淀的模式：URL 同步筛选、TanStack Query 15s 轮询、错误态 + 重试、服务端分页（API `pageSize≤100`，无需虚拟滚动）。

- **运行事件页**：事件名 / 房间号 / 会话 / 远端地址 / 来源 / 结果六个文本筛选 + **时间范围**（`from`/`to` 服务端一直支持但旧 UI 从未暴露，本次补上 RangePicker）+ 含系统事件开关；事件名 Tag + 常见事件中文标签（与 `logEvent` 实际事件名对照核实）；详情 JSON 弹窗
- **审计日志页**：操作人 / 动作 / 目标 ID 筛选 + 目标类型、结果下拉 + 时间范围；动作中文标签、结果徽章、请求参数 JSON 弹窗
- **"原因"列展示修正**：服务端把成功动作的 reason 记录在 `request.reason`（`action-service.ts` 的 `writeAudit(..., { reason }, "ok")`），顶层 `reason` 字段仅部分路径写入——旧 UI 该列对成功动作恒显示"未填写"。新页回退取 `request.reason`，E2E 中实际验证了这一行为差异
- 提炼共享件：`useUrlQueryState`（URL 查询状态钩子，默认值不落地址栏）、`ResultBadge`、`JsonModal`

## Test plan

- [x] 10 条新增测试：两页渲染 / URL 筛选透传 / 筛选提交重置页码 / JSON 弹窗 / 错误态重试 / reason 回退（admin-ui 共 61 条全绿）
- [x] 完整预提交序列（含 CI 实际执行的 coverage 路径）逐项退出码确认通过
- [x] 手动 E2E（真实服务端 + WS 建房 + 管理动作产生真实数据）：事件按房间过滤、时间范围过滤、审计记录 actor/action/target/result 形状与前端类型吻合
- [ ] 浏览器内可视化验证（部署后）

🤖 Generated with [Claude Code](https://claude.com/claude-code)