### PR TITLE
fix: 程序化 apply 的事件回声不再被记为显式用户动作

### DIFF
--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -189,9 +189,21 @@ export function createPlaybackBindingController(args: {
    * broadcast play-state forcing, and even `shouldSuppressProgrammaticEvent`'s
    * own bypass — letting an apply wave itself back out to the room.
    *
-   * A gesture made AFTER the window opened is still genuinely the user (they
-   * may well have grabbed the player mid-apply), so only echoes whose most
-   * recent gesture predates the window are discarded.
+   * Taking over the player mid-apply is still genuinely the user, so a gesture
+   * made AFTER the window opened lifts the guard — but it has to be an
+   * IN-PLAYER one. The tracker is document/window level, so a click on blank
+   * space or the danmaku box refreshes `lastUserGestureAt` without expressing
+   * any intent to control playback; accepting that would leave the exact hole
+   * this guard exists to close, since the echoes would then be recorded and go
+   * on to satisfy `shouldSuppressProgrammaticEvent`'s explicit-action bypass.
+   *
+   * Known limitation: `isGestureInsidePlayer` only counts play-toggle keys, so
+   * an arrow-key seek inside the (700ms) window is not recognised as taking
+   * over and its `explicit-seek` tag is dropped. The seek itself still reaches
+   * the room through the ordinary position path — it is just not flagged as
+   * deliberate. Widening the key set is deliberately avoided here because the
+   * same predicate authorizes playback on "load paused" pages, where arrow keys
+   * must NOT count.
    *
    * Both timestamps come from `Date.now()`, whose resolution browsers coarsen,
    * so a gesture landing in the same tick as the window opening is genuinely
@@ -202,7 +214,7 @@ export function createPlaybackBindingController(args: {
   function isProgrammaticEventEcho(): boolean {
     return (
       nowOf() < args.runtimeState.programmaticApplyUntil &&
-      args.runtimeState.lastUserGestureAt <
+      args.runtimeState.lastUserGestureInPlayerAt <
         args.runtimeState.programmaticApplyAt
     );
   }

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -176,7 +176,35 @@ export function createPlaybackBindingController(args: {
     }
   }
 
+  /**
+   * Whether the event being handled is our own programmatic apply echoing back
+   * rather than something the user did.
+   *
+   * Applying a remote state writes `currentTime`/`playbackRate` and calls
+   * `play()`/`pause()`, all of which dispatch exactly the DOM events a user
+   * would produce. The `rememberExplicit*` helpers below only ask whether *any*
+   * page gesture happened in the last `userGestureGraceMs`, so an unrelated
+   * click moments earlier is enough for those echoes to be recorded as
+   * deliberate user actions. They then feed the seek-intent tagging, the
+   * broadcast play-state forcing, and even `shouldSuppressProgrammaticEvent`'s
+   * own bypass — letting an apply wave itself back out to the room.
+   *
+   * A gesture made AFTER the window opened is still genuinely the user (they
+   * may well have grabbed the player mid-apply), so only echoes whose most
+   * recent gesture predates the window are discarded.
+   */
+  function isProgrammaticEventEcho(): boolean {
+    return (
+      nowOf() < args.runtimeState.programmaticApplyUntil &&
+      args.runtimeState.lastUserGestureAt <=
+        args.runtimeState.programmaticApplyAt
+    );
+  }
+
   function rememberExplicitPlaybackAction(playState: "playing" | "paused") {
+    if (isProgrammaticEventEcho()) {
+      return;
+    }
     if (
       nowOf() - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs &&
       args.runtimeState.lastUserGestureAt > args.runtimeState.lastForcedPauseAt
@@ -189,6 +217,9 @@ export function createPlaybackBindingController(args: {
   }
 
   function rememberExplicitUserAction(kind: ExplicitUserActionKind) {
+    if (isProgrammaticEventEcho()) {
+      return;
+    }
     if (
       nowOf() - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs &&
       args.runtimeState.lastUserGestureAt > args.runtimeState.lastForcedPauseAt

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -192,11 +192,17 @@ export function createPlaybackBindingController(args: {
    * A gesture made AFTER the window opened is still genuinely the user (they
    * may well have grabbed the player mid-apply), so only echoes whose most
    * recent gesture predates the window are discarded.
+   *
+   * Both timestamps come from `Date.now()`, whose resolution browsers coarsen,
+   * so a gesture landing in the same tick as the window opening is genuinely
+   * ambiguous. Ties go to the user (`<`, not `<=`): mistaking an echo for a user
+   * action is merely the behaviour that existed before this guard, whereas
+   * discarding a real interaction would be a new harm introduced by it.
    */
   function isProgrammaticEventEcho(): boolean {
     return (
       nowOf() < args.runtimeState.programmaticApplyUntil &&
-      args.runtimeState.lastUserGestureAt <=
+      args.runtimeState.lastUserGestureAt <
         args.runtimeState.programmaticApplyAt
     );
   }

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -131,6 +131,13 @@ export interface ContentRuntimeState {
   pauseHoldUntil: number;
   pendingPlaybackApplication: PlaybackState | null;
   programmaticApplyUntil: number;
+  /**
+   * When the current programmatic-apply window opened. Applying a remote state
+   * fires the same DOM events a user would, so distinguishing our own echo from
+   * a real interaction needs the window's *start*: only a gesture made after it
+   * can belong to the user.
+   */
+  programmaticApplyAt: number;
   programmaticApplySignature: ProgrammaticPlaybackSignature | null;
   softApplyCooldownUntil: number;
   softApplyCooldownUrl: string | null;
@@ -288,6 +295,7 @@ export function createContentRuntimeState(): ContentRuntimeState {
     pauseHoldUntil: 0,
     pendingPlaybackApplication: null,
     programmaticApplyUntil: 0,
+    programmaticApplyAt: 0,
     programmaticApplySignature: null,
     softApplyCooldownUntil: 0,
     softApplyCooldownUrl: null,

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -253,6 +253,7 @@ export function createSyncController(args: {
       ...signature,
       url: normalizedSignatureUrl,
     };
+    args.runtimeState.programmaticApplyAt = nowOf();
     args.runtimeState.programmaticApplyUntil =
       nowOf() + args.programmaticApplyWindowMs;
     args.debugLog(
@@ -288,6 +289,7 @@ export function createSyncController(args: {
     args.runtimeState.pendingPlaybackApplication = null;
     pendingLocalOverride.clearPendingLocalPlaybackOverride("reset");
     args.runtimeState.programmaticApplyUntil = 0;
+    args.runtimeState.programmaticApplyAt = 0;
     args.runtimeState.programmaticApplySignature = null;
     softApply.clearSoftApplyCooldown();
     args.runtimeState.lastLocalPlaybackVersion = null;

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -1095,6 +1095,7 @@ export function createSyncController(args: {
     }
     const programmaticDecision = shouldSuppressProgrammaticEventGuard({
       programmaticApplyUntil: args.runtimeState.programmaticApplyUntil,
+      programmaticApplyAt: args.runtimeState.programmaticApplyAt,
       programmaticApplySignature: args.runtimeState.programmaticApplySignature,
       normalizedCurrentUrl: normalizedCurrentVideoUrl,
       playState,

--- a/extension/src/content/sync-guards.ts
+++ b/extension/src/content/sync-guards.ts
@@ -64,6 +64,8 @@ export interface RemotePlayTransitionGuardInput {
 
 export interface ProgrammaticEventSuppressionInput {
   programmaticApplyUntil: number;
+  /** When the current programmatic-apply window opened. */
+  programmaticApplyAt: number;
   programmaticApplySignature: ProgrammaticPlaybackSignature | null;
   normalizedCurrentUrl: string | null;
   playState: PlaybackState["playState"];
@@ -326,9 +328,16 @@ export function shouldSuppressProgrammaticEvent(
   const matchedExplicitAction = mapEventSourceToExplicitAction(
     input.eventSource,
   );
+  // The bypass exists so a genuine user action DURING an apply is not mistaken
+  // for our own echo. An action recorded BEFORE the window opened is not
+  // evidence about anything happening inside it: the user may have seeked
+  // moments before a remote state arrived, and honouring that stale record here
+  // lets the apply's own `seeking`/`play` echo pass as an explicit action and be
+  // broadcast straight back to the room.
   if (
     matchedExplicitAction &&
     input.lastExplicitUserAction?.kind === matchedExplicitAction &&
+    input.lastExplicitUserAction.at >= input.programmaticApplyAt &&
     input.now - input.lastExplicitUserAction.at < input.userGestureGraceMs
   ) {
     return {

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -3546,8 +3546,10 @@ test("playback binding controller still records a gesture made during a programm
   runtimeState.programmaticApplyAt = 5_000;
   runtimeState.programmaticApplyUntil = 5_700;
   // The user grabbed the player AFTER the apply started — that is genuinely
-  // them, and must not be discarded along with the echo.
+  // them, and must not be discarded along with the echo. A real in-player
+  // gesture refreshes both timestamps.
   runtimeState.lastUserGestureAt = 5_050;
+  runtimeState.lastUserGestureInPlayerAt = 5_050;
 
   const controller = createEchoHarness(runtimeState, () => now);
 
@@ -3571,6 +3573,7 @@ test("playback binding controller records user actions normally once the apply w
   runtimeState.programmaticApplyAt = 5_000;
   runtimeState.programmaticApplyUntil = 5_700; // already elapsed
   runtimeState.lastUserGestureAt = 5_900;
+  runtimeState.lastUserGestureInPlayerAt = 5_900;
 
   const controller = createEchoHarness(runtimeState, () => now);
 
@@ -3598,6 +3601,7 @@ test("playback binding controller gives a same-tick gesture to the user, not the
   runtimeState.programmaticApplyAt = 5_000;
   runtimeState.programmaticApplyUntil = 5_700;
   runtimeState.lastUserGestureAt = 5_000;
+  runtimeState.lastUserGestureInPlayerAt = 5_000;
 
   const controller = createEchoHarness(runtimeState, () => now);
 
@@ -3609,6 +3613,31 @@ test("playback binding controller gives a same-tick gesture to the user, not the
       kind: "seek",
       at: 5_100,
     });
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller does not let a stray page click authorize apply echoes", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  const now = 5_100;
+  runtimeState.programmaticApplyAt = 5_000;
+  runtimeState.programmaticApplyUntil = 5_700;
+  // A click on blank space / the danmaku box during the apply: the tracker is
+  // document-level so it refreshes `lastUserGestureAt`, but it expresses no
+  // intent to control the player and must not make the apply's own echoes look
+  // like deliberate user actions.
+  runtimeState.lastUserGestureAt = 5_050;
+  runtimeState.lastUserGestureInPlayerAt = 4_900;
+
+  const controller = createEchoHarness(runtimeState, () => now);
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("seeking")?.(new Event("seeking"));
+
+    assert.equal(runtimeState.lastExplicitUserAction, null);
   } finally {
     dom.restore();
   }

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -3485,3 +3485,104 @@ test("playback binding controller upgrades an unobserved stall to paused after t
     dom.restore();
   }
 });
+
+function createEchoHarness(
+  runtimeState: ReturnType<typeof createContentRuntimeState>,
+  getNow: () => number,
+) {
+  return createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow,
+  });
+}
+
+test("playback binding controller does not record its own programmatic apply as a user action", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  const now = 5_100;
+  // A remote state is being applied. The page gesture predates the window, so
+  // the seek/pause events it produces are our own echo, not the user.
+  runtimeState.programmaticApplyAt = 5_000;
+  runtimeState.programmaticApplyUntil = 5_700;
+  runtimeState.lastUserGestureAt = 4_900;
+
+  const controller = createEchoHarness(runtimeState, () => now);
+
+  try {
+    controller.attachPlaybackListeners();
+
+    dom.listeners.get("seeking")?.(new Event("seeking"));
+    assert.equal(runtimeState.lastExplicitUserAction, null);
+
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+    assert.equal(runtimeState.lastExplicitUserAction, null);
+    assert.equal(runtimeState.lastExplicitPlaybackAction, null);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller still records a gesture made during a programmatic apply", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  const now = 5_100;
+  runtimeState.programmaticApplyAt = 5_000;
+  runtimeState.programmaticApplyUntil = 5_700;
+  // The user grabbed the player AFTER the apply started — that is genuinely
+  // them, and must not be discarded along with the echo.
+  runtimeState.lastUserGestureAt = 5_050;
+
+  const controller = createEchoHarness(runtimeState, () => now);
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("seeking")?.(new Event("seeking"));
+
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "seek",
+      at: 5_100,
+    });
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller records user actions normally once the apply window closes", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  const now = 6_000;
+  runtimeState.programmaticApplyAt = 5_000;
+  runtimeState.programmaticApplyUntil = 5_700; // already elapsed
+  runtimeState.lastUserGestureAt = 5_900;
+
+  const controller = createEchoHarness(runtimeState, () => now);
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("seeking")?.(new Event("seeking"));
+
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "seek",
+      at: 6_000,
+    });
+  } finally {
+    dom.restore();
+  }
+});

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -3586,3 +3586,30 @@ test("playback binding controller records user actions normally once the apply w
     dom.restore();
   }
 });
+
+test("playback binding controller gives a same-tick gesture to the user, not the echo", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  const now = 5_100;
+  // Date.now() resolution is coarsened by browsers, so a user grabbing the
+  // player as the window opens can share its timestamp. That tie must resolve
+  // in the user's favour: losing a real interaction would be a new harm, while
+  // treating an echo as a user action is merely the pre-guard behaviour.
+  runtimeState.programmaticApplyAt = 5_000;
+  runtimeState.programmaticApplyUntil = 5_700;
+  runtimeState.lastUserGestureAt = 5_000;
+
+  const controller = createEchoHarness(runtimeState, () => now);
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("seeking")?.(new Event("seeking"));
+
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "seek",
+      at: 5_100,
+    });
+  } finally {
+    dom.restore();
+  }
+});

--- a/extension/test/sync-guards.test.ts
+++ b/extension/test/sync-guards.test.ts
@@ -230,6 +230,9 @@ test("treats buffering after a programmatic playing apply as the same suppressio
 test("allows explicit user actions to bypass programmatic suppression", () => {
   assert.equal(
     shouldSuppressProgrammaticEvent({
+      // Window opened at 9_800 (700ms), so the 10_000 action happened *during*
+      // the apply — a genuine user seek that must not be suppressed.
+      programmaticApplyAt: 9_800,
       programmaticApplyUntil: 10_500,
       programmaticApplySignature: {
         url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
@@ -488,4 +491,34 @@ test("applies self playback only when paused state, timeline, or rate actually d
     }),
     false,
   );
+});
+
+test("does not let an explicit action from before the apply window bypass suppression", () => {
+  const decision = shouldSuppressProgrammaticEvent({
+    // The user seeked at 9_700, then a remote state arrived and the apply
+    // window opened at 9_800. The `seeked` echo the apply produces must not be
+    // waved through by that earlier, unrelated action — doing so broadcasts the
+    // state we just applied straight back to the room.
+    programmaticApplyAt: 9_800,
+    programmaticApplyUntil: 10_500,
+    programmaticApplySignature: {
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      playState: "paused",
+      currentTime: 36,
+      playbackRate: 1,
+    },
+    normalizedCurrentUrl: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    playState: "paused",
+    currentTime: 36.1,
+    playbackRate: 1,
+    eventSource: "seeked",
+    lastExplicitUserAction: {
+      kind: "seek",
+      at: 9_700,
+    },
+    now: 10_100,
+    userGestureGraceMs: 1_200,
+  });
+
+  assert.equal(decision.shouldSuppress, true);
 });


### PR DESCRIPTION
Refs #190 — 这是 #190 的第一步（R1，地基）。

## 问题

应用远端状态会写 `currentTime`/`playbackRate` 并调用 `play()`/`pause()`，派发的**正是用户操作会产生的那些 DOM 事件**。

而 `rememberExplicitUserAction` 与 `rememberExplicitPlaybackAction` 唯一的门槛是"`userGestureGraceMs` 内有过任意页面手势"——所以只要用户片刻前点过页面任意位置（哪怕是空白处），这些回声就会被记成深思熟虑的用户动作。

`lastExplicitUserAction` 有 **49 处读取、跨 7 个文件**，包括：

- `derivePlaybackSyncIntent` 的 `explicit-seek` 标记
- `getBroadcastPlayState` 的强制上报 `playing`
- **`shouldSuppressProgrammaticEvent` 自身的放行分支**（`sync-guards.ts:326-337`）

最后一条构成闭环：一次 apply 产生的回声被记成用户 seek，该记录又让 apply 的程序化抑制放行，于是 apply 把自己广播回房间。这正是 #189 第 6 轮复审指出的现象之一。

## 改动

处于程序化 apply 窗口内、**且最近一次页面手势早于窗口开始时间**时，不记录显式动作。

窗口开始后发生的新手势仍算真实用户操作——用户完全可能在 apply 进行中操作播放器，不能一并丢弃。为此需要记录窗口的**开始**时刻（`programmaticApplyAt`），此前只存 `until`。

## 同类审计

按 AGENTS.md 逐一检查了"从 DOM 事件推断用户意图"的所有位置：

| 位置 | 来源 | 判定 |
|---|---|---|
| `lastUserGestureAt` / `lastUserGestureInPlayerAt`（`index.ts:222-224`） | 手势追踪器，只监听 document/window 的真实 pointer/key/popstate | 可信，正是本 PR 用作判别依据的信号 |
| `rememberExplicitPlaybackAction`（`:212`） | video 事件 | ✅ 已加守卫 |
| `rememberExplicitUserAction`（`:237`） | video 事件 | ✅ 已加守卫 |

从 video 事件写入"显式动作"的位置只有后两处，覆盖完整。

## 测试

新增 3 条：

| 测试 | 类型 |
|---|---|
| `does not record its own programmatic apply as a user action` | **判别**（回退源码后失败） |
| `still records a gesture made during a programmatic apply` | 守卫：不误伤 apply 期间的真实操作 |
| `records user actions normally once the apply window closes` | 守卫：窗口外行为不变 |

完整检查全绿：`format:check` / `lint` / `typecheck` / `build` / `test`（extension 509 项）。

## 关于 #190 的后续

#190 记录的 7 条症状可归结为 4 个根因，本 PR 是第一个：

| 阶段 | 内容 |
|---|---|
| **R1（本 PR）** | 程序化回声污染"显式用户动作"信号 |
| R2 | `intendedPlayState` 同时是"房间意图"与"上次广播状态"，被广播回写后使门控自我失效 |
| R3 | 发送端两套规则（`derivePlaybackSyncIntent` 2500ms/6 事件源 vs `getBroadcastPlayState` 1200ms/5 事件源）不一致 |
| R4 | `buffering` 在 soft-apply 会话生命周期里等同 `paused`（含 target-shifted、cooldown 三处需同改） |

顺序为 R1 → R3 → R4，R2 最后评估——R1 不修，后续任何门控都建立在可能被污染的信号上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)