### PR TITLE
fix: 未观测到的暂停改在广播漏斗统一分类

### DIFF
--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -168,6 +168,13 @@ export function createPlaybackBindingController(args: {
     eventSource: LocalPlaybackEventSource,
     followUpMs?: number,
   ) {
+    // Every DOM-event-driven broadcast funnels through here, so this is the one
+    // place guaranteed to see an unobserved pause before it is reported. Which
+    // event happens to notice first is not predictable — a stalled element has
+    // been observed surfacing through `ratechange` (the player resetting the
+    // rate) with no transport event ahead of it — so classifying per handler
+    // leaves a hole for every source that was not listed.
+    classifyUnobservedPauseAsBuffer(video);
     void args.broadcastPlayback(video, eventSource);
     if (followUpMs) {
       window.setTimeout(() => {
@@ -303,16 +310,22 @@ export function createPlaybackBindingController(args: {
    * Bilibili's player rebuilds its media element to recover from a buffer
    * stall, and the replacement element *starts* paused — there is no state
    * transition, so no `pause` event is dispatched and `onPause`'s classifier
-   * never runs. The element then emits `seeking`/`seeked`/`canplay` while it
-   * restores the playhead, and each of those broadcasts reports `paused` to the
-   * room: every peer stops, hard-seeks, and resumes about a second later.
+   * never runs. Whatever the element emits next reports `paused` to the room:
+   * every peer stops, hard-seeks, and resumes about a second later.
    *
-   * Detect it from the transport events instead — the element is paused, we
-   * never recorded a pause for it, the room still believes we are playing, and
-   * no user gesture accounts for it. Classifying it as buffer-induced routes
-   * the broadcast through the existing `buffering` state (which leaves peers
-   * playing) and arms the same bounded upgrade, so a stall that never recovers
-   * is still reported as a genuine `paused` afterwards.
+   * Detect it from the state instead — the element is paused, we never recorded
+   * a pause for it, the room still believes we are playing, and no user gesture
+   * accounts for it. Classifying it as buffer-induced routes the broadcast
+   * through the existing `buffering` state (which leaves peers playing) and arms
+   * the same bounded upgrade, so a stall that never recovers is still reported
+   * as a genuine `paused` afterwards.
+   *
+   * Called from `scheduleBroadcast` rather than from individual handlers: the
+   * event that first observes the stall varies (`seeking`/`canplay` were the
+   * originally handled cases, but `ratechange` has been observed arriving first
+   * when the player resets the playback rate), and every miss costs peers a
+   * spurious pause. All five preconditions below are event-agnostic, so running
+   * it on the shared path is both safe and complete.
    */
   function classifyUnobservedPauseAsBuffer(video: HTMLVideoElement): void {
     const now = nowOf();
@@ -1046,12 +1059,10 @@ export function createPlaybackBindingController(args: {
       },
       onWaiting: () => {
         args.runtimeState.lastBufferSignalAt = nowOf();
-        classifyUnobservedPauseAsBuffer(video);
         scheduleBroadcast(video, "waiting");
       },
       onStalled: () => {
         args.runtimeState.lastBufferSignalAt = nowOf();
-        classifyUnobservedPauseAsBuffer(video);
         scheduleBroadcast(video, "stalled");
       },
       onLoadedMetadata: () => {
@@ -1063,7 +1074,6 @@ export function createPlaybackBindingController(args: {
         if (!forcePauseWhileWaitingForInitialRoomState(video)) {
           args.applyPendingPlaybackApplication(video);
         }
-        classifyUnobservedPauseAsBuffer(video);
         scheduleBroadcast(video, "canplay", 120);
       },
       onPlaying: () => {
@@ -1083,7 +1093,6 @@ export function createPlaybackBindingController(args: {
           args.cancelActiveSoftApply(video, "seek");
         }
         rememberExplicitUserAction("seek");
-        classifyUnobservedPauseAsBuffer(video);
         scheduleBroadcast(video, "seeking");
       },
       onSeeked: () => {
@@ -1091,7 +1100,6 @@ export function createPlaybackBindingController(args: {
           args.cancelActiveSoftApply(video, "seek");
         }
         rememberExplicitUserAction("seek");
-        classifyUnobservedPauseAsBuffer(video);
         scheduleBroadcast(video, "seeked", 120);
       },
       onRateChange: () => {

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -3752,3 +3752,87 @@ test("a user pause that cancels an active rate catch-up is still recorded", () =
     dom.restore();
   }
 });
+
+test("a ratechange is enough to classify an unobserved pause as buffering", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  // The player stalled and silently reset the catch-up rate: the element is
+  // paused, no `pause` event ever fired, and `ratechange` is the first handler
+  // to see it. Reporting that as a hard `paused` makes every peer stop and
+  // resume ~1s later, which is what the room observed.
+  (dom.video as { paused: boolean }).paused = true;
+  runtimeState.intendedPlayState = "playing";
+  runtimeState.pauseStartedAt = 0;
+  runtimeState.lastUserGestureAt = 0;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("ratechange")?.(new Event("ratechange"));
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
+    assert.equal(runtimeState.pauseStartedAt, 10_000);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("a real user pause is not reclassified by the shared broadcast path", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  (dom.video as { paused: boolean }).paused = true;
+  runtimeState.intendedPlayState = "playing";
+  // A fresh in-player gesture accounts for this pause, so it is a real stop.
+  runtimeState.lastUserGestureAt = 9_900;
+  runtimeState.lastUserGestureInPlayerAt = 9_900;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 10_000,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("pause")?.(new Event("pause"));
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
+  } finally {
+    dom.restore();
+  }
+});


### PR DESCRIPTION
## 现象

同步播放中出现一次"暂停又立刻恢复"。日志来自发出端。

## 根因

`classifyUnobservedPauseAsBuffer`（#184 引入）用于处理"播放器把元素置为 paused 却不派发 `pause` 事件"的情况，但它只挂在五个处理器上：`waiting` / `stalled` / `canplay` / `seeking` / `seeked`。

这次日志里第一个观察到该状态的是 **`ratechange`**——播放器把我们追赶用的临时倍速 1.12 重置回 1.00 时触发的：

```
14:24:19 Playback reconcile mode=rate-only ... appliedRate=1.12 restoreRate=1.00
14:24:19 Started soft apply target=253.43
...
14:24:21 Broadcast trace result=enter source=ratechange playState=paused t=255.11 rate=1.00
                                                          ^^^^^^^^^^^^^^^ 元素已暂停
14:24:21 Cancelled soft apply result=buffer-interrupt
14:24:21 Dispatch playback update playState=paused seq=2 source=ratechange
...
14:24:21 Dispatch playback update playState=playing seq=6 source=play
```

整段 14:24:21 **没有任何 `source=pause`**（对比 14:24:15 远端暂停应用时是有的），确认 `pause` 事件确实没派发。`ratechange` 不在名单内 → 分类器没跑 → `getBroadcastPlayState` 返回硬 `paused` → 广播出去，约 300ms 后再广播 `playing`。

逐条核对了分类器在那一刻的五个前置条件，**全部满足**：

| 条件 | 当时状态 |
|---|---|
| `video.paused` | ✓ trace `playState=paused` |
| `pauseStartedAt === 0` | ✓ 14:24:18 的 `onPlay` 走到了 `scheduleBroadcast`，说明 `clearActivePauseClassification()` 已执行 |
| `intendedPlayState === "playing"` | ✓ trace `intendedState=playing` |
| 无近期手势 | ✓ `lastGestureAt` 是 204 秒前 |
| 不在程序化暂停窗口 | ✓ trace `programmatic=none@0` |

即：只要被调用就会命中，广播就会是 `buffering`，对端保持播放。

随后 14:24:21 确实有 `source=seeking`（`onSeeking` 会调分类器），但那时 seq=2 的 paused 广播已把 `intendedPlayState` 翻成 paused，第三个条件失效，静默返回——日志中没有 `Classified unobserved pause as buffering` 一行，与此吻合。

## 修复

哪个事件先观察到卡顿是不可预测的，而分类器的五个前置条件全部与事件源无关。因此改为在 `scheduleBroadcast`（所有 DOM 事件广播的必经漏斗）统一调用一次，并移除五处按处理器的重复调用。

对原有五个事件源，相对顺序不变（分类器仍在 `rememberExplicitUserAction` / `lastBufferSignalAt` 赋值之后、广播之前），行为等价；新覆盖 `play` / `pause` / `playing` / `ratechange`。

### 未纳入的三个直发广播点

| 位置 | 理由 |
|---|---|
| `armBufferPauseUpgrade` 的重播（:129） | 其职责正是把 buffering 升级回真实 `paused`，分类会与之矛盾（且 `pauseStartedAt > 0` 本就会短路） |
| 自然结束冲刷（:552） | 必须保持真实 `paused` |
| `timeupdate` 周期广播（:1130） | 自身已要求 `!video.paused`，分类器第一个条件永不成立 |

## 验证

- `a ratechange is enough to classify an unobserved pause as buffering` —— **区分性测试**，已 `git stash` 源文件确认修复前失败
- `a real user pause is not reclassified by the shared broadcast path` —— 守卫测试（修复前后均通过），确保新漏斗不会把真实用户暂停误判成缓冲

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` 全部通过，extension 532 → 534。

## 相关

同一份日志还暴露了一个独立问题：`defaultPlaybackRate` 在追赶会话取消时可能残留在追赶值上，导致约 4 秒内所有广播被 `unexpected-rate` 守卫拦截。与本 PR 无耦合，另开 PR 处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)