### PR TITLE
chore: release 1.3.0

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -333,6 +333,7 @@ This command updates:
 
 - the root `package.json`
 - `packages/protocol/package.json`
+- `packages/admin-ui/package.json`
 - `server/package.json`
 - `extension/package.json`
 - `package-lock.json`

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-exclude='../packages/**' test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.2.4"
+    "@bili-syncplay/protocol": "1.3.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.2.2",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["alarms", "storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "workspaces": [
         "packages/*",
         "server",
@@ -28,9 +28,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.2.4"
+        "@bili-syncplay/protocol": "1.3.0"
       },
       "devDependencies": {
         "@types/chrome": "^0.2.2",
@@ -5700,10 +5700,10 @@
     },
     "packages/admin-ui": {
       "name": "@bili-syncplay/admin-ui",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
-        "@bili-syncplay/protocol": "1.2.4",
+        "@bili-syncplay/protocol": "1.3.0",
         "@tanstack/react-query": "^5.101.2",
         "antd": "^6.5.1",
         "dayjs": "^1.11.21",
@@ -5726,16 +5726,16 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "devDependencies": {
         "typescript": "^6.0.3"
       }
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.2.4",
+        "@bili-syncplay/protocol": "1.3.0",
         "ioredis": "^5.10.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/admin-ui",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
-    "@bili-syncplay/protocol": "1.2.4",
+    "@bili-syncplay/protocol": "1.3.0",
     "@tanstack/react-query": "^5.101.2",
     "antd": "^6.5.1",
     "dayjs": "^1.11.21",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.2.4",
+    "@bili-syncplay/protocol": "1.3.0",
     "ioredis": "^5.10.0",
     "ws": "^8.21.0"
   },


### PR DESCRIPTION
## Summary

版本 1.2.4 → 1.3.0（minor）。本版主要变更：

- **管理后台全面重写**（#171 #174 #175 #176 #177 #178 #180）：React 19 + Ant Design 6 新控制台，覆盖概览/房间/事件/审计/配置五页 + 批量操作；`/admin` 302 至 `/admin-next`；旧面板、demo 模式与 `ADMIN_UI_DEMO_ENABLED` 移除
- **admin API CORS 支持**（#173）：UI/API 分离部署可用
- **配置文件废弃键容忍**（#181）：升级不再因残留 `adminUi.demoEnabled` 拒绝启动
- **新面板资源长缓存**（#179）

`npm run release:version -- 1.3.0` 产出（含 admin-ui workspace）；`docs/development.md` 的脚本文件清单同步补全。

合并后将在 main 打 `v1.3.0` tag，触发 release.yml（扩展包 GitHub Release）与 docker-release.yml（GHCR + Docker Hub 镜像）。

## Test plan

- [x] 完整预提交序列逐项退出码确认通过
- [x] 七个 package/manifest 文件版本一致为 1.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)