### PR TITLE
fix: 用户拖动进度不再被自己触发的倍速回写窗口吞掉

### DIFF
--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -211,7 +211,18 @@ export function createPlaybackBindingController(args: {
    * action is merely the behaviour that existed before this guard, whereas
    * discarding a real interaction would be a new harm introduced by it.
    */
-  function isProgrammaticEventEcho(): boolean {
+  function isProgrammaticEventEcho(kind: ExplicitUserActionKind): boolean {
+    // A ratechange-scoped window only wrote a playback rate, so it can only
+    // explain a `ratechange`. It is typically armed BY the action being
+    // recorded here (`onSeeking` / `onPause` cancel the soft apply before
+    // recording), which would otherwise make every such gesture look like our
+    // own echo a few milliseconds after the user made it.
+    if (
+      args.runtimeState.programmaticApplyScope === "ratechange" &&
+      kind !== "ratechange"
+    ) {
+      return false;
+    }
     return (
       nowOf() < args.runtimeState.programmaticApplyUntil &&
       args.runtimeState.lastUserGestureInPlayerAt <
@@ -220,7 +231,7 @@ export function createPlaybackBindingController(args: {
   }
 
   function rememberExplicitPlaybackAction(playState: "playing" | "paused") {
-    if (isProgrammaticEventEcho()) {
+    if (isProgrammaticEventEcho(playState === "playing" ? "play" : "pause")) {
       return;
     }
     if (
@@ -235,7 +246,7 @@ export function createPlaybackBindingController(args: {
   }
 
   function rememberExplicitUserAction(kind: ExplicitUserActionKind) {
-    if (isProgrammaticEventEcho()) {
+    if (isProgrammaticEventEcho(kind)) {
       return;
     }
     if (
@@ -269,6 +280,11 @@ export function createPlaybackBindingController(args: {
     const signature = args.runtimeState.programmaticApplySignature;
     if (
       signature === null ||
+      // A ratechange-scoped window never applied a remote pause; its playState
+      // is only whatever the element happened to be doing when the rate was
+      // restored, so reading it as an in-flight paused-apply would suppress the
+      // buffer classification for a stall we really are experiencing.
+      args.runtimeState.programmaticApplyScope !== "all" ||
       signature.playState !== "paused" ||
       now >= args.runtimeState.programmaticApplyUntil
     ) {

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -54,6 +54,8 @@ export interface ProgrammaticPlaybackSignature {
   playbackRate: number;
 }
 
+export type ProgrammaticApplyScope = "all" | "ratechange";
+
 export type PendingLocalPlaybackOverrideKind = "seek" | "ratechange";
 
 export interface PendingLocalPlaybackOverride {
@@ -138,6 +140,18 @@ export interface ContentRuntimeState {
    * can belong to the user.
    */
   programmaticApplyAt: number;
+  /**
+   * Which local events the open window is allowed to explain.
+   *
+   * `"all"` is a real apply of a remote state: it writes currentTime and/or
+   * play/pause, so every transport event that follows may be its echo.
+   * `"ratechange"` is the soft-apply cancel restoring its snapshot playback
+   * rate — the only DOM event that write can produce. Scoping it matters
+   * because that cancel is usually triggered BY the user (their `seeking` /
+   * `pause` handler calls it): a window that also claimed their seek would
+   * discard the very interaction that opened it.
+   */
+  programmaticApplyScope: ProgrammaticApplyScope;
   programmaticApplySignature: ProgrammaticPlaybackSignature | null;
   softApplyCooldownUntil: number;
   softApplyCooldownUrl: string | null;
@@ -296,6 +310,7 @@ export function createContentRuntimeState(): ContentRuntimeState {
     pendingPlaybackApplication: null,
     programmaticApplyUntil: 0,
     programmaticApplyAt: 0,
+    programmaticApplyScope: "all",
     programmaticApplySignature: null,
     softApplyCooldownUntil: 0,
     softApplyCooldownUrl: null,

--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -11,6 +11,7 @@ import {
 import type {
   ContentRuntimeState,
   LocalPlaybackEventSource,
+  ProgrammaticApplyScope,
 } from "./runtime-state";
 
 const SOFT_APPLY_RECOVERY_THRESHOLD_SECONDS = 0.2;
@@ -72,6 +73,7 @@ export function createSoftApplyController(args: {
     signature: ReturnType<typeof createProgrammaticPlaybackSignature>,
     reason: "pending" | "apply",
     actorId?: string,
+    scope?: ProgrammaticApplyScope,
   ) => void;
 }): SoftApplyController {
   const nowOf = () => args.getNow?.() ?? Date.now();
@@ -159,6 +161,12 @@ export function createSoftApplyController(args: {
       Math.abs(video.playbackRate - session.restorePlaybackRate) > 0.01
     ) {
       setVideoPlaybackRate(video, session.restorePlaybackRate);
+      // Scope the window to `ratechange`: the rate write above is the only DOM
+      // event this cancel produces. Most cancels are triggered by the user —
+      // `onSeeking` / `onPause` call us before recording their explicit action —
+      // so an unscoped window would open microseconds after their gesture and
+      // then classify their own seek/pause as our echo, dropping both the
+      // recorded action and the broadcast. The room would then pull them back.
       args.armProgrammaticApplyWindow(
         {
           url: session.normalizedUrl,
@@ -167,6 +175,8 @@ export function createSoftApplyController(args: {
           playbackRate: session.restorePlaybackRate,
         },
         "apply",
+        "system",
+        "ratechange",
       );
     }
     if (

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -37,6 +37,7 @@ import { createPendingLocalOverrideController } from "./pending-local-override";
 import type {
   ContentRuntimeState,
   LocalPlaybackEventSource,
+  ProgrammaticApplyScope,
 } from "./runtime-state";
 
 /** Tolerance for treating two broadcast positions as the same frozen instant. */
@@ -240,6 +241,7 @@ export function createSyncController(args: {
     signature: ReturnType<typeof createProgrammaticPlaybackSignature>,
     reason: "pending" | "apply",
     actorId = "system",
+    scope: ProgrammaticApplyScope = "all",
   ): void {
     // Normalize the signature url at the single write point so every consumer
     // (programmatic-event guard, programmatic-paused window, programmatic
@@ -254,10 +256,11 @@ export function createSyncController(args: {
       url: normalizedSignatureUrl,
     };
     args.runtimeState.programmaticApplyAt = nowOf();
+    args.runtimeState.programmaticApplyScope = scope;
     args.runtimeState.programmaticApplyUntil =
       nowOf() + args.programmaticApplyWindowMs;
     args.debugLog(
-      `Programmatic apply window armed actor=${actorId} playState=${signature.playState} url=${signature.url} delta=n/a result=${reason} until=${args.runtimeState.programmaticApplyUntil}`,
+      `Programmatic apply window armed actor=${actorId} playState=${signature.playState} url=${signature.url} delta=n/a result=${reason} scope=${scope} until=${args.runtimeState.programmaticApplyUntil}`,
     );
   }
 
@@ -290,6 +293,7 @@ export function createSyncController(args: {
     pendingLocalOverride.clearPendingLocalPlaybackOverride("reset");
     args.runtimeState.programmaticApplyUntil = 0;
     args.runtimeState.programmaticApplyAt = 0;
+    args.runtimeState.programmaticApplyScope = "all";
     args.runtimeState.programmaticApplySignature = null;
     softApply.clearSoftApplyCooldown();
     args.runtimeState.lastLocalPlaybackVersion = null;
@@ -1117,6 +1121,7 @@ export function createSyncController(args: {
     const programmaticDecision = shouldSuppressProgrammaticEventGuard({
       programmaticApplyUntil: args.runtimeState.programmaticApplyUntil,
       programmaticApplyAt: args.runtimeState.programmaticApplyAt,
+      programmaticApplyScope: args.runtimeState.programmaticApplyScope,
       programmaticApplySignature: args.runtimeState.programmaticApplySignature,
       normalizedCurrentUrl: normalizedCurrentVideoUrl,
       playState,
@@ -1388,8 +1393,13 @@ export function createSyncController(args: {
       lastExplicitUserAction: args.runtimeState.lastExplicitUserAction,
       lastForcedPauseAt: args.runtimeState.lastForcedPauseAt,
       programmaticApplyUntil: args.runtimeState.programmaticApplyUntil,
+      // A ratechange-scoped window only restored a playback rate, so its
+      // signature playState is incidental (it is whatever the element happened
+      // to be doing) and must not veto the user-initiated flag on a real pause.
       programmaticApplyPlayState:
-        args.runtimeState.programmaticApplySignature?.playState ?? null,
+        args.runtimeState.programmaticApplyScope === "all"
+          ? (args.runtimeState.programmaticApplySignature?.playState ?? null)
+          : null,
       now,
       userGestureGraceMs: args.userGestureGraceMs,
     });

--- a/extension/src/content/sync-guards.ts
+++ b/extension/src/content/sync-guards.ts
@@ -4,6 +4,7 @@ import type {
   ExplicitUserAction,
   ExplicitUserActionKind,
   LocalPlaybackEventSource,
+  ProgrammaticApplyScope,
   ProgrammaticPlaybackSignature,
   RecentRemotePlayingIntent,
   SuppressedRemotePlayback,
@@ -66,6 +67,8 @@ export interface ProgrammaticEventSuppressionInput {
   programmaticApplyUntil: number;
   /** When the current programmatic-apply window opened. */
   programmaticApplyAt: number;
+  /** Which event sources the open window is allowed to explain. */
+  programmaticApplyScope: ProgrammaticApplyScope;
   programmaticApplySignature: ProgrammaticPlaybackSignature | null;
   normalizedCurrentUrl: string | null;
   playState: PlaybackState["playState"];
@@ -317,6 +320,22 @@ export function shouldSuppressProgrammaticEvent(
   if (
     !input.normalizedCurrentUrl ||
     input.normalizedCurrentUrl !== input.programmaticApplySignature.url
+  ) {
+    return {
+      shouldSuppress: false,
+      nextProgrammaticApplyUntil: input.programmaticApplyUntil,
+      nextProgrammaticApplySignature: input.programmaticApplySignature,
+    };
+  }
+
+  // A ratechange-scoped window was opened by the soft-apply cancel restoring
+  // its snapshot rate, and a rate write produces exactly one DOM event. Any
+  // other transport event inside it belongs to whatever triggered the cancel —
+  // usually the user's own seek or pause, which must still reach the room.
+  // The window stays armed so the `ratechange` it exists for is still caught.
+  if (
+    input.programmaticApplyScope === "ratechange" &&
+    input.eventSource !== "ratechange"
   ) {
     return {
       shouldSuppress: false,

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -3642,3 +3642,113 @@ test("playback binding controller does not let a stray page click authorize appl
     dom.restore();
   }
 });
+
+test("a user seek that cancels an active rate catch-up is still recorded", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 1_000;
+  runtimeState.lastUserGestureInPlayerAt = 1_000;
+  const events: string[] = [];
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async (_video, eventSource) => {
+      events.push(eventSource ?? "manual");
+    },
+    // Mirror the real soft-apply cancel: restoring the snapshot rate arms a
+    // programmatic window whose start (1_100) post-dates the gesture (1_000)
+    // that triggered this very cancel.
+    cancelActiveSoftApply: () => {
+      runtimeState.programmaticApplyAt = 1_100;
+      runtimeState.programmaticApplyUntil = 1_800;
+      runtimeState.programmaticApplyScope = "ratechange";
+      runtimeState.programmaticApplySignature = {
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        playState: "buffering",
+        currentTime: 119.49,
+        playbackRate: 2,
+      };
+    },
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 1_100,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("seeking")?.(new Event("seeking"));
+
+    // Without this the action stays null, `derivePlaybackSyncIntent` cannot tag
+    // the broadcast and the guard's explicit-action bypass has nothing to match,
+    // so the seek never leaves this client and the room pulls it back.
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "seek",
+      at: 1_100,
+    });
+
+    await Promise.resolve();
+    assert.deepEqual(events, ["seeking"]);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("a user pause that cancels an active rate catch-up is still recorded", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 1_000;
+  runtimeState.lastUserGestureInPlayerAt = 1_000;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {
+      runtimeState.programmaticApplyAt = 1_100;
+      runtimeState.programmaticApplyUntil = 1_800;
+      runtimeState.programmaticApplyScope = "ratechange";
+      runtimeState.programmaticApplySignature = {
+        url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+        playState: "paused",
+        currentTime: 119.49,
+        playbackRate: 2,
+      };
+    },
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 1_100,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("pause")?.(new Event("pause"));
+
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "pause",
+      at: 1_100,
+    });
+    assert.deepEqual(runtimeState.lastExplicitPlaybackAction, {
+      playState: "paused",
+      at: 1_100,
+    });
+  } finally {
+    dom.restore();
+  }
+});

--- a/extension/test/soft-apply-controller.test.ts
+++ b/extension/test/soft-apply-controller.test.ts
@@ -480,3 +480,40 @@ test("hasActiveCorrectionSession covers real soft-apply, not just rate-only catc
     windowStub.restore();
   }
 });
+
+test("the rate restore on cancel arms a ratechange-scoped window", () => {
+  const windowStub = installWindowStub();
+  try {
+    const runtimeState = createContentRuntimeState();
+    const video = createVideo({ currentTime: 24, playbackRate: 1 });
+    const armed: Array<{ actorId?: string; scope?: string }> = [];
+    const controller = createSoftApplyController({
+      runtimeState,
+      normalizeUrl: (url) => url?.trim() ?? null,
+      getVideoElement: () => video,
+      debugLog: () => {},
+      userGestureGraceMs: 300,
+      programmaticApplyWindowMs: 700,
+      getNow: () => 10_000,
+      armProgrammaticApplyWindow: (_signature, _reason, actorId, scope) => {
+        armed.push({ actorId, scope });
+      },
+    });
+
+    controller.upsertActiveSoftApply(
+      createPlayback({ currentTime: 25.4 }),
+      1.4,
+    );
+    // The reconcile (not the session) writes the elevated rate; mirror it so
+    // the cancel below has a rate to restore, which is what arms the window.
+    video.playbackRate = 1.25;
+
+    // `onSeeking` calls this before recording the user's explicit seek, so the
+    // window it opens must only claim the `ratechange` the restore produces.
+    controller.cancelActiveSoftApply(video, "seek");
+
+    assert.deepEqual(armed, [{ actorId: "system", scope: "ratechange" }]);
+  } finally {
+    windowStub.restore();
+  }
+});

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -2457,3 +2457,88 @@ test("a buffering apply that actually wrote the rate still clears the cooldown",
   assert.equal(harness.runtimeState.softApplyCooldownUntil, 0);
   assert.ok(Math.abs(video.currentTime - 514.9) < 0.001);
 });
+
+test("sync controller keeps userInitiated on a pause that cancelled a rate catch-up", async () => {
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({
+    paused: true,
+    readyState: 4,
+    currentTime: 40,
+  });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.intendedPlayState = "paused";
+  harness.runtimeState.lastUserGestureAt = 20_350;
+  harness.runtimeState.lastForcedPauseAt = 0;
+  harness.runtimeState.lastExplicitUserAction = { kind: "pause", at: 20_350 };
+  harness.runtimeState.pauseStartedAt = 20_350;
+  harness.runtimeState.pauseClassifiedAsBuffer = false;
+  // The user's own `pause` handler cancelled the active catch-up, and the rate
+  // restore armed this window. Its signature playState is merely whatever the
+  // element was doing (paused) — it is NOT an in-flight remote paused-apply, so
+  // it must not strip the user-initiated flag and subject peers to the pause
+  // debounce.
+  harness.runtimeState.programmaticApplyAt = 20_360;
+  harness.runtimeState.programmaticApplyUntil = 21_060;
+  harness.runtimeState.programmaticApplyScope = "ratechange";
+  harness.runtimeState.programmaticApplySignature = {
+    url: sharedVideo.url,
+    playState: "paused",
+    currentTime: 40,
+    playbackRate: 1,
+  };
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+
+  harness.controller = createSyncController({
+    runtimeState: harness.runtimeState,
+    lastAppliedVersionByActor: new Map(),
+    broadcastLogState: { key: null, at: 0 },
+    ignoredSelfPlaybackLogState: { key: null, at: 0 },
+    localIntentGuardMs: 500,
+    pauseHoldMs: 1_000,
+    initialRoomStatePauseHoldMs: 1_500,
+    remoteEchoSuppressionMs: 800,
+    remotePlayTransitionGuardMs: 500,
+    remoteFollowPlayingWindowMs: 3_000,
+    programmaticApplyWindowMs: 700,
+    userGestureGraceMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    remotePauseDebounceMs: 0,
+    duplicateBroadcastWindowMs: 1_000,
+    nextSeq: () => 1,
+    markBroadcastAt: () => {},
+    getNow: () => 20_400,
+    debugLog: (message) => harness.debugLogs.push(message),
+    shouldLogHeartbeat: () => true,
+    runtimeSendMessage: async (message) => {
+      harness.runtimeMessages.push(message);
+      return null;
+    },
+    getVideoElement: () => video,
+    getCurrentPlaybackVideo: async () => sharedVideo,
+    getSharedVideo: () => sharedVideo,
+    normalizeUrl: (url) => url?.trim() ?? null,
+    notifyRoomStateToasts: () => {},
+    maybeShowSharedVideoToast: () => {},
+  });
+
+  await harness.controller.broadcastPlayback(video, "pause");
+
+  assert.equal(harness.runtimeMessages.length, 1);
+  const payload = (
+    harness.runtimeMessages[0] as {
+      payload: { playState: string; userInitiated?: boolean };
+    }
+  ).payload;
+  assert.equal(payload.playState, "paused");
+  assert.equal(payload.userInitiated, true);
+});

--- a/extension/test/sync-guards.test.ts
+++ b/extension/test/sync-guards.test.ts
@@ -522,3 +522,71 @@ test("does not let an explicit action from before the apply window bypass suppre
 
   assert.equal(decision.shouldSuppress, true);
 });
+
+test("a ratechange-scoped window does not swallow the seek that opened it", () => {
+  // Reproduces the observed "seek gets pulled back": the user's `onSeeking`
+  // handler cancels the active rate catch-up, the cancel restores the snapshot
+  // rate and arms a window microseconds later, and the window then matched the
+  // user's own `seeking` broadcast (same url, same time, same rate) and dropped
+  // it. With no broadcast, the next peer heartbeat hard-seeked them back.
+  const input = {
+    programmaticApplyAt: 10_000,
+    programmaticApplyUntil: 10_700,
+    programmaticApplySignature: {
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      playState: "buffering" as const,
+      currentTime: 119.49,
+      playbackRate: 2,
+    },
+    normalizedCurrentUrl: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    playState: "buffering" as const,
+    currentTime: 119.49,
+    playbackRate: 2,
+    eventSource: "seeking" as const,
+    // Swallowed by `isProgrammaticEventEcho`, so the record is still the stale
+    // ratechange from before the seek and cannot bypass the guard.
+    lastExplicitUserAction: { kind: "ratechange" as const, at: 9_000 },
+    now: 10_005,
+    userGestureGraceMs: 1_200,
+  };
+
+  assert.equal(
+    shouldSuppressProgrammaticEvent({
+      ...input,
+      programmaticApplyScope: "ratechange",
+    }).shouldSuppress,
+    false,
+  );
+  // A real apply of a remote state still suppresses the identical echo.
+  assert.equal(
+    shouldSuppressProgrammaticEvent({ ...input, programmaticApplyScope: "all" })
+      .shouldSuppress,
+    true,
+  );
+});
+
+test("a ratechange-scoped window still suppresses its own rate echo", () => {
+  const decision = shouldSuppressProgrammaticEvent({
+    programmaticApplyAt: 10_000,
+    programmaticApplyUntil: 10_700,
+    programmaticApplyScope: "ratechange",
+    programmaticApplySignature: {
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      playState: "playing",
+      currentTime: 119.49,
+      playbackRate: 2,
+    },
+    normalizedCurrentUrl: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    playState: "playing",
+    currentTime: 119.49,
+    playbackRate: 2,
+    eventSource: "ratechange",
+    lastExplicitUserAction: null,
+    now: 10_005,
+    userGestureGraceMs: 1_200,
+  });
+
+  assert.equal(decision.shouldSuppress, true);
+  // The window must survive so a follow-up rate echo is caught too.
+  assert.equal(decision.nextProgrammaticApplyUntil, 10_700);
+});


### PR DESCRIPTION
## 现象

同步播放中拖动进度条，进度会在约 1 秒后被拉回原处。测试日志里连续复现两次。

## 根因

`onSeeking` / `onPause` 的第一件事是调用 `cancelActiveSoftApply`。该取消会把漂移追赶用的临时倍速写回快照值，并为这次写入武装一个 700ms 的 programmatic apply 窗口 —— 窗口起点因此比触发它的用户手势晚几毫秒。

日志（seek 端，tab=637604932）：

```
13:25:21 Programmatic apply window armed actor=system playState=buffering ... until=...922675
13:25:21 Cancelled soft apply url=... target=1120.34 result=seek
13:25:21 Broadcast trace source=seeking playState=buffering t=119.49
         explicitAction=ratechange@...909619   ← 12 秒前的陈旧记录
         lastGestureAt=...921971               ← 手势比窗口早 4ms
         programmatic=buffering@...@922675
13:25:21 Skip broadcast result=programmatic-seeking
```

两道门同时关上：

1. `isProgrammaticEventEcho` 判定 `lastUserGestureInPlayerAt(921971) < programmaticApplyAt(921975)` 成立，`rememberExplicitUserAction("seek")` 被早退，用户这次 seek 从未被记为显式动作；
2. 因此 `shouldSuppressProgrammaticEventGuard` 的显式动作旁路（要求 `kind` 匹配且 `at >= programmaticApplyAt`）失效，而签名（同 url / 同 currentTime / 同 rate）恰好完全匹配 → 整条 `seeking` 广播被当成自身回声丢弃。

本端跳转从未发出房间，对端 1 秒后的下一次心跳（`playing-hard-drift`）把它 hard-seek 回旧位置。同一份日志里 13:25:25 的那次 seek 成功了，正因为当时 `programmatic=none@0` —— 没有活跃的追赶会话可取消。

`hasActiveCorrectionSession` 相关会话在 #188 改为收敛到零后存续更久，撞上这个窗口的概率随之上升，这解释了为何近期才显现。

## 修复

给 programmatic apply 窗口加作用域。倍速回写只可能产生 `ratechange` 一个 DOM 事件，所以 `cancelActiveSoftApply` 武装的窗口标记为 `ratechange` 作用域，只解释 ratechange；真正应用远端状态（会写 currentTime / play / pause）仍是 `all`。

四个消费点相应收敛：

| 消费点 | 变更 |
|---|---|
| `shouldSuppressProgrammaticEventGuard` | ratechange 作用域下放行其他事件源，窗口保留以继续捕获自身倍速回声 |
| `isProgrammaticEventEcho` | 按被记录的动作类型判断，非 ratechange 不算回声 |
| `isInsideProgrammaticPausedWindow` | ratechange 作用域不是"远端暂停应用进行中" |
| `deriveUserInitiatedPause` | ratechange 作用域的签名 playState 是偶然值，不参与判定 |

## 同类路径审计

| 武装点 | 结论 |
|---|---|
| `room-state-apply-controller.ts:773`（pending 应用） | 真实远端应用，保持 `all` |
| `sync-controller.ts:416`（`markProgrammaticApply`） | 真实远端应用，保持 `all`；紧随 cancel 之后覆盖作用域，顺序正确 |
| `onRateChange` | 走 `user-ratechange` 分支不做回写、不武装窗口；且记录先于取消，本就无此问题 |

## 验证

6 个新增测试，每个都逐一 `git stash` 对应源文件确认在修复前失败：

- `soft-apply-controller.test.ts` — 取消时的倍速回写以 `ratechange` 作用域武装
- `sync-guards.test.ts` ×2 — ratechange 作用域放行 seeking / 仍拦截自身 ratechange；同一组输入在 `all` 作用域下仍然拦截
- `playback-binding-controller.test.ts` ×2 — 取消追赶的用户 seek / pause 仍被记为显式动作并广播
- `sync-controller.test.ts` — 取消了追赶的用户暂停仍带 `userInitiated`

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` 全部通过，extension 526 → 532。

🤖 Generated with [Claude Code](https://claude.com/claude-code)