### PR TITLE
fix: 周期心跳不再携带 explicit-seek 意图

### DIFF
--- a/extension/src/content/playback-broadcast.ts
+++ b/extension/src/content/playback-broadcast.ts
@@ -153,13 +153,24 @@ export function derivePlaybackSyncIntent(args: {
     return "explicit-ratechange";
   }
 
+  // `timeupdate` is deliberately absent. It is a periodic heartbeat, not part of
+  // the seek: it fires whenever 2s have passed since the last broadcast, which
+  // lands it squarely inside EXPLICIT_SEEK_BROADCAST_GRACE_MS after every user
+  // seek. Receivers turn `playing` + `explicit-seek` into an UNCONDITIONAL
+  // hard-seek (drift thresholds bypassed) that also tears down any in-flight
+  // correction session and arms the soft-apply cooldown — so tagging the
+  // heartbeat forced every peer to jump, and blacked out corrections, roughly
+  // two seconds after each seek even when they were already within 0.02s.
+  //
+  // The jump itself is never lost: the events below ARE the seek, and a seek
+  // large enough to matter still crosses the ordinary `playing-hard-drift`
+  // threshold if they were all suppressed.
   if (
     (args.eventSource !== "seeking" &&
       args.eventSource !== "seeked" &&
       args.eventSource !== "play" &&
       args.eventSource !== "playing" &&
-      args.eventSource !== "canplay" &&
-      args.eventSource !== "timeupdate") ||
+      args.eventSource !== "canplay") ||
     !hasActiveExplicitUserAction ||
     args.lastExplicitUserAction.kind !== "seek" ||
     args.now - args.lastExplicitUserAction.at >=

--- a/extension/test/playback-broadcast.test.ts
+++ b/extension/test/playback-broadcast.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { derivePlaybackSyncIntent } from "../src/content/playback-broadcast";
+import type { LocalPlaybackEventSource } from "../src/content/runtime-state";
+
+function deriveAfterSeek(
+  eventSource: LocalPlaybackEventSource,
+  now: number,
+): ReturnType<typeof derivePlaybackSyncIntent> {
+  return derivePlaybackSyncIntent({
+    eventSource,
+    lastExplicitUserAction: { kind: "seek", at: 20_000 },
+    lastForcedPauseAt: 0,
+    now,
+    userGestureGraceMs: 1_200,
+  });
+}
+
+test("the seek's own events carry explicit-seek", () => {
+  for (const eventSource of [
+    "seeking",
+    "seeked",
+    "play",
+    "playing",
+    "canplay",
+  ] as const) {
+    assert.equal(
+      deriveAfterSeek(eventSource, 20_100),
+      "explicit-seek",
+      `${eventSource} should carry the seek intent`,
+    );
+  }
+});
+
+test("the periodic timeupdate heartbeat never carries explicit-seek", () => {
+  // `timeupdate` broadcasts fire once ~2s have passed since the last one, so
+  // after a seek there is reliably one inside the 2.5s intent window. Receivers
+  // turn `playing` + `explicit-seek` into an unconditional hard-seek that also
+  // tears down in-flight corrections, so tagging the heartbeat made every peer
+  // jump ~2s after each seek even when already in sync.
+  assert.equal(deriveAfterSeek("timeupdate", 22_100), undefined);
+  // Not merely a window question — it must not carry the intent at any point.
+  assert.equal(deriveAfterSeek("timeupdate", 20_100), undefined);
+});
+
+test("explicit-seek still expires once the broadcast grace elapses", () => {
+  assert.equal(deriveAfterSeek("seeked", 22_400), "explicit-seek");
+  assert.equal(deriveAfterSeek("seeked", 22_600), undefined);
+});
+
+test("an unrelated action kind never produces explicit-seek", () => {
+  assert.equal(
+    derivePlaybackSyncIntent({
+      eventSource: "seeked",
+      lastExplicitUserAction: { kind: "play", at: 20_000 },
+      lastForcedPauseAt: 0,
+      now: 20_100,
+      userGestureGraceMs: 1_200,
+    }),
+    undefined,
+  );
+});
+
+test("a ratechange gesture is reported as explicit-ratechange", () => {
+  assert.equal(
+    derivePlaybackSyncIntent({
+      eventSource: "ratechange",
+      lastExplicitUserAction: { kind: "ratechange", at: 20_000 },
+      lastForcedPauseAt: 0,
+      now: 20_100,
+      userGestureGraceMs: 1_200,
+    }),
+    "explicit-ratechange",
+  );
+});
+
+test("an action that predates a forced pause is not an active user intent", () => {
+  assert.equal(
+    derivePlaybackSyncIntent({
+      eventSource: "seeked",
+      lastExplicitUserAction: { kind: "seek", at: 20_000 },
+      lastForcedPauseAt: 20_050,
+      now: 20_100,
+      userGestureGraceMs: 1_200,
+    }),
+    undefined,
+  );
+});


### PR DESCRIPTION
Refs #190 — 这是 #190 的第三步（R3）。前两步 R1/R4 已由 #192 / #193 合入。

## 问题

`derivePlaybackSyncIntent` 把 `timeupdate` 也列入可携带 `explicit-seek` 的事件源，窗口为 `max(userGestureGraceMs, EXPLICIT_SEEK_BROADCAST_GRACE_MS)` = **2500ms**。

而 `timeupdate` 的广播条件是"距上次广播超过 2000ms"（`playback-binding-controller.ts` 的 `onTimeUpdate`），所以每次用户 seek 之后约 **T+2000~2400 必有一条落在该窗口内**。

接收端的处理链：

| 环节 | 行为 |
|---|---|
| `shouldTreatAsExplicitSeek` | `playing` + `explicit-seek` → true |
| `decidePlaybackReconcileMode` | `isExplicitSeek` → **无条件 hard-seek**，绕过全部漂移阈值 |
| `onPlaybackAdjusted` | `apply-hard-seek` → 取消追赶会话 + 武装 2500ms cooldown |

结果：**每次 seek 之后约两秒，所有对端会被强制跳转一次并进入 2.5 秒校正黑屏期**——哪怕它们本已同步到 0.02s 以内。这与 #185 / #188 / #193 建立的收敛机制直接冲突：刚修好的平滑收敛会被这一下强制跳转打断。

## 改动

从事件源列表中移除 `timeupdate`。它是**周期心跳**而非 seek 的组成部分，两秒后重新断言一次 seek 不携带任何新信息。

跳转本身不会丢失：

- 其余事件源（`seeking`/`seeked`/`play`/`playing`/`canplay`）**就是** seek 本身；
- 即使它们全部被其他守卫抑制，足够大的跳转仍会越过常规的 `playing-hard-drift` 阈值（1.2s）而被 hard-seek 跟随；
- 小到不越过阈值的跳转，本就意味着对端已经基本对齐，无需强制。

`EXPLICIT_SEEK_BROADCAST_GRACE_MS = 2500` 本身保留——它对真正的 seek 完成事件（慢速 seek 的 `seeked`/`canplay` 可能晚到）有意义。

## 来源考据

该事件源与 2500ms 窗口同为 `44f87c5 "fix: harden synced playback state handling"` 一并引入，commit message 只有一行，无更细的理由记录。所以移除它没有与某个已知修复冲突的证据。

## 测试

`playback-broadcast.ts` 此前没有任何测试，新建测试文件覆盖 6 条，其中判别测试回退源码后失败：

```
not ok 2 - the periodic timeupdate heartbeat never carries explicit-seek
```

其余 5 条是守卫，锁定这次改动**不应**波及的行为：seek 自身事件仍带意图、意图仍会在 grace 后过期、不相关的动作类型不产生 seek 意图、ratechange 仍产生 `explicit-ratechange`、早于强制暂停的动作不算活动意图。

完整检查全绿：`format:check` / `lint` / `typecheck` / `build` / `test`（extension 526 项）。

## #190 剩余

| 阶段 | 状态 |
|---|---|
| R1 程序化回声污染显式动作信号 | ✅ #192 |
| R4 buffering 中断追赶 | ✅ #193 |
| **R3 发送端 seek 规则（本 PR）** | 本 PR |
| R2 `intendedPlayState` 双重角色 | 待评估 |

R2 是纯重构（该字段同时表示"房间意图"与"上次广播状态"，被广播回写后使门控自我失效）。前三步落地后我会重新评估它是否仍有实际危害，还是仅剩概念上的不整洁。

🤖 Generated with [Claude Code](https://claude.com/claude-code)