### PR TITLE
fix: 对端卡顿不再中断健康成员的漂移收敛

### DIFF
--- a/extension/src/content/player-binding.ts
+++ b/extension/src/content/player-binding.ts
@@ -248,8 +248,19 @@ export function syncPlaybackPosition(
     };
   }
 
+  // A frozen `buffering` snapshot must be a true no-op: writing the sender's
+  // base rate here would wipe out an in-flight catch-up rate on this (healthy)
+  // client, so a stalling peer would still interrupt someone else's drift
+  // convergence even though its position is being ignored.
+  //
+  // `explicit-ratechange` is exempt: the sender's stall and their deliberate
+  // speed change are orthogonal, and swallowing the latter would leave the room
+  // out of sync on playback rate until the peer recovers.
+  const isBufferingNoop =
+    decision.reason === "buffering-not-authoritative" &&
+    syncIntent !== "explicit-ratechange";
   const shouldWritePlaybackRate =
-    Math.abs(video.playbackRate - playbackRate) > 0.01;
+    !isBufferingNoop && Math.abs(video.playbackRate - playbackRate) > 0.01;
   if (shouldWritePlaybackRate) {
     setVideoPlaybackRate(video, playbackRate);
   }

--- a/extension/src/content/player-binding.ts
+++ b/extension/src/content/player-binding.ts
@@ -253,11 +253,18 @@ export function syncPlaybackPosition(
   // client, so a stalling peer would still interrupt someone else's drift
   // convergence even though its position is being ignored.
   //
-  // `explicit-ratechange` is exempt: the sender's stall and their deliberate
-  // speed change are orthogonal, and swallowing the latter would leave the room
-  // out of sync on playback rate until the peer recovers.
+  // Gated on there actually being a catch-up to protect. `syncIntent` only
+  // exists inside the short explicit-action window, so ordinary heartbeats are
+  // still how the room's current rate reaches us; skipping those on a receiver
+  // that is not correcting anything would strand it on a stale rate until the
+  // stalled peer recovers.
+  //
+  // `explicit-ratechange` is exempt regardless: the sender's stall and their
+  // deliberate speed change are orthogonal, and swallowing the latter would
+  // leave the room out of sync on playback rate until the peer recovers.
   const isBufferingNoop =
     decision.reason === "buffering-not-authoritative" &&
+    hasActiveCatchUp &&
     syncIntent !== "explicit-ratechange";
   const shouldWritePlaybackRate =
     !isBufferingNoop && Math.abs(video.playbackRate - playbackRate) > 0.01;

--- a/extension/src/content/player-binding.ts
+++ b/extension/src/content/player-binding.ts
@@ -156,6 +156,13 @@ export function syncPlaybackPosition(
   syncIntent: PlaybackState["syncIntent"] | undefined,
   playbackRate: number,
   hasActiveCatchUp = false,
+  /**
+   * Whether a correction session (rate-only catch-up OR real soft-apply) is
+   * running for this video. Distinct from `hasActiveCatchUp`, which is
+   * rate-only and drives the reconcile hysteresis: both kinds elevate
+   * `playbackRate`, so both need that rate protected here.
+   */
+  hasActiveCorrectionSession = false,
 ): AppliedPlaybackAdjustment {
   const previousCurrentTime = video.currentTime;
   const decision = decidePlaybackReconcileMode({
@@ -253,18 +260,19 @@ export function syncPlaybackPosition(
   // client, so a stalling peer would still interrupt someone else's drift
   // convergence even though its position is being ignored.
   //
-  // Gated on there actually being a catch-up to protect. `syncIntent` only
+  // Gated on there actually being a correction to protect. `syncIntent` only
   // exists inside the short explicit-action window, so ordinary heartbeats are
   // still how the room's current rate reaches us; skipping those on a receiver
   // that is not correcting anything would strand it on a stale rate until the
-  // stalled peer recovers.
+  // stalled peer recovers. A real soft-apply counts as well as a rate-only
+  // catch-up — it elevates the rate the same way.
   //
   // `explicit-ratechange` is exempt regardless: the sender's stall and their
   // deliberate speed change are orthogonal, and swallowing the latter would
   // leave the room out of sync on playback rate until the peer recovers.
   const isBufferingNoop =
     decision.reason === "buffering-not-authoritative" &&
-    hasActiveCatchUp &&
+    hasActiveCorrectionSession &&
     syncIntent !== "explicit-ratechange";
   const shouldWritePlaybackRate =
     !isBufferingNoop && Math.abs(video.playbackRate - playbackRate) > 0.01;
@@ -290,6 +298,8 @@ export function applyPendingPlaybackApplication(args: {
   pendingPlaybackApplication: PlaybackState | null;
   /** See {@link syncPlaybackPosition}. */
   hasActiveCatchUp?: boolean;
+  /** See {@link syncPlaybackPosition}. */
+  hasActiveCorrectionSession?: boolean;
   clearPendingPlaybackApplication: () => void;
   onPlaybackAdjusted?: (
     adjustment: AppliedPlaybackAdjustment,
@@ -322,6 +332,7 @@ export function applyPendingPlaybackApplication(args: {
     playback.syncIntent,
     playback.playbackRate,
     args.hasActiveCatchUp ?? false,
+    args.hasActiveCorrectionSession ?? false,
   );
   args.onPlaybackAdjusted?.(appliedSignature, playback);
   const needsPlayStateChange =

--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -46,6 +46,12 @@ export interface SoftApplyController {
     now: number;
   }): boolean;
   isActiveRateOnlyCatchUp(normalizedUrl: string | null): boolean;
+  /**
+   * Whether ANY correction session is running for this url — a pure rate-only
+   * catch-up or a real soft-apply. Both elevate `playbackRate`, so both need
+   * that rate protected from being written back to the room's base value.
+   */
+  hasActiveCorrectionSession(normalizedUrl: string | null): boolean;
   shouldSuppressByCooldown(
     video: HTMLVideoElement,
     playback: PlaybackState,
@@ -412,6 +418,14 @@ export function createSoftApplyController(args: {
     );
   }
 
+  function hasActiveCorrectionSession(normalizedUrl: string | null): boolean {
+    return (
+      activeSoftApply !== null &&
+      normalizedUrl !== null &&
+      normalizedUrl === activeSoftApply.normalizedUrl
+    );
+  }
+
   function shouldSuppressByCooldown(
     video: HTMLVideoElement,
     playback: PlaybackState,
@@ -463,6 +477,7 @@ export function createSoftApplyController(args: {
     shouldCancelActiveSoftApplyForPlayback,
     shouldSuppressActiveSoftApplyBroadcast,
     isActiveRateOnlyCatchUp,
+    hasActiveCorrectionSession,
     shouldSuppressByCooldown,
     clearSoftApplyCooldown,
     destroy,

--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -283,7 +283,17 @@ export function createSoftApplyController(args: {
     if (!normalizedUrl || normalizedUrl !== activeSoftApply.normalizedUrl) {
       return "url-changed";
     }
-    if (playback.playState !== "playing") {
+    // `buffering` is a transient stall of the SENDER, not a change to where the
+    // room is. Treating it as a state change lets any member's hiccup abort a
+    // healthy member's drift convergence — the session would restore its base
+    // rate and leave the residual behind, re-creating the ratchet #185 removed.
+    // A real `paused` (or anything else non-playing) still ends the session, and
+    // the behind-a-stalled-peer case still tears it down through the normal
+    // `apply-hard-seek` path.
+    if (
+      playback.playState !== "playing" &&
+      playback.playState !== "buffering"
+    ) {
       return "play-state-changed";
     }
     if (
@@ -310,6 +320,14 @@ export function createSoftApplyController(args: {
     // behind. Age the snapshot by the elapsed wall time so this only fires for a
     // genuine unannounced jump. (Announced ones are caught by the `explicit-seek`
     // check above, and a stalled/paused peer by `play-state-changed`.)
+    // A stalled sender's `currentTime` is frozen, so it falls behind the
+    // extrapolated target by exactly the stall duration and would read as a jump
+    // after ~SOFT_APPLY_TARGET_SHIFT_CANCEL_THRESHOLD_SECONDS — cancelling the
+    // very session the check above just preserved. A frozen position is not
+    // comparable; skip it and let a real state change end the session.
+    if (playback.playState === "buffering") {
+      return null;
+    }
     const elapsedSeconds = Math.max(
       0,
       (nowOf() - activeSoftApply.startedAt) / 1_000,

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -335,6 +335,9 @@ export function createSyncController(args: {
       hasActiveCatchUp:
         pending !== null &&
         softApply.isActiveRateOnlyCatchUp(args.normalizeUrl(pending.url)),
+      hasActiveCorrectionSession:
+        pending !== null &&
+        softApply.hasActiveCorrectionSession(args.normalizeUrl(pending.url)),
       clearPendingPlaybackApplication: () => {
         args.runtimeState.pendingPlaybackApplication = null;
       },

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -352,15 +352,22 @@ export function createSyncController(args: {
           (adjustment.mode === "rate-only" &&
             Math.abs(adjustment.playbackRate - adjustment.restorePlaybackRate) >
               0.01);
-        // Completing the no-op: a frozen `buffering` snapshot neither moves the
-        // playhead nor touches the rate, so it must not clear the cooldown a
-        // soft-apply convergence just armed either. `shouldSuppressByCooldown`
-        // only screens `playing` updates, so a lagging `buffering` would
-        // otherwise strip that protection and let the next ordinary drift
-        // re-trigger a correction immediately.
-        const isBufferingNoop =
+        // A frozen `buffering` snapshot never moves the playhead, so it must
+        // not tear down an in-flight catch-up (see the early return below).
+        //
+        // Clearing the cooldown is a separate question: that bookkeeping may
+        // only be skipped when the apply genuinely wrote nothing. A buffering
+        // update still carries the room's rate (and an `explicit-ratechange`
+        // always applies), so treating those as no-ops would keep a stale
+        // cooldown alive — and `shouldSuppressByCooldown` only screens
+        // `playing` updates, so the next real position correction would be
+        // suppressed with nothing to clear it.
+        const isBufferingApply =
           adjustment.reason === "buffering-not-authoritative";
-        if (!isSelfRestoringRateAdjust && !isBufferingNoop) {
+        if (
+          !isSelfRestoringRateAdjust &&
+          !(isBufferingApply && !adjustment.didChange)
+        ) {
           softApply.clearSoftApplyCooldown();
         }
         args.debugLog(
@@ -372,7 +379,7 @@ export function createSyncController(args: {
             },
           )} wroteTime=${adjustment.didWriteCurrentTime} wroteRate=${adjustment.didWritePlaybackRate} targetTime=${adjustment.targetTime.toFixed(2)} appliedTime=${adjustment.currentTime.toFixed(2)} appliedRate=${adjustment.playbackRate.toFixed(2)} restoreRate=${adjustment.restorePlaybackRate.toFixed(2)}`,
         );
-        if (isBufferingNoop) {
+        if (isBufferingApply) {
           return;
         }
         if (isSelfRestoringRateAdjust) {

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -352,7 +352,15 @@ export function createSyncController(args: {
           (adjustment.mode === "rate-only" &&
             Math.abs(adjustment.playbackRate - adjustment.restorePlaybackRate) >
               0.01);
-        if (!isSelfRestoringRateAdjust) {
+        // Completing the no-op: a frozen `buffering` snapshot neither moves the
+        // playhead nor touches the rate, so it must not clear the cooldown a
+        // soft-apply convergence just armed either. `shouldSuppressByCooldown`
+        // only screens `playing` updates, so a lagging `buffering` would
+        // otherwise strip that protection and let the next ordinary drift
+        // re-trigger a correction immediately.
+        const isBufferingNoop =
+          adjustment.reason === "buffering-not-authoritative";
+        if (!isSelfRestoringRateAdjust && !isBufferingNoop) {
           softApply.clearSoftApplyCooldown();
         }
         args.debugLog(
@@ -364,6 +372,9 @@ export function createSyncController(args: {
             },
           )} wroteTime=${adjustment.didWriteCurrentTime} wroteRate=${adjustment.didWritePlaybackRate} targetTime=${adjustment.targetTime.toFixed(2)} appliedTime=${adjustment.currentTime.toFixed(2)} appliedRate=${adjustment.playbackRate.toFixed(2)} restoreRate=${adjustment.restorePlaybackRate.toFixed(2)}`,
         );
+        if (isBufferingNoop) {
+          return;
+        }
         if (isSelfRestoringRateAdjust) {
           const driftSeconds = Math.abs(
             adjustment.targetTime - adjustment.currentTime,

--- a/extension/test/player-binding.test.ts
+++ b/extension/test/player-binding.test.ts
@@ -302,3 +302,45 @@ test("applying a buffering peer state leaves the local playhead untouched", () =
   assert.equal(applied.mode, "ignore");
   assert.equal(applied.reason, "buffering-not-authoritative");
 });
+
+test("a frozen buffering snapshot leaves an in-flight catch-up rate alone", () => {
+  const video = createVideo({
+    currentTime: 514.9,
+    paused: false,
+    playbackRate: 1.12,
+  });
+
+  const applied = syncPlaybackPosition(
+    video,
+    511.94,
+    "buffering",
+    undefined,
+    1,
+  );
+
+  assert.ok(Math.abs(video.playbackRate - 1.12) < 0.001);
+  assert.equal(applied.didWritePlaybackRate, false);
+  assert.equal(applied.reason, "buffering-not-authoritative");
+});
+
+test("a deliberate rate change still applies even while the sender is buffering", () => {
+  // The sender's stall and their speed change are orthogonal — swallowing the
+  // latter would leave the room out of sync on rate until the peer recovers.
+  const video = createVideo({
+    currentTime: 514.9,
+    paused: false,
+    playbackRate: 1,
+  });
+
+  const applied = syncPlaybackPosition(
+    video,
+    511.94,
+    "buffering",
+    "explicit-ratechange",
+    1.5,
+  );
+
+  assert.ok(Math.abs(video.playbackRate - 1.5) < 0.001);
+  assert.equal(applied.didWritePlaybackRate, true);
+  assert.equal(applied.didWriteCurrentTime, false);
+});

--- a/extension/test/player-binding.test.ts
+++ b/extension/test/player-binding.test.ts
@@ -316,6 +316,7 @@ test("a frozen buffering snapshot leaves an in-flight catch-up rate alone", () =
     "buffering",
     undefined,
     1,
+    true, // a catch-up is running: its elevated rate must survive
   );
 
   assert.ok(Math.abs(video.playbackRate - 1.12) < 0.001);
@@ -343,4 +344,29 @@ test("a deliberate rate change still applies even while the sender is buffering"
   assert.ok(Math.abs(video.playbackRate - 1.5) < 0.001);
   assert.equal(applied.didWritePlaybackRate, true);
   assert.equal(applied.didWriteCurrentTime, false);
+});
+
+test("a buffering snapshot still carries the room rate when nothing is catching up", () => {
+  // `syncIntent` only exists inside the short explicit-action window, so
+  // ordinary heartbeats are how the room's rate reaches us. A receiver that is
+  // not correcting anything has no catch-up rate to protect, so skipping the
+  // write would strand it on a stale rate until the stalled peer recovers.
+  const video = createVideo({
+    currentTime: 514.9,
+    paused: false,
+    playbackRate: 1,
+  });
+
+  const applied = syncPlaybackPosition(
+    video,
+    511.94,
+    "buffering",
+    undefined,
+    1.5,
+  );
+
+  assert.ok(Math.abs(video.playbackRate - 1.5) < 0.001);
+  assert.equal(applied.didWritePlaybackRate, true);
+  assert.equal(applied.didWriteCurrentTime, false);
+  assert.equal(applied.reason, "buffering-not-authoritative");
 });

--- a/extension/test/player-binding.test.ts
+++ b/extension/test/player-binding.test.ts
@@ -316,7 +316,8 @@ test("a frozen buffering snapshot leaves an in-flight catch-up rate alone", () =
     "buffering",
     undefined,
     1,
-    true, // a catch-up is running: its elevated rate must survive
+    false,
+    true, // a correction session is running: its elevated rate must survive
   );
 
   assert.ok(Math.abs(video.playbackRate - 1.12) < 0.001);
@@ -368,5 +369,31 @@ test("a buffering snapshot still carries the room rate when nothing is catching 
   assert.ok(Math.abs(video.playbackRate - 1.5) < 0.001);
   assert.equal(applied.didWritePlaybackRate, true);
   assert.equal(applied.didWriteCurrentTime, false);
+  assert.equal(applied.reason, "buffering-not-authoritative");
+});
+
+test("a real soft-apply's elevated rate survives a lagging buffering snapshot", () => {
+  // `hasActiveCatchUp` is rate-only by construction, so gating the rate
+  // protection on it left real soft-apply sessions unprotected: a stalled
+  // peer's heartbeat would write the base rate back and silently interrupt the
+  // correction while the session itself was preserved.
+  const video = createVideo({
+    currentTime: 514.9,
+    paused: false,
+    playbackRate: 1.12,
+  });
+
+  const applied = syncPlaybackPosition(
+    video,
+    511.94,
+    "buffering",
+    undefined,
+    1,
+    false, // not a rate-only catch-up...
+    true, // ...but a soft-apply session is active
+  );
+
+  assert.ok(Math.abs(video.playbackRate - 1.12) < 0.001);
+  assert.equal(applied.didWritePlaybackRate, false);
   assert.equal(applied.reason, "buffering-not-authoritative");
 });

--- a/extension/test/soft-apply-controller.test.ts
+++ b/extension/test/soft-apply-controller.test.ts
@@ -392,3 +392,58 @@ test("a steadily advancing peer no longer cancels a catch-up as target-shifted",
     windowStub.restore();
   }
 });
+
+test("a peer's buffering does not abort an active catch-up, a real pause still does", () => {
+  const windowStub = installWindowStub();
+  try {
+    const runtimeState = createContentRuntimeState();
+    let now = 20_000;
+    const controller = createSoftApplyController({
+      runtimeState,
+      normalizeUrl: (url) => url ?? null,
+      getVideoElement: () => null,
+      debugLog: () => {},
+      userGestureGraceMs: 300,
+      programmaticApplyWindowMs: 700,
+      getNow: () => now,
+      armProgrammaticApplyWindow: () => {},
+    });
+
+    controller.upsertActiveSoftApply(
+      createPlayback({ currentTime: 24.8 }),
+      0.8,
+      {
+        armCooldownOnConverge: false,
+        relativeDriftClose: { driftSeconds: 0.8, rateOffsetSeconds: 0.12 },
+      },
+    );
+
+    // A transient stall of the sender is not a change to where the room is.
+    assert.equal(
+      controller.shouldCancelActiveSoftApplyForPlayback(
+        createPlayback({ currentTime: 24.8, playState: "buffering" }),
+      ),
+      null,
+    );
+
+    // Its frozen position falls further behind the extrapolated target the
+    // longer it stalls; that must not read as an unannounced jump either.
+    now = 23_000;
+    assert.equal(
+      controller.shouldCancelActiveSoftApplyForPlayback(
+        createPlayback({ currentTime: 24.8, playState: "buffering" }),
+      ),
+      null,
+    );
+
+    // A real stop still ends the session.
+    assert.equal(
+      controller.shouldCancelActiveSoftApplyForPlayback(
+        createPlayback({ currentTime: 24.8, playState: "paused" }),
+      ),
+      "play-state-changed",
+    );
+  } finally {
+    windowStub.restore();
+  }
+});

--- a/extension/test/soft-apply-controller.test.ts
+++ b/extension/test/soft-apply-controller.test.ts
@@ -447,3 +447,36 @@ test("a peer's buffering does not abort an active catch-up, a real pause still d
     windowStub.restore();
   }
 });
+
+test("hasActiveCorrectionSession covers real soft-apply, not just rate-only catch-ups", () => {
+  const windowStub = installWindowStub();
+  try {
+    const runtimeState = createContentRuntimeState();
+    const controller = createSoftApplyController({
+      runtimeState,
+      normalizeUrl: (url) => url ?? null,
+      getVideoElement: () => null,
+      debugLog: () => {},
+      userGestureGraceMs: 300,
+      programmaticApplyWindowMs: 700,
+      getNow: () => 20_000,
+      armProgrammaticApplyWindow: () => {},
+    });
+    const url = "https://www.bilibili.com/video/BV1xx411c7mD?p=1";
+
+    // A real soft-apply: it writes currentTime AND elevates the rate, so
+    // `isActiveRateOnlyCatchUp` deliberately excludes it — but its rate needs
+    // the same protection from being written back to the room's base value.
+    controller.upsertActiveSoftApply(
+      createPlayback({ currentTime: 24.8 }),
+      1.1,
+    );
+
+    assert.equal(controller.isActiveRateOnlyCatchUp(url), false);
+    assert.equal(controller.hasActiveCorrectionSession(url), true);
+    assert.equal(controller.hasActiveCorrectionSession("https://other"), false);
+    assert.equal(controller.hasActiveCorrectionSession(null), false);
+  } finally {
+    windowStub.restore();
+  }
+});

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -2414,3 +2414,46 @@ test("a lagging buffering snapshot does not strip the soft-apply cooldown", asyn
   assert.equal(harness.runtimeState.softApplyCooldownUrl, sharedVideo.url);
   assert.ok(Math.abs(video.currentTime - 514.9) < 0.001);
 });
+
+test("a buffering apply that actually wrote the rate still clears the cooldown", async () => {
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({
+    paused: false,
+    currentTime: 514.9,
+    playbackRate: 1,
+  });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.activeSharedUrl = sharedVideo.url;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+  harness.runtimeState.softApplyCooldownUrl = sharedVideo.url;
+  harness.runtimeState.softApplyCooldownUntil = 22_500;
+
+  // Nothing is catching up, so this buffering heartbeat does carry the room's
+  // new rate — it is not a no-op, and leaving the cooldown armed would suppress
+  // the next real position correction with nothing left to clear it.
+  await harness.controller.applyRoomState(
+    createRoomState({
+      actorId: "remote-member",
+      seq: 10,
+      serverTime: 19_900,
+      currentTime: 511.94,
+      playState: "buffering",
+      playbackRate: 1.5,
+    }),
+  );
+
+  assert.ok(Math.abs(video.playbackRate - 1.5) < 0.001);
+  assert.equal(harness.runtimeState.softApplyCooldownUntil, 0);
+  assert.ok(Math.abs(video.currentTime - 514.9) < 0.001);
+});

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -2367,3 +2367,50 @@ test("sync controller keeps refreshing the local intent guard while deduping", a
   assert.equal(harness.runtimeState.lastLocalIntentAt, 20_900);
   assert.equal(harness.runtimeState.lastLocalIntentPlayState, "paused");
 });
+
+test("a lagging buffering snapshot does not strip the soft-apply cooldown", async () => {
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({
+    paused: false,
+    currentTime: 514.9,
+    playbackRate: 1,
+  });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.activeSharedUrl = sharedVideo.url;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_000);
+
+  // A soft-apply convergence just armed the cooldown that keeps the next
+  // correction from firing immediately.
+  harness.runtimeState.softApplyCooldownUrl = sharedVideo.url;
+  harness.runtimeState.softApplyCooldownUntil = 22_500;
+
+  // A peer stalls behind us. Its frozen position is ignored — and because that
+  // is a true no-op it must not clear the cooldown either. `shouldSuppressByCooldown`
+  // only screens `playing` updates, so stripping it here would let the next
+  // ordinary drift re-trigger a correction right away.
+  await harness.controller.applyRoomState(
+    createRoomState({
+      actorId: "remote-member",
+      seq: 10,
+      serverTime: 19_900,
+      currentTime: 511.94,
+      playState: "buffering",
+      playbackRate: 1,
+    }),
+  );
+
+  assert.equal(harness.runtimeState.softApplyCooldownUntil, 22_500);
+  assert.equal(harness.runtimeState.softApplyCooldownUrl, sharedVideo.url);
+  assert.ok(Math.abs(video.currentTime - 514.9) < 0.001);
+});


### PR DESCRIPTION
Refs #190 — 这是 #190 的第二步（R4）。第一步 R1 已由 #192 合入。

## 问题

`buffering` 在 soft-apply 会话生命周期里等同 `paused`，于是**任一成员的瞬时卡顿都会取消其他健康成员正在进行的追赶**：会话恢复基础速率、留下残留偏移——正好抵消 #185/#188 修复的棘轮效应。

## 四处一并处理

#189 的教训是只改一处会立刻暴露其余（那个 PR 因此走了六轮），所以这次一次做完：

| # | 位置 | 改动 |
|---|---|---|
| 1 | `shouldCancelActiveSoftApplyForPlayback` | `buffering` 不再返回 `play-state-changed` |
| 2 | 同函数的 `target-shifted` 检查 | 对 `buffering` 直接跳过 |
| 3 | `syncPlaybackPosition` 的 `ignore` 分支 | 不为 `buffering-not-authoritative` 写回基准速率 |
| 4 | `onPlaybackAdjusted` | 对该 reason 既不清 cooldown 也不取消会话 |

各自的必要性：

- **第 2 条**：卡顿端 `currentTime` 是冻结的，会按停顿时长落后于外推目标，约 `SOFT_APPLY_TARGET_SHIFT_CANCEL_THRESHOLD_SECONDS`（0.6s）后必被判为跳转——**正好取消第 1 条刚保住的会话**。
- **第 3 条**：不跳过就会把本端正在使用的追赶速率抹掉，第 1、2 条的保留形同虚设。
- **第 4 条**：`shouldSuppressByCooldown` 只筛查 `playing` 状态的更新，所以一个落后的 `buffering` 清掉 cooldown 后，下一次普通漂移会立刻重新触发校正。

不受影响的路径：真正的 `paused`（及其余非 playing 状态）仍然结束会话；"落后于卡顿端"的情形依旧经由 `apply-hard-seek` 常规路径终止会话。

## 约束：不得吞掉显式倍速变更

#190 第 4 条记录的边界。发送端的卡顿与其刻意的倍速调整**正交**——一并吞掉会让房间倍速直到对端恢复才同步。

第 3 条因此对 `explicit-ratechange` 例外。`syncPlaybackPosition` 本就接收 `syncIntent` 参数，无需新增管道。

## 测试

新增 4 条，其中 3 条判别测试回退源码后各自失败：

```
not ok 46 - a lagging buffering snapshot does not strip the soft-apply cooldown     (sync-controller)
not ok  8 - a peer's buffering does not abort an active catch-up, a real pause still does  (soft-apply)
not ok 13 - a frozen buffering snapshot leaves an in-flight catch-up rate alone     (player-binding)
```

第 4 条 `a deliberate rate change still applies even while the sender is buffering` 是守卫，改动前后都通过（改动前 rate 本就会写入）——这里如实标注，它的作用是防止日后把第 3 条的跳过扩大成吞掉 `explicit-ratechange`。

soft-apply 那条同时覆盖第 1、2 项：先断言刚卡顿时不取消，再把时间推进 3 秒（冻结位置已远落后于外推目标）断言仍不取消，最后断言真正的 `paused` 照常取消。

完整检查全绿：`format:check` / `lint` / `typecheck` / `build` / `test`（extension 516 项）。

## #190 剩余

| 阶段 | 状态 |
|---|---|
| R1 程序化回声污染显式动作信号 | ✅ #192 |
| **R4 buffering 中断追赶（本 PR）** | 本 PR |
| R3 发送端两套 seek 规则不一致 | 待办——危害已被 #189 部分化解，残留为"seek 后 2.5s 内的 canplay/timeupdate 仍带 explicit-seek，令对端无条件 hard-seek" |
| R2 `intendedPlayState` 双重角色 | 待办，前三步落地后重新评估 |

顺序较原计划做了调整：复核发现 R3 的危害因 #189 的接收端改动（`shouldTreatAsExplicitSeek` 现要求 `playState === "playing"`）已部分化解，而 R4 三条全部存活且直接削弱刚合入的 #188，故先做 R4。

🤖 Generated with [Claude Code](https://claude.com/claude-code)