### PR TITLE
docs: 将 buffering seek 缺口的追踪指针改指 #198

### DIFF
--- a/extension/src/content/playback-reconcile.ts
+++ b/extension/src/content/playback-reconcile.ts
@@ -118,7 +118,7 @@ export function decidePlaybackReconcileMode(args: {
   // forced, so an ahead receiver will not follow it until the sender recovers or
   // the stall upgrades to `paused` — both bounded by the stall itself. Closing
   // that needs the sender-side broadcast rules to agree on `buffering`; tracked
-  // in issue #190 rather than patched at this call site.
+  // in issue #198 rather than patched at this call site.
   if (
     args.playState === "buffering" &&
     args.localCurrentTime > args.targetTime


### PR DESCRIPTION
## 背景

`playback-reconcile.ts` 的 `buffering` 豁免分支里有一条 KNOWN GAP 注释，指向 #190 作为跟踪 issue。但 #190 已于 2026-07-22 关闭，其关闭清单只覆盖 R1(#192) / R3(#194) / R4(#193)，R2 判定为设计气味不做——**这条 GAP 不属于其中任何一条**，注释指针因此失效，该缺口失去跟踪。

已开 #198 承接，本 PR 把注释指针改指过去。

## 改动

`extension/src/content/playback-reconcile.ts:121` 一处注释：`issue #190` → `issue #198`。

## 缺口本身仍然存在（未在本 PR 修复）

核实过链路是闭合的：

1. 发送端卡顿 → `getPlayState` 因 `!video.paused && video.readyState < 3` 返回 `buffering`（`player-binding.ts:43`）
2. `broadcastPlayback` 把 `intendedPlayState` 回写为 `"buffering"`（`sync-controller.ts:1453`）
3. 此时发起的 seek → `getBroadcastPlayState` 要求 `intendedPlayState === "playing"` 才强制上报 playing（`sync-controller.ts:746`），条件不满足
4. 该 seek 仍以 `buffering` 广播 → 领先的接收端命中 `buffering-not-authoritative` 豁免 → 不跟随

不在本 PR 修复的原因：#189 曾把第 3 步放宽为 `|| === "buffering"`，在同一 PR 第 6 轮复审中发现引入新 bug 并撤回；正确的关闭方式是按 #190 建议方向让发送端广播规则对 `buffering` 与用户意图正交，属于独立改动。详见 #198。

## 验证

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`（1018 项断言，0 失败）

仅注释改动，无行为变化。

Refs #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)