### PR TITLE
fix: 追赶会话取消时不再遗留抬高的 defaultPlaybackRate

### DIFF
--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -155,10 +155,22 @@ export function createSoftApplyController(args: {
     // When the user explicitly changes the playback rate, they have taken over
     // the rate — restoring the stale snapshot rate here would silently undo
     // their change once the session deadline elapses, so skip the restore.
+    //
+    // Both rates have to be checked, because the catch-up elevated both:
+    // `setVideoPlaybackRate` writes `defaultPlaybackRate` as well, and a media
+    // element resets `playbackRate` from that default on its next load. When the
+    // player has already reset the LIVE rate on its own (it does this while
+    // recovering from a stall), testing only `playbackRate` skips the restore
+    // and strands the elevated default. The element then resurrects the catch-up
+    // rate on the next load with no session left to undo it, and every broadcast
+    // is dropped by the unexpected-rate guard until some remote apply happens to
+    // write the rate back.
     if (
       reason !== "user-ratechange" &&
       video &&
-      Math.abs(video.playbackRate - session.restorePlaybackRate) > 0.01
+      (Math.abs(video.playbackRate - session.restorePlaybackRate) > 0.01 ||
+        Math.abs(video.defaultPlaybackRate - session.restorePlaybackRate) >
+          0.01)
     ) {
       setVideoPlaybackRate(video, session.restorePlaybackRate);
       // Scope the window to `ratechange`: the rate write above is the only DOM

--- a/extension/test/soft-apply-controller.test.ts
+++ b/extension/test/soft-apply-controller.test.ts
@@ -517,3 +517,85 @@ test("the rate restore on cancel arms a ratechange-scoped window", () => {
     windowStub.restore();
   }
 });
+
+test("cancel restores an elevated defaultPlaybackRate the player already reset", () => {
+  const windowStub = installWindowStub();
+  try {
+    const runtimeState = createContentRuntimeState();
+    const video = createVideo({
+      currentTime: 24,
+      playbackRate: 1,
+      defaultPlaybackRate: 1,
+    });
+    const controller = createSoftApplyController({
+      runtimeState,
+      normalizeUrl: (url) => url?.trim() ?? null,
+      getVideoElement: () => video,
+      debugLog: () => {},
+      userGestureGraceMs: 300,
+      programmaticApplyWindowMs: 700,
+      getNow: () => 10_000,
+      armProgrammaticApplyWindow: () => {},
+    });
+
+    controller.upsertActiveSoftApply(
+      createPlayback({ currentTime: 25.4 }),
+      1.4,
+    );
+    // The catch-up elevates both rates (`setVideoPlaybackRate` writes the
+    // default too, so the elevated rate survives a media-element reload).
+    video.playbackRate = 1.12;
+    video.defaultPlaybackRate = 1.12;
+    // While stalled, the player resets only the LIVE rate back to its own
+    // setting; the elevated default is left behind.
+    video.playbackRate = 1;
+
+    controller.cancelActiveSoftApply(video, "buffer-interrupt");
+
+    assert.equal(video.playbackRate, 1);
+    assert.equal(
+      video.defaultPlaybackRate,
+      1,
+      "the stranded default would resurrect the catch-up rate on the next load",
+    );
+  } finally {
+    windowStub.restore();
+  }
+});
+
+test("cancel still leaves an explicit user rate alone", () => {
+  const windowStub = installWindowStub();
+  try {
+    const runtimeState = createContentRuntimeState();
+    const video = createVideo({
+      currentTime: 24,
+      playbackRate: 1,
+      defaultPlaybackRate: 1,
+    });
+    const controller = createSoftApplyController({
+      runtimeState,
+      normalizeUrl: (url) => url?.trim() ?? null,
+      getVideoElement: () => video,
+      debugLog: () => {},
+      userGestureGraceMs: 300,
+      programmaticApplyWindowMs: 700,
+      getNow: () => 10_000,
+      armProgrammaticApplyWindow: () => {},
+    });
+
+    controller.upsertActiveSoftApply(
+      createPlayback({ currentTime: 25.4 }),
+      1.4,
+    );
+    // The user picked 2x from the speed menu, which sets both rates.
+    video.playbackRate = 2;
+    video.defaultPlaybackRate = 2;
+
+    controller.cancelActiveSoftApply(video, "user-ratechange");
+
+    assert.equal(video.playbackRate, 2);
+    assert.equal(video.defaultPlaybackRate, 2);
+  } finally {
+    windowStub.restore();
+  }
+});


### PR DESCRIPTION
## 现象

一次卡顿后，本端在约 4 秒内对房间完全静默——所有广播被 `unexpected-rate` 守卫拦掉：

```
14:24:21 → 14:24:24  unexpected-rate-{ratechange,play,playing,timeupdate} ×7
                      localRate=1.12 expectedRate=1.00
14:24:25 Playback reconcile mode=ignore ... wroteRate=true appliedRate=1.00   ← 靠远端心跳才恢复
```

## 根因

`setVideoPlaybackRate`（`player-binding.ts:56`）同时写 `playbackRate` 和 `defaultPlaybackRate`——这是有意的，元素重载时会用 default 重置实时倍速，写 default 才能让追赶倍速在重载后存活。

但 `cancelActiveSoftApply`（`soft-apply-controller.ts:158`）的恢复条件**只比较 `playbackRate`**：

```js
if (reason !== "user-ratechange" && video &&
    Math.abs(video.playbackRate - session.restorePlaybackRate) > 0.01) {
  setVideoPlaybackRate(video, session.restorePlaybackRate);   // 两个都写
}
```

日志中的实际序列：

| 时刻 | playbackRate | defaultPlaybackRate |
|---|---|---|
| 14:24:19 追赶启动 | 1.00 → **1.12** | 1.00 → **1.12** |
| 14:24:21 播放器卡顿恢复，自行重置实时倍速 | 1.12 → **1.00** | 1.12（未动） |
| 14:24:21 `buffer-interrupt` 取消会话 | 条件 `\|1.00-1.00\| > 0.01` 为假 → **整个分支跳过** | 1.12 **留下** |
| 之后元素重载 | ← default = **1.12** 复活 | 1.12 |

会话已经丢弃，没有任何东西再负责这个 default。房间期望 1.00，元素是 1.12，于是 `unexpected-rate` 守卫把每一条广播都拦掉，直到 14:24:25 一次远端应用的 ignore 分支恰好把倍速写回。

## 修复

改为两个倍速任一偏离即执行恢复。

恢复值是 `session.restorePlaybackRate`——会话启动时拍下的快照，即我们动手前的原值，所以这个写入只可能撤销我们自己的改动，不会碰用户的偏好。用户在会话期间显式改速会走 `user-ratechange` 分支，仍然完全跳过恢复（已有守卫测试覆盖）。

编程化窗口的武装保持在写入分支内不变：按 HTML 规范 `defaultPlaybackRate` 的变更同样触发 `ratechange`，所以 default-only 的恢复也需要这个窗口来吸收自身回声。

## 同类路径审计

其余四处 `setVideoPlaybackRate` 调用：

| 位置 | 结论 |
|---|---|
| `player-binding.ts:217`、`:242`（soft-apply / rate-only 抬速） | 无条件写入，本就同时写两个值；抬高的值由本 PR 修复后的取消路径负责归还，闭环成立 |
| `player-binding.ts:185`（hard-seek 分支）、`:280`（ignore 分支） | **不改**。它们是"把元素对齐到房间倍速"的应用方，不是我们自己写入的撤销方。本 PR 之后抬高的 default 只可能由 soft-apply 产生、且必由取消路径归还，不存在需要它们兜底的残留；反过来放宽条件会让每次 reconcile 都改写 `defaultPlaybackRate`，而那可能承载用户在播放器里记住的倍速偏好 |
| `soft-apply-controller.ts:255`（`upsertActiveSoftApply` 遇到无法归一化的 url 时直接丢弃会话，不恢复） | 同类形状，但实际不可达：调用方 `room-state-apply` 在到达此处前已用同一个 url 完成归一化与共享匹配。仅记录，不做投机性改动 |

## 验证

- `cancel restores an elevated defaultPlaybackRate the player already reset` —— **区分性测试**，已 `git stash` 源文件确认修复前失败
- `cancel still leaves an explicit user rate alone` —— 守卫测试（修复前后均通过），确认放宽条件没有波及用户显式改速的豁免

`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` 全部通过，extension 532 → 534。

## 相关

与 #196 出自同一份日志，但两者无耦合：#196 修的是那次卡顿为何被广播成 `paused`，本 PR 修的是卡顿过后为何静默 4 秒。

🤖 Generated with [Claude Code](https://claude.com/claude-code)