### PR TITLE
chore: 解除依赖审计门禁对 CI 的阻塞

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,14 @@ npm run release:version        # Bump version numbers
 **Before every commit**, run in order:
 
 ```bash
-npm run format:check && npm run lint && npm run typecheck && npm run build && npm test
+npm run format:check && npm run lint && npm run typecheck && npm run build && npm test && npm run audit
 ```
+
+`npm run audit` is the same dependency gate CI runs in the `verify` job. It is
+not covered by `npm test`, and it can start failing without any local change
+when a new advisory is published — so run it before pushing, not only after CI
+turns red. Findings that do not apply to this repository go in
+`audit-allowlist.json` with a reason and a mandatory expiry date.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Single source of truth for `ClientMessage`, `ServerMessage`, domain types (`Room
 - ALWAYS create a feature branch before making changes; NEVER push directly to `main`.
 - Do not rewrite published history unless explicitly requested by the repository maintainer.
 - Before every `git push`, run `npm run format:check` and the full pre-commit check sequence to avoid CI failures.
-- Before committing changes, run `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run build`, and `npm test`.
+- Before committing changes, run `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run build`, `npm test`, and `npm run audit`.
 - Keep formatting-only changes separate from behavior changes whenever practical.
 - Do not mix unrelated refactors, docs updates, and feature or bug-fix changes in a single commit when they can be reviewed independently.
 - Prefer small, reviewable commits that preserve behavior at each step of a refactor.

--- a/audit-allowlist.json
+++ b/audit-allowlist.json
@@ -1,4 +1,10 @@
 {
   "version": 1,
-  "entries": []
+  "entries": [
+    {
+      "id": "npm:react-router:1124282",
+      "reason": "GHSA-qwww-vcr4-c8h2 只影响 react-router 的 RSC (React Server Components) framework mode。admin-ui 是 Vite 构建的纯客户端 SPA,packages/admin-ui/src/app.tsx 用声明式 BrowserRouter,不存在服务端 action 执行路径,该 CSRF 绕过在本仓库不可达。修复版 8.3.0 为大版本,单独排期迁移而非顺带升级。",
+      "expires": "2026-10-31"
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3197,16 +3197,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {


### PR DESCRIPTION
## 问题

两条新公布的 high 公告让 `verify` 作业在**所有分支**上转红,与任何代码改动无关。main 在 2026-07-23 的最后一次 CI 还是绿的,公告是之后发布的。

## 处理

**brace-expansion**(GHSA-mh99-v99m-4gvg,DoS)—— 直接升级
`eslint → minimatch` 的传递依赖,仅 devDependency,不进产物。5.0.8 已修复,`npm update` 即可,lockfile 只动 4 行。

**react-router**(GHSA-qwww-vcr4-c8h2,RSC Mode CSRF Bypass)—— 允许清单 + 到期日
该公告只影响 react-router 的 RSC (React Server Components) framework mode。admin-ui 是 Vite 构建的纯客户端 SPA,`packages/admin-ui/src/app.tsx:23` 用的是声明式 `BrowserRouter`,不存在服务端 action 执行路径,**该 CSRF 绕过在本仓库不可达**。

修复版 8.3.0 是大版本,顺带升级会引入一整套本不需要的路由回归面。因此按到期日 `2026-10-31` 写入 `audit-allowlist.json`——门禁对过期条目会主动报错,所以到期后会自动重新拦截,不会变成永久豁免。

## 顺带

把 `npm run audit` 补进 AGENTS.md 的预提交序列。它不在 `npm test` 覆盖范围内,而且会在本地毫无改动的情况下因新公告转红——本次就是本地五项全绿、推上去才被 CI 拦。

## 验证

`format:check` / `lint` / `typecheck` / `build` / `test`(带 `REDIS_URL`)/ `audit` 全部通过。审计门禁输出确认 react-router 那条走的是 allowlist 分支:

```
npm audit gate: 1 high+ finding(s) covered by active allowlist entries.
npm audit gate passed: no unallowlisted high+ vulnerability findings.
```

## 合并顺序

这个 PR 需要先落地,#203 与 #204 再 rebase 到 main,它们的 `verify` 才会转绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)