### PR TITLE
fix: 配置文件中已废弃的键改为告警忽略，修复升级后 crash loop

### DIFF
--- a/server/src/config/runtime-config.ts
+++ b/server/src/config/runtime-config.ts
@@ -101,15 +101,27 @@ function isPlainObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+// 已从 schema 移除的历史配置键：容忍并告警，避免升级变成破坏性变更
+// （严格校验只用于拦截拼写错误，不应拒绝旧配置文件启动）。
+const DEPRECATED_CONFIG_KEYS = new Set(["adminUi.demoEnabled"]);
+
 function assertAllowedKeys(
   scope: string,
   value: JsonObject,
   allowedKeys: readonly string[],
 ): void {
   for (const key of Object.keys(value)) {
-    if (!allowedKeys.includes(key)) {
-      throw new Error(`Unsupported config key "${scope}${key}".`);
+    if (allowedKeys.includes(key)) {
+      continue;
     }
+    if (DEPRECATED_CONFIG_KEYS.has(`${scope}${key}`)) {
+      console.warn(
+        `[config] Ignoring deprecated config key "${scope}${key}"; remove it from the config file.`,
+      );
+      delete value[key];
+      continue;
+    }
+    throw new Error(`Unsupported config key "${scope}${key}".`);
   }
 }
 

--- a/server/test/runtime-config.test.ts
+++ b/server/test/runtime-config.test.ts
@@ -303,6 +303,31 @@ test("runtime config rejects unsupported admin config in file", async () => {
   });
 });
 
+test("runtime config tolerates deprecated adminUi.demoEnabled in file", async () => {
+  await withTempDir(async (tempDir) => {
+    await writeFile(
+      join(tempDir, "server.config.json"),
+      JSON.stringify({
+        adminUi: {
+          demoEnabled: true,
+          apiBaseUrl: "https://admin.example.com",
+        },
+      }),
+      "utf8",
+    );
+
+    // 已废弃的键必须被忽略而非拒绝启动（线上配置文件残留导致 crash loop）。
+    const config = await loadRuntimeConfig(
+      { ALLOW_MISSING_ORIGIN_IN_DEV: "true" },
+      { cwd: tempDir },
+    );
+    assert.deepEqual(config.adminUiConfig, {
+      apiBaseUrl: "https://admin.example.com",
+      enabled: true,
+    });
+  });
+});
+
 test("runtime config reports invalid JSON config files", async () => {
   await withTempDir(async (tempDir) => {
     await writeFile(join(tempDir, "server.config.json"), "{invalid", "utf8");


### PR DESCRIPTION
## Summary

**线上事故修复**：#180 从 schema 移除 `adminUi.demoEnabled` 后，配置文件（`server.config.json`）残留该键的部署被严格键校验拒绝启动——`Unsupported config key "adminUi.demoEnabled"`，global-admin 进入 systemd 重启循环（生产已确认，restart counter 17）。

根因是 #180 的验证盲区：删除时验证了**环境变量**路径被静默忽略，漏了**配置文件**路径的严格校验会 throw。

- 引入 `DEPRECATED_CONFIG_KEYS` 集合：历史存在过、后被移除的键**告警并忽略**（`[config] Ignoring deprecated config key ...`），删除配置键不再构成破坏性变更
- 未知键的严格校验保留（拦截拼写错误的初衷不变）
- 临时止血方案（已提供给运维）：从配置文件删除该键后重启服务

## Test plan

- [x] 回归测试：残留 `demoEnabled` 的配置文件正常加载、其余字段不受影响
- [x] E2E 复现修复：带残留键的 `server.config.json` 启动 `global-admin-index.js`，进程存活并打出废弃告警（修复前立即 exit 1）
- [x] 完整预提交序列 + redis 套件逐项确认通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)