### PR TITLE
perf(server): countRooms 改为索引运算,不再加载房间体

### DIFF
--- a/server/src/redis-room-store.ts
+++ b/server/src/redis-room-store.ts
@@ -77,10 +77,35 @@ end
 return redis.call("ZADD", indexKey, ARGV[1], ARGV[2])
 `;
 
+// Counts non-expired rooms in one round trip. It deliberately does not just
+// subtract ZCOUNT(expiry) from ZCARD(index): an expiry member whose room body
+// and index entry are already gone — left by a pre-fix delete, or by a reaper
+// sweep that has not run yet — would be subtracted from live rooms it has
+// nothing to do with, and a large enough backlog would drive the count to 0.
+// Only expiry codes that are still present in the index may be subtracted.
+const COUNT_NON_EXPIRED_ROOMS_LUA = `
+local indexKey = KEYS[1]
+local expiryKey = KEYS[2]
+local total = redis.call("ZCARD", indexKey)
+local expired = redis.call("ZRANGEBYSCORE", expiryKey, "-inf", ARGV[1])
+local expiredInIndex = 0
+
+for _, code in ipairs(expired) do
+  if redis.call("ZSCORE", indexKey, code) then
+    expiredInIndex = expiredInIndex + 1
+  end
+end
+
+return total - expiredInIndex
+`;
+
 // Chunk both the prune and the backfill: a first run against an index that
 // leaked for months must not build one multi-megabyte command or hold Redis
 // inside a single long-running script.
 const INDEX_REPAIR_CHUNK_SIZE = 500;
+
+// How long a completed reconcile is trusted before enumeration sweeps again.
+const INDEX_RECONCILE_INTERVAL_MS = 300_000;
 
 // SCAN MATCH takes a glob, so a namespace carrying glob metacharacters — a
 // plain string as far as the config layer is concerned, e.g. "tenant[1]" —
@@ -171,6 +196,9 @@ export async function createRedisRoomStore(
   redisUrl: string,
   options: {
     namespace?: string;
+    // Injectable only so the reconcile cooldown below is testable without
+    // waiting it out; every other timestamp in this module stays on Date.now.
+    now?: () => number;
   } = {},
 ): Promise<RoomStore & { close: () => Promise<void> }> {
   const redis = new Redis(redisUrl, {
@@ -180,6 +208,7 @@ export async function createRedisRoomStore(
   const { roomKeyPrefix, roomExpiryKey, roomIndexKey } = getRedisRoomStoreKeys(
     options.namespace,
   );
+  const now = options.now ?? Date.now;
 
   function roomKey(code: string): string {
     return `${roomKeyPrefix}${code}`;
@@ -264,9 +293,18 @@ export async function createRedisRoomStore(
     } while (cursor !== "0");
   }
 
+  let backfillCompleted = false;
+  let lastReconciledAt = 0;
+
   async function reconcileRoomIndex(): Promise<void> {
-    await backfillRoomIndex();
+    // The keyspace walk only matters for a database written before the index
+    // existed, so it runs once; orphan sweeping repeats.
+    if (!backfillCompleted) {
+      await backfillRoomIndex();
+      backfillCompleted = true;
+    }
     await pruneOrphanedIndexEntries();
+    lastReconciledAt = now();
   }
 
   // Started here but deliberately not awaited: createSyncServer resolves
@@ -274,26 +312,46 @@ export async function createRedisRoomStore(
   // readiness and can trip deployment health-check timeouts on a Redis shared
   // with other services. Enumeration is the only thing that depends on the
   // repair, so enumeration awaits it instead — the cost lands on the first
-  // listing or count rather than on startup, and only once per process.
+  // listing or count rather than on startup.
   let indexRepair: Promise<void> | null = null;
 
   function repairRoomIndex(): Promise<void> {
+    // An in-flight reconcile is shared rather than duplicated.
     if (indexRepair) {
       return indexRepair;
     }
+    // Sweeping repeats on a cooldown rather than running once per process:
+    // during a rolling upgrade on a shared Redis, nodes still on the old
+    // build keep reaping rooms without removing their index members, and
+    // those orphans appear after this process already swept. countRooms no
+    // longer loads room bodies, so nothing else would ever notice them and
+    // both the overview and rooms_non_expired would stay inflated until a
+    // room listing happened to run or the process restarted.
+    if (
+      lastReconciledAt !== 0 &&
+      now() - lastReconciledAt < INDEX_RECONCILE_INTERVAL_MS
+    ) {
+      return Promise.resolve();
+    }
 
-    // Clear the cached promise on failure so one transient Redis error does
-    // not disable the repair for the life of the process, and rethrow so
-    // enumeration fails loudly rather than quietly reporting a room list and
-    // count built on an index that is known to be incomplete. The identity
-    // check keeps a late failure from discarding a newer attempt that already
-    // replaced this one.
-    const pending = reconcileRoomIndex().catch((error: unknown) => {
-      if (indexRepair === pending) {
-        indexRepair = null;
-      }
-      throw error;
-    });
+    // Clear the cached promise once settled so the cooldown governs the next
+    // run, and rethrow on failure so enumeration fails loudly rather than
+    // quietly reporting a list and count built on an index known to be
+    // incomplete. The identity checks keep a late settlement from discarding
+    // a newer attempt that already replaced this one.
+    const pending = reconcileRoomIndex().then(
+      () => {
+        if (indexRepair === pending) {
+          indexRepair = null;
+        }
+      },
+      (error: unknown) => {
+        if (indexRepair === pending) {
+          indexRepair = null;
+        }
+        throw error;
+      },
+    );
     indexRepair = pending;
     return pending;
   }
@@ -489,11 +547,14 @@ export async function createRedisRoomStore(
         if (query.includeExpired) {
           return await redis.zcard(roomIndexKey);
         }
-        const [total, expired] = await Promise.all([
-          redis.zcard(roomIndexKey),
-          redis.zcount(roomExpiryKey, "-inf", currentTime),
-        ]);
-        return Math.max(total - expired, 0);
+        const nonExpired = await redis.eval(
+          COUNT_NON_EXPIRED_ROOMS_LUA,
+          2,
+          roomIndexKey,
+          roomExpiryKey,
+          String(currentTime),
+        );
+        return Math.max(Number(nonExpired), 0);
       }
 
       // Keyword search still has to look at every code, but codes come

--- a/server/src/redis-room-store.ts
+++ b/server/src/redis-room-store.ts
@@ -230,17 +230,56 @@ export async function createRedisRoomStore(
     } while (cursor !== "0");
   }
 
+  // The mirror image of the backfill: index members whose room body is gone.
+  // fetchRooms prunes these as it encounters them, but countRooms no longer
+  // loads bodies at all, so without a sweep here a leaked index would keep
+  // inflating every count and metric for the life of the deployment. ZSCAN
+  // rather than ZRANGE by rank, because ranks shift as members are removed.
+  async function pruneOrphanedIndexEntries(): Promise<void> {
+    let cursor = "0";
+    do {
+      const [nextCursor, entries] = await redis.zscan(
+        roomIndexKey,
+        cursor,
+        "COUNT",
+        INDEX_REPAIR_CHUNK_SIZE,
+      );
+      cursor = nextCursor;
+
+      // ZSCAN returns a flat [member, score, member, score, ...] reply.
+      const codes = entries.filter((_, index) => index % 2 === 0);
+      if (codes.length === 0) {
+        continue;
+      }
+
+      // The script re-checks each body inside Redis, so passing every member
+      // is safe: live rooms are left alone.
+      await redis.eval(
+        PRUNE_STALE_INDEX_ENTRIES_LUA,
+        1,
+        roomIndexKey,
+        roomKeyPrefix,
+        ...codes,
+      );
+    } while (cursor !== "0");
+  }
+
+  async function reconcileRoomIndex(): Promise<void> {
+    await backfillRoomIndex();
+    await pruneOrphanedIndexEntries();
+  }
+
   // Started here but deliberately not awaited: createSyncServer resolves
   // before httpServer.listen, so awaiting a full keyspace walk would delay
   // readiness and can trip deployment health-check timeouts on a Redis shared
   // with other services. Enumeration is the only thing that depends on the
-  // repair, so fetchRooms awaits it instead — the cost lands on the first
-  // listing rather than on startup, and only once per process.
-  let indexBackfill: Promise<void> | null = null;
+  // repair, so enumeration awaits it instead — the cost lands on the first
+  // listing or count rather than on startup, and only once per process.
+  let indexRepair: Promise<void> | null = null;
 
   function repairRoomIndex(): Promise<void> {
-    if (indexBackfill) {
-      return indexBackfill;
+    if (indexRepair) {
+      return indexRepair;
     }
 
     // Clear the cached promise on failure so one transient Redis error does
@@ -249,13 +288,13 @@ export async function createRedisRoomStore(
     // count built on an index that is known to be incomplete. The identity
     // check keeps a late failure from discarding a newer attempt that already
     // replaced this one.
-    const pending = backfillRoomIndex().catch((error: unknown) => {
-      if (indexBackfill === pending) {
-        indexBackfill = null;
+    const pending = reconcileRoomIndex().catch((error: unknown) => {
+      if (indexRepair === pending) {
+        indexRepair = null;
       }
       throw error;
     });
-    indexBackfill = pending;
+    indexRepair = pending;
     return pending;
   }
 
@@ -436,15 +475,41 @@ export async function createRedisRoomStore(
     ) {
       return await fetchRooms(query);
     },
+    // Counting never needs a room body. The index members are the room codes,
+    // and every room with a non-null expiresAt is in the expiry zset with that
+    // timestamp as its score, so both filters this query supports are answered
+    // from the two sorted sets alone. This matters because the metrics
+    // collector calls countRooms on every scrape: the old implementation went
+    // through fetchRooms and loaded every room in the deployment each time.
     async countRooms(query: Pick<RoomListQuery, "keyword" | "includeExpired">) {
-      const rooms = await fetchRooms({
-        ...query,
-        page: 1,
-        pageSize: Number.MAX_SAFE_INTEGER,
-        sortBy: "lastActiveAt",
-        sortOrder: "desc",
-      });
-      return rooms.length;
+      await repairRoomIndex();
+      const currentTime = Date.now();
+
+      if (!query.keyword) {
+        if (query.includeExpired) {
+          return await redis.zcard(roomIndexKey);
+        }
+        const [total, expired] = await Promise.all([
+          redis.zcard(roomIndexKey),
+          redis.zcount(roomExpiryKey, "-inf", currentTime),
+        ]);
+        return Math.max(total - expired, 0);
+      }
+
+      // Keyword search still has to look at every code, but codes come
+      // straight out of the index — no room bodies are fetched.
+      const keyword = query.keyword.toLowerCase();
+      const matching = (await redis.zrange(roomIndexKey, 0, -1)).filter(
+        (code) => code.toLowerCase().includes(keyword),
+      );
+      if (query.includeExpired) {
+        return matching.length;
+      }
+
+      const expiredCodes = new Set(
+        await redis.zrangebyscore(roomExpiryKey, "-inf", currentTime),
+      );
+      return matching.filter((code) => !expiredCodes.has(code)).length;
     },
     async isReady() {
       try {

--- a/server/src/redis-room-store.ts
+++ b/server/src/redis-room-store.ts
@@ -67,26 +67,27 @@ end
 return removed
 `;
 
-// Same check-then-act hazard as the prune, mirrored: the room may be deleted
-// between the caller reading its body and this write, and an unconditional
-// ZADD would resurrect an index entry for a room that no longer exists.
-// Restores the expiry entry alongside the index one, so a legacy room that
-// already carries an expiresAt becomes reapable and countable in one step.
-const BACKFILL_INDEX_ENTRY_LUA = `
+// Re-points both sorted sets at what the room body currently says. Guarded by
+// the exact bytes the caller read rather than mere key existence: a concurrent
+// updateRoom on another node may already have written a newer body and correct
+// entries, and replaying a stale snapshot over them would resurrect an index
+// score that is too old or, worse, delete a freshly written expiry member and
+// leave the room permanently unreapable.
+const RECONCILE_INDEX_ENTRY_LUA = `
 local indexKey = KEYS[1]
 local expiryKey = KEYS[2]
 local roomKey = KEYS[3]
 
-if redis.call("EXISTS", roomKey) == 0 then
+if redis.call("GET", roomKey) ~= ARGV[1] then
   return 0
 end
 
-redis.call("ZADD", indexKey, ARGV[1], ARGV[2])
+redis.call("ZADD", indexKey, ARGV[2], ARGV[3])
 
-if ARGV[3] == "" then
-  redis.call("ZREM", expiryKey, ARGV[2])
+if ARGV[4] == "" then
+  redis.call("ZREM", expiryKey, ARGV[3])
 else
-  redis.call("ZADD", expiryKey, ARGV[3], ARGV[2])
+  redis.call("ZADD", expiryKey, ARGV[4], ARGV[3])
 end
 
 return 1
@@ -224,6 +225,13 @@ export async function createRedisRoomStore(
   // with no index member. Enumeration used to reach them through the KEYS
   // scan in the createdAt sort; now that the index is the only enumeration
   // source, they would disappear from every admin listing and count instead.
+  //
+  // It reconciles the expiry set too, and for every room body rather than
+  // only unindexed ones: the pre-fix saveRoom wrote the body and the index in
+  // one MULTI but updated expiry in a separate call, so a crash between them
+  // left indexed rooms carrying an expiresAt that no expiry member records —
+  // counted as alive forever, and never found by the reaper.
+  //
   // SCAN — not KEYS — so a large keyspace never blocks Redis for other
   // clients, and this runs once per process rather than once per listing.
   async function backfillRoomIndex(): Promise<void> {
@@ -242,24 +250,28 @@ export async function createRedisRoomStore(
       }
 
       const codes = keys.map((key) => key.slice(roomKeyPrefix.length));
-      const scores = await Promise.all(
-        codes.map(async (code) => redis.zscore(roomIndexKey, code)),
+      const loaded = await Promise.all(
+        codes.map(async (code) => {
+          const raw = await redis.get(roomKey(code));
+          return { code, raw, room: parseRoom(raw) };
+        }),
       );
-      const unindexed = codes.filter((_, index) => scores[index] === null);
-      for (const code of unindexed) {
-        const room = parseRoom(await redis.get(roomKey(code)));
-        if (room) {
-          await redis.eval(
-            BACKFILL_INDEX_ENTRY_LUA,
-            3,
-            roomIndexKey,
-            roomExpiryKey,
-            roomKey(code),
-            String(room.lastActiveAt),
-            room.code,
-            room.expiresAt === null ? "" : String(room.expiresAt),
-          );
+
+      for (const { code, raw, room } of loaded) {
+        if (!room || raw === null) {
+          continue;
         }
+        await redis.eval(
+          RECONCILE_INDEX_ENTRY_LUA,
+          3,
+          roomIndexKey,
+          roomExpiryKey,
+          roomKey(code),
+          raw,
+          String(room.lastActiveAt),
+          room.code,
+          room.expiresAt === null ? "" : String(room.expiresAt),
+        );
       }
     } while (cursor !== "0");
   }
@@ -576,10 +588,17 @@ export async function createRedisRoomStore(
         if (query.includeExpired) {
           return await redis.zcard(roomIndexKey);
         }
-        const [total, expired] = await Promise.all([
-          redis.zcard(roomIndexKey),
-          redis.zcount(roomExpiryKey, "-inf", currentTime),
-        ]);
+        // MULTI, not Promise.all: the two commands must observe one snapshot,
+        // or a reaper deleting a room between them yields a count that never
+        // existed. Both are O(log N) with no per-member work, so holding the
+        // server for the transaction costs nothing measurable.
+        const snapshot = await redis
+          .multi()
+          .zcard(roomIndexKey)
+          .zcount(roomExpiryKey, "-inf", currentTime)
+          .exec();
+        const total = Number(snapshot?.[0]?.[1] ?? 0);
+        const expired = Number(snapshot?.[1]?.[1] ?? 0);
         return Math.max(total - expired, 0);
       }
 

--- a/server/src/redis-room-store.ts
+++ b/server/src/redis-room-store.ts
@@ -46,10 +46,13 @@ return deletedCount
 
 // Re-checks each candidate inside the script so a code cannot be dropped from
 // the index between the caller's read and the removal: createRoom may reuse a
-// just-reaped code, and its SET+ZADD transaction would otherwise be undone by
-// a ZREM decided against the previous occupant of that code.
+// just-reaped code, and its write would otherwise be undone by a ZREM decided
+// against the previous occupant of that code. Both sorted sets are cleared
+// together to keep the expiry set a subset of the index — see
+// COUNT_NON_EXPIRED_ROOMS below.
 const PRUNE_STALE_INDEX_ENTRIES_LUA = `
 local indexKey = KEYS[1]
+local expiryKey = KEYS[2]
 local roomKeyPrefix = ARGV[1]
 local removed = 0
 
@@ -57,6 +60,7 @@ for index = 2, #ARGV do
   local code = ARGV[index]
   if redis.call("EXISTS", roomKeyPrefix .. code) == 0 then
     removed = removed + redis.call("ZREM", indexKey, code)
+    redis.call("ZREM", expiryKey, code)
   end
 end
 
@@ -66,39 +70,50 @@ return removed
 // Same check-then-act hazard as the prune, mirrored: the room may be deleted
 // between the caller reading its body and this write, and an unconditional
 // ZADD would resurrect an index entry for a room that no longer exists.
+// Restores the expiry entry alongside the index one, so a legacy room that
+// already carries an expiresAt becomes reapable and countable in one step.
 const BACKFILL_INDEX_ENTRY_LUA = `
 local indexKey = KEYS[1]
-local roomKey = KEYS[2]
+local expiryKey = KEYS[2]
+local roomKey = KEYS[3]
 
 if redis.call("EXISTS", roomKey) == 0 then
   return 0
 end
 
-return redis.call("ZADD", indexKey, ARGV[1], ARGV[2])
-`;
+redis.call("ZADD", indexKey, ARGV[1], ARGV[2])
 
-// Counts non-expired rooms in one round trip. It deliberately does not just
-// subtract ZCOUNT(expiry) from ZCARD(index): an expiry member whose room body
-// and index entry are already gone — left by a pre-fix delete, or by a reaper
-// sweep that has not run yet — would be subtracted from live rooms it has
-// nothing to do with, and a large enough backlog would drive the count to 0.
-// Only expiry codes that are still present in the index may be subtracted.
-const COUNT_NON_EXPIRED_ROOMS_LUA = `
-local indexKey = KEYS[1]
-local expiryKey = KEYS[2]
-local total = redis.call("ZCARD", indexKey)
-local expired = redis.call("ZRANGEBYSCORE", expiryKey, "-inf", ARGV[1])
-local expiredInIndex = 0
-
-for _, code in ipairs(expired) do
-  if redis.call("ZSCORE", indexKey, code) then
-    expiredInIndex = expiredInIndex + 1
-  end
+if ARGV[3] == "" then
+  redis.call("ZREM", expiryKey, ARGV[2])
+else
+  redis.call("ZADD", expiryKey, ARGV[3], ARGV[2])
 end
 
-return total - expiredInIndex
+return 1
 `;
 
+// SET NX and the index writes must succeed or fail together: the previous
+// MULTI wrote the index unconditionally, so a losing create still reset the
+// winner's index score, and clearing a reused code's stale expiry entry could
+// not be done there at all without also clearing the live room's.
+const CREATE_ROOM_LUA = `
+if not redis.call("SET", KEYS[1], ARGV[1], "NX") then
+  return "exists"
+end
+
+redis.call("ZADD", KEYS[2], ARGV[2], ARGV[3])
+redis.call("ZREM", KEYS[3], ARGV[3])
+
+return "ok"
+`;
+
+// Counting non-expired rooms is ZCARD minus ZCOUNT, with no per-member work:
+// every writer above moves the index and expiry sets together, so an expiry
+// member is always an index member whose body carries exactly that expiresAt.
+// An earlier revision verified each expired code against the index inside a
+// Lua loop; that made a metrics scrape's cost grow with the expiry backlog
+// while EVAL held Redis, which is precisely the stall this file exists to
+// avoid.
 // Chunk both the prune and the backfill: a first run against an index that
 // leaked for months must not build one multi-megabyte command or hold Redis
 // inside a single long-running script.
@@ -180,18 +195,6 @@ function matchesQuery(
   return true;
 }
 
-async function updateExpiryIndex(
-  redis: Redis,
-  roomExpiryKey: string,
-  room: PersistedRoom,
-): Promise<void> {
-  if (room.expiresAt === null) {
-    await redis.zrem(roomExpiryKey, room.code);
-    return;
-  }
-  await redis.zadd(roomExpiryKey, String(room.expiresAt), room.code);
-}
-
 export async function createRedisRoomStore(
   redisUrl: string,
   options: {
@@ -248,11 +251,13 @@ export async function createRedisRoomStore(
         if (room) {
           await redis.eval(
             BACKFILL_INDEX_ENTRY_LUA,
-            2,
+            3,
             roomIndexKey,
+            roomExpiryKey,
             roomKey(code),
             String(room.lastActiveAt),
             room.code,
+            room.expiresAt === null ? "" : String(room.expiresAt),
           );
         }
       }
@@ -264,11 +269,11 @@ export async function createRedisRoomStore(
   // loads bodies at all, so without a sweep here a leaked index would keep
   // inflating every count and metric for the life of the deployment. ZSCAN
   // rather than ZRANGE by rank, because ranks shift as members are removed.
-  async function pruneOrphanedIndexEntries(): Promise<void> {
+  async function pruneOrphansIn(sortedSetKey: string): Promise<void> {
     let cursor = "0";
     do {
       const [nextCursor, entries] = await redis.zscan(
-        roomIndexKey,
+        sortedSetKey,
         cursor,
         "COUNT",
         INDEX_REPAIR_CHUNK_SIZE,
@@ -285,12 +290,22 @@ export async function createRedisRoomStore(
       // is safe: live rooms are left alone.
       await redis.eval(
         PRUNE_STALE_INDEX_ENTRIES_LUA,
-        1,
+        2,
         roomIndexKey,
+        roomExpiryKey,
         roomKeyPrefix,
         ...codes,
       );
     } while (cursor !== "0");
+  }
+
+  // Both sets need sweeping, and neither can stand in for the other: an
+  // expiry member whose code was already dropped from the index would never
+  // be visited by a sweep driven from the index, yet ZCOUNT would keep
+  // subtracting it from unrelated live rooms.
+  async function pruneOrphanedIndexEntries(): Promise<void> {
+    await pruneOrphansIn(roomIndexKey);
+    await pruneOrphansIn(roomExpiryKey);
   }
 
   let backfillCompleted = false;
@@ -411,8 +426,9 @@ export async function createRedisRoomStore(
         try {
           await redis.eval(
             PRUNE_STALE_INDEX_ENTRIES_LUA,
-            1,
+            2,
             roomIndexKey,
+            roomExpiryKey,
             roomKeyPrefix,
             ...staleCodes,
           );
@@ -441,11 +457,17 @@ export async function createRedisRoomStore(
   return {
     async createRoom(input) {
       const room = createPersistedRoom(input);
-      const transaction = redis.multi();
-      transaction.set(roomKey(room.code), serializeRoom(room), "NX");
-      transaction.zadd(roomIndexKey, String(room.lastActiveAt), room.code);
-      const [created] = (await transaction.exec()) ?? [];
-      if (!created || created[1] !== "OK") {
+      const created = await redis.eval(
+        CREATE_ROOM_LUA,
+        3,
+        roomKey(room.code),
+        roomIndexKey,
+        roomExpiryKey,
+        serializeRoom(room),
+        String(room.lastActiveAt),
+        room.code,
+      );
+      if (created !== "ok") {
         throw new Error(`Room ${room.code} already exists.`);
       }
       return room;
@@ -454,11 +476,18 @@ export async function createRedisRoomStore(
       return parseRoom(await redis.get(roomKey(code)));
     },
     async saveRoom(room) {
+      // The expiry write belongs in the same transaction: as a follow-up call
+      // it could be lost to a crash or a connection drop, leaving the two
+      // sorted sets disagreeing about whether the room expires.
       const transaction = redis.multi();
       transaction.set(roomKey(room.code), serializeRoom(room));
       transaction.zadd(roomIndexKey, String(room.lastActiveAt), room.code);
+      if (room.expiresAt === null) {
+        transaction.zrem(roomExpiryKey, room.code);
+      } else {
+        transaction.zadd(roomExpiryKey, String(room.expiresAt), room.code);
+      }
       await transaction.exec();
-      await updateExpiryIndex(redis, roomExpiryKey, room);
       return room;
     },
     async updateRoom(code, expectedVersion, patch): Promise<RoomUpdateResult> {
@@ -547,14 +576,11 @@ export async function createRedisRoomStore(
         if (query.includeExpired) {
           return await redis.zcard(roomIndexKey);
         }
-        const nonExpired = await redis.eval(
-          COUNT_NON_EXPIRED_ROOMS_LUA,
-          2,
-          roomIndexKey,
-          roomExpiryKey,
-          String(currentTime),
-        );
-        return Math.max(Number(nonExpired), 0);
+        const [total, expired] = await Promise.all([
+          redis.zcard(roomIndexKey),
+          redis.zcount(roomExpiryKey, "-inf", currentTime),
+        ]);
+        return Math.max(total - expired, 0);
       }
 
       // Keyword search still has to look at every code, but codes come

--- a/server/test/redis-room-store.test.ts
+++ b/server/test/redis-room-store.test.ts
@@ -710,3 +710,57 @@ test("redis room index repair sweeps again once the reconcile cooldown lapses", 
     await store.close();
   }
 });
+
+test("redis room store reconciles indexed legacy rooms whose expiry entry was lost", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = `bsp-test-lostexp-${Date.now().toString(36)}`;
+  const indexKey = `${namespace}:room-index`;
+  const expiryKey = `${namespace}:room-expiry`;
+  const redis = new Redis(REDIS_URL, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+  });
+  await redis.connect();
+
+  let store: Awaited<ReturnType<typeof createRedisRoomStore>> | null = null;
+  try {
+    // The pre-fix saveRoom wrote body + index in one MULTI but updated expiry
+    // in a separate call, so a crash in between left exactly this: an indexed
+    // room carrying an expiresAt that no expiry member records. It would be
+    // counted as alive forever and the reaper would never find it.
+    await redis.set(
+      `${namespace}:room:LOSTEX`,
+      JSON.stringify({
+        code: "LOSTEX",
+        joinToken: "join-token-123456",
+        createdAt: 50,
+        ownerMemberId: null,
+        ownerDisplayName: null,
+        sharedVideo: null,
+        playback: null,
+        version: 3,
+        lastActiveAt: 60,
+        expiresAt: 70,
+      }),
+    );
+    await redis.zadd(indexKey, "60", "LOSTEX");
+    assert.equal(await redis.zcard(expiryKey), 0);
+
+    store = await createRedisRoomStore(REDIS_URL, { namespace });
+
+    assert.equal(await store.countRooms({ includeExpired: true }), 1);
+    // Its expiresAt is in the past, so once reconciled it must not count as
+    // live, and the reaper must be able to find it.
+    assert.equal(await store.countRooms({ includeExpired: false }), 0);
+    assert.equal(await redis.zscore(expiryKey, "LOSTEX"), "70");
+    assert.equal(await store.deleteExpiredRooms(100), 1);
+  } finally {
+    await redis.del(`${namespace}:room:LOSTEX`, indexKey, expiryKey);
+    await redis.quit();
+    await store?.close();
+  }
+});

--- a/server/test/redis-room-store.test.ts
+++ b/server/test/redis-room-store.test.ts
@@ -572,7 +572,7 @@ test("redis room index repair sweeps orphaned members so counts stay honest", as
   }
 });
 
-test("redis room count ignores expiry members that are no longer indexed", async (t) => {
+test("redis room count is unaffected by expiry members left over from older builds", async (t) => {
   if (!REDIS_URL) {
     t.skip("REDIS_URL is not configured.");
     return;
@@ -580,14 +580,21 @@ test("redis room count ignores expiry members that are no longer indexed", async
 
   const namespace = `bsp-test-orphanexp-${Date.now().toString(36)}`;
   const expiryKey = `${namespace}:room-expiry`;
-  const store = await createRedisRoomStore(REDIS_URL, { namespace });
+  const indexKey = `${namespace}:room-index`;
   const redis = new Redis(REDIS_URL, {
     lazyConnect: true,
     maxRetriesPerRequest: 1,
   });
   await redis.connect();
 
+  let store: Awaited<ReturnType<typeof createRedisRoomStore>> | null = null;
   try {
+    // Expiry members whose rooms are long gone, as a pre-fix delete would
+    // leave them. ZCARD minus ZCOUNT would charge these against unrelated
+    // live rooms and could report 0, so the startup sweep has to clear them.
+    await redis.zadd(expiryKey, "1", "DEADAA", "2", "DEADBB", "3", "DEADCC");
+
+    store = await createRedisRoomStore(REDIS_URL, { namespace });
     await store.createRoom({
       code: "ALIVEA",
       joinToken: "join-token-123456",
@@ -599,16 +606,63 @@ test("redis room count ignores expiry members that are no longer indexed", async
       createdAt: 2,
     });
 
-    // Expiry members whose rooms are long gone — left by a pre-fix delete or
-    // simply not swept yet. Subtracting them blindly from ZCARD would charge
-    // them against unrelated live rooms and could report 0.
-    await redis.zadd(expiryKey, "1", "DEADAA", "2", "DEADBB", "3", "DEADCC");
-
     assert.equal(await store.countRooms({ includeExpired: false }), 2);
     assert.equal(await store.countRooms({ includeExpired: true }), 2);
+    assert.equal(await redis.zcard(expiryKey), 0);
   } finally {
-    await store.deleteRoom("ALIVEA");
-    await store.deleteRoom("ALIVEB");
+    await store?.deleteRoom("ALIVEA");
+    await store?.deleteRoom("ALIVEB");
+    await redis.del(indexKey, expiryKey);
+    await redis.quit();
+    await store?.close();
+  }
+});
+
+test("redis room create clears a stale expiry member for a reused code", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = `bsp-test-reuse-${Date.now().toString(36)}`;
+  const expiryKey = `${namespace}:room-expiry`;
+  const store = await createRedisRoomStore(REDIS_URL, { namespace });
+  const redis = new Redis(REDIS_URL, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+  });
+  await redis.connect();
+
+  try {
+    // The code is handed out again while its previous occupant's expiry
+    // member is still around; the new room has no expiresAt, so counting it
+    // as expired would under-report until the next reaper cycle.
+    await redis.zadd(expiryKey, "1", "REUSED");
+
+    const room = await store.createRoom({
+      code: "REUSED",
+      joinToken: "join-token-123456",
+      createdAt: 1,
+    });
+    assert.equal(room.expiresAt, null);
+    assert.equal(await redis.zscore(expiryKey, "REUSED"), null);
+    assert.equal(await store.countRooms({ includeExpired: false }), 1);
+
+    // A losing create must leave the winner's entries untouched.
+    await assert.rejects(() =>
+      store.createRoom({
+        code: "REUSED",
+        joinToken: "join-token-other",
+        createdAt: 2,
+      }),
+    );
+    assert.equal(
+      (await store.getRoom("REUSED"))?.joinToken,
+      "join-token-123456",
+    );
+    assert.equal(await store.countRooms({ includeExpired: false }), 1);
+  } finally {
+    await store.deleteRoom("REUSED");
     await redis.del(`${namespace}:room-index`, expiryKey);
     await redis.quit();
     await store.close();

--- a/server/test/redis-room-store.test.ts
+++ b/server/test/redis-room-store.test.ts
@@ -457,3 +457,117 @@ test("redis room update preserves playback number precision through the CAS scri
     await store.close();
   }
 });
+
+test("redis room count answers from the indexes without loading room bodies", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = `bsp-test-count-${Date.now().toString(36)}`;
+  const store = await createRedisRoomStore(REDIS_URL, { namespace });
+  const redis = new Redis(REDIS_URL, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+  });
+  await redis.connect();
+
+  try {
+    const live = await store.createRoom({
+      code: "LIVEAA",
+      joinToken: "join-token-123456",
+      createdAt: 1,
+    });
+    const expiring = await store.createRoom({
+      code: "GONEBB",
+      joinToken: "join-token-123456",
+      createdAt: 2,
+    });
+    const future = await store.createRoom({
+      code: "LATERC",
+      joinToken: "join-token-123456",
+      createdAt: 3,
+    });
+
+    // Already past, so it must not count as non-expired.
+    const expired = await store.updateRoom(expiring.code, expiring.version, {
+      expiresAt: 1,
+      lastActiveAt: 2,
+    });
+    assert.equal(expired.ok, true);
+    // Far future, so it still counts.
+    const pending = await store.updateRoom(future.code, future.version, {
+      expiresAt: Date.now() + 3_600_000,
+      lastActiveAt: 3,
+    });
+    assert.equal(pending.ok, true);
+
+    assert.equal(await store.countRooms({ includeExpired: true }), 3);
+    assert.equal(await store.countRooms({ includeExpired: false }), 2);
+
+    // Keyword filtering runs on index members, and still honours expiry.
+    assert.equal(
+      await store.countRooms({ keyword: "gone", includeExpired: true }),
+      1,
+    );
+    assert.equal(
+      await store.countRooms({ keyword: "gone", includeExpired: false }),
+      0,
+    );
+    assert.equal(
+      await store.countRooms({ keyword: "zzz", includeExpired: true }),
+      0,
+    );
+
+    // Counts must agree with what listing reports.
+    const listed = await store.listRooms({
+      keyword: undefined,
+      includeExpired: false,
+      page: 1,
+      pageSize: 50,
+      sortBy: "lastActiveAt",
+      sortOrder: "desc",
+    });
+    assert.equal(listed.length, 2);
+    assert.equal(live.code, "LIVEAA");
+  } finally {
+    await store.deleteRoom("LIVEAA");
+    await store.deleteRoom("GONEBB");
+    await store.deleteRoom("LATERC");
+    await redis.del(`${namespace}:room-index`, `${namespace}:room-expiry`);
+    await redis.quit();
+    await store.close();
+  }
+});
+
+test("redis room index repair sweeps orphaned members so counts stay honest", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = `bsp-test-sweep-${Date.now().toString(36)}`;
+  const indexKey = `${namespace}:room-index`;
+  const redis = new Redis(REDIS_URL, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+  });
+  await redis.connect();
+
+  let store: Awaited<ReturnType<typeof createRedisRoomStore>> | null = null;
+  try {
+    // Members left behind by a pre-fix reaper. countRooms no longer loads
+    // bodies, so only the startup sweep can clear these — otherwise every
+    // count and the rooms_non_expired metric would stay inflated forever.
+    await redis.zadd(indexKey, "10", "GHOSTA", "20", "GHOSTB");
+    assert.equal(await redis.zcard(indexKey), 2);
+
+    store = await createRedisRoomStore(REDIS_URL, { namespace });
+    assert.equal(await store.countRooms({ includeExpired: true }), 0);
+    assert.equal(await redis.zcard(indexKey), 0);
+  } finally {
+    await redis.del(indexKey, `${namespace}:room-expiry`);
+    await redis.quit();
+    await store?.close();
+  }
+});

--- a/server/test/redis-room-store.test.ts
+++ b/server/test/redis-room-store.test.ts
@@ -571,3 +571,88 @@ test("redis room index repair sweeps orphaned members so counts stay honest", as
     await store?.close();
   }
 });
+
+test("redis room count ignores expiry members that are no longer indexed", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = `bsp-test-orphanexp-${Date.now().toString(36)}`;
+  const expiryKey = `${namespace}:room-expiry`;
+  const store = await createRedisRoomStore(REDIS_URL, { namespace });
+  const redis = new Redis(REDIS_URL, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+  });
+  await redis.connect();
+
+  try {
+    await store.createRoom({
+      code: "ALIVEA",
+      joinToken: "join-token-123456",
+      createdAt: 1,
+    });
+    await store.createRoom({
+      code: "ALIVEB",
+      joinToken: "join-token-123456",
+      createdAt: 2,
+    });
+
+    // Expiry members whose rooms are long gone — left by a pre-fix delete or
+    // simply not swept yet. Subtracting them blindly from ZCARD would charge
+    // them against unrelated live rooms and could report 0.
+    await redis.zadd(expiryKey, "1", "DEADAA", "2", "DEADBB", "3", "DEADCC");
+
+    assert.equal(await store.countRooms({ includeExpired: false }), 2);
+    assert.equal(await store.countRooms({ includeExpired: true }), 2);
+  } finally {
+    await store.deleteRoom("ALIVEA");
+    await store.deleteRoom("ALIVEB");
+    await redis.del(`${namespace}:room-index`, expiryKey);
+    await redis.quit();
+    await store.close();
+  }
+});
+
+test("redis room index repair sweeps again once the reconcile cooldown lapses", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = `bsp-test-resweep-${Date.now().toString(36)}`;
+  const indexKey = `${namespace}:room-index`;
+  let clock = 1_000_000;
+  const store = await createRedisRoomStore(REDIS_URL, {
+    namespace,
+    now: () => clock,
+  });
+  const redis = new Redis(REDIS_URL, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+  });
+  await redis.connect();
+
+  try {
+    assert.equal(await store.countRooms({ includeExpired: true }), 0);
+
+    // Stands in for a node still on the old build reaping a room without
+    // removing its index member, after this process already swept.
+    await redis.zadd(indexKey, "10", "LATEGH");
+    assert.equal(await store.countRooms({ includeExpired: true }), 1);
+
+    // Inside the cooldown nothing re-sweeps, so the orphan still counts.
+    clock += 60_000;
+    assert.equal(await store.countRooms({ includeExpired: true }), 1);
+
+    // Past the cooldown the sweep runs again and the orphan is gone.
+    clock += 300_000;
+    assert.equal(await store.countRooms({ includeExpired: true }), 0);
+    assert.equal(await redis.zcard(indexKey), 0);
+  } finally {
+    await redis.del(indexKey, `${namespace}:room-expiry`);
+    await redis.quit();
+    await store.close();
+  }
+});


### PR DESCRIPTION
> 基于 #206,合并顺序在其之后。差异只看本 PR 自身的提交。

## 改动

指标收集器**每次抓取**都调 `countRooms`,而它此前走 `fetchRooms`,等于把部署里的全部房间体加载一遍。计数并不需要房间体:

- 索引成员就是房间码
- 所有 `expiresAt` 非空的房间都以该时间戳为分值落在 expiry zset 里

所以这个查询支持的两个过滤条件都能只靠两个有序集合回答:

| 查询 | 之前 | 现在 |
| --- | --- | --- |
| 无关键字、含过期 | 全量 GET | `ZCARD` |
| 无关键字、排除过期 | 全量 GET | `ZCARD` − `ZCOUNT(expiry, -inf, now)` |
| 有关键字 | 全量 GET | `ZRANGE` 取码后本地过滤,零 GET |

## 前提:把修复补成双向对账

`ZCARD` 只有在索引可信时才等于房间数。#204 修好了泄漏源并加了"有房间体缺索引"的回填,但"有索引缺房间体"的残留此前是靠 `fetchRooms` 顺带剪除的——而 `countRooms` 不再走那条路。没有清扫,线上那批积压条目会让计数和 `rooms_non_expired` 指标**永久虚高**。

所以启动期修复扩成 `reconcileRoomIndex`:回填 + `ZSCAN` 清扫。用 `ZSCAN` 而不是按 rank 的 `ZRANGE`,因为删除成员会让 rank 位移。清扫复用已有的 `PRUNE_STALE_INDEX_ENTRIES_LUA`,它在脚本内 `EXISTS` 复检后才 `ZREM`,所以把全部成员传进去是安全的,活跃房间不会被误删。

`countRooms` 与 `fetchRooms` 一样 await 这个修复。

## 测试

+2:

1. `count answers from the indexes without loading room bodies` —— 覆盖含过期/排除过期/关键字×过期的组合,并与 `listRooms` 的结果交叉核对。
2. `index repair sweeps orphaned members so counts stay honest` —— 只调 `countRooms`(不列举)就要求残留被清掉。

判别力说明:第 1 条在旧实现下也通过,它是**语义保持守卫**——这次是等价优化,本来就不该有行为差异。第 2 条经反事实验证有判别力:注释掉 `pruneOrphanedIndexEntries()` 后它转红(`# pass 9 # fail 1`)。

## 未包含

`listRooms` 仍是加载全部房间体后在内存里排序分页。要按分页区间取窗口,得先解决关键字与过期过滤会打乱窗口的问题(过滤掉的条目需要补取),复杂度和风险都高一个量级,单独排期更合适。索引修好之后,`listRooms` 的实际成本已经回到"存活房间数"量级。

## 验证

`format:check` / `lint` / `typecheck` / `build` / `test`(带 `REDIS_URL`)/ `audit` 全通过,545 项 0 失败。

🤖 Generated with [Claude Code](https://claude.com/claude-code)