### PR TITLE
fix: 新控制台 hashed 资源长缓存，消除每次访问全量重下 bundle

### DIFF
--- a/packages/admin-ui/vite.config.ts
+++ b/packages/admin-ui/vite.config.ts
@@ -19,6 +19,12 @@ const devProxyEntry: ProxyOptions = {
 export default defineConfig({
   base: "/admin-next/",
   plugins: [react()],
+  build: {
+    // 管理后台是内部工具，不追首屏体积；产物带内容 hash 且服务端已
+    // 对 assets/ 长缓存，单 chunk（AntD+React 约 1.3MB/gzip 404KB）
+    // 只在发版后首次访问下载一次，无需路由级代码分割。
+    chunkSizeWarningLimit: 1500,
+  },
   server: {
     proxy: {
       "/api": devProxyEntry,

--- a/server/src/admin-panel.ts
+++ b/server/src/admin-panel.ts
@@ -136,13 +136,21 @@ export function createAdminPanelHandler(
       ? path.join(target.rootDir, "index.html")
       : assetPath;
 
+    // Vite 产物在 assets/ 下且文件名含内容 hash，内容变则 URL 变，
+    // 可安全地长缓存；index.html 与旧面板的非 hash 文件维持禁缓存，
+    // 保证发版即生效。
+    const isImmutableAsset =
+      !shouldServeIndex && sanitizedPath.startsWith(`assets${path.sep}`);
+
     try {
       const body = await readFile(filePath);
       const contentType =
         assetTypes.get(path.extname(filePath)) ?? "application/octet-stream";
       response.writeHead(200, {
         "content-type": contentType,
-        "cache-control": "no-cache, no-store, must-revalidate",
+        "cache-control": isImmutableAsset
+          ? "public, max-age=31536000, immutable"
+          : "no-cache, no-store, must-revalidate",
       });
 
       if (request.method === "HEAD") {

--- a/server/test/admin-panel.test.ts
+++ b/server/test/admin-panel.test.ts
@@ -162,6 +162,32 @@ test("serves hashed assets under /admin-next/assets", async () => {
     "text/javascript; charset=utf-8",
   );
   assert.equal(captured.body, "console.log(1);");
+  // assets/ 下的内容寻址产物可长缓存。
+  assert.equal(
+    captured.headers["cache-control"],
+    "public, max-age=31536000, immutable",
+  );
+});
+
+test("keeps no-store caching for index and non-hashed files", async () => {
+  const { handler } = await createHandler();
+
+  const index = createResponse();
+  await handler(createRequest("GET", "/admin-next"), index.response);
+  assert.equal(
+    index.captured.headers["cache-control"],
+    "no-cache, no-store, must-revalidate",
+  );
+
+  const legacyAsset = createResponse();
+  await handler(
+    createRequest("GET", "/admin-legacy/index.html"),
+    legacyAsset.response,
+  );
+  assert.equal(
+    legacyAsset.captured.headers["cache-control"],
+    "no-cache, no-store, must-revalidate",
+  );
 });
 
 test("rejects path traversal outside the panel root", async () => {


### PR DESCRIPTION
## Summary

由 Vite 的 chunk 体积警告引出的真实问题：`admin-panel.ts` 沿用旧面板时代的策略对**所有**静态资源发 `no-cache, no-store`，而新控制台的产物是内容寻址的（`index-<hash>.js`），被禁缓存意味着每次打开管理后台都重新下载约 404KB（gzip）的 bundle。

- `assets/` 下的 hashed 产物改发 `public, max-age=31536000, immutable`（内容变则 URL 变，长缓存安全）
- `index.html` 与旧面板非 hash 文件维持 `no-store`，发版即生效
- `chunkSizeWarningLimit` 调至 1500 并注释决策依据：内部工具不追首屏体积，配合长缓存单 chunk 仅发版后下载一次，不做路由级代码分割

## Test plan

- [x] 2 条新增缓存头测试（immutable 侧 + no-store 侧），服务端测试全绿
- [x] 完整预提交序列逐项退出码确认通过；构建警告确认消失
- [x] 手动 E2E（真实服务端 curl -I）：hashed asset 返回 immutable、index 与旧面板文件维持 no-store

🤖 Generated with [Claude Code](https://claude.com/claude-code)