### PR TITLE
fix: 播放器卡顿/重建不再被当作用户暂停广播给房间

### DIFF
--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -39,6 +39,7 @@ const PROGRAMMATIC_APPLY_WINDOW_MS = 700;
 const USER_GESTURE_GRACE_MS = 1200;
 const BUFFER_SIGNAL_WINDOW_MS = 300;
 const BUFFER_PAUSE_UPGRADE_MS = 1500;
+const VIDEO_REBIND_BUFFER_SIGNAL_MS = 1000;
 const REMOTE_PAUSE_DEBOUNCE_MS = 250;
 const FESTIVAL_SNAPSHOT_TTL_MS = 1200;
 const NAVIGATION_WATCH_INTERVAL_MS = 400;
@@ -133,6 +134,7 @@ const playbackBindingController = createPlaybackBindingController({
   initialRoomStatePauseHoldMs: INITIAL_ROOM_STATE_PAUSE_HOLD_MS,
   bufferSignalWindowMs: BUFFER_SIGNAL_WINDOW_MS,
   bufferPauseUpgradeMs: BUFFER_PAUSE_UPGRADE_MS,
+  videoRebindBufferSignalMs: VIDEO_REBIND_BUFFER_SIGNAL_MS,
   getSharedVideo: () => shareController.getSharedVideo(),
   hasRecentRemoteStopIntent: (currentVideoUrl) =>
     syncController.hasRecentRemoteStopIntent(currentVideoUrl),

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -40,6 +40,12 @@ export function createPlaybackBindingController(args: {
    * worst-case desync if a buffer stall turns into a real stop.
    */
   bufferPauseUpgradeMs: number;
+  /**
+   * Window after the local `<video>` element was (re)bound during which a
+   * paused element is presumed to be the player rebuilding itself rather than
+   * the user stopping playback. See {@link ContentRuntimeState.lastVideoElementBoundAt}.
+   */
+  videoRebindBufferSignalMs: number;
   getSharedVideo: () => SharedVideo | null;
   hasRecentRemoteStopIntent: (currentVideoUrl: string) => boolean;
   normalizeUrl: (url: string | undefined | null) => string | null;
@@ -103,6 +109,25 @@ export function createPlaybackBindingController(args: {
     args.runtimeState.pauseStartedAt = 0;
     args.runtimeState.pauseClassifiedAsBuffer = false;
     clearBufferUpgradeTimer();
+  };
+  /**
+   * Bound the `buffering` classification: if the element is still paused once
+   * the window elapses this was not a hiccup, so drop the classification and
+   * re-broadcast the real `paused` state to the room.
+   */
+  const armBufferPauseUpgrade = (video: HTMLVideoElement) => {
+    clearBufferUpgradeTimer();
+    pauseBufferUpgradeTimerId = scheduleUpgradeTimer(() => {
+      pauseBufferUpgradeTimerId = null;
+      if (!video.paused) {
+        return;
+      }
+      args.runtimeState.pauseClassifiedAsBuffer = false;
+      args.debugLog(
+        `Buffer-pause upgraded to paused after ${args.bufferPauseUpgradeMs}ms, re-broadcasting`,
+      );
+      void args.broadcastPlayback(video, "pause");
+    }, args.bufferPauseUpgradeMs);
   };
   const hasRecentUserGesture = () =>
     nowOf() - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs;
@@ -183,6 +208,68 @@ export function createPlaybackBindingController(args: {
         at: nowOf(),
       };
     }
+  }
+
+  /**
+   * Whether a paused-apply we performed ourselves is still in flight. When we
+   * apply a remote `paused` we hard-seek and then call `video.pause()`, which
+   * trips the very events the buffer classifiers watch; treating those as a
+   * local stall would leak the applied state back out as `buffering`.
+   */
+  function isInsideProgrammaticPausedWindow(now: number): boolean {
+    const signature = args.runtimeState.programmaticApplySignature;
+    if (
+      signature === null ||
+      signature.playState !== "paused" ||
+      now >= args.runtimeState.programmaticApplyUntil
+    ) {
+      return false;
+    }
+
+    const normalizedSharedUrl = args.normalizeUrl(args.getSharedVideo()?.url);
+    return (
+      normalizedSharedUrl !== null && normalizedSharedUrl === signature.url
+    );
+  }
+
+  /**
+   * Classify a paused element that never emitted a `pause` event.
+   *
+   * Bilibili's player rebuilds its media element to recover from a buffer
+   * stall, and the replacement element *starts* paused — there is no state
+   * transition, so no `pause` event is dispatched and `onPause`'s classifier
+   * never runs. The element then emits `seeking`/`seeked`/`canplay` while it
+   * restores the playhead, and each of those broadcasts reports `paused` to the
+   * room: every peer stops, hard-seeks, and resumes about a second later.
+   *
+   * Detect it from the transport events instead — the element is paused, we
+   * never recorded a pause for it, the room still believes we are playing, and
+   * no user gesture accounts for it. Classifying it as buffer-induced routes
+   * the broadcast through the existing `buffering` state (which leaves peers
+   * playing) and arms the same bounded upgrade, so a stall that never recovers
+   * is still reported as a genuine `paused` afterwards.
+   */
+  function classifyUnobservedPauseAsBuffer(video: HTMLVideoElement): void {
+    const now = nowOf();
+    if (
+      !video.paused ||
+      args.runtimeState.pauseStartedAt > 0 ||
+      args.runtimeState.intendedPlayState !== "playing" ||
+      hasRecentUserGesture() ||
+      isInsideProgrammaticPausedWindow(now)
+    ) {
+      return;
+    }
+
+    args.runtimeState.pauseStartedAt = now;
+    args.runtimeState.pauseClassifiedAsBuffer = true;
+    const boundAt = args.runtimeState.lastVideoElementBoundAt;
+    args.debugLog(
+      `Classified unobserved pause as buffering (no pause event, boundAgo=${
+        boundAt > 0 ? now - boundAt : "n/a"
+      })`,
+    );
+    armBufferPauseUpgrade(video);
   }
 
   function shouldTreatRateChangeAsProgrammatic(
@@ -794,7 +881,7 @@ export function createPlaybackBindingController(args: {
       return false;
     };
 
-    bindVideoElement({
+    const boundNewElement = bindVideoElement({
       video,
       onPlay: () => {
         if (shouldPreRecordNonSharedExplicitPlay()) {
@@ -842,6 +929,16 @@ export function createPlaybackBindingController(args: {
           hasRecentUserGesture() &&
           args.runtimeState.lastUserGestureAt >
             args.runtimeState.lastForcedPauseAt;
+        // A player rebuilding its media element produces a stall the user never
+        // asked for, but no `waiting`/`stalled` precedes it. When the rebuilt
+        // element is bound early enough to still catch its `pause`, the recent
+        // (re)bind is the only evidence available — treat it as a buffer signal
+        // in its own right. (When we bind too late to see the `pause` at all,
+        // `classifyUnobservedPauseAsBuffer` covers the same stall instead.)
+        const recentVideoRebind =
+          args.runtimeState.lastVideoElementBoundAt > 0 &&
+          now - args.runtimeState.lastVideoElementBoundAt <
+            args.videoRebindBufferSignalMs;
         // When applying a remote `paused`, we hard-seek then call `video.pause()`.
         // The seek trips a `waiting` event milliseconds before the `pause`, so the
         // buffer-signal window will look "fresh" even though no real stall occurred.
@@ -851,34 +948,15 @@ export function createPlaybackBindingController(args: {
         // which blocks the peer's next `playing` via local-intent-guard for up
         // to LOCAL_INTENT_GUARD_MS — the visible "resume takes a few seconds"
         // symptom after a remote pause→play.
-        const programmaticSignature =
-          args.runtimeState.programmaticApplySignature;
-        const normalizedSharedUrl = args.normalizeUrl(currentVideo?.url);
-        const insideProgrammaticPausedWindow =
-          programmaticSignature !== null &&
-          programmaticSignature.playState === "paused" &&
-          now < args.runtimeState.programmaticApplyUntil &&
-          normalizedSharedUrl !== null &&
-          normalizedSharedUrl === programmaticSignature.url;
         const bufferInduced =
-          !insideProgrammaticPausedWindow &&
-          recentBufferSignal &&
+          !isInsideProgrammaticPausedWindow(now) &&
+          (recentBufferSignal || recentVideoRebind) &&
           !userInitiatedPause;
         args.runtimeState.pauseStartedAt = now;
         args.runtimeState.pauseClassifiedAsBuffer = bufferInduced;
         clearBufferUpgradeTimer();
         if (bufferInduced) {
-          pauseBufferUpgradeTimerId = scheduleUpgradeTimer(() => {
-            pauseBufferUpgradeTimerId = null;
-            if (!video.paused) {
-              return;
-            }
-            args.runtimeState.pauseClassifiedAsBuffer = false;
-            args.debugLog(
-              `Buffer-pause upgraded to paused after ${args.bufferPauseUpgradeMs}ms, re-broadcasting`,
-            );
-            void args.broadcastPlayback(video, "pause");
-          }, args.bufferPauseUpgradeMs);
+          armBufferPauseUpgrade(video);
         }
         rememberExplicitPlaybackAction("paused");
         rememberExplicitUserAction("pause");
@@ -903,10 +981,12 @@ export function createPlaybackBindingController(args: {
       },
       onWaiting: () => {
         args.runtimeState.lastBufferSignalAt = nowOf();
+        classifyUnobservedPauseAsBuffer(video);
         scheduleBroadcast(video, "waiting");
       },
       onStalled: () => {
         args.runtimeState.lastBufferSignalAt = nowOf();
+        classifyUnobservedPauseAsBuffer(video);
         scheduleBroadcast(video, "stalled");
       },
       onLoadedMetadata: () => {
@@ -918,6 +998,7 @@ export function createPlaybackBindingController(args: {
         if (!forcePauseWhileWaitingForInitialRoomState(video)) {
           args.applyPendingPlaybackApplication(video);
         }
+        classifyUnobservedPauseAsBuffer(video);
         scheduleBroadcast(video, "canplay", 120);
       },
       onPlaying: () => {
@@ -937,6 +1018,7 @@ export function createPlaybackBindingController(args: {
           args.cancelActiveSoftApply(video, "seek");
         }
         rememberExplicitUserAction("seek");
+        classifyUnobservedPauseAsBuffer(video);
         scheduleBroadcast(video, "seeking");
       },
       onSeeked: () => {
@@ -944,6 +1026,7 @@ export function createPlaybackBindingController(args: {
           args.cancelActiveSoftApply(video, "seek");
         }
         rememberExplicitUserAction("seek");
+        classifyUnobservedPauseAsBuffer(video);
         scheduleBroadcast(video, "seeked", 120);
       },
       onRateChange: () => {
@@ -983,6 +1066,14 @@ export function createPlaybackBindingController(args: {
         }
       },
     });
+
+    if (boundNewElement) {
+      // A *replacement* element (the player rebuilt itself) is indistinguishable
+      // here from the first bind on a freshly loaded page; both leave an element
+      // whose paused state we never observed transitioning. The pause
+      // classifiers use this timestamp to avoid reporting either as a user pause.
+      args.runtimeState.lastVideoElementBoundAt = nowOf();
+    }
   }
 
   return {

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -207,6 +207,14 @@ export interface ContentRuntimeState {
    */
   lastBufferSignalAt: number;
   /**
+   * Timestamp when playback listeners were most recently attached to a *new*
+   * `<video>` element. Bilibili's player recreates its media element to recover
+   * from a buffer stall, and the replacement element starts out paused — no
+   * `pause` event ever fires for it, so the pause classifier below has no other
+   * way to tell that stall apart from the user pressing pause.
+   */
+  lastVideoElementBoundAt: number;
+  /**
    * Timestamp when the local video most recently transitioned to `paused`.
    * Reset to 0 once playback resumes. Together with
    * [[pauseClassifiedAsBuffer]] this powers the "buffer-pause → buffering"
@@ -299,6 +307,7 @@ export function createContentRuntimeState(): ContentRuntimeState {
     sharedVideoNaturalEndAfterSeek: false,
     festivalSnapshot: null,
     lastBufferSignalAt: 0,
+    lastVideoElementBoundAt: 0,
     pauseStartedAt: 0,
     pauseClassifiedAsBuffer: false,
     deferredRemotePausedState: null,

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -3236,3 +3236,252 @@ test("playback binding controller does not arm sharer end suppression for a non-
     dom.restore();
   }
 });
+
+test("playback binding controller classifies a stall on a rebuilt element as buffering when no pause event fired", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 0;
+  runtimeState.intendedPlayState = "playing";
+  let now = 5_000;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+
+    // The player rebuilt its media element: it is already paused and no `pause`
+    // event was ever dispatched, so only the restore transport events arrive.
+    now = 5_400;
+    dom.video.paused = true;
+    dom.listeners.get("seeked")?.(new Event("seeked"));
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
+    assert.equal(runtimeState.pauseStartedAt, 5_400);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller does not reclassify a user pause when transport events follow it", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.intendedPlayState = "playing";
+  runtimeState.lastUserGestureAt = 4_950;
+  runtimeState.lastForcedPauseAt = 0;
+  let now = 5_000;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
+
+    // A `seeked`/`canplay` arriving long after the user's pause must not
+    // relabel it as a buffer stall — the room would then never learn the video
+    // is actually stopped.
+    now = 9_000;
+    dom.listeners.get("seeked")?.(new Event("seeked"));
+    dom.listeners.get("canplay")?.(new Event("canplay"));
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
+    assert.equal(runtimeState.pauseStartedAt, 5_000);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller leaves an unobserved pause alone when the room intent is paused", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 0;
+  runtimeState.intendedPlayState = "paused";
+  let now = 5_000;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    now = 5_400;
+    dom.video.paused = true;
+    dom.listeners.get("seeked")?.(new Event("seeked"));
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
+    assert.equal(runtimeState.pauseStartedAt, 0);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller classifies a pause right after a video rebind as buffer-induced", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 0;
+  runtimeState.intendedPlayState = "playing";
+  let now = 5_000;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    assert.equal(runtimeState.lastVideoElementBoundAt, 5_000);
+
+    // No `waiting`/`stalled` at all — the rebind is the only buffer evidence.
+    now = 5_200;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
+
+    // Well past the rebind window the same pause is a real one again.
+    runtimeState.pauseStartedAt = 0;
+    runtimeState.pauseClassifiedAsBuffer = false;
+    now = 6_500;
+    dom.listeners.get("pause")?.(new Event("pause"));
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller upgrades an unobserved stall to paused after the threshold", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 0;
+  runtimeState.intendedPlayState = "playing";
+  let now = 5_000;
+  const broadcasts: string[] = [];
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const scheduledTimers: Array<{ cb: () => void; ms: number }> = [];
+  globalThis.window.setTimeout = ((callback: TimerHandler, ms?: number) => {
+    if (typeof callback === "function") {
+      scheduledTimers.push({ cb: callback as () => void, ms: ms ?? 0 });
+    }
+    return scheduledTimers.length;
+  }) as typeof globalThis.window.setTimeout;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async (_video, eventSource) => {
+      broadcasts.push(eventSource ?? "manual");
+    },
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    now = 5_400;
+    dom.video.paused = true;
+    dom.listeners.get("seeked")?.(new Event("seeked"));
+
+    await Promise.resolve();
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
+
+    const upgradeTimer = scheduledTimers.find((timer) => timer.ms === 1_500);
+    assert.notEqual(upgradeTimer, undefined);
+
+    now = 6_900;
+    broadcasts.length = 0;
+    upgradeTimer?.cb();
+    await Promise.resolve();
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
+    assert.equal(broadcasts.includes("pause"), true);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.restore();
+  }
+});


### PR DESCRIPTION
## 现象

同步播放过程中偶尔出现「某一段暂停又立刻恢复播放」。两份来自不同客户端的日志各独立复现了一次。

## 根因

B 站播放器为从缓冲失速中恢复会重建其 media 元素。**替换后的元素一开始就是 `paused`——没有状态跃迁，因此永远不会派发 `pause` 事件**，`onPause` 里的缓冲分类器根本不会运行。该元素随后在恢复播放头时发出 `seeking`/`seeked`/`canplay`，每一条都把 `paused` 广播给房间：所有对端因此暂停并 hard-seek，约 1 秒后又恢复。

日志证据（两端，时间戳已按各自 clock offset 对齐）：

| | 发出端 A | 发出端 B |
|---|---|---|
| 事件序列 | `seeked`→`canplay`→`seeked`→`canplay`→`play` | `seeking`→`seeked`→`canplay`→`seeked`→`canplay`→`play` |
| 播放位置 | 全程冻结在 t=511.94 | 全程冻结在 t=622.35 |
| 有无 `pause` 事件 | 无 | 无 |
| 最近一次用户手势 | 8.5 分钟前 | 2.8 分钟前 |
| 广播出去的状态 | `paused` ×4 → `playing` ×4 | `paused` ×5 → `playing` ×4 |

接收端日志确认了传播路径：`Deferred remote paused ... for 250ms` ×4 →`hard-seek reason=paused-or-buffering delta=0.53` → 1 秒后 `playing`。250ms 的闪烁防抖挡不住约 1 秒的间隔。

已有的四道防线都没拦住：

1. `sync-controller.ts` 的「seek 期间继续上报 playing」兜底要求 `hasRecentExplicitSeek`，而 `rememberExplicitUserAction` 只在有用户手势时记录 seek——播放器内部的恢复性 seek 没有手势。
2. `bufferInduced` 只在 `onPause` 里算，本场景没有 `pause` 事件；即便有，它依赖 300ms 内的 `waiting`/`stalled`，而实测上一次 `waiting` 在 39 秒前。
3. `getPlayState` 的 buffering 分支要求 `!video.paused`，元素本身已 paused。
4. `bindVideoElement` 的返回值（是否首次绑定）被丢弃，没有任何「元素刚换过」的信号可用。

## 改动

复用现成机制而非新造一套——接收端对 `buffering` **不会**暂停本地视频（`player-binding.ts` 的 `applyPendingPlaybackApplication`），这正是需要的语义：

- **`classifyUnobservedPauseAsBuffer`**：在 `seeking`/`seeked`/`canplay`/`waiting`/`stalled` 上识别「元素已 paused、但从未记录过 pause、房间仍认为在播、且无用户手势」的情况，标记为缓冲态。走既有的 `buffering` 广播路径，并沿用**同一套有界升级**——卡顿若在 `bufferPauseUpgradeMs`(1500ms) 后仍未恢复，依旧会作为真正的 `paused` 重新广播出去。
- **`onPause` 新增一路缓冲信号**：「元素在 `videoRebindBufferSignalMs`(1000ms) 内刚被重新绑定」本身即视为缓冲证据，覆盖绑定足够早、还能捕获到 `pause` 事件的那条路径。
- 顺带抽出 `armBufferPauseUpgrade` 与 `isInsideProgrammaticPausedWindow` 两个辅助函数，消除重复。

守卫条件（`intendedPlayState === "playing"`、无近期手势、不在 programmatic paused 窗口内、`pauseStartedAt === 0`）保证真实的用户暂停、远端 paused 的本地应用、以及房间本就暂停的情形都不受影响。

## 测试

新增 5 个回归测试；其中 3 个行为测试在回退源码改动后确认失败：

```
not ok 49 - classifies a stall on a rebuilt element as buffering when no pause event fired
not ok 52 - classifies a pause right after a video rebind as buffer-induced
not ok 53 - upgrades an unobserved stall to paused after the threshold
```

另 2 个是反向守卫（用户暂停不被误标、房间意图为 paused 时不介入），改动前后均通过。

完整检查全绿：`format:check` / `lint` / `typecheck` / `build` / `test`（extension 490 项全过）。

## 未包含（后续单独处理）

- 接收端 `hard-seek` 对 `paused` 无条件回写 `currentTime`，是本次事故留下约 0.31s 固定偏移的原因；delta < 1s 的 paused 可以只暂停不回拽。
- 一次卡顿放大成 5~9 条 `playback:update`（`scheduleBroadcast` 的 follow-up + 多个事件源），值得收敛。

🤖 Generated with [Claude Code](https://claude.com/claude-code)