### PR TITLE
feat: 房间管理页支持批量关闭与批量提前过期

### DIFF
--- a/packages/admin-ui/src/pages/rooms/batch-result-modal.tsx
+++ b/packages/admin-ui/src/pages/rooms/batch-result-modal.tsx
@@ -1,0 +1,66 @@
+import { Modal, Table, Tag, Typography } from "antd";
+
+export type BatchOutcome = {
+  roomCode: string;
+  ok: boolean;
+  message?: string;
+};
+
+export type BatchResult = {
+  title: string;
+  outcomes: BatchOutcome[];
+};
+
+export function BatchResultModal({
+  result,
+  onClose,
+}: {
+  result: BatchResult | null;
+  onClose: () => void;
+}) {
+  const failed = result?.outcomes.filter((outcome) => !outcome.ok) ?? [];
+  const succeeded = (result?.outcomes.length ?? 0) - failed.length;
+
+  return (
+    <Modal
+      open={result !== null}
+      title={result?.title}
+      footer={null}
+      onCancel={onClose}
+      width={560}
+    >
+      <Typography.Paragraph>
+        成功 {succeeded} 个，失败 {failed.length} 个。
+        {failed.length > 0 ? "失败的房间保持勾选，可修正后重试。" : ""}
+      </Typography.Paragraph>
+      {failed.length > 0 ? (
+        <Table<BatchOutcome>
+          size="small"
+          rowKey="roomCode"
+          pagination={false}
+          dataSource={failed}
+          columns={[
+            {
+              title: "房间",
+              dataIndex: "roomCode",
+              width: 120,
+              render: (value: string) => (
+                <Typography.Text code>{value}</Typography.Text>
+              ),
+            },
+            {
+              title: "失败原因",
+              dataIndex: "message",
+              render: (value: string | undefined) => (
+                <>
+                  <Tag color="error">失败</Tag>
+                  {value ?? "未知错误"}
+                </>
+              ),
+            },
+          ]}
+        />
+      ) : null}
+    </Modal>
+  );
+}

--- a/packages/admin-ui/src/pages/rooms/rooms-page.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-page.tsx
@@ -19,6 +19,8 @@ import type {
 import { useAuth } from "../../auth/auth-context.js";
 import { formatTime } from "../../lib/format.js";
 import { canManage } from "../../lib/roles.js";
+import { BatchResultModal } from "./batch-result-modal.js";
+import type { BatchOutcome, BatchResult } from "./batch-result-modal.js";
 import { ReasonModal } from "./reason-modal.js";
 import type { PendingGovernanceAction } from "./reason-modal.js";
 import { RoomDetailDrawer } from "./room-detail-drawer.js";
@@ -66,6 +68,8 @@ export function RoomsPage() {
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [pendingAction, setPendingAction] =
     useState<PendingGovernanceAction | null>(null);
+  const [selectedRoomCodes, setSelectedRoomCodes] = useState<string[]>([]);
+  const [batchResult, setBatchResult] = useState<BatchResult | null>(null);
 
   const query = queryFromSearchParams(searchParams);
   const roomsQuery = useRoomsQuery(query, autoRefresh);
@@ -135,6 +139,63 @@ export function RoomsPage() {
     }),
   };
 
+  const runBatch = async (
+    roomCodes: string[],
+    title: string,
+    action: (roomCode: string, reason: string) => Promise<unknown>,
+    reason: string,
+  ) => {
+    const outcomes: BatchOutcome[] = [];
+    // 顺序执行避免瞬时打爆管理接口；管理场景下批量规模有限。
+    for (const roomCode of roomCodes) {
+      try {
+        await action(roomCode, reason);
+        outcomes.push({ roomCode, ok: true });
+      } catch (cause) {
+        outcomes.push({
+          roomCode,
+          ok: false,
+          message: cause instanceof Error ? cause.message : "请求失败。",
+        });
+      }
+    }
+    // 失败的房间保持勾选，便于修正后重试。
+    setSelectedRoomCodes(
+      outcomes
+        .filter((outcome) => !outcome.ok)
+        .map((outcome) => outcome.roomCode),
+    );
+    setBatchResult({ title, outcomes });
+    await queryClient.invalidateQueries({ queryKey: ["rooms"] });
+    await queryClient.invalidateQueries({ queryKey: ["room"] });
+  };
+
+  const batchGovernance = {
+    closeRooms: (roomCodes: string[]): PendingGovernanceAction => ({
+      title: `批量关闭 ${roomCodes.length} 个房间`,
+      description: "关闭后房间立即解散，所有在线成员会被断开。",
+      danger: true,
+      execute: (reason) =>
+        runBatch(
+          roomCodes,
+          "批量关闭结果",
+          (roomCode, batchReason) => api.closeRoom(roomCode, batchReason),
+          reason,
+        ),
+    }),
+    expireRooms: (roomCodes: string[]): PendingGovernanceAction => ({
+      title: `批量提前过期 ${roomCodes.length} 个房间`,
+      description: "仅空闲房间可提前过期；仍有在线成员的房间会失败并列出。",
+      execute: (reason) =>
+        runBatch(
+          roomCodes,
+          "批量提前过期结果",
+          (roomCode, batchReason) => api.expireRoom(roomCode, batchReason),
+          reason,
+        ),
+    }),
+  };
+
   const memberGovernance = {
     kickMember: (
       room: RoomSummary,
@@ -180,6 +241,41 @@ export function RoomsPage() {
               更新于 {formatTime(roomsQuery.dataUpdatedAt)}
             </Typography.Text>
           </Space>
+          {manageable && selectedRoomCodes.length > 0 ? (
+            <Space wrap>
+              <Typography.Text strong>
+                已选 {selectedRoomCodes.length} 个房间
+              </Typography.Text>
+              <Button
+                danger
+                size="small"
+                onClick={() =>
+                  setPendingAction(
+                    batchGovernance.closeRooms(selectedRoomCodes),
+                  )
+                }
+              >
+                批量关闭
+              </Button>
+              <Button
+                size="small"
+                onClick={() =>
+                  setPendingAction(
+                    batchGovernance.expireRooms(selectedRoomCodes),
+                  )
+                }
+              >
+                批量过期
+              </Button>
+              <Button
+                size="small"
+                type="text"
+                onClick={() => setSelectedRoomCodes([])}
+              >
+                取消选择
+              </Button>
+            </Space>
+          ) : null}
         </Space>
       </Card>
 
@@ -205,6 +301,8 @@ export function RoomsPage() {
           loading={roomsQuery.isPending}
           query={query}
           manageable={manageable}
+          selectedRoomCodes={selectedRoomCodes}
+          onSelectionChange={setSelectedRoomCodes}
           onQueryChange={updateQuery}
           onOpenRoom={openRoom}
           onAction={setPendingAction}
@@ -225,6 +323,11 @@ export function RoomsPage() {
       <ReasonModal
         pending={pendingAction}
         onClose={() => setPendingAction(null)}
+      />
+
+      <BatchResultModal
+        result={batchResult}
+        onClose={() => setBatchResult(null)}
       />
     </Space>
   );

--- a/packages/admin-ui/src/pages/rooms/rooms-table.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-table.tsx
@@ -24,6 +24,8 @@ export function RoomsTable({
   loading,
   query,
   manageable,
+  selectedRoomCodes,
+  onSelectionChange,
   onQueryChange,
   onOpenRoom,
   onAction,
@@ -33,6 +35,8 @@ export function RoomsTable({
   loading: boolean;
   query: RoomListQuery;
   manageable: boolean;
+  selectedRoomCodes: string[];
+  onSelectionChange: (roomCodes: string[]) => void;
   onQueryChange: (patch: Partial<RoomListQuery>) => void;
   onOpenRoom: (roomCode: string) => void;
   onAction: (pending: PendingGovernanceAction) => void;
@@ -79,6 +83,16 @@ export function RoomsTable({
       loading={loading}
       dataSource={data?.items ?? []}
       locale={{ emptyText: "没有符合条件的房间。" }}
+      rowSelection={
+        manageable
+          ? {
+              selectedRowKeys: selectedRoomCodes,
+              onChange: (keys) => onSelectionChange(keys.map(String)),
+              // 翻页/筛选后不在当前页的选中项保留，便于跨页批量。
+              preserveSelectedRowKeys: true,
+            }
+          : undefined
+      }
       onChange={handleTableChange}
       pagination={{
         current: query.page ?? 1,

--- a/packages/admin-ui/test/rooms-page.test.tsx
+++ b/packages/admin-ui/test/rooms-page.test.tsx
@@ -317,6 +317,97 @@ describe("RoomsPage", () => {
   });
 });
 
+describe("RoomsPage batch governance", () => {
+  function makeTwoRooms() {
+    return [
+      makeRoom({ isActive: false, memberCount: 0 }),
+      makeRoom({ roomCode: "ROOM2", isActive: false, memberCount: 0 }),
+    ];
+  }
+
+  it("closes all selected rooms and clears the selection on success", async () => {
+    const closeRoom = vi.fn().mockResolvedValue({});
+    const user = userEvent.setup({ delay: null });
+    renderRooms(
+      createOperatorAuth({
+        listRooms: vi.fn().mockResolvedValue(makeListResult(makeTwoRooms())),
+        closeRoom,
+      }),
+    );
+
+    await screen.findByText("ROOM2");
+    // 第一个 checkbox 是表头全选。
+    // 页面里筛选区也有 checkbox（含已过期），全选框要在表格作用域内取。
+    await user.click(
+      within(screen.getByRole("table")).getAllByRole("checkbox")[0],
+    );
+    expect(await screen.findByText("已选 2 个房间")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /批量关闭/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.type(
+      within(dialog).getByPlaceholderText(/操作原因/),
+      "夜间清理",
+    );
+    await user.click(within(dialog).getByRole("button", { name: /确认执行/ }));
+
+    await waitFor(() => {
+      expect(closeRoom).toHaveBeenCalledWith("ROOM1", "夜间清理");
+      expect(closeRoom).toHaveBeenCalledWith("ROOM2", "夜间清理");
+    });
+    expect(await screen.findByText("成功 2 个，失败 0 个。")).toBeTruthy();
+    expect(screen.queryByText(/已选 \d+ 个房间/)).toBeNull();
+  });
+
+  it("keeps failed rooms selected and lists failures", async () => {
+    const expireRoom = vi.fn((roomCode: string) =>
+      roomCode === "ROOM2"
+        ? Promise.reject(new Error("房间仍有在线成员"))
+        : Promise.resolve({}),
+    );
+    const user = userEvent.setup({ delay: null });
+    renderRooms(
+      createOperatorAuth({
+        listRooms: vi.fn().mockResolvedValue(makeListResult(makeTwoRooms())),
+        expireRoom: expireRoom as never,
+      }),
+    );
+
+    await screen.findByText("ROOM2");
+    await user.click(
+      within(screen.getByRole("table")).getAllByRole("checkbox")[0],
+    );
+    await user.click(screen.getByRole("button", { name: /批量过期/ }));
+    const dialog = await screen.findByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: /确认执行/ }));
+
+    expect(
+      await screen.findByText(/成功 1 个，失败 1 个。失败的房间保持勾选/),
+    ).toBeTruthy();
+    expect(screen.getByText("房间仍有在线成员")).toBeTruthy();
+    // 失败的 ROOM2 保持勾选，可重试。
+    expect(await screen.findByText("已选 1 个房间")).toBeTruthy();
+  });
+
+  it("hides row selection for viewers", async () => {
+    renderRooms(
+      createAuthValue({
+        token: "token-1",
+        me: { id: "admin-2", username: "watcher", role: "viewer" },
+        api: createStubApi({
+          listRooms: vi.fn().mockResolvedValue(makeListResult(makeTwoRooms())),
+        }),
+      }),
+    );
+
+    expect(await screen.findByText("ROOM2")).toBeTruthy();
+    // viewer 仍能看到筛选区的 checkbox，但表格内不应有选择框。
+    expect(
+      within(screen.getByRole("table")).queryAllByRole("checkbox"),
+    ).toHaveLength(0);
+  });
+});
+
 describe("RoomsFilter", () => {
   it("syncs the keyword input when the routed query changes", () => {
     const onChange = vi.fn();


### PR DESCRIPTION
## Summary

管理后台重写的遗留小 PR（#175 时约定后补）。纯前端编排，逐个调用现有治理 API，服务端零改动。

- 表格多选：仅 `operator/admin` 角色显示选择框，翻页/筛选后选中项保留（跨页批量）
- 批量操作栏：选中后出现"批量关闭 / 批量过期 / 取消选择"
- 复用 reason 确认弹窗（写入审计日志），顺序执行避免瞬时打爆管理接口
- **部分失败的结果展示**：结果弹窗给出成功/失败计数，失败房间逐行列出服务端错误（已 E2E 验证活跃房间批量过期会收到 `room_active` 并正确列出）；失败房间保持勾选，修正后可直接重试

## Test plan

- [x] 3 条新增测试：全成功后清空选择、部分失败保留勾选并列出原因、viewer 不显示选择框（admin-ui 共 68 条全绿，含 coverage 路径）
- [x] 完整预提交序列逐项退出码确认通过
- [x] 手动 E2E（真实服务端 + WS 建房）：活跃房间 expire 返回 room_active 错误信封、成员离线后 expire 成功——批量结果弹窗依赖的两种语义均验证
- [ ] 浏览器内可视化验证（部署后）

🤖 Generated with [Claude Code](https://claude.com/claude-code)