### PR TITLE
feat(server): 暴露进程 CPU 指标并计量 sync:request 耗时

### DIFF
--- a/server/src/admin/metrics.ts
+++ b/server/src/admin/metrics.ts
@@ -1,3 +1,4 @@
+import { availableParallelism } from "node:os";
 import {
   constants as perfHooksConstants,
   monitorEventLoopDelay,
@@ -13,6 +14,7 @@ const DEFAULT_HISTOGRAM_BUCKETS_SECONDS = [
 ] as const;
 
 const NANOSECONDS_PER_SECOND = 1e9;
+const MICROSECONDS_PER_SECOND = 1e6;
 
 const GC_KIND_NAMES: Readonly<Record<number, string>> = Object.freeze({
   [perfHooksConstants.NODE_PERFORMANCE_GC_MAJOR]: "major",
@@ -49,7 +51,11 @@ const RATE_LIMITED_MESSAGE_TYPES = [
 ] as const;
 
 export type MonitoredMessageType =
-  "video:share" | "playback:update" | "room:join" | "room:leave";
+  | "video:share"
+  | "playback:update"
+  | "room:join"
+  | "room:leave"
+  | "sync:request";
 
 type LabelValues = Record<string, string>;
 
@@ -181,6 +187,7 @@ export function createMetricsCollector(options: {
   let runtimeStore = options.runtimeStore;
   const serviceVersion = options.serviceVersion ?? "unknown";
   const processStartTimeSeconds = (Date.now() - process.uptime() * 1000) / 1000;
+  const availableCores = availableParallelism();
   const eventCounter: CounterMetric = {
     help: "Total structured log events grouped by event name",
     samples: new Map(),
@@ -294,6 +301,7 @@ export function createMetricsCollector(options: {
       includeExpired: false,
     });
     const memory = process.memoryUsage();
+    const cpu = process.cpuUsage();
     const eventSamples = Array.from(eventCounter.samples.values()).sort(
       (a, b) => (a.labels.event ?? "").localeCompare(b.labels.event ?? ""),
     );
@@ -390,6 +398,29 @@ export function createMetricsCollector(options: {
       "# HELP bili_syncplay_nodejs_process_rss_bytes Resident set size of the server process, in bytes",
       "# TYPE bili_syncplay_nodejs_process_rss_bytes gauge",
       formatMetricLine("bili_syncplay_nodejs_process_rss_bytes", memory.rss),
+      // rate() over this counter yields CPU cores consumed. The server runs a
+      // single Node process without cluster workers, so the JS main thread
+      // saturates at 1.0 regardless of how many cores the host reports —
+      // compare against bili_syncplay_process_cpu_cores_available to tell
+      // "one core is full" apart from "the box is idle".
+      "# HELP bili_syncplay_process_cpu_seconds_total Cumulative process CPU time in seconds, grouped by mode",
+      "# TYPE bili_syncplay_process_cpu_seconds_total counter",
+      formatMetricLine(
+        "bili_syncplay_process_cpu_seconds_total",
+        cpu.user / MICROSECONDS_PER_SECOND,
+        { mode: "user" },
+      ),
+      formatMetricLine(
+        "bili_syncplay_process_cpu_seconds_total",
+        cpu.system / MICROSECONDS_PER_SECOND,
+        { mode: "system" },
+      ),
+      "# HELP bili_syncplay_process_cpu_cores_available Logical cores available to the process",
+      "# TYPE bili_syncplay_process_cpu_cores_available gauge",
+      formatMetricLine(
+        "bili_syncplay_process_cpu_cores_available",
+        availableCores,
+      ),
       "# HELP bili_syncplay_connections Current websocket connection count",
       "# TYPE bili_syncplay_connections gauge",
       formatMetricLine(

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -746,14 +746,16 @@ export function createMessageHandler(options: {
             return;
           }
 
-          const state = await roomService.getRoomStateForSession(
-            session,
-            message.payload.memberToken,
-            message.type,
-          );
-          send(socket, {
-            type: "room:state",
-            payload: state,
+          await measureMessageHandling("sync:request", async () => {
+            const state = await roomService.getRoomStateForSession(
+              session,
+              message.payload.memberToken,
+              message.type,
+            );
+            send(socket, {
+              type: "room:state",
+              payload: state,
+            });
           });
           return;
         }

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -699,6 +699,10 @@ test("message handler records monitored duration metrics for critical room paths
     },
   });
   await handler.handleClientMessage(session, {
+    type: "sync:request",
+    payload: { memberToken: "member-token-1" },
+  });
+  await handler.handleClientMessage(session, {
     type: "room:leave",
     payload: { memberToken: "member-token-1" },
   });
@@ -707,6 +711,7 @@ test("message handler records monitored duration metrics for critical room paths
     "room:join",
     "video:share",
     "playback:update",
+    "sync:request",
     "room:leave",
   ]);
 });

--- a/server/test/metrics.test.ts
+++ b/server/test/metrics.test.ts
@@ -164,6 +164,29 @@ test("metrics collector renders event counters, histograms, and redis failure co
     assert.notEqual(match, null, gauge);
     assert.equal(Number(match![1]) > 0, true, gauge);
   }
+  // CPU time is the headroom signal for a single-process server: rate() over
+  // this counter is cores consumed, and the JS main thread tops out at 1.0.
+  for (const mode of ["user", "system"]) {
+    const match = rendered.match(
+      new RegExp(
+        `^bili_syncplay_process_cpu_seconds_total\\{mode="${mode}"\\} (\\d+(?:\\.\\d+)?)$`,
+        "m",
+      ),
+    );
+    assert.notEqual(match, null, mode);
+    // Only user time is reliably non-zero this early in a process; asserting
+    // system > 0 here would be flaky.
+    assert.equal(Number(match![1]) >= 0, true, mode);
+  }
+  assert.match(
+    rendered,
+    /^bili_syncplay_process_cpu_seconds_total\{mode="user"\} (?!0$)\d+(?:\.\d+)?$/m,
+  );
+  const coresMatch = rendered.match(
+    /^bili_syncplay_process_cpu_cores_available (\d+)$/m,
+  );
+  assert.notEqual(coresMatch, null);
+  assert.equal(Number(coresMatch![1]) >= 1, true);
   // GC kinds are pre-seeded so "no major GC" is an explicit zero series.
   for (const kind of ["major", "minor", "incremental", "weakcb"]) {
     assert.match(


### PR DESCRIPTION
## 背景

在评估用户增长驱动的扩容时,发现 `/metrics` 缺少判断单节点余量的关键信号:

- **没有进程 CPU 指标**。服务是单 Node 进程、无 cluster worker,JS 主线程跑满一个核就是天花板,但现有指标只有堆内存和 RSS,无法判断距离这个天花板还有多远。
- **`sync:request` 没有耗时观测**。它是线上限流次数最多的消息类型(累计 171 万次,`playback:update` 只有 31 万次),却是唯一没进 `message_handler_duration` 的路径。

## 改动

- `metrics.ts`:新增 `bili_syncplay_process_cpu_seconds_total{mode="user"|"system"}`(counter,`rate()` 即为消耗的核数)与 `bili_syncplay_process_cpu_cores_available`(gauge)。按现有手写注册表的写法用 `process.cpuUsage()` 实现,**不引入 prom-client**,保持服务端运行时依赖只有 ioredis + ws。
- `message-handler.ts`:`sync:request` 分支包进 `measureMessageHandling`,与其它已计量路径一致(`finally` 记录,异常照常向上抛)。
- `MonitoredMessageType` 增加 `"sync:request"`。

## 测试

- `metrics.test.ts`:断言两个 mode 的 CPU 序列存在且可解析,`user` 非零;`cores_available >= 1`。`system` 只断言 `>= 0`,进程早期它可能仍是 0,断非零会 flaky。
- `message-handler.test.ts`:已有的"按序记录被计量消息类型"用例补上 `sync:request`。

## 验证

`format:check` / `lint` / `typecheck` / `build` / `test` 全部通过(5 个测试套件,0 失败)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)