### PR TITLE
chore: release 1.3.1

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-exclude='../packages/**' test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.0"
+    "@bili-syncplay/protocol": "1.3.1"
   },
   "devDependencies": {
     "@types/chrome": "^0.2.2",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["alarms", "storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "workspaces": [
         "packages/*",
         "server",
@@ -28,9 +28,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.0"
+        "@bili-syncplay/protocol": "1.3.1"
       },
       "devDependencies": {
         "@types/chrome": "^0.2.2",
@@ -5700,10 +5700,10 @@
     },
     "packages/admin-ui": {
       "name": "@bili-syncplay/admin-ui",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
-        "@bili-syncplay/protocol": "1.3.0",
+        "@bili-syncplay/protocol": "1.3.1",
         "@tanstack/react-query": "^5.101.2",
         "antd": "^6.5.1",
         "dayjs": "^1.11.21",
@@ -5726,16 +5726,16 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "devDependencies": {
         "typescript": "^6.0.3"
       }
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.0",
+        "@bili-syncplay/protocol": "1.3.1",
         "ioredis": "^5.10.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/admin-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
-    "@bili-syncplay/protocol": "1.3.0",
+    "@bili-syncplay/protocol": "1.3.1",
     "@tanstack/react-query": "^5.101.2",
     "antd": "^6.5.1",
     "dayjs": "^1.11.21",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.0",
+    "@bili-syncplay/protocol": "1.3.1",
     "ioredis": "^5.10.0",
     "ws": "^8.21.0"
   },


### PR DESCRIPTION
## 版本发布 1.3.1

自 `v1.3.0` 起累计 13 个 commit，全部集中在同步/卡顿/seek 状态机的稳定性修复与变速追赶收敛优化，无新增用户可见功能，按 **patch** 发布。

### 包含的变更（#184 ~ #201）
- 卡顿/播放器重建不再被误判为用户暂停，或把领先成员拽回其冻结位置（#184、#189、#193、#200）
- 同步漂移追赶收敛到零；变速追赶收敛更快（峰值 1.16x、比例增益 0.30）（#188、#201）
- 程序化 apply 的事件回声、周期心跳不再被记为显式用户动作（#192、#194）
- 合并单次播放器事件产生的重复 `playback:update`；修复倍速回写窗口吞掉用户拖动（#191、#195）
- 追赶会话取消时不再遗留抬高的 `defaultPlaybackRate`（#197）

### 版本改动
`npm run release:version -- 1.3.1`：更新根与各 workspace 的 `package.json`、`extension/public/manifest.json`、`package-lock.json`。

### 验证
`npm run format:check && npm run lint && npm run typecheck && npm run build && npm test` 全部通过（测试 `# fail 0`）。

合并后打 `v1.3.1` tag 推送，触发扩展与 Docker 镜像发布。

🤖 Generated with [Claude Code](https://claude.com/claude-code)