### PR TITLE
fix: 同步漂移追赶不再停在阈值上，改为收敛到零

### DIFF
--- a/extension/src/content/playback-reconcile.ts
+++ b/extension/src/content/playback-reconcile.ts
@@ -23,6 +23,18 @@ export function formatPlaybackReconcileDecision(
 
 const PAUSED_HARD_SEEK_THRESHOLD_SECONDS = 0.15;
 const PLAYING_IGNORE_THRESHOLD_SECONDS = 0.45;
+/**
+ * Ignore threshold while a catch-up is already running for this video.
+ *
+ * `PLAYING_IGNORE_THRESHOLD_SECONDS` is the threshold at which a correction
+ * *starts*. Using the same value to decide when it stops gave the loop no
+ * hysteresis: a catch-up was abandoned the instant the drift dipped back under
+ * 0.45s, so every correction settled at the threshold rather than at zero and
+ * each buffer hiccup ratcheted the residual offset up until playback sat
+ * permanently ~0.45s away from the room. Once correcting, keep correcting until
+ * the drift is genuinely closed.
+ */
+const PLAYING_CATCH_UP_IGNORE_THRESHOLD_SECONDS = 0.05;
 const PLAYING_RATE_ONLY_THRESHOLD_SECONDS = 0.9;
 const PLAYING_SOFT_APPLY_THRESHOLD_SECONDS = 1.2;
 
@@ -30,16 +42,22 @@ function getPlaybackRateMultiplier(playbackRate: number | undefined): number {
   return Math.max(1, playbackRate ?? 1);
 }
 
-function getAdaptivePlayingThresholds(playbackRate: number | undefined): {
+function getAdaptivePlayingThresholds(
+  playbackRate: number | undefined,
+  hasActiveCatchUp: boolean,
+): {
   ignoreThreshold: number;
   rateOnlyThreshold: number;
   softApplyThreshold: number;
 } {
   const rateMultiplier = getPlaybackRateMultiplier(playbackRate);
   const extraRate = rateMultiplier - 1;
+  const baseIgnoreThreshold = hasActiveCatchUp
+    ? PLAYING_CATCH_UP_IGNORE_THRESHOLD_SECONDS
+    : PLAYING_IGNORE_THRESHOLD_SECONDS;
 
   return {
-    ignoreThreshold: PLAYING_IGNORE_THRESHOLD_SECONDS * (1 + extraRate * 0.35),
+    ignoreThreshold: baseIgnoreThreshold * (1 + extraRate * 0.35),
     rateOnlyThreshold:
       PLAYING_RATE_ONLY_THRESHOLD_SECONDS * (1 + extraRate * 0.7),
     softApplyThreshold:
@@ -60,6 +78,12 @@ export function decidePlaybackReconcileMode(args: {
   playState: PlaybackState["playState"];
   isExplicitSeek?: boolean;
   playbackRate?: number;
+  /**
+   * Whether a catch-up session is already running for this video. Lowers the
+   * ignore threshold so the correction converges instead of stopping the moment
+   * the drift falls back under the (much larger) threshold that started it.
+   */
+  hasActiveCatchUp?: boolean;
 }): PlaybackReconcileDecision {
   const delta = Math.abs(args.targetTime - args.localCurrentTime);
 
@@ -82,7 +106,10 @@ export function decidePlaybackReconcileMode(args: {
     };
   }
 
-  const adaptiveThresholds = getAdaptivePlayingThresholds(args.playbackRate);
+  const adaptiveThresholds = getAdaptivePlayingThresholds(
+    args.playbackRate,
+    args.hasActiveCatchUp ?? false,
+  );
 
   return {
     mode:

--- a/extension/src/content/player-binding.ts
+++ b/extension/src/content/player-binding.ts
@@ -155,6 +155,7 @@ export function syncPlaybackPosition(
   playState: PlaybackState["playState"],
   syncIntent: PlaybackState["syncIntent"] | undefined,
   playbackRate: number,
+  hasActiveCatchUp = false,
 ): AppliedPlaybackAdjustment {
   const previousCurrentTime = video.currentTime;
   const decision = decidePlaybackReconcileMode({
@@ -162,6 +163,7 @@ export function syncPlaybackPosition(
     targetTime,
     playState,
     playbackRate,
+    hasActiveCatchUp,
     isExplicitSeek: shouldTreatAsExplicitSeek({
       syncIntent,
       playState,
@@ -268,6 +270,8 @@ export function syncPlaybackPosition(
 export function applyPendingPlaybackApplication(args: {
   video: HTMLVideoElement;
   pendingPlaybackApplication: PlaybackState | null;
+  /** See {@link syncPlaybackPosition}. */
+  hasActiveCatchUp?: boolean;
   clearPendingPlaybackApplication: () => void;
   onPlaybackAdjusted?: (
     adjustment: AppliedPlaybackAdjustment,
@@ -299,6 +303,7 @@ export function applyPendingPlaybackApplication(args: {
     playback.playState,
     playback.syncIntent,
     playback.playbackRate,
+    args.hasActiveCatchUp ?? false,
   );
   args.onPlaybackAdjusted?.(appliedSignature, playback);
   const needsPlayStateChange =

--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -84,6 +84,10 @@ export function createSoftApplyController(args: {
     // the remote head keeps advancing, so converging on the stale target would
     // restore the base rate too early and leave residual drift behind.
     convergeByRelativeDrift: boolean;
+    // When `targetTime` was captured. The remote head keeps advancing from it,
+    // so any comparison against a *live* remote position has to age the
+    // snapshot by the elapsed time first.
+    startedAt: number;
   } | null = null;
   let activeSoftApplyTimer: number | null = null;
 
@@ -257,6 +261,7 @@ export function createSoftApplyController(args: {
       deadlineAt: nowOf() + timeoutMs,
       armCooldownOnConverge: nextArmCooldownOnConverge,
       convergeByRelativeDrift,
+      startedAt: nowOf(),
     };
     scheduleActiveSoftApplyTimeout();
     args.debugLog(
@@ -295,8 +300,25 @@ export function createSoftApplyController(args: {
     ) {
       return "rate-changed";
     }
+    // `targetTime` is a snapshot of the remote head taken when the session
+    // started, but the peer keeps playing. Comparing a live remote position
+    // against the frozen snapshot makes every routine heartbeat look like a
+    // jump once more than SOFT_APPLY_TARGET_SHIFT_CANCEL_THRESHOLD_SECONDS of
+    // content has elapsed — for a peer playing steadily and heartbeating every
+    // couple of seconds that is guaranteed to happen long before a catch-up can
+    // converge, so the session was always killed early and left residual drift
+    // behind. Age the snapshot by the elapsed wall time so this only fires for a
+    // genuine unannounced jump. (Announced ones are caught by the `explicit-seek`
+    // check above, and a stalled/paused peer by `play-state-changed`.)
+    const elapsedSeconds = Math.max(
+      0,
+      (nowOf() - activeSoftApply.startedAt) / 1_000,
+    );
+    const expectedTargetTime =
+      activeSoftApply.targetTime +
+      elapsedSeconds * activeSoftApply.restorePlaybackRate;
     if (
-      Math.abs(playback.currentTime - activeSoftApply.targetTime) >
+      Math.abs(playback.currentTime - expectedTargetTime) >
       SOFT_APPLY_TARGET_SHIFT_CANCEL_THRESHOLD_SECONDS
     ) {
       return "target-shifted";

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -287,9 +287,16 @@ export function createSyncController(args: {
   }
 
   function applyPendingPlaybackApplication(video: HTMLVideoElement): void {
+    const pending = args.runtimeState.pendingPlaybackApplication;
     const result = applyPendingPlaybackApplicationWithBinding({
       video,
-      pendingPlaybackApplication: args.runtimeState.pendingPlaybackApplication,
+      pendingPlaybackApplication: pending,
+      // While a catch-up is running for this video, converge on the drift
+      // instead of stopping as soon as it re-enters the (much wider) band that
+      // triggered the catch-up in the first place.
+      hasActiveCatchUp:
+        pending !== null &&
+        softApply.isActiveRateOnlyCatchUp(args.normalizeUrl(pending.url)),
       clearPendingPlaybackApplication: () => {
         args.runtimeState.pendingPlaybackApplication = null;
       },

--- a/extension/test/playback-reconcile.test.ts
+++ b/extension/test/playback-reconcile.test.ts
@@ -153,3 +153,40 @@ test("keeps paused playback on the fast hard-seek path", () => {
   assert.equal(decision.reason, "paused-or-buffering");
   assert.ok(Math.abs(decision.delta - 0.4) < 0.001);
 });
+
+test("playing ignore threshold has hysteresis while a catch-up is running", () => {
+  const input = {
+    localCurrentTime: 27.36,
+    targetTime: 27.8,
+    playState: "playing" as const,
+    playbackRate: 1,
+  };
+
+  // 0.44s is inside the band that would never have started a correction...
+  assert.equal(
+    decidePlaybackReconcileMode({ ...input, hasActiveCatchUp: false }).mode,
+    "ignore",
+  );
+
+  // ...but once one is running, stopping here is what left the residual drift
+  // behind and let each buffer hiccup ratchet the offset up.
+  const duringCatchUp = decidePlaybackReconcileMode({
+    ...input,
+    hasActiveCatchUp: true,
+  });
+  assert.equal(duringCatchUp.mode, "rate-only");
+  assert.equal(duringCatchUp.reason, "playing-rate-adjust");
+});
+
+test("a catch-up still terminates once the drift is genuinely closed", () => {
+  const decision = decidePlaybackReconcileMode({
+    localCurrentTime: 29.78,
+    targetTime: 29.8,
+    playState: "playing",
+    playbackRate: 1,
+    hasActiveCatchUp: true,
+  });
+
+  assert.equal(decision.mode, "ignore");
+  assert.equal(decision.reason, "within-threshold");
+});

--- a/extension/test/soft-apply-controller.test.ts
+++ b/extension/test/soft-apply-controller.test.ts
@@ -343,3 +343,52 @@ test("relative-drift session settling via the timer still honors a sticky cooldo
     windowStub.restore();
   }
 });
+
+test("a steadily advancing peer no longer cancels a catch-up as target-shifted", () => {
+  const windowStub = installWindowStub();
+  try {
+    const runtimeState = createContentRuntimeState();
+    let now = 20_000;
+    const controller = createSoftApplyController({
+      runtimeState,
+      normalizeUrl: (url) => url ?? null,
+      getVideoElement: () => null,
+      debugLog: () => {},
+      userGestureGraceMs: 300,
+      programmaticApplyWindowMs: 700,
+      getNow: () => now,
+      armProgrammaticApplyWindow: () => {},
+    });
+
+    controller.upsertActiveSoftApply(
+      createPlayback({ currentTime: 24.8 }),
+      0.8,
+      {
+        armCooldownOnConverge: false,
+        relativeDriftClose: { driftSeconds: 0.8, rateOffsetSeconds: 0.12 },
+      },
+    );
+
+    // A routine heartbeat 3s later from a peer playing steadily at 1x. Against
+    // the frozen snapshot this looks like a 3s jump and used to cancel the
+    // session long before it could converge.
+    now = 23_000;
+    assert.equal(
+      controller.shouldCancelActiveSoftApplyForPlayback(
+        createPlayback({ currentTime: 27.8 }),
+      ),
+      null,
+    );
+
+    // A genuine unannounced jump still cancels: the peer is 2s past where
+    // steady playback would have put it.
+    assert.equal(
+      controller.shouldCancelActiveSoftApplyForPlayback(
+        createPlayback({ currentTime: 29.8 }),
+      ),
+      "target-shifted",
+    );
+  } finally {
+    windowStub.restore();
+  }
+});

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -2139,3 +2139,84 @@ test("programmatic apply signature stores the normalized url for mismatched (fes
     windowHarness.restore();
   }
 });
+
+test("sync controller converges a catch-up instead of stopping at the ignore threshold", async () => {
+  const windowHarness = installWindowStub();
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({
+    paused: false,
+    currentTime: 24,
+    playbackRate: 1,
+  });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+
+  try {
+    // Drift 0.8s crosses the 0.45s threshold and starts a rate-only catch-up.
+    await harness.controller.applyRoomState(
+      createRoomState({
+        actorId: "remote-member",
+        seq: 10,
+        serverTime: 19_900,
+        currentTime: 24.8,
+        playState: "playing",
+        playbackRate: 1,
+      }),
+    );
+    assert.ok(Math.abs(video.playbackRate - 1.12) < 0.001);
+
+    // A routine heartbeat 3s later. The peer advanced 3s; the local head
+    // advanced 3s at the elevated 1.12x, so the remaining drift is 0.44s —
+    // just under the threshold that started the catch-up.
+    harness.setNow(23_000);
+    video.currentTime = 27.36;
+    await harness.controller.applyRoomState(
+      createRoomState({
+        actorId: "remote-member",
+        seq: 11,
+        serverTime: 22_900,
+        currentTime: 27.8,
+        playState: "playing",
+        playbackRate: 1,
+      }),
+    );
+
+    // Previously this heartbeat killed the catch-up twice over: the frozen
+    // snapshot made it look like a 3s jump (`target-shifted`), and the `ignore`
+    // reconcile wrote the base rate back. Both left the 0.44s residual forever.
+    assert.equal(
+      harness.debugLogs.some((message) => message.includes("target-shifted")),
+      false,
+    );
+    assert.ok(video.playbackRate > 1.01);
+
+    // Once the drift really is closed the catch-up ends and the base rate is
+    // restored — the hysteresis lowers the floor, it does not remove it.
+    harness.setNow(26_000);
+    video.currentTime = 29.78;
+    await harness.controller.applyRoomState(
+      createRoomState({
+        actorId: "remote-member",
+        seq: 12,
+        serverTime: 25_900,
+        currentTime: 29.8,
+        playState: "playing",
+        playbackRate: 1,
+      }),
+    );
+
+    assert.ok(Math.abs(video.playbackRate - 1) < 0.001);
+  } finally {
+    windowHarness.restore();
+  }
+});


### PR DESCRIPTION
Closes #185

## 根因

漂移纠正的**启停共用同一个门限** `PLAYING_IGNORE_THRESHOLD_SECONDS = 0.45`，没有回差。追赶一旦把漂移压回 0.45 以下就立刻收手，于是每次纠正都停在阈值附近而非归零；缓冲卡顿逐次把残留往上垫，最终稳定偏离房间约半秒且永不自愈。

对实测日志 21:27:43 那次做了完整反演，参数逐项吻合：

| 日志值 | 代码推导 |
|---|---|
| `appliedRate=0.92` | `rateOffset = -0.47 × 0.18 = -0.0846` → `1 - 0.0846 = 0.9154` |
| `timeout=5556` | `computeRelativeDriftCloseMs: 0.47 / 0.0846 × 1000 = 5555` |

会话计划跑 5.5 秒追平 0.47s，实际约 2 秒就被杀掉，残留 0.18 就此固化。

## 三个独立的过早中止出口

**1. `target-shifted` 是必然触发的，不是偶发**

`soft-apply-controller.ts` 的取消判定拿**冻结的 `targetTime` 快照**去比对端的实时位置，阈值 0.6s。对端在以 1x 正常播放、每约 2 秒发一次心跳——只要过了 0.6 秒，下一条心跳必定越界。代码注释本身就写着"rate-only 会话不会收敛到陈旧的快照目标"，但取消判定仍在用那个陈旧目标。

改为按已过时长把快照外推后再比较。真正的无预告跳转仍会取消；有预告的由上方 `explicit-seek` 分支拦截，对端卡顿/暂停由 `play-state-changed` 拦截。

**2. `ignore` 会取消追赶会话**

漂移跌回 0.45 以下时 `decidePlaybackReconcileMode` 返回 `ignore`，会话随即被 `apply-ignore` 取消、速率还原。新增 `hasActiveCatchUp` 回差：追赶进行中门限降到 0.05，追平后才停。

**3. `ignore` 分支自己会抹平追赶速率**

`syncPlaybackPosition` 的 `ignore` 分支无条件把 `playbackRate` 写回基准值，所以单靠第 2 点还不够——即使不取消会话，速率也会被下一条心跳清掉。该标志一路传入 `applyPendingPlaybackApplication` → `syncPlaybackPosition` 以避免。

三者是同一个病的三个出口，缺一不可：只修任意一个或两个，追赶仍会被剩下的那个杀掉。

## 边界

回差只是**降低**了停止门限，没有取消它。漂移真正收敛（< 0.05s）后追赶照常结束并还原速率——测试里明确覆盖了这一点。启动门限 0.45 未改，所以正常抖动不会触发额外纠正。

## 测试

新增 4 个测试，逐个回退源码验证过确实捕捉旧行为：

```
not ok 13 - playing ignore threshold has hysteresis while a catch-up is running   (reconcile)
not ok  7 - a steadily advancing peer no longer cancels a catch-up as target-shifted   (soft-apply)
not ok 39 - sync controller converges a catch-up instead of stopping at the ignore threshold   (端到端)
```

端到端那条完整复现了事故场景：0.8s 漂移触发追赶 → 3 秒后一条常规心跳（旧代码在此会沿两条路径双杀）→ 追赶继续 → 漂移追平后正常终止并还原速率。

完整检查全绿：`format:check` / `lint` / `typecheck` / `build` / `test`（extension 494 项）。

## 与 #184 的关系

#184 修的是"卡顿被误报为暂停"，本 PR 修的是"卡顿造成的漂移无法收敛"。两者独立——即使没有任何误报，本问题同样成立。

剩余的 #186（buffering 回拽）、#187（消息放大）未包含。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
