### PR TITLE
perf: 加快变速追赶收敛(峰值1.16x、比例增益0.30)

### DIFF
--- a/extension/src/content/player-binding.ts
+++ b/extension/src/content/player-binding.ts
@@ -7,7 +7,13 @@ import type { ProgrammaticPlaybackSignature } from "./runtime-state";
 
 const SOFT_APPLY_STEP_SECONDS = 0.22;
 const SOFT_APPLY_MAX_STEP_SECONDS = 0.4;
-const SOFT_APPLY_RATE_OFFSET = 0.12;
+// Peak rate offset a catch-up may apply at base 1x (i.e. up to 1.16x). The
+// remote head advances at the base rate, so this offset *is* the relative
+// closing speed: at 0.16 a drift takes drift / 0.16 seconds to absorb. Kept
+// modest so the pitch shift stays barely perceptible, but high enough that
+// autoplay-next hand-offs and steady drift converge in a few seconds rather
+// than a dozen.
+const SOFT_APPLY_RATE_OFFSET = 0.16;
 
 interface AppliedPlaybackAdjustment {
   mode: "ignore" | "rate-only" | "soft-apply" | "hard-seek";
@@ -136,8 +142,12 @@ function getRateAdjustedPlaybackRate(args: {
 }): number {
   const tuning = getPlaybackAdjustmentTuning(args.basePlaybackRate);
   const drift = args.targetTime - args.localCurrentTime;
+  // Proportional gain: the rate hits its cap once |drift| exceeds
+  // rateOffsetLimit / 0.3 (~0.53s at base 1x) and holds there through most of
+  // the correction, so the asymptotic tail that dominated convergence time
+  // stays near the cap far longer before tapering to zero.
   const rateOffset = clamp(
-    drift * 0.18,
+    drift * 0.3,
     -tuning.rateOffsetLimit,
     tuning.rateOffsetLimit,
   );

--- a/extension/test/player-binding.test.ts
+++ b/extension/test/player-binding.test.ts
@@ -31,12 +31,12 @@ test("rate-only adjustment nudges playback rate without rewriting current time f
   const applied = syncPlaybackPosition(video, 12.8, "playing", undefined, 1);
 
   assert.ok(Math.abs(video.currentTime - 12) < 0.001);
-  assert.ok(Math.abs(video.playbackRate - 1.12) < 0.001);
+  assert.ok(Math.abs(video.playbackRate - 1.16) < 0.001);
   assert.equal(applied.mode, "rate-only");
   assert.equal(applied.targetTime, 12.8);
   assert.equal(applied.restorePlaybackRate, 1);
   assert.equal(applied.currentTime, 12);
-  assert.equal(applied.playbackRate, 1.12);
+  assert.equal(applied.playbackRate, 1.16);
   assert.equal(applied.reason, "playing-rate-adjust");
   assert.ok(Math.abs(applied.delta - 0.8) < 0.001);
   assert.equal(applied.didWriteCurrentTime, false);
@@ -52,12 +52,12 @@ test("rate-only adjustment slows playback without rewriting current time when lo
   const applied = syncPlaybackPosition(video, 12, "playing", undefined, 1);
 
   assert.ok(Math.abs(video.currentTime - 12.8) < 0.001);
-  assert.ok(Math.abs(video.playbackRate - 0.88) < 0.001);
+  assert.ok(Math.abs(video.playbackRate - 0.84) < 0.001);
   assert.equal(applied.mode, "rate-only");
   assert.equal(applied.targetTime, 12);
   assert.equal(applied.restorePlaybackRate, 1);
   assert.equal(applied.currentTime, 12.8);
-  assert.equal(applied.playbackRate, 0.88);
+  assert.equal(applied.playbackRate, 0.84);
   assert.equal(applied.reason, "playing-rate-adjust");
   assert.ok(Math.abs(applied.delta - 0.8) < 0.001);
   assert.equal(applied.didWriteCurrentTime, false);
@@ -74,7 +74,7 @@ test("rate-only adjustment widens playback-rate correction at 2x", () => {
 
   assert.equal(applied.mode, "rate-only");
   assert.ok(Math.abs(video.currentTime - 12) < 0.001);
-  assert.ok(Math.abs(video.playbackRate - 2.198) < 0.001);
+  assert.ok(Math.abs(video.playbackRate - 2.26) < 0.001);
   assert.equal(applied.didWriteCurrentTime, false);
   assert.equal(applied.didWritePlaybackRate, true);
 });
@@ -114,7 +114,7 @@ test("programmatic apply signature tracks the soft-applied position instead of t
   assert.equal(applied.didChange, true);
   assert.equal(signatures.length, 1);
   assert.ok(Math.abs(signatures[0]!.currentTime - 12.4) < 0.001);
-  assert.ok(Math.abs(signatures[0]!.playbackRate - 1.12) < 0.001);
+  assert.ok(Math.abs(signatures[0]!.playbackRate - 1.16) < 0.001);
 });
 
 test("soft apply uses a more conservative time step than the raw drift", () => {
@@ -142,7 +142,7 @@ test("soft apply keeps a smaller time step but a wider rate offset at 2x", () =>
   assert.equal(applied.mode, "soft-apply");
   assert.ok(video.currentTime > 12);
   assert.ok(video.currentTime < 12.4);
-  assert.ok(Math.abs(video.playbackRate - 2.22) < 0.001);
+  assert.ok(Math.abs(video.playbackRate - 2.26) < 0.001);
   assert.equal(applied.didWriteCurrentTime, true);
   assert.equal(applied.didWritePlaybackRate, true);
 });

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -314,7 +314,7 @@ test("sync controller uses rate-only reconcile for medium playing drift", async 
     );
 
     assert.ok(Math.abs(video.currentTime - 24) < 0.001);
-    assert.ok(Math.abs(video.playbackRate - 1.12) < 0.001);
+    assert.ok(Math.abs(video.playbackRate - 1.16) < 0.001);
     assert.equal(
       harness.debugLogs.some(
         (message) =>
@@ -336,12 +336,12 @@ test("sync controller uses rate-only reconcile for medium playing drift", async 
 
     // Reaching the stale snapshot target must NOT restore the base rate early:
     // the remote head keeps advancing, so converging on the old target would
-    // leave residual drift. The drift (0.8s) at a 0.12x offset needs ~6.7s to
+    // leave residual drift. The drift (0.8s) at a 0.16x offset needs ~5s to
     // close, well beyond the moment the playhead passes the snapshot target.
     video.currentTime = 24.8;
     harness.setNow(20_500);
     harness.controller.maintainActiveSoftApply(video);
-    assert.ok(Math.abs(video.playbackRate - 1.12) < 0.001);
+    assert.ok(Math.abs(video.playbackRate - 1.16) < 0.001);
 
     // Once enough real time has elapsed for the rate offset to absorb the drift,
     // the base rate is restored instead of running ahead forever.
@@ -973,7 +973,7 @@ test("sync controller suppresses repeated apply during the soft-apply cooldown w
     );
 
     assert.ok(Math.abs(video.currentTime - 24.4) < 0.001);
-    assert.ok(Math.abs(video.playbackRate - 1.12) < 0.001);
+    assert.ok(Math.abs(video.playbackRate - 1.16) < 0.001);
 
     video.currentTime = 25;
     harness.controller.maintainActiveSoftApply(video);
@@ -1075,7 +1075,7 @@ test("sync controller does not arm cooldown when soft apply times out", async ()
     );
 
     assert.ok(Math.abs(video.currentTime - 26.4) < 0.001);
-    assert.ok(Math.abs(video.playbackRate - 1.12) < 0.001);
+    assert.ok(Math.abs(video.playbackRate - 1.16) < 0.001);
     assert.equal(
       harness.debugLogs.some(
         (message) =>
@@ -2111,7 +2111,7 @@ test("sync controller abandons a rate-only catch-up to broadcast a real stall wi
   harness.setNow(20_000);
 
   try {
-    // A medium drift registers a pure rate-only catch-up (rate bumped to 1.12)
+    // A medium drift registers a pure rate-only catch-up (rate bumped to 1.16)
     // and arms the remote-follow window by following the remote playing state.
     await harness.controller.applyRoomState(
       createRoomState({
@@ -2123,11 +2123,11 @@ test("sync controller abandons a rate-only catch-up to broadcast a real stall wi
         playbackRate: 1,
       }),
     );
-    assert.ok(Math.abs(video.playbackRate - 1.12) < 0.001);
+    assert.ok(Math.abs(video.playbackRate - 1.16) < 0.001);
 
     // A genuine stall interrupts the catch-up after the 700ms programmatic
     // window (so it is not mistaken for the rate-apply echo) but well within the
-    // ~6.7s relative-drift window and the 3s remote-follow window.
+    // ~5s relative-drift window and the 3s remote-follow window.
     harness.setNow(21_000);
     video.readyState = 2;
     await harness.controller.broadcastPlayback(video, "waiting");
@@ -2283,13 +2283,13 @@ test("sync controller converges a catch-up instead of stopping at the ignore thr
         playbackRate: 1,
       }),
     );
-    assert.ok(Math.abs(video.playbackRate - 1.12) < 0.001);
+    assert.ok(Math.abs(video.playbackRate - 1.16) < 0.001);
 
     // A routine heartbeat 3s later. The peer advanced 3s; the local head
-    // advanced 3s at the elevated 1.12x, so the remaining drift is 0.44s —
+    // advanced 3s at the elevated 1.16x, so the remaining drift is 0.32s —
     // just under the threshold that started the catch-up.
     harness.setNow(23_000);
-    video.currentTime = 27.36;
+    video.currentTime = 27.48;
     await harness.controller.applyRoomState(
       createRoomState({
         actorId: "remote-member",
@@ -2303,7 +2303,7 @@ test("sync controller converges a catch-up instead of stopping at the ignore thr
 
     // Previously this heartbeat killed the catch-up twice over: the frozen
     // snapshot made it look like a 3s jump (`target-shifted`), and the `ignore`
-    // reconcile wrote the base rate back. Both left the 0.44s residual forever.
+    // reconcile wrote the base rate back. Both left the 0.32s residual forever.
     assert.equal(
       harness.debugLogs.some((message) => message.includes("target-shifted")),
       false,


### PR DESCRIPTION
## 背景

自动连播换片 / 漂移追赶时，跟随端靠**变速收敛**偏慢。实测一次约 0.74s 落差需约 **13s** 才追平。

根因是两处叠加（`player-binding.ts`）：

1. **变速峰值只有 +12%**（`SOFT_APPLY_RATE_OFFSET = 0.12`）。领先端以 1.0× 播放，跟随端最多 1.12×，相对追赶速度仅 0.12 s/s。
2. **比例系数 0.18 让倍速过早衰减**：`rateOffset = clamp(drift * 0.18, ±limit)`，drift 一旦 < 0.667s 倍速就跌破峰值并持续下滑，拖长了收敛尾部（尾部是主要拖慢因素）。

## 改动

只调 tuning 常数，逻辑与阈值不变：

| 常数 | 旧 | 新 | 作用 |
|---|---|---|---|
| `SOFT_APPLY_RATE_OFFSET` | `0.12` | `0.16` | 峰值 1.12× → **1.16×**，初段更快 |
| 比例增益 `drift * 0.18` | `0.18` | `0.30` | 倍速顶在峰值到 drift ~0.53s 才衰减，削掉收敛尾部 |

base 2× 等场景通过既有 `rateOffsetLimit = min(0.26, …)` 自动缩放，未破坏上限。

同样落差现约 **5s** 内收敛。代价：大落差时短暂 1.16× 的音调轻微可察觉。

## 回归测试

按算法**重算**所有受影响断言（非照抄旧值）：

- `player-binding.test.ts`：7 处计算 rate（1.12→1.16、0.88→0.84、2.198/2.22→2.26、signature 1.12→1.16）。**保留**两处"变速在 buffering 快照下存活"的预设值 1.12（任意预设、非公式产物，≤1.16 仍合法）。
- `sync-controller.test.ts`：6 处计算 rate 断言 + 3 处注释（`0.12x/~6.7s`→`0.16x/~5s`）；block 2286 手写场景值 `27.36→27.48`、残差注释 `0.44s→0.32s`，保持物理自洽。

## 验证

`typecheck` / 全量 `npm test`（EXIT=0）/ `format:check` / `lint` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)