### PR TITLE
fix(extension): 播放位置外推改以本地单调锚点为准，消除钟差驱动的倍速抖动

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,38 @@ Single source of truth for `ClientMessage`, `ServerMessage`, domain types (`Room
 - Protocol types/guards must stay in `@bili-syncplay/protocol`.
 - Server env parsing must stay in the server config layer.
 
+### Playback timing invariants
+
+These three cost four review rounds on #210 between them. Nothing in the type
+system enforces any of them, so they have to be checked by hand whenever a
+background path touches room state or playback timing.
+
+- **Never subtract a local timestamp from a server one.** `serverTime` belongs to
+  the server's clock; a local timestamp belongs to this machine's. Their
+  difference is the clock disagreement, which is not a duration and drifts on its
+  own — a receiver aiming at it wobbles the playback rate forever. Extrapolate
+  playback from a local monotonic anchor instead (`clock-controller`), and to send
+  an age across machines send a _duration_, never a timestamp. Comparing two
+  server timestamps to each other is fine (version ordering); comparing two local
+  ones is fine (elapsed).
+- **Record a playback snapshot's arrival before the snapshot is observable.** Once
+  it is in `roomSessionState.roomState`, a rehydrating content script
+  (`content:get-room-state`) can read it and a member join/leave can rewrap it,
+  and whichever path compensates first would otherwise anchor it at _its_ moment
+  and lose everything the room played before that. `markPlaybackArrival` must run
+  before the write and before any `await`. Serializing socket messages would not
+  cover this: those readers arrive on the `chrome.runtime` channel, not the socket.
+- **After any `await`, confirm the room state you hold is still the current one
+  before compensating or delivering it.** Handlers are started per socket message
+  with `void handleServerMessage(...)` and do not serialize, so a newer state can
+  take over while one awaits (`ensureSharedVideoOpen` may open a tab). A
+  superseded snapshot must be dropped, not delivered: the content script's
+  staleness check is per actor (`lastAppliedVersionByActor`), so an overtaken
+  snapshot from a _different_ member is accepted and moves playback backwards.
+  `handleRoomStateMessage`, `applyRoomMemberState` and
+  `expireBootstrapRoomStateWait` each carry this check; a new delivery path needs
+  its own.
+
 ## Engineering Constraints
 
 - Repository-wide contribution and refactoring constraints are defined in [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/extension/src/background/clock-controller.ts
+++ b/extension/src/background/clock-controller.ts
@@ -55,19 +55,26 @@ export function createClockController(args: {
     serverReceiveTime: number,
     serverSendTime: number,
   ): void {
-    const sample = updateClockSample({
+    const result = updateClockSample({
       clientSendTime,
       serverReceiveTime,
       serverSendTime,
       now: Date.now(),
       previousRttMs: args.clockState.rttMs,
       previousClockOffsetMs: args.clockState.clockOffsetMs,
+      previousSamples: args.clockState.clockSamples,
     });
-    args.clockState.rttMs = sample.rttMs;
-    args.clockState.clockOffsetMs = sample.clockOffsetMs;
+    args.clockState.rttMs = result.rttMs;
+    args.clockState.clockOffsetMs = result.clockOffsetMs;
+    args.clockState.clockSamples = result.samples;
+    // The raw sample is logged alongside the published estimate: a sample that
+    // swings while `rtt` stays flat is the signature of a late-written
+    // timestamp, and `out`/`in` say which direction it came from.
     args.log(
       "background",
-      `Clock sync offset=${args.clockState.clockOffsetMs}ms rtt=${args.clockState.rttMs}ms`,
+      `Clock sync offset=${args.clockState.clockOffsetMs}ms rtt=${args.clockState.rttMs}ms ` +
+        `sample=${Math.round(result.sample.offsetMs)}ms sampleRtt=${result.sample.rttMs}ms ` +
+        `out=${result.sample.outboundMs}ms in=${result.sample.inboundMs}ms window=${result.samples.length}`,
     );
   }
 

--- a/extension/src/background/clock-controller.ts
+++ b/extension/src/background/clock-controller.ts
@@ -1,6 +1,10 @@
-import type { ClientMessage, RoomState } from "@bili-syncplay/protocol";
+import type {
+  ClientMessage,
+  PlaybackState,
+  RoomState,
+} from "@bili-syncplay/protocol";
 import {
-  compensateRoomStateForClock,
+  extrapolatePlayingRoomState,
   CLOCK_SYNC_INTERVAL_MS,
   updateClockSample,
 } from "./clock-sync";
@@ -18,12 +22,36 @@ export interface ClockController {
   compensateRoomState(state: RoomState): RoomState;
 }
 
+/**
+ * Identity of a playback snapshot. Two broadcasts of the same snapshot share it;
+ * a playing room always advances `currentTime`, so consecutive snapshots differ.
+ */
+function playbackSnapshotKey(playback: PlaybackState): string {
+  return [
+    playback.actorId,
+    playback.seq,
+    playback.playState,
+    playback.url,
+    playback.currentTime,
+    playback.playbackRate,
+  ].join("|");
+}
+
 export function createClockController(args: {
   connectionState: ConnectionState;
   clockState: ClockState;
   sendToServer: (message: ClientMessage) => void;
   log: (scope: "background", message: string) => void;
+  /**
+   * Monotonic time source for anchoring snapshots. Must not be the wall clock:
+   * the whole point of the anchor is to be immune to clock adjustments, and
+   * `Date.now()` moves when the clock is stepped.
+   */
+  getMonotonicNow?: () => number;
 }): ClockController {
+  const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
+  // When the snapshot we are currently extrapolating from first reached us.
+  let playbackAnchor: { key: string; atMs: number } | null = null;
   function syncClock(): void {
     if (!args.connectionState.connected) {
       return;
@@ -78,8 +106,33 @@ export function createClockController(args: {
     );
   }
 
+  /**
+   * Advance a room state's playback position to now.
+   *
+   * The elapsed time is measured from when this snapshot first arrived, on a
+   * monotonic local clock — never by comparing `serverTime` against a local
+   * timestamp, which spans two clocks (see `extrapolatePlayingRoomState`). A
+   * freshly arrived snapshot is therefore passed through as the sender reported
+   * it, and a replay (a tab binding late, a popup asking for current state) is
+   * advanced by the time that genuinely passed since it arrived.
+   *
+   * The cost is that we no longer know how stale a snapshot already was when it
+   * reached us — on joining a room mid-playback that can be up to one broadcast
+   * interval, which the receiver closes with a single seek. Recovering it needs
+   * the server to report the snapshot's age as a *duration*, which is safe to
+   * send across disagreeing clocks; `serverTime` is not.
+   */
   function compensateRoomState(state: RoomState): RoomState {
-    return compensateRoomStateForClock(state, args.clockState.clockOffsetMs);
+    if (!state.playback || state.playback.playState !== "playing") {
+      return state;
+    }
+
+    const key = playbackSnapshotKey(state.playback);
+    const now = monotonicNow();
+    if (!playbackAnchor || playbackAnchor.key !== key) {
+      playbackAnchor = { key, atMs: now };
+    }
+    return extrapolatePlayingRoomState(state, now - playbackAnchor.atMs);
   }
 
   return {

--- a/extension/src/background/clock-controller.ts
+++ b/extension/src/background/clock-controller.ts
@@ -20,6 +20,20 @@ export interface ClockController {
     serverSendTime: number,
   ): void;
   compensateRoomState(state: RoomState, receivedAtMs?: number): RoomState;
+  /**
+   * Record when a playback snapshot arrived, before anything else can observe it.
+   *
+   * Anchoring at ingress rather than at the first `compensateRoomState` call takes
+   * the question of which caller has to supply an arrival time out of the picture:
+   * a snapshot becomes readable (`content:get-room-state`) and gets rewrapped
+   * (member joins/leaves) while its own handler is still persisting state or
+   * opening a tab, and any of those paths compensating first would otherwise anchor
+   * it at their own, later moment — losing everything the room played in between.
+   */
+  markPlaybackArrival(
+    playback: PlaybackState | null | undefined,
+    atMs: number,
+  ): void;
 }
 
 /**
@@ -140,42 +154,50 @@ export function createClockController(args: {
    * the server to report the snapshot's age as a *duration*, which is safe to
    * send across disagreeing clocks; `serverTime` is not.
    */
+  function markPlaybackArrival(
+    playback: PlaybackState | null | undefined,
+    atMs: number,
+  ): void {
+    if (!playback || playback.playState !== "playing") {
+      // An anchor only ever describes the snapshot the room is currently playing
+      // out. Dropping it keeps a stale one from outliving a pause, so no future
+      // snapshot can be extrapolated across the paused interval.
+      playbackAnchor = null;
+      return;
+    }
+
+    const key = playbackSnapshotKey(playback);
+    if (!playbackAnchor || playbackAnchor.key !== key) {
+      playbackAnchor = { key, atMs };
+      return;
+    }
+    // Only ever earlier. The same snapshot can be presented more than once (a
+    // re-broadcast, a replay), and the room has been at that position since the
+    // first time it reached us, so the earliest evidence is the best evidence.
+    if (atMs < playbackAnchor.atMs) {
+      playbackAnchor = { key, atMs };
+    }
+  }
+
   function compensateRoomState(
     state: RoomState,
     receivedAtMs?: number,
   ): RoomState {
     if (!state.playback || state.playback.playState !== "playing") {
-      // An anchor only ever describes the snapshot the room is currently playing
-      // out. Dropping it here keeps a stale one from outliving a pause, so no
-      // future snapshot can be extrapolated across the paused interval.
       playbackAnchor = null;
       return state;
     }
 
-    const key = playbackSnapshotKey(state.playback);
     const now = monotonicNow();
-    if (!playbackAnchor || playbackAnchor.key !== key) {
-      playbackAnchor = { key, atMs: receivedAtMs ?? now };
-    } else if (
-      receivedAtMs !== undefined &&
-      receivedAtMs < playbackAnchor.atMs
-    ) {
-      // A snapshot becomes readable before its own handler finishes: it is written
-      // to the room state, then persisted and the shared video's tab opened. A
-      // content script rehydrating in that window (`content:get-room-state`) asks
-      // for it with no arrival time, which anchors it at *request* time — later
-      // than it really arrived. When the handler then supplies the real arrival,
-      // correct the anchor backwards, or the interval between the two is lost for
-      // as long as the snapshot lasts.
-      //
-      // Only ever earlier: an arrival cannot postdate a reading of the same
-      // snapshot, so the earliest evidence is the best evidence.
-      playbackAnchor = { key, atMs: receivedAtMs };
-    }
-    return extrapolatePlayingRoomState(state, now - playbackAnchor.atMs);
+    // Anchors the snapshot if ingress did not already (a replay of a snapshot from
+    // a previous service-worker session has no anchor), and corrects one that a
+    // reader established late.
+    markPlaybackArrival(state.playback, receivedAtMs ?? now);
+    return extrapolatePlayingRoomState(state, now - playbackAnchor!.atMs);
   }
 
   return {
+    markPlaybackArrival,
     syncClock,
     startClockSyncTimer,
     stopClockSyncTimer,

--- a/extension/src/background/clock-controller.ts
+++ b/extension/src/background/clock-controller.ts
@@ -156,6 +156,21 @@ export function createClockController(args: {
     const now = monotonicNow();
     if (!playbackAnchor || playbackAnchor.key !== key) {
       playbackAnchor = { key, atMs: receivedAtMs ?? now };
+    } else if (
+      receivedAtMs !== undefined &&
+      receivedAtMs < playbackAnchor.atMs
+    ) {
+      // A snapshot becomes readable before its own handler finishes: it is written
+      // to the room state, then persisted and the shared video's tab opened. A
+      // content script rehydrating in that window (`content:get-room-state`) asks
+      // for it with no arrival time, which anchors it at *request* time — later
+      // than it really arrived. When the handler then supplies the real arrival,
+      // correct the anchor backwards, or the interval between the two is lost for
+      // as long as the snapshot lasts.
+      //
+      // Only ever earlier: an arrival cannot postdate a reading of the same
+      // snapshot, so the earliest evidence is the best evidence.
+      playbackAnchor = { key, atMs: receivedAtMs };
     }
     return extrapolatePlayingRoomState(state, now - playbackAnchor.atMs);
   }

--- a/extension/src/background/clock-controller.ts
+++ b/extension/src/background/clock-controller.ts
@@ -24,12 +24,22 @@ export interface ClockController {
 
 /**
  * Identity of a playback snapshot. Two broadcasts of the same snapshot share it;
- * a playing room always advances `currentTime`, so consecutive snapshots differ.
+ * two different snapshots must not.
+ *
+ * `serverTime` is in here as the server's version tag for the snapshot — compared
+ * only for equality, never subtracted from a local timestamp, which is the thing
+ * this module exists to avoid. Without it the identity is forgeable: `seq` is a
+ * per-content-script counter that restarts at 0 on every page load (see
+ * `content/index.ts`), so a member who reloads the page and resumes at a position
+ * an early-`seq` snapshot already reported would produce a key that has been seen
+ * before, and the anchor from that older snapshot would still be standing — adding
+ * everything that happened in between to the playback position.
  */
 function playbackSnapshotKey(playback: PlaybackState): string {
   return [
     playback.actorId,
     playback.seq,
+    playback.serverTime,
     playback.playState,
     playback.url,
     playback.currentTime,
@@ -135,6 +145,10 @@ export function createClockController(args: {
     receivedAtMs?: number,
   ): RoomState {
     if (!state.playback || state.playback.playState !== "playing") {
+      // An anchor only ever describes the snapshot the room is currently playing
+      // out. Dropping it here keeps a stale one from outliving a pause, so no
+      // future snapshot can be extrapolated across the paused interval.
+      playbackAnchor = null;
       return state;
     }
 

--- a/extension/src/background/clock-controller.ts
+++ b/extension/src/background/clock-controller.ts
@@ -19,7 +19,7 @@ export interface ClockController {
     serverReceiveTime: number,
     serverSendTime: number,
   ): void;
-  compensateRoomState(state: RoomState): RoomState;
+  compensateRoomState(state: RoomState, receivedAtMs?: number): RoomState;
 }
 
 /**
@@ -116,13 +116,24 @@ export function createClockController(args: {
    * it, and a replay (a tab binding late, a popup asking for current state) is
    * advanced by the time that genuinely passed since it arrived.
    *
+   * `receivedAtMs` (monotonic, same source as this controller's) is when the
+   * snapshot actually arrived, and callers handling a fresh `room:state` must
+   * pass it: work between arrival and here — persisting state, opening the shared
+   * video's tab — is not instant, and anchoring at this call instead would credit
+   * that time to nobody. The room kept playing through it, so the receiver would
+   * apply a position already that stale as though it were current and then have to
+   * seek. Omit it only when replaying a snapshot that was anchored on arrival.
+   *
    * The cost is that we no longer know how stale a snapshot already was when it
    * reached us — on joining a room mid-playback that can be up to one broadcast
    * interval, which the receiver closes with a single seek. Recovering it needs
    * the server to report the snapshot's age as a *duration*, which is safe to
    * send across disagreeing clocks; `serverTime` is not.
    */
-  function compensateRoomState(state: RoomState): RoomState {
+  function compensateRoomState(
+    state: RoomState,
+    receivedAtMs?: number,
+  ): RoomState {
     if (!state.playback || state.playback.playState !== "playing") {
       return state;
     }
@@ -130,7 +141,7 @@ export function createClockController(args: {
     const key = playbackSnapshotKey(state.playback);
     const now = monotonicNow();
     if (!playbackAnchor || playbackAnchor.key !== key) {
-      playbackAnchor = { key, atMs: now };
+      playbackAnchor = { key, atMs: receivedAtMs ?? now };
     }
     return extrapolatePlayingRoomState(state, now - playbackAnchor.atMs);
   }

--- a/extension/src/background/clock-sync.ts
+++ b/extension/src/background/clock-sync.ts
@@ -31,15 +31,12 @@ export const CLOCK_SAMPLE_MIN_TRUSTED_SIZE = 3;
  * How far the robust estimate has to move before the *published* offset follows
  * it.
  *
- * Stability matters more here than absolute accuracy. A residual bias shifts a
- * receiver a fixed amount from the room and is invisible while watching; an
- * offset that wanders re-times every extrapolated target, which the drift
- * controller cannot tell apart from real drift — it answers with a playback-rate
- * correction, and a wandering offset therefore produces a permanent rate wobble
- * (see PLAYING_CATCH_UP_IGNORE_THRESHOLD_SECONDS, whose 0.05s exit threshold sits
- * far below the noise this filter exists to remove). Holding the published value
- * still inside the deadband keeps extrapolated targets advancing at exactly real
- * time, which is what makes a measured drift mean real drift.
+ * The offset is a diagnostic here, not an input to playback: positions are
+ * extrapolated from a local monotonic anchor instead (see
+ * `extrapolatePlayingRoomState`), precisely because no filter can make a
+ * two-clock comparison trustworthy. It is still filtered rather than smoothed so
+ * that the number shown in the popup reflects what the clocks are doing instead
+ * of jumping with every sample.
  */
 export const CLOCK_OFFSET_DEADBAND_MS = 120;
 
@@ -183,41 +180,44 @@ export function updateClockSample(args: {
   };
 }
 
-export function compensateRoomStateForClock(
+/**
+ * Advance a playing snapshot by the time that has passed since it was taken.
+ *
+ * `elapsedMs` is measured locally — see `ClockController.compensateRoomState` —
+ * rather than derived from `serverTime` and a clock offset. Comparing a server
+ * timestamp against a local one spans two clocks, so their disagreement lands
+ * directly in the extrapolated position: a client whose clock sits 500ms from
+ * the server's aims 500ms away from the room, and every time that disagreement
+ * moves, the target moves with it. The drift controller cannot tell that apart
+ * from real drift and answers with a playback-rate correction, so a clock that
+ * wanders produces a permanent rate wobble.
+ *
+ * Measuring the elapsed time on one clock removes the comparison — and with it
+ * the entire class of failure. A dev setup with the server in WSL and the
+ * browser on the Windows host (two clocks in one box, resynced by the
+ * hypervisor) showed samples spanning -893ms to +1264ms within a minute over a
+ * 1ms loopback round trip; no filter can recover a stable offset from that,
+ * because there is no stable offset to find.
+ */
+export function extrapolatePlayingRoomState(
   state: RoomState,
-  clockOffsetMs: number | null,
-  now = Date.now(),
+  elapsedMs: number,
 ): RoomState {
-  if (
-    !state.playback ||
-    clockOffsetMs === null ||
-    state.playback.playState !== "playing"
-  ) {
+  if (!state.playback || state.playback.playState !== "playing") {
     return state;
   }
 
-  const estimatedServerNow = now + clockOffsetMs;
-  // A state cannot reach us before the server stamped it, so a negative estimate
-  // is always offset error rather than information: pinning it to zero (i.e.
-  // "this snapshot is current") is strictly the better guess, and it bounds how
-  // far a bad offset can drag the target. The clamp is one-sided on purpose —
-  // the upper side has to stay open because `serverTime` is legitimately old
-  // whenever a stored state is replayed (a member joining a room that has been
-  // playing for a while, or a tab binding late), and those must extrapolate the
-  // full elapsed time.
-  //
-  // It does mean an offset estimate crossing zero steps the target by whatever
-  // the estimate was off by. That is why the estimate is filtered for stability
-  // rather than just smoothed (see CLOCK_OFFSET_DEADBAND_MS); the clamp cannot
-  // paper over a wandering offset, it only bounds one side of it.
-  const elapsedMs = Math.max(0, estimatedServerNow - state.playback.serverTime);
+  // Time does not run backwards on the clock this is measured with, so a
+  // negative value would have to be a caller bug; ignore it rather than rewind
+  // the room.
+  const advanceMs = Math.max(0, elapsedMs);
   return {
     ...state,
     playback: {
       ...state.playback,
       currentTime:
         state.playback.currentTime +
-        (elapsedMs / 1000) * state.playback.playbackRate,
+        (advanceMs / 1000) * state.playback.playbackRate,
     },
   };
 }

--- a/extension/src/background/clock-sync.ts
+++ b/extension/src/background/clock-sync.ts
@@ -86,7 +86,8 @@ export function toConnectionCheckUrl(url: string): string | null {
 
 export interface ClockSampleResult {
   rttMs: number;
-  clockOffsetMs: number;
+  /** `null` while no sample has ever been believable. */
+  clockOffsetMs: number | null;
   /** Retained window, oldest first. Feed back in as `previousSamples`. */
   samples: ClockSample[];
   /** The raw sample this call produced, for diagnostics. */
@@ -114,21 +115,34 @@ function median(values: number[]): number {
 }
 
 /**
- * The offset the window agrees on: the median of the samples whose round trip
- * was competitive, which drops both a slow (and therefore likely asymmetric)
- * round trip and an isolated wild reading.
+ * The offset the window agrees on: the median of the samples whose round trip was
+ * competitive, which drops both a slow (and therefore likely asymmetric) round
+ * trip and an isolated wild reading.
+ *
+ * Returns `null` when the window holds nothing worth believing.
  */
-function estimateOffsetMs(samples: ClockSample[]): number {
-  // Floored at zero: a negative round trip is impossible, so an inconsistent
-  // sample must not be allowed to set a bar that excludes every honest one.
-  const fastestRtt = Math.max(
-    0,
-    Math.min(...samples.map((sample) => sample.rttMs)),
-  );
-  const competing = samples.filter(
+function estimateOffsetMs(
+  samples: ClockSample[],
+): { offsetMs: number; usableCount: number } | null {
+  // A negative round trip means the four timestamps contradict each other, so the
+  // offset that sample carries is not evidence of anything and is dropped outright
+  // — flooring the *bar* at zero is not enough, because a negative round trip
+  // always clears `0 + tolerance` and would keep competing for the median (and win
+  // it outright once such samples are the majority). They stay in the raw log,
+  // where an impossible round trip is itself the diagnostic.
+  const usable = samples.filter((sample) => sample.rttMs >= 0);
+  if (usable.length === 0) {
+    return null;
+  }
+
+  const fastestRtt = Math.min(...usable.map((sample) => sample.rttMs));
+  const competing = usable.filter(
     (sample) => sample.rttMs <= fastestRtt + CLOCK_SAMPLE_RTT_TOLERANCE_MS,
   );
-  return median(competing.map((sample) => sample.offsetMs));
+  return {
+    offsetMs: median(competing.map((sample) => sample.offsetMs)),
+    usableCount: usable.length,
+  };
 }
 
 export function updateClockSample(args: {
@@ -152,17 +166,19 @@ export function updateClockSample(args: {
     { offsetMs: sampleOffset, rttMs: sampleRtt, at: args.now },
   ].slice(-CLOCK_SAMPLE_WINDOW_SIZE);
 
-  const estimatedOffset = estimateOffsetMs(samples);
+  const estimate = estimateOffsetMs(samples);
   // Only follow the estimate once it has moved beyond the deadband, so routine
-  // sample noise leaves the published offset — and every target extrapolated
-  // from it — untouched.
+  // sample noise leaves the published offset untouched. With nothing believable in
+  // the window, keep whatever was published rather than inventing a number.
   const clockOffsetMs =
-    args.previousClockOffsetMs === null ||
-    samples.length < CLOCK_SAMPLE_MIN_TRUSTED_SIZE ||
-    Math.abs(estimatedOffset - args.previousClockOffsetMs) >
-      CLOCK_OFFSET_DEADBAND_MS
-      ? Math.round(estimatedOffset)
-      : args.previousClockOffsetMs;
+    estimate === null
+      ? args.previousClockOffsetMs
+      : args.previousClockOffsetMs === null ||
+          estimate.usableCount < CLOCK_SAMPLE_MIN_TRUSTED_SIZE ||
+          Math.abs(estimate.offsetMs - args.previousClockOffsetMs) >
+            CLOCK_OFFSET_DEADBAND_MS
+        ? Math.round(estimate.offsetMs)
+        : args.previousClockOffsetMs;
 
   return {
     rttMs:

--- a/extension/src/background/clock-sync.ts
+++ b/extension/src/background/clock-sync.ts
@@ -2,6 +2,53 @@ import type { RoomState } from "@bili-syncplay/protocol";
 
 export const CLOCK_SYNC_INTERVAL_MS = 15000;
 
+/**
+ * How many ping samples the robust offset estimate is drawn from (~2 minutes at
+ * `CLOCK_SYNC_INTERVAL_MS`).
+ */
+export const CLOCK_SAMPLE_WINDOW_SIZE = 8;
+/**
+ * Samples older than this are dropped before estimating. Also the recovery path
+ * for a genuine clock step: after a suspend/resume (or any gap longer than this)
+ * the whole window ages out, so the estimate reseeds from fresh samples instead
+ * of being held back by pre-step ones.
+ */
+export const CLOCK_SAMPLE_MAX_AGE_MS = 150_000;
+/**
+ * A sample only competes for the estimate if its round trip is within this much
+ * of the fastest one in the window. A slow round trip is asymmetric far more
+ * often than not, and its offset is skewed by up to half the excess delay.
+ */
+export const CLOCK_SAMPLE_RTT_TOLERANCE_MS = 20;
+/**
+ * Samples needed before the deadband is trusted to reject anything. Below this
+ * the window has no majority to appeal to, so the estimate keeps tracking it —
+ * otherwise a wild first sample would be published and then *held* by the very
+ * deadband meant to protect against it.
+ */
+export const CLOCK_SAMPLE_MIN_TRUSTED_SIZE = 3;
+/**
+ * How far the robust estimate has to move before the *published* offset follows
+ * it.
+ *
+ * Stability matters more here than absolute accuracy. A residual bias shifts a
+ * receiver a fixed amount from the room and is invisible while watching; an
+ * offset that wanders re-times every extrapolated target, which the drift
+ * controller cannot tell apart from real drift — it answers with a playback-rate
+ * correction, and a wandering offset therefore produces a permanent rate wobble
+ * (see PLAYING_CATCH_UP_IGNORE_THRESHOLD_SECONDS, whose 0.05s exit threshold sits
+ * far below the noise this filter exists to remove). Holding the published value
+ * still inside the deadband keeps extrapolated targets advancing at exactly real
+ * time, which is what makes a measured drift mean real drift.
+ */
+export const CLOCK_OFFSET_DEADBAND_MS = 120;
+
+export interface ClockSample {
+  offsetMs: number;
+  rttMs: number;
+  at: number;
+}
+
 export function toHealthcheckUrl(url: string): string | null {
   try {
     const parsed = new URL(url);
@@ -40,6 +87,53 @@ export function toConnectionCheckUrl(url: string): string | null {
   }
 }
 
+export interface ClockSampleResult {
+  rttMs: number;
+  clockOffsetMs: number;
+  /** Retained window, oldest first. Feed back in as `previousSamples`. */
+  samples: ClockSample[];
+  /** The raw sample this call produced, for diagnostics. */
+  sample: {
+    offsetMs: number;
+    rttMs: number;
+    /**
+     * `serverReceiveTime - clientSendTime` and `serverSendTime - now`: each is
+     * the clock offset plus a one-way delay, with opposite signs. Their
+     * half-sum is the offset, their difference the round trip — so a pair that
+     * is large while the round trip stays small means one of the four
+     * timestamps was written late rather than the clocks genuinely differing.
+     */
+    outboundMs: number;
+    inboundMs: number;
+  };
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1
+    ? sorted[middle]!
+    : (sorted[middle - 1]! + sorted[middle]!) / 2;
+}
+
+/**
+ * The offset the window agrees on: the median of the samples whose round trip
+ * was competitive, which drops both a slow (and therefore likely asymmetric)
+ * round trip and an isolated wild reading.
+ */
+function estimateOffsetMs(samples: ClockSample[]): number {
+  // Floored at zero: a negative round trip is impossible, so an inconsistent
+  // sample must not be allowed to set a bar that excludes every honest one.
+  const fastestRtt = Math.max(
+    0,
+    Math.min(...samples.map((sample) => sample.rttMs)),
+  );
+  const competing = samples.filter(
+    (sample) => sample.rttMs <= fastestRtt + CLOCK_SAMPLE_RTT_TOLERANCE_MS,
+  );
+  return median(competing.map((sample) => sample.offsetMs));
+}
+
 export function updateClockSample(args: {
   clientSendTime: number;
   serverReceiveTime: number;
@@ -47,29 +141,45 @@ export function updateClockSample(args: {
   now: number;
   previousRttMs: number | null;
   previousClockOffsetMs: number | null;
-}): {
-  rttMs: number;
-  clockOffsetMs: number;
-} {
-  const sampleRtt =
-    args.now -
-    args.clientSendTime -
-    (args.serverSendTime - args.serverReceiveTime);
-  const sampleOffset =
-    (args.serverReceiveTime -
-      args.clientSendTime +
-      (args.serverSendTime - args.now)) /
-    2;
+  previousSamples?: ClockSample[];
+}): ClockSampleResult {
+  const outboundMs = args.serverReceiveTime - args.clientSendTime;
+  const inboundMs = args.serverSendTime - args.now;
+  const sampleRtt = outboundMs - inboundMs;
+  const sampleOffset = (outboundMs + inboundMs) / 2;
+
+  const samples = [
+    ...(args.previousSamples ?? []).filter(
+      (sample) => args.now - sample.at <= CLOCK_SAMPLE_MAX_AGE_MS,
+    ),
+    { offsetMs: sampleOffset, rttMs: sampleRtt, at: args.now },
+  ].slice(-CLOCK_SAMPLE_WINDOW_SIZE);
+
+  const estimatedOffset = estimateOffsetMs(samples);
+  // Only follow the estimate once it has moved beyond the deadband, so routine
+  // sample noise leaves the published offset — and every target extrapolated
+  // from it — untouched.
+  const clockOffsetMs =
+    args.previousClockOffsetMs === null ||
+    samples.length < CLOCK_SAMPLE_MIN_TRUSTED_SIZE ||
+    Math.abs(estimatedOffset - args.previousClockOffsetMs) >
+      CLOCK_OFFSET_DEADBAND_MS
+      ? Math.round(estimatedOffset)
+      : args.previousClockOffsetMs;
 
   return {
     rttMs:
       args.previousRttMs === null
         ? sampleRtt
         : Math.round(args.previousRttMs * 0.7 + sampleRtt * 0.3),
-    clockOffsetMs:
-      args.previousClockOffsetMs === null
-        ? sampleOffset
-        : Math.round(args.previousClockOffsetMs * 0.7 + sampleOffset * 0.3),
+    clockOffsetMs,
+    samples,
+    sample: {
+      offsetMs: sampleOffset,
+      rttMs: sampleRtt,
+      outboundMs,
+      inboundMs,
+    },
   };
 }
 
@@ -87,6 +197,19 @@ export function compensateRoomStateForClock(
   }
 
   const estimatedServerNow = now + clockOffsetMs;
+  // A state cannot reach us before the server stamped it, so a negative estimate
+  // is always offset error rather than information: pinning it to zero (i.e.
+  // "this snapshot is current") is strictly the better guess, and it bounds how
+  // far a bad offset can drag the target. The clamp is one-sided on purpose —
+  // the upper side has to stay open because `serverTime` is legitimately old
+  // whenever a stored state is replayed (a member joining a room that has been
+  // playing for a while, or a tab binding late), and those must extrapolate the
+  // full elapsed time.
+  //
+  // It does mean an offset estimate crossing zero steps the target by whatever
+  // the estimate was off by. That is why the estimate is filtered for stability
+  // rather than just smoothed (see CLOCK_OFFSET_DEADBAND_MS); the clamp cannot
+  // paper over a wandering offset, it only bounds one side of it.
   const elapsedMs = Math.max(0, estimatedServerNow - state.playback.serverTime);
   return {
     ...state,

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -126,6 +126,8 @@ const roomSessionController = createRoomSessionController({
   notifyContentScripts,
   compensateRoomState: (state, receivedAtMs) =>
     clockController.compensateRoomState(state, receivedAtMs),
+  markPlaybackArrival: (playback, atMs) =>
+    clockController.markPlaybackArrival(playback, atMs),
   clearPendingLocalShare: (reason) =>
     shareController.clearPendingLocalShare(reason),
   expirePendingLocalShareIfNeeded: () =>

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -124,7 +124,8 @@ const roomSessionController = createRoomSessionController({
   flushPendingShare,
   ensureSharedVideoOpen: () => tabController.ensureSharedVideoOpen(),
   notifyContentScripts,
-  compensateRoomState: (state) => clockController.compensateRoomState(state),
+  compensateRoomState: (state, receivedAtMs) =>
+    clockController.compensateRoomState(state, receivedAtMs),
   clearPendingLocalShare: (reason) =>
     shareController.clearPendingLocalShare(reason),
   expirePendingLocalShareIfNeeded: () =>

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -67,6 +67,7 @@ export function createRoomSessionController(args: {
   ensureSharedVideoOpen: (state: RoomState) => Promise<void>;
   notifyContentScripts: (message: BackgroundToContentMessage) => Promise<void>;
   compensateRoomState: (state: RoomState, receivedAtMs?: number) => RoomState;
+  markPlaybackArrival: (playback: RoomState["playback"], atMs: number) => void;
   clearPendingLocalShare: (reason: string) => void;
   expirePendingLocalShareIfNeeded: () => void;
   normalizeUrl: (url: string | undefined | null) => string | null;
@@ -457,10 +458,24 @@ export function createRoomSessionController(args: {
     args.connectionState.lastError = null;
 
     await args.persistState();
+
+    // Same hazard as `handleRoomStateMessage`: handlers do not serialize, so a
+    // newer state can take over while this one awaits. This one carries the *older*
+    // playback snapshot, and the content script's staleness check is per actor, so
+    // pushing it would move playback backwards for real rather than being ignored.
+    // The newer state carries the server's own member list, so nothing is lost by
+    // dropping this delta — its join/leave toast comes from the content script
+    // diffing that state.
+    if (args.roomSessionState.roomState !== nextState) {
+      args.log(
+        "background",
+        `Dropped superseded member state for ${nextState.roomCode}`,
+      );
+      return;
+    }
+
     // No arrival stamp: a member delta carries the playback snapshot we already
-    // have, so it keeps the anchor established when that snapshot arrived. Passing
-    // "now" here would restart the anchor and silently drop however long the room
-    // has been playing since.
+    // have, and its anchor was established when that snapshot arrived at ingress.
     const compensatedRoomState = args.compensateRoomState(nextState);
     await args.notifyContentScripts({
       type: "background:apply-room-state",
@@ -547,6 +562,11 @@ export function createRoomSessionController(args: {
 
     const resolvedState = consumePendingMemberDeltas(nextState);
     stopWaitingForBootstrapRoomState();
+    // Anchored before the state becomes observable and before anything awaits:
+    // from here a rehydrating content script can read it and a member delta can
+    // rewrap it, and whichever of those compensates first must find the arrival
+    // already recorded rather than anchoring the snapshot at its own moment.
+    args.markPlaybackArrival(resolvedState.playback, receivedAtMs);
     args.roomSessionState.roomState = resolvedState;
     args.roomSessionState.roomCode = resolvedState.roomCode;
     args.connectionState.lastError = null;

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -564,8 +564,18 @@ export function createRoomSessionController(args: {
     // Anchored on arrival, not on reaching this line: the two awaits above can
     // take a while (`ensureSharedVideoOpen` may open a tab) and the room played on
     // through them.
+    //
+    // Deliberately `resolvedState` and not `roomSessionState.roomState`: handlers
+    // are started with `void handleServerMessage(...)` per socket message and do
+    // not serialize, so a later state can land in shared state while this one is
+    // awaiting. Re-reading it here would pair that newer snapshot with *this*
+    // message's arrival time and anchor it too early — and the correctly paired
+    // call that follows could not repair it, because the content script drops the
+    // second apply of a snapshot it has already versioned. Each handler applies
+    // the snapshot it is responsible for, with the arrival time that belongs to
+    // it; an out-of-order apply is rejected by that same version guard.
     const compensatedRoomState = args.compensateRoomState(
-      args.roomSessionState.roomState,
+      resolvedState,
       receivedAtMs,
     );
     await args.notifyContentScripts({

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -66,12 +66,18 @@ export function createRoomSessionController(args: {
   flushPendingShare: () => void;
   ensureSharedVideoOpen: (state: RoomState) => Promise<void>;
   notifyContentScripts: (message: BackgroundToContentMessage) => Promise<void>;
-  compensateRoomState: (state: RoomState) => RoomState;
+  compensateRoomState: (state: RoomState, receivedAtMs?: number) => RoomState;
   clearPendingLocalShare: (reason: string) => void;
   expirePendingLocalShareIfNeeded: () => void;
   normalizeUrl: (url: string | undefined | null) => string | null;
   logServerError: (code: string, message: string) => void;
   shareToastTtlMs: number;
+  /**
+   * Monotonic time source, shared with the clock controller: it stamps when a
+   * `room:state` arrived so that the work before applying it is not credited to
+   * nobody. See `ClockController.compensateRoomState`.
+   */
+  getMonotonicNow?: () => number;
   bootstrapRoomStateTimeoutMs?: number;
 }): RoomSessionController {
   let pendingJoinAttemptResolvers: Array<(result: JoinAttemptResult) => void> =
@@ -83,6 +89,7 @@ export function createRoomSessionController(args: {
     null;
   const bootstrapRoomStateTimeoutMs =
     args.bootstrapRoomStateTimeoutMs ?? DEFAULT_BOOTSTRAP_ROOM_STATE_TIMEOUT_MS;
+  const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
 
   function clearPendingMemberDeltas(): void {
     pendingMemberDeltas = [];
@@ -241,6 +248,8 @@ export function createRoomSessionController(args: {
       await args.persistState();
       return;
     }
+    // As in `applyRoomMemberState`: the queued deltas only change membership, so
+    // the playback snapshot — and its anchor — is the one that already arrived.
     const compensatedRoomState = args.compensateRoomState(resolvedState);
     await args.notifyContentScripts({
       type: "background:apply-room-state",
@@ -335,6 +344,9 @@ export function createRoomSessionController(args: {
   }
 
   async function handleServerMessage(message: ServerMessage): Promise<void> {
+    // Stamped before anything can await: everything between the socket event and
+    // here is synchronous, so this is when the message reached us.
+    const receivedAtMs = monotonicNow();
     switch (message.type) {
       case "room:created":
         clearPendingMemberDeltas();
@@ -371,7 +383,7 @@ export function createRoomSessionController(args: {
         args.notifyAll();
         return;
       case "room:state":
-        await handleRoomStateMessage(message.payload);
+        await handleRoomStateMessage(message.payload, receivedAtMs);
         return;
       case "room:member-joined":
         await handleRoomMemberJoined(
@@ -445,6 +457,10 @@ export function createRoomSessionController(args: {
     args.connectionState.lastError = null;
 
     await args.persistState();
+    // No arrival stamp: a member delta carries the playback snapshot we already
+    // have, so it keeps the anchor established when that snapshot arrived. Passing
+    // "now" here would restart the anchor and silently drop however long the room
+    // has been playing since.
     const compensatedRoomState = args.compensateRoomState(nextState);
     await args.notifyContentScripts({
       type: "background:apply-room-state",
@@ -490,7 +506,10 @@ export function createRoomSessionController(args: {
     );
   }
 
-  async function handleRoomStateMessage(nextState: RoomState): Promise<void> {
+  async function handleRoomStateMessage(
+    nextState: RoomState,
+    receivedAtMs: number,
+  ): Promise<void> {
     args.expirePendingLocalShareIfNeeded();
     const decision = decideIncomingRoomState({
       currentRoomState: args.roomSessionState.roomState,
@@ -542,8 +561,12 @@ export function createRoomSessionController(args: {
 
     await args.persistState();
     await args.ensureSharedVideoOpen(args.roomSessionState.roomState);
+    // Anchored on arrival, not on reaching this line: the two awaits above can
+    // take a while (`ensureSharedVideoOpen` may open a tab) and the room played on
+    // through them.
     const compensatedRoomState = args.compensateRoomState(
       args.roomSessionState.roomState,
+      receivedAtMs,
     );
     await args.notifyContentScripts({
       type: "background:apply-room-state",

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -561,19 +561,32 @@ export function createRoomSessionController(args: {
 
     await args.persistState();
     await args.ensureSharedVideoOpen(args.roomSessionState.roomState);
-    // Anchored on arrival, not on reaching this line: the two awaits above can
-    // take a while (`ensureSharedVideoOpen` may open a tab) and the room played on
-    // through them.
+
+    // Handlers are started with `void handleServerMessage(...)` per socket message
+    // and do not serialize, so a later state can take over while this one is
+    // awaiting (`ensureSharedVideoOpen` may open a tab). Once that has happened
+    // this handler has nothing left to deliver: the newer state is what the room
+    // is, and its own handler applies and announces it.
     //
-    // Deliberately `resolvedState` and not `roomSessionState.roomState`: handlers
-    // are started with `void handleServerMessage(...)` per socket message and do
-    // not serialize, so a later state can land in shared state while this one is
-    // awaiting. Re-reading it here would pair that newer snapshot with *this*
-    // message's arrival time and anchor it too early — and the correctly paired
-    // call that follows could not repair it, because the content script drops the
-    // second apply of a snapshot it has already versioned. Each handler applies
-    // the snapshot it is responsible for, with the arrival time that belongs to
-    // it; an out-of-order apply is rejected by that same version guard.
+    // Pushing our snapshot anyway would move playback backwards. The content
+    // script's staleness check is per actor
+    // (`room-state-apply-controller` looks up `lastAppliedVersionByActor`), so an
+    // older snapshot from a *different* member is not recognised as stale and gets
+    // applied — the position is a real regression, not a dropped message. Even for
+    // the same actor, compensating here would already have re-pointed the single
+    // anchor at the older snapshot before the content script rejects it.
+    if (args.roomSessionState.roomState !== resolvedState) {
+      args.log(
+        "background",
+        `Dropped superseded room state for ${resolvedState.roomCode}`,
+      );
+      return;
+    }
+
+    // Anchored on arrival, not on reaching this line: the awaits above can take a
+    // while and the room played on through them. `resolvedState` and its own
+    // arrival time, never a re-read of shared state — a snapshot must only ever be
+    // paired with the arrival that belongs to it.
     const compensatedRoomState = args.compensateRoomState(
       resolvedState,
       receivedAtMs,

--- a/extension/src/background/runtime-state.ts
+++ b/extension/src/background/runtime-state.ts
@@ -7,6 +7,7 @@ import type {
   DebugLogEntry,
   SharedVideoToastPayload,
 } from "../shared/messages";
+import type { ClockSample } from "./clock-sync";
 
 declare const __BILI_SYNCPLAY_DEFAULT_SERVER_URL__: string | undefined;
 
@@ -107,6 +108,8 @@ export interface ShareState {
 export interface ClockState {
   clockOffsetMs: number | null;
   rttMs: number | null;
+  /** Recent ping samples backing the robust offset estimate, oldest first. */
+  clockSamples: ClockSample[];
   clockSyncTimer: number | null;
 }
 
@@ -171,6 +174,7 @@ export function createBackgroundRuntimeState(): BackgroundRuntimeState {
     clock: {
       clockOffsetMs: null,
       rttMs: null,
+      clockSamples: [],
       clockSyncTimer: null,
     },
     diagnostics: {

--- a/extension/src/background/runtime-sync-controller.ts
+++ b/extension/src/background/runtime-sync-controller.ts
@@ -61,6 +61,7 @@ export function createRuntimeSyncController(args: {
       clock: {
         clockOffsetMs: args.clockState.clockOffsetMs,
         rttMs: args.clockState.rttMs,
+        clockSamples: args.clockState.clockSamples,
         clockSyncTimer: args.clockState.clockSyncTimer,
       },
       diagnostics: {

--- a/extension/src/content/room-state-controller.ts
+++ b/extension/src/content/room-state-controller.ts
@@ -48,16 +48,24 @@ export function createRoomStateController(args: {
   }
 
   function notifyRoomStateToasts(state: RoomState): void {
+    // Monotonic: every timing decision downstream is an interval measured on
+    // this machine, and none of them may move when a clock is adjusted.
+    const now = performance.now();
     const plan = getRoomStateToastMessages({
       previousState: args.toastState.lastRoomState,
       nextState: state,
       localMemberId: args.runtimeState.localMemberId,
       pendingRoomStateHydration: args.runtimeState.pendingRoomStateHydration,
       isCurrentPageShowingSharedVideo: isCurrentPageShowingSharedVideo(state),
-      now: Date.now(),
+      now,
+      elapsedSincePreviousStateMs:
+        args.toastState.lastRoomStateAtMs === null
+          ? 0
+          : now - args.toastState.lastRoomStateAtMs,
       lastSeekToastByActor: args.toastState.lastSeekToastByActor,
     });
     args.toastState.lastRoomState = state;
+    args.toastState.lastRoomStateAtMs = now;
     args.toastState.lastSeekToastByActor = plan.nextSeekToastByActor;
     for (const message of plan.messages) {
       args.toastPresenter.show(message);

--- a/extension/src/content/toast.ts
+++ b/extension/src/content/toast.ts
@@ -8,6 +8,8 @@ const SEEK_START_TOAST_SUPPRESSION_MS = 1600;
 
 export interface ToastCoordinatorState {
   lastRoomState: RoomState | null;
+  /** Monotonic timestamp of when `lastRoomState` reached us. */
+  lastRoomStateAtMs: number | null;
   lastSeekToastByActor: Map<string, number>;
   lastSharedVideoToastKey: string | null;
 }
@@ -15,6 +17,7 @@ export interface ToastCoordinatorState {
 export function createToastCoordinatorState(): ToastCoordinatorState {
   return {
     lastRoomState: null,
+    lastRoomStateAtMs: null,
     lastSeekToastByActor: new Map(),
     lastSharedVideoToastKey: null,
   };
@@ -139,32 +142,56 @@ function formatPlaybackRate(rate: number): string {
   return `${rounded.toFixed(2).replace(/0+$/, "").replace(/\.$/, "")}x`;
 }
 
+/**
+ * Whether the room's position moved by more than playing it out can explain —
+ * i.e. somebody seeked.
+ *
+ * The content advance is checked against *two independent* references for how
+ * much time really passed, and only counts as a seek when both agree, because
+ * each has its own way of lying:
+ *
+ * - `serverTime` deltas are immune to anything happening on this machine, but
+ *   they are stamped with the server's wall clock. A server whose clock is
+ *   stepped (a container or VM being resynced — a WSL dev server was seen moving
+ *   ~1.9s between pings) reports an interval that never happened, and the
+ *   difference lands here as a phantom jump.
+ * - The locally measured interval between the two states arriving is immune to
+ *   any clock being adjusted, but not to this page being starved: two states
+ *   processed back to back after the main thread stalls look like no time passed
+ *   at all, which reads as the room having jumped forward.
+ *
+ * A real seek moves the position against *both* references, so requiring both to
+ * exceed the threshold removes both families of false positive. The cost is a
+ * missed toast when a genuine seek coincides with a clock step or a stall —
+ * cosmetic, and the next update tells the story anyway. A false toast is worse:
+ * it says a peer did something they did not do.
+ */
 function shouldShowSeekToast(
   previousPlayback: PlaybackState,
   nextPlayback: PlaybackState,
+  localElapsedMs: number,
 ): boolean {
   const actualDelta = nextPlayback.currentTime - previousPlayback.currentTime;
-  const elapsedSeconds =
+  const serverElapsedSeconds =
     Math.max(0, nextPlayback.serverTime - previousPlayback.serverTime) / 1000;
-  const expectedDelta = elapsedSeconds * previousPlayback.playbackRate;
+  const localElapsedSeconds = Math.max(0, localElapsedMs) / 1000;
+  const unexplainedBy = (elapsedSeconds: number): number =>
+    Math.abs(actualDelta - elapsedSeconds * previousPlayback.playbackRate);
 
-  if (
-    previousPlayback.playState === "playing" &&
-    nextPlayback.playState !== "playing"
-  ) {
-    return (
-      Math.abs(actualDelta - expectedDelta) >= SEEK_TOAST_THRESHOLD_SECONDS
-    );
-  }
-
-  if (
-    previousPlayback.playState !== "playing" ||
-    nextPlayback.playState !== "playing"
-  ) {
+  if (previousPlayback.playState !== "playing") {
+    // The room was not advancing, so no amount of elapsed time explains a move:
+    // any change of position since then was somebody seeking. This also covers
+    // resuming from a pause, where crediting the elapsed time would report the
+    // paused interval as a backwards jump.
     return Math.abs(actualDelta) >= SEEK_TOAST_THRESHOLD_SECONDS;
   }
 
-  return Math.abs(actualDelta - expectedDelta) >= SEEK_TOAST_THRESHOLD_SECONDS;
+  return (
+    Math.min(
+      unexplainedBy(serverElapsedSeconds),
+      unexplainedBy(localElapsedSeconds),
+    ) >= SEEK_TOAST_THRESHOLD_SECONDS
+  );
 }
 
 export function getRoomStateToastMessages(args: {
@@ -173,7 +200,17 @@ export function getRoomStateToastMessages(args: {
   localMemberId: string | null;
   pendingRoomStateHydration: boolean;
   isCurrentPageShowingSharedVideo: boolean;
+  /**
+   * Monotonic "now", also the clock `lastSeekToastByActor` timestamps are on.
+   * Monotonic so that a clock adjustment cannot widen or collapse either the
+   * seek check or the suppression window.
+   */
   now: number;
+  /**
+   * Locally measured interval between `previousState` and `nextState` arriving,
+   * on the same monotonic clock as `now`. See {@link shouldShowSeekToast}.
+   */
+  elapsedSincePreviousStateMs: number;
   lastSeekToastByActor: Map<string, number>;
 }): {
   messages: string[];
@@ -229,7 +266,11 @@ export function getRoomStateToastMessages(args: {
     args.nextState.playback &&
     args.previousState.sharedVideo?.url === args.nextState.sharedVideo?.url &&
     args.nextState.playback.actorId !== args.localMemberId &&
-    shouldShowSeekToast(args.previousState.playback, args.nextState.playback),
+    shouldShowSeekToast(
+      args.previousState.playback,
+      args.nextState.playback,
+      args.elapsedSincePreviousStateMs,
+    ),
   );
 
   if (

--- a/extension/test/clock-controller.test.ts
+++ b/extension/test/clock-controller.test.ts
@@ -277,3 +277,54 @@ test("a later arrival stamp never pushes an anchor forward", () => {
       0.001,
   );
 });
+
+test("an arrival marked at ingress survives a reader compensating first", () => {
+  // The member-delta and hydration paths compensate without an arrival time; with
+  // the anchor already recorded at ingress they no longer restart it.
+  const { controller, setMonotonicNow } = createHarness();
+  const state = roomState({ seq: 1, currentTime: 42, serverTime: 1_000 });
+
+  controller.markPlaybackArrival(state.playback, 1_000);
+  setMonotonicNow(3_000);
+
+  assert.ok(
+    Math.abs(controller.compensateRoomState(state).playback!.currentTime - 44) <
+      0.001,
+  );
+});
+
+test("marking a non-playing arrival drops the anchor", () => {
+  const { controller, setMonotonicNow } = createHarness();
+  const playing = roomState({ seq: 1, currentTime: 42, serverTime: 1_000 });
+  controller.markPlaybackArrival(playing.playback, 1_000);
+
+  controller.markPlaybackArrival(
+    roomState({
+      seq: 2,
+      currentTime: 42,
+      serverTime: 2_000,
+      playState: "paused",
+    }).playback,
+    2_000,
+  );
+  setMonotonicNow(120_000);
+
+  assert.equal(
+    controller.compensateRoomState(playing).playback!.currentTime,
+    42,
+  );
+});
+
+test("a repeated arrival of one snapshot keeps the earliest", () => {
+  const { controller, setMonotonicNow } = createHarness();
+  const state = roomState({ seq: 1, currentTime: 42, serverTime: 1_000 });
+
+  controller.markPlaybackArrival(state.playback, 1_000);
+  controller.markPlaybackArrival(state.playback, 2_500);
+  setMonotonicNow(3_000);
+
+  assert.ok(
+    Math.abs(controller.compensateRoomState(state).playback!.currentTime - 44) <
+      0.001,
+  );
+});

--- a/extension/test/clock-controller.test.ts
+++ b/extension/test/clock-controller.test.ts
@@ -202,3 +202,43 @@ test("updateClockOffset still publishes the diagnostic offset and rtt", () => {
   );
   assert.equal(clockState.clockSamples.length, 1);
 });
+
+test("a reused seq at a repeated position is still a new snapshot", () => {
+  // `seq` restarts at 0 on every content-script load, so identity cannot rest on
+  // it: a member who reloads and resumes where an early-seq snapshot already was
+  // would otherwise match a key the controller has seen, and inherit its anchor.
+  const { controller, setMonotonicNow } = createHarness();
+  controller.compensateRoomState(
+    roomState({ seq: 1, currentTime: 42, serverTime: 1_000 }),
+  );
+
+  setMonotonicNow(120_000);
+  const afterReload = controller.compensateRoomState(
+    roomState({ seq: 1, currentTime: 42, serverTime: 500_000 }),
+  );
+
+  assert.equal(afterReload.playback!.currentTime, 42);
+});
+
+test("a pause drops the anchor so nothing extrapolates across it", () => {
+  const { controller, setMonotonicNow } = createHarness();
+  const playing = roomState({ seq: 1, currentTime: 42, serverTime: 1_000 });
+  controller.compensateRoomState(playing);
+
+  controller.compensateRoomState(
+    roomState({
+      seq: 2,
+      currentTime: 42,
+      serverTime: 2_000,
+      playState: "paused",
+    }),
+  );
+  setMonotonicNow(120_000);
+
+  // Same snapshot as before the pause: without dropping the anchor this would be
+  // advanced by the whole paused interval.
+  assert.equal(
+    controller.compensateRoomState(playing).playback!.currentTime,
+    42,
+  );
+});

--- a/extension/test/clock-controller.test.ts
+++ b/extension/test/clock-controller.test.ts
@@ -242,3 +242,38 @@ test("a pause drops the anchor so nothing extrapolates across it", () => {
     42,
   );
 });
+
+test("an explicit arrival corrects an anchor a reader established late", () => {
+  // A snapshot is readable before its own handler finishes, so a rehydrating
+  // content script can ask for it — with no arrival time — first, anchoring it at
+  // request time. Reported by Codex review on #210.
+  const { controller, setMonotonicNow } = createHarness();
+  const state = roomState({ seq: 1, currentTime: 42, serverTime: 1_000 });
+
+  setMonotonicNow(2_500);
+  controller.compensateRoomState(state); // hydration read, anchors at 2500
+  setMonotonicNow(3_000);
+  controller.compensateRoomState(state, 1_000); // handler: it arrived at 1000
+
+  setMonotonicNow(4_000);
+
+  // 3s since the real arrival, not 1.5s since it was first read.
+  assert.ok(
+    Math.abs(controller.compensateRoomState(state).playback!.currentTime - 45) <
+      0.001,
+  );
+});
+
+test("a later arrival stamp never pushes an anchor forward", () => {
+  const { controller, setMonotonicNow } = createHarness();
+  const state = roomState({ seq: 1, currentTime: 42, serverTime: 1_000 });
+  controller.compensateRoomState(state, 1_000);
+
+  setMonotonicNow(3_000);
+  controller.compensateRoomState(state, 2_500);
+
+  assert.ok(
+    Math.abs(controller.compensateRoomState(state).playback!.currentTime - 44) <
+      0.001,
+  );
+});

--- a/extension/test/clock-controller.test.ts
+++ b/extension/test/clock-controller.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { RoomState } from "@bili-syncplay/protocol";
+import { createClockController } from "../src/background/clock-controller";
+import type {
+  ClockState,
+  ConnectionState,
+} from "../src/background/runtime-state";
+
+function createHarness(): {
+  controller: ReturnType<typeof createClockController>;
+  clockState: ClockState;
+  setMonotonicNow: (value: number) => void;
+} {
+  let monotonicNow = 1_000;
+  const clockState: ClockState = {
+    clockOffsetMs: null,
+    rttMs: null,
+    clockSamples: [],
+    clockSyncTimer: null,
+  };
+  const controller = createClockController({
+    connectionState: { connected: true } as unknown as ConnectionState,
+    clockState,
+    sendToServer: () => {},
+    log: () => {},
+    getMonotonicNow: () => monotonicNow,
+  });
+
+  return {
+    controller,
+    clockState,
+    setMonotonicNow: (value) => {
+      monotonicNow = value;
+    },
+  };
+}
+
+function roomState(args: {
+  seq: number;
+  currentTime: number;
+  playState?: "playing" | "paused";
+  playbackRate?: number;
+  serverTime?: number;
+}): RoomState {
+  return {
+    roomCode: "ABC123",
+    members: [],
+    sharedVideo: null,
+    playback: {
+      actorId: "peer",
+      seq: args.seq,
+      url: "https://www.bilibili.com/video/BV1",
+      playState: args.playState ?? "playing",
+      currentTime: args.currentTime,
+      playbackRate: args.playbackRate ?? 1,
+      serverTime: args.serverTime ?? 0,
+    },
+  } as unknown as RoomState;
+}
+
+test("a freshly arrived snapshot is passed through as reported", () => {
+  const { controller } = createHarness();
+
+  const compensated = controller.compensateRoomState(
+    roomState({ seq: 1, currentTime: 42 }),
+  );
+
+  assert.equal(compensated.playback!.currentTime, 42);
+});
+
+test("replaying the same snapshot advances it by the time since it arrived", () => {
+  const { controller, setMonotonicNow } = createHarness();
+  const state = roomState({ seq: 1, currentTime: 42 });
+
+  controller.compensateRoomState(state);
+  setMonotonicNow(3_500);
+
+  // 2.5s of real time passed since this snapshot arrived, so the room has moved
+  // on by 2.5s of content — a late-binding tab must be told where it is *now*.
+  assert.ok(
+    Math.abs(
+      controller.compensateRoomState(state).playback!.currentTime - 44.5,
+    ) < 0.001,
+  );
+});
+
+test("each new snapshot re-anchors instead of accumulating", () => {
+  const { controller, setMonotonicNow } = createHarness();
+
+  controller.compensateRoomState(roomState({ seq: 1, currentTime: 42 }));
+  setMonotonicNow(3_100);
+  const next = controller.compensateRoomState(
+    roomState({ seq: 2, currentTime: 44.1 }),
+  );
+
+  assert.equal(next.playback!.currentTime, 44.1);
+});
+
+test("a wall-clock step cannot move the extrapolated position", () => {
+  // The failure this design exists to remove: the server in WSL and the browser
+  // on the host disagree by an amount that jumps by ~1s within a ping interval.
+  // Anchoring on a monotonic local clock makes `serverTime` — and therefore any
+  // disagreement with it — irrelevant.
+  const { controller, setMonotonicNow } = createHarness();
+  const arrived = roomState({ seq: 1, currentTime: 42, serverTime: 1_000 });
+  controller.compensateRoomState(arrived);
+
+  setMonotonicNow(2_000);
+  const stepped = controller.compensateRoomState(
+    roomState({ seq: 1, currentTime: 42, serverTime: 1_000 }),
+  );
+
+  assert.ok(Math.abs(stepped.playback!.currentTime - 43) < 0.001);
+});
+
+test("scales the advance by the room playback rate", () => {
+  const { controller, setMonotonicNow } = createHarness();
+  const state = roomState({ seq: 1, currentTime: 42, playbackRate: 2 });
+
+  controller.compensateRoomState(state);
+  setMonotonicNow(2_000);
+
+  assert.ok(
+    Math.abs(controller.compensateRoomState(state).playback!.currentTime - 44) <
+      0.001,
+  );
+});
+
+test("paused snapshots are never extrapolated", () => {
+  const { controller, setMonotonicNow } = createHarness();
+  const paused = roomState({ seq: 1, currentTime: 42, playState: "paused" });
+
+  controller.compensateRoomState(paused);
+  setMonotonicNow(60_000);
+
+  assert.equal(
+    controller.compensateRoomState(paused).playback!.currentTime,
+    42,
+  );
+});
+
+test("a paused snapshot does not become the anchor for the next playing one", () => {
+  const { controller, setMonotonicNow } = createHarness();
+
+  controller.compensateRoomState(
+    roomState({ seq: 1, currentTime: 42, playState: "paused" }),
+  );
+  setMonotonicNow(30_000);
+  const resumed = controller.compensateRoomState(
+    roomState({ seq: 2, currentTime: 42 }),
+  );
+
+  assert.equal(resumed.playback!.currentTime, 42);
+});
+
+test("updateClockOffset still publishes the diagnostic offset and rtt", () => {
+  const { controller, clockState } = createHarness();
+
+  // A round trip of ~40ms with the server clock ~200ms ahead. The reply is timed
+  // against the real wall clock inside the controller, so allow a few ms of slack
+  // for the call itself.
+  const sentAt = Date.now() - 40;
+  const serverStamp = sentAt + 20 + 200;
+  controller.updateClockOffset(sentAt, serverStamp, serverStamp);
+
+  assert.ok(
+    Math.abs(clockState.rttMs! - 40) <= 5,
+    `unexpected rtt ${clockState.rttMs}`,
+  );
+  assert.ok(
+    Math.abs(clockState.clockOffsetMs! - 200) <= 5,
+    `unexpected offset ${clockState.clockOffsetMs}`,
+  );
+  assert.equal(clockState.clockSamples.length, 1);
+});

--- a/extension/test/clock-controller.test.ts
+++ b/extension/test/clock-controller.test.ts
@@ -85,6 +85,34 @@ test("replaying the same snapshot advances it by the time since it arrived", () 
   );
 });
 
+test("anchors on the supplied arrival stamp, not on the call", () => {
+  // Work between arrival and applying a snapshot (persisting state, opening the
+  // shared video's tab) is not instant, and the room plays on through it.
+  const { controller, setMonotonicNow } = createHarness();
+  setMonotonicNow(1_800);
+
+  const compensated = controller.compensateRoomState(
+    roomState({ seq: 1, currentTime: 42 }),
+    1_000,
+  );
+
+  assert.ok(Math.abs(compensated.playback!.currentTime - 42.8) < 0.001);
+});
+
+test("keeps extrapolating from the arrival stamp on later replays", () => {
+  const { controller, setMonotonicNow } = createHarness();
+  const state = roomState({ seq: 1, currentTime: 42 });
+  setMonotonicNow(1_500);
+  controller.compensateRoomState(state, 1_000);
+
+  setMonotonicNow(3_000);
+
+  assert.ok(
+    Math.abs(controller.compensateRoomState(state).playback!.currentTime - 44) <
+      0.001,
+  );
+});
+
 test("each new snapshot re-anchors instead of accumulating", () => {
   const { controller, setMonotonicNow } = createHarness();
 

--- a/extension/test/clock-sync.test.ts
+++ b/extension/test/clock-sync.test.ts
@@ -1,0 +1,365 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { RoomState } from "@bili-syncplay/protocol";
+import {
+  CLOCK_OFFSET_DEADBAND_MS,
+  CLOCK_SAMPLE_MAX_AGE_MS,
+  CLOCK_SAMPLE_MIN_TRUSTED_SIZE,
+  CLOCK_SAMPLE_WINDOW_SIZE,
+  compensateRoomStateForClock,
+  updateClockSample,
+  type ClockSample,
+} from "../src/background/clock-sync";
+
+/**
+ * A round trip that took `rttMs` while the server clock ran `offsetMs` ahead,
+ * with the delay split evenly between the two directions (the case the
+ * estimator is exact for).
+ */
+function pingRoundTrip(args: {
+  clientSendTime: number;
+  offsetMs: number;
+  rttMs: number;
+  serverProcessingMs?: number;
+}): {
+  clientSendTime: number;
+  serverReceiveTime: number;
+  serverSendTime: number;
+  now: number;
+} {
+  const oneWay = args.rttMs / 2;
+  const processing = args.serverProcessingMs ?? 0;
+  return {
+    clientSendTime: args.clientSendTime,
+    serverReceiveTime: args.clientSendTime + oneWay + args.offsetMs,
+    serverSendTime: args.clientSendTime + oneWay + args.offsetMs + processing,
+    now: args.clientSendTime + args.rttMs + processing,
+  };
+}
+
+/** Feed a series of samples through the estimator, threading its state. */
+function runSamples(
+  samples: { offsetMs: number; rttMs: number; atMs: number }[],
+): {
+  clockOffsetMs: number | null;
+  rttMs: number | null;
+  window: ClockSample[];
+} {
+  let clockOffsetMs: number | null = null;
+  let rttMs: number | null = null;
+  let window: ClockSample[] = [];
+
+  for (const sample of samples) {
+    const result = updateClockSample({
+      ...pingRoundTrip({
+        clientSendTime: sample.atMs,
+        offsetMs: sample.offsetMs,
+        rttMs: sample.rttMs,
+      }),
+      previousRttMs: rttMs,
+      previousClockOffsetMs: clockOffsetMs,
+      previousSamples: window,
+    });
+    clockOffsetMs = result.clockOffsetMs;
+    rttMs = result.rttMs;
+    window = result.samples;
+  }
+
+  return { clockOffsetMs, rttMs, window };
+}
+
+test("recovers the clock offset and round trip from a single sample", () => {
+  const result = updateClockSample({
+    ...pingRoundTrip({ clientSendTime: 1_000, offsetMs: 200, rttMs: 40 }),
+    previousRttMs: null,
+    previousClockOffsetMs: null,
+  });
+
+  assert.equal(result.clockOffsetMs, 200);
+  assert.equal(result.rttMs, 40);
+  assert.equal(result.sample.offsetMs, 200);
+  assert.equal(result.samples.length, 1);
+});
+
+test("server processing time is excluded from the round trip", () => {
+  const result = updateClockSample({
+    ...pingRoundTrip({
+      clientSendTime: 1_000,
+      offsetMs: 0,
+      rttMs: 30,
+      serverProcessingMs: 500,
+    }),
+    previousRttMs: null,
+    previousClockOffsetMs: null,
+  });
+
+  assert.equal(result.rttMs, 30);
+  assert.equal(result.sample.offsetMs, 0);
+});
+
+test("an isolated wild sample does not move the published offset", () => {
+  const steady = Array.from({ length: 5 }, (_value, index) => ({
+    offsetMs: 200,
+    rttMs: 10,
+    atMs: 1_000 + index * 15_000,
+  }));
+  const settled = runSamples(steady);
+  assert.equal(settled.clockOffsetMs, 200);
+
+  const withOutlier = runSamples([
+    ...steady,
+    { offsetMs: 900, rttMs: 10, atMs: 1_000 + 5 * 15_000 },
+  ]);
+
+  assert.equal(withOutlier.clockOffsetMs, 200);
+});
+
+test("alternating noise leaves the published offset still", () => {
+  // The observed failure mode: samples swinging by hundreds of ms while the
+  // round trip stays flat. Every one of these would have been mixed straight
+  // into an EWMA and re-timed each extrapolated playback target.
+  const noisy = [-200, 550, 120, 480, 210, 330, 150, 520, 190].map(
+    (offsetMs, index) => ({
+      offsetMs,
+      rttMs: 10,
+      atMs: 1_000 + index * 15_000,
+    }),
+  );
+
+  const published: (number | null)[] = [];
+  let clockOffsetMs: number | null = null;
+  let window: ClockSample[] = [];
+  for (const sample of noisy) {
+    const result = updateClockSample({
+      ...pingRoundTrip({
+        clientSendTime: sample.atMs,
+        offsetMs: sample.offsetMs,
+        rttMs: sample.rttMs,
+      }),
+      previousRttMs: null,
+      previousClockOffsetMs: clockOffsetMs,
+      previousSamples: window,
+    });
+    clockOffsetMs = result.clockOffsetMs;
+    window = result.samples;
+    published.push(clockOffsetMs);
+  }
+
+  // Once the window has a majority to appeal to, the published offset stops
+  // moving: the median of a symmetric spread never travels a full deadband from
+  // where it settled, so extrapolated targets keep advancing at exactly 1x.
+  const settled = published.slice(CLOCK_SAMPLE_MIN_TRUSTED_SIZE);
+  assert.ok(settled.length >= 5, "expected enough samples past warm-up");
+  assert.deepEqual(
+    [...new Set(settled)],
+    [settled[0]],
+    `expected the published offset to hold, saw: ${published.join(",")}`,
+  );
+});
+
+test("follows a sustained offset change once the window turns over", () => {
+  const settled = runSamples(
+    Array.from({ length: CLOCK_SAMPLE_WINDOW_SIZE }, (_value, index) => ({
+      offsetMs: 100,
+      rttMs: 10,
+      atMs: 1_000 + index * 15_000,
+    })),
+  );
+  assert.equal(settled.clockOffsetMs, 100);
+
+  const shifted = runSamples([
+    ...Array.from({ length: CLOCK_SAMPLE_WINDOW_SIZE }, (_value, index) => ({
+      offsetMs: 100,
+      rttMs: 10,
+      atMs: 1_000 + index * 15_000,
+    })),
+    ...Array.from({ length: CLOCK_SAMPLE_WINDOW_SIZE }, (_value, index) => ({
+      offsetMs: 900,
+      rttMs: 10,
+      atMs: 1_000 + (CLOCK_SAMPLE_WINDOW_SIZE + index) * 15_000,
+    })),
+  ]);
+
+  assert.equal(shifted.clockOffsetMs, 900);
+});
+
+test("a slow round trip loses to the faster samples in the window", () => {
+  const result = runSamples([
+    { offsetMs: 100, rttMs: 8, atMs: 1_000 },
+    { offsetMs: 100, rttMs: 8, atMs: 16_000 },
+    // Asymmetric delay: a 600ms round trip can skew a sample by up to 300ms.
+    { offsetMs: 400, rttMs: 600, atMs: 31_000 },
+  ]);
+
+  assert.equal(result.clockOffsetMs, 100);
+});
+
+test("an impossible round trip cannot disqualify the honest samples", () => {
+  // A negative round trip means the four timestamps disagree; such a sample must
+  // not become the bar that every other sample is measured against.
+  let clockOffsetMs: number | null = null;
+  let window: ClockSample[] = [];
+  const steady = [
+    { offsetMs: 100, rttMs: 10, atMs: 1_000 },
+    { offsetMs: 100, rttMs: 10, atMs: 16_000 },
+    { offsetMs: 100, rttMs: 10, atMs: 31_000 },
+  ];
+  for (const sample of steady) {
+    const result = updateClockSample({
+      ...pingRoundTrip({
+        clientSendTime: sample.atMs,
+        offsetMs: sample.offsetMs,
+        rttMs: sample.rttMs,
+      }),
+      previousRttMs: null,
+      previousClockOffsetMs: clockOffsetMs,
+      previousSamples: window,
+    });
+    clockOffsetMs = result.clockOffsetMs;
+    window = result.samples;
+  }
+  assert.equal(clockOffsetMs, 100);
+
+  // Reported server processing (800ms) exceeds the whole round trip the client
+  // measured (0ms), so the derived round trip comes out negative.
+  const withImpossible = updateClockSample({
+    clientSendTime: 46_000,
+    serverReceiveTime: 46_100,
+    serverSendTime: 46_900,
+    now: 46_000,
+    previousRttMs: 10,
+    previousClockOffsetMs: clockOffsetMs,
+    previousSamples: window,
+  });
+
+  assert.ok(withImpossible.sample.rttMs < 0);
+  assert.equal(withImpossible.clockOffsetMs, 100);
+});
+
+test("samples older than the retention window are dropped", () => {
+  const result = updateClockSample({
+    ...pingRoundTrip({ clientSendTime: 10_000_000, offsetMs: 300, rttMs: 10 }),
+    previousRttMs: 10,
+    previousClockOffsetMs: 100,
+    previousSamples: [
+      {
+        offsetMs: 100,
+        rttMs: 10,
+        at: 10_000_000 - CLOCK_SAMPLE_MAX_AGE_MS - 1,
+      },
+      {
+        offsetMs: 100,
+        rttMs: 10,
+        at: 10_000_000 - CLOCK_SAMPLE_MAX_AGE_MS - 2,
+      },
+    ],
+  });
+
+  assert.equal(result.samples.length, 1);
+  assert.equal(result.clockOffsetMs, 300);
+});
+
+test("the window is bounded", () => {
+  const result = runSamples(
+    Array.from({ length: CLOCK_SAMPLE_WINDOW_SIZE + 6 }, (_value, index) => ({
+      offsetMs: 50,
+      rttMs: 10,
+      atMs: 1_000 + index * 15_000,
+    })),
+  );
+
+  assert.equal(result.window.length, CLOCK_SAMPLE_WINDOW_SIZE);
+});
+
+test("a move just inside the deadband is ignored, just outside is taken", () => {
+  const base = Array.from(
+    { length: CLOCK_SAMPLE_WINDOW_SIZE },
+    (_v, index) => ({
+      offsetMs: 0,
+      rttMs: 10,
+      atMs: 1_000 + index * 15_000,
+    }),
+  );
+  const shiftBy = (delta: number) =>
+    runSamples([
+      ...base,
+      ...Array.from({ length: CLOCK_SAMPLE_WINDOW_SIZE }, (_v, index) => ({
+        offsetMs: delta,
+        rttMs: 10,
+        atMs: 1_000 + (CLOCK_SAMPLE_WINDOW_SIZE + index) * 15_000,
+      })),
+    ]).clockOffsetMs;
+
+  assert.equal(shiftBy(CLOCK_OFFSET_DEADBAND_MS), 0);
+  assert.equal(
+    shiftBy(CLOCK_OFFSET_DEADBAND_MS + 1),
+    CLOCK_OFFSET_DEADBAND_MS + 1,
+  );
+});
+
+function playingRoomState(args: {
+  currentTime: number;
+  serverTime: number;
+  playbackRate?: number;
+}): RoomState {
+  return {
+    roomCode: "ABC123",
+    members: [],
+    sharedVideo: null,
+    playback: {
+      actorId: "actor",
+      seq: 1,
+      url: "https://www.bilibili.com/video/BV1",
+      playState: "playing",
+      currentTime: args.currentTime,
+      playbackRate: args.playbackRate ?? 1,
+      serverTime: args.serverTime,
+    },
+  } as unknown as RoomState;
+}
+
+test("extrapolates a playing snapshot by the estimated elapsed time", () => {
+  const compensated = compensateRoomStateForClock(
+    playingRoomState({ currentTime: 100, serverTime: 5_000 }),
+    200,
+    6_000,
+  );
+
+  // 6000 + 200 - 5000 = 1200ms of room time has passed since the snapshot.
+  assert.ok(Math.abs(compensated.playback!.currentTime - 101.2) < 0.001);
+});
+
+test("scales the extrapolation by the room playback rate", () => {
+  const compensated = compensateRoomStateForClock(
+    playingRoomState({ currentTime: 100, serverTime: 5_000, playbackRate: 2 }),
+    0,
+    6_000,
+  );
+
+  assert.ok(Math.abs(compensated.playback!.currentTime - 102) < 0.001);
+});
+
+test("a snapshot that would predate its own stamp is treated as current", () => {
+  const compensated = compensateRoomStateForClock(
+    playingRoomState({ currentTime: 100, serverTime: 5_000 }),
+    -800,
+    5_200,
+  );
+
+  assert.equal(compensated.playback!.currentTime, 100);
+});
+
+test("leaves paused states and unknown offsets untouched", () => {
+  const paused = playingRoomState({ currentTime: 100, serverTime: 5_000 });
+  paused.playback!.playState = "paused";
+  assert.equal(
+    compensateRoomStateForClock(paused, 200, 9_000).playback!.currentTime,
+    100,
+  );
+
+  const playing = playingRoomState({ currentTime: 100, serverTime: 5_000 });
+  assert.equal(
+    compensateRoomStateForClock(playing, null, 9_000).playback!.currentTime,
+    100,
+  );
+});

--- a/extension/test/clock-sync.test.ts
+++ b/extension/test/clock-sync.test.ts
@@ -6,7 +6,7 @@ import {
   CLOCK_SAMPLE_MAX_AGE_MS,
   CLOCK_SAMPLE_MIN_TRUSTED_SIZE,
   CLOCK_SAMPLE_WINDOW_SIZE,
-  compensateRoomStateForClock,
+  extrapolatePlayingRoomState,
   updateClockSample,
   type ClockSample,
 } from "../src/background/clock-sync";
@@ -318,48 +318,54 @@ function playingRoomState(args: {
   } as unknown as RoomState;
 }
 
-test("extrapolates a playing snapshot by the estimated elapsed time", () => {
-  const compensated = compensateRoomStateForClock(
+test("extrapolates a playing snapshot by the elapsed time", () => {
+  const advanced = extrapolatePlayingRoomState(
     playingRoomState({ currentTime: 100, serverTime: 5_000 }),
-    200,
-    6_000,
+    1_200,
   );
 
-  // 6000 + 200 - 5000 = 1200ms of room time has passed since the snapshot.
-  assert.ok(Math.abs(compensated.playback!.currentTime - 101.2) < 0.001);
+  assert.ok(Math.abs(advanced.playback!.currentTime - 101.2) < 0.001);
 });
 
 test("scales the extrapolation by the room playback rate", () => {
-  const compensated = compensateRoomStateForClock(
+  const advanced = extrapolatePlayingRoomState(
     playingRoomState({ currentTime: 100, serverTime: 5_000, playbackRate: 2 }),
-    0,
-    6_000,
+    1_000,
   );
 
-  assert.ok(Math.abs(compensated.playback!.currentTime - 102) < 0.001);
+  assert.ok(Math.abs(advanced.playback!.currentTime - 102) < 0.001);
 });
 
-test("a snapshot that would predate its own stamp is treated as current", () => {
-  const compensated = compensateRoomStateForClock(
+test("never rewinds the room on a negative elapsed time", () => {
+  const advanced = extrapolatePlayingRoomState(
     playingRoomState({ currentTime: 100, serverTime: 5_000 }),
     -800,
-    5_200,
   );
 
-  assert.equal(compensated.playback!.currentTime, 100);
+  assert.equal(advanced.playback!.currentTime, 100);
 });
 
-test("leaves paused states and unknown offsets untouched", () => {
-  const paused = playingRoomState({ currentTime: 100, serverTime: 5_000 });
-  paused.playback!.playState = "paused";
-  assert.equal(
-    compensateRoomStateForClock(paused, 200, 9_000).playback!.currentTime,
-    100,
+test("ignores serverTime entirely", () => {
+  // The snapshot's own stamp is irrelevant to the extrapolation: it belongs to
+  // the server's clock, which this no longer compares against a local one.
+  const stale = extrapolatePlayingRoomState(
+    playingRoomState({ currentTime: 100, serverTime: 0 }),
+    500,
+  );
+  const future = extrapolatePlayingRoomState(
+    playingRoomState({ currentTime: 100, serverTime: 9_999_999 }),
+    500,
   );
 
-  const playing = playingRoomState({ currentTime: 100, serverTime: 5_000 });
+  assert.equal(stale.playback!.currentTime, future.playback!.currentTime);
+});
+
+test("leaves non-playing states untouched", () => {
+  const paused = playingRoomState({ currentTime: 100, serverTime: 5_000 });
+  paused.playback!.playState = "paused";
+
   assert.equal(
-    compensateRoomStateForClock(playing, null, 9_000).playback!.currentTime,
+    extrapolatePlayingRoomState(paused, 4_000).playback!.currentTime,
     100,
   );
 });

--- a/extension/test/clock-sync.test.ts
+++ b/extension/test/clock-sync.test.ts
@@ -369,3 +369,69 @@ test("leaves non-playing states untouched", () => {
     100,
   );
 });
+
+test("negative round trips cannot carry the estimate even in the majority", () => {
+  // Flooring the competitiveness bar at zero is not enough: a negative round trip
+  // always clears `0 + tolerance`, so once such samples are the majority they win
+  // the median outright and publish an offset built from contradictory timestamps.
+  let clockOffsetMs: number | null = null;
+  let window: ClockSample[] = [];
+  const feed = (offsetMs: number, rttMs: number, atMs: number) => {
+    const result = updateClockSample({
+      clientSendTime: atMs,
+      // Construct the pair directly so the round trip can be made negative:
+      // reported server processing exceeding the client-measured round trip.
+      serverReceiveTime: atMs + offsetMs + rttMs / 2,
+      serverSendTime: atMs + offsetMs + rttMs / 2 + (rttMs < 0 ? -rttMs : 0),
+      now: atMs + (rttMs < 0 ? 0 : rttMs),
+      previousRttMs: null,
+      previousClockOffsetMs: clockOffsetMs,
+      previousSamples: window,
+    });
+    clockOffsetMs = result.clockOffsetMs;
+    window = result.samples;
+    return result;
+  };
+
+  feed(100, 10, 1_000);
+  feed(100, 10, 16_000);
+  feed(100, 10, 31_000);
+  assert.equal(clockOffsetMs, 100);
+
+  // Four contradictory samples agreeing on a wild offset: a majority of the
+  // window, and each one "faster" than every honest sample.
+  const contradictory = [46_000, 61_000, 76_000, 91_000];
+  for (const atMs of contradictory) {
+    const result = feed(5_000, -800, atMs);
+    assert.ok(result.sample.rttMs < 0, "expected an impossible round trip");
+  }
+
+  assert.equal(clockOffsetMs, 100);
+});
+
+test("keeps the published offset when nothing in the window is believable", () => {
+  const first = updateClockSample({
+    clientSendTime: 1_000,
+    serverReceiveTime: 1_205,
+    serverSendTime: 1_205,
+    now: 1_010,
+    previousRttMs: null,
+    previousClockOffsetMs: null,
+  });
+  assert.equal(first.clockOffsetMs, 200);
+
+  // Only an impossible sample in the window: publishing anything from it would be
+  // inventing a number.
+  const second = updateClockSample({
+    clientSendTime: 2_000,
+    serverReceiveTime: 2_100,
+    serverSendTime: 2_900,
+    now: 2_000,
+    previousRttMs: first.rttMs,
+    previousClockOffsetMs: first.clockOffsetMs,
+    previousSamples: [],
+  });
+
+  assert.ok(second.sample.rttMs < 0);
+  assert.equal(second.clockOffsetMs, 200);
+});

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -12,6 +12,8 @@ import { setLocaleForTests } from "../src/shared/i18n";
 function createControllerHarness(options?: {
   bootstrapRoomStateTimeoutMs?: number;
   persistState?: (callCount: number) => Promise<void> | void;
+  getMonotonicNow?: () => number;
+  onEnsureSharedVideoOpen?: () => void;
 }) {
   const runtimeState = createBackgroundRuntimeState();
   const sendToServerCalls: Array<unknown> = [];
@@ -20,6 +22,10 @@ function createControllerHarness(options?: {
   const logs: string[] = [];
   const ensureSharedVideoOpenCalls: RoomState[] = [];
   const clearPendingLocalShareReasons: string[] = [];
+  const compensateCalls: Array<{
+    state: RoomState;
+    receivedAtMs: number | undefined;
+  }> = [];
   const roomLifecycleResets: Array<{ action: string; reason: string }> = [];
   let connectCalls = 0;
   let disconnectCalls = 0;
@@ -61,11 +67,15 @@ function createControllerHarness(options?: {
     },
     ensureSharedVideoOpen: async (state) => {
       ensureSharedVideoOpenCalls.push(state);
+      options?.onEnsureSharedVideoOpen?.();
     },
     notifyContentScripts: async (message) => {
       notifyContentMessages.push(message);
     },
-    compensateRoomState: (state) => state,
+    compensateRoomState: (state, receivedAtMs) => {
+      compensateCalls.push({ state, receivedAtMs });
+      return state;
+    },
     clearPendingLocalShare: (reason) => {
       clearPendingLocalShareReasons.push(reason);
       runtimeState.share.pendingLocalShareUrl = null;
@@ -77,6 +87,7 @@ function createControllerHarness(options?: {
       logs.push(`server-error:${code}:${message}`);
     },
     shareToastTtlMs: 8_000,
+    getMonotonicNow: options?.getMonotonicNow,
     bootstrapRoomStateTimeoutMs: options?.bootstrapRoomStateTimeoutMs,
   });
 
@@ -89,6 +100,7 @@ function createControllerHarness(options?: {
     logs,
     ensureSharedVideoOpenCalls,
     clearPendingLocalShareReasons,
+    compensateCalls,
     roomLifecycleResets,
     get connectCalls() {
       return connectCalls;
@@ -731,4 +743,80 @@ test("room session controller syncs display name after room join completes", asy
       },
     },
   ]);
+});
+
+test("anchors an incoming room state on arrival, not after the work it triggers", async () => {
+  // `handleRoomStateMessage` persists state and may open the shared video's tab
+  // before the state is applied. The room keeps playing through that, so the
+  // anchor has to be the arrival, or the receiver treats an already-stale
+  // position as current and has to seek. Reported by Codex review on #210.
+  let monotonicNow = 1_000;
+  const harness = createControllerHarness({
+    getMonotonicNow: () => monotonicNow,
+    persistState: () => {
+      monotonicNow += 300;
+    },
+    onEnsureSharedVideoOpen: () => {
+      monotonicNow += 500;
+    },
+  });
+
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: {
+      roomCode: "ROOM05",
+      sharedVideo: null,
+      playback: {
+        actorId: "peer",
+        seq: 1,
+        url: "https://www.bilibili.com/video/BV1",
+        playState: "playing",
+        currentTime: 42,
+        playbackRate: 1,
+        serverTime: 1,
+      },
+      members: [{ id: "member-1", name: "Alice" }],
+    },
+  } satisfies ServerMessage);
+
+  assert.equal(harness.compensateCalls.length, 1);
+  assert.equal(harness.compensateCalls[0]?.receivedAtMs, 1_000);
+  // Proof the stamp is not simply "now": the awaited work moved the clock on.
+  assert.equal(monotonicNow, 1_800);
+});
+
+test("member deltas keep the anchor of the snapshot that arrived", async () => {
+  // A membership change carries the playback snapshot we already hold, so it must
+  // not restamp the anchor — that would drop however long the room has played.
+  let monotonicNow = 5_000;
+  const harness = createControllerHarness({
+    getMonotonicNow: () => monotonicNow,
+  });
+  harness.runtimeState.room.roomCode = "ROOM06";
+  harness.runtimeState.room.roomState = {
+    roomCode: "ROOM06",
+    sharedVideo: null,
+    playback: {
+      actorId: "peer",
+      seq: 1,
+      url: "https://www.bilibili.com/video/BV1",
+      playState: "playing",
+      currentTime: 42,
+      playbackRate: 1,
+      serverTime: 1,
+    },
+    members: [{ id: "member-1", name: "Alice" }],
+  } as unknown as RoomState;
+
+  monotonicNow = 9_000;
+  await harness.controller.handleServerMessage({
+    type: "room:member-joined",
+    payload: {
+      roomCode: "ROOM06",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  assert.equal(harness.compensateCalls.length, 1);
+  assert.equal(harness.compensateCalls[0]?.receivedAtMs, undefined);
 });

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -820,3 +820,58 @@ test("member deltas keep the anchor of the snapshot that arrived", async () => {
   assert.equal(harness.compensateCalls.length, 1);
   assert.equal(harness.compensateCalls[0]?.receivedAtMs, undefined);
 });
+
+test("pairs each room state with its own arrival time when handlers interleave", async () => {
+  // Handlers are started per socket message with `void handleServerMessage(...)`,
+  // so a later state can land in shared state while this one is awaiting. Applying
+  // that newer snapshot with *this* message's arrival time would anchor it too
+  // early — by however long the tab took to open. Reported by Codex review on #210.
+  let monotonicNow = 1_000;
+  const laterSnapshot = {
+    roomCode: "ROOM07",
+    sharedVideo: null,
+    playback: {
+      actorId: "peer",
+      seq: 9,
+      url: "https://www.bilibili.com/video/BV1",
+      playState: "playing" as const,
+      currentTime: 99,
+      playbackRate: 1,
+      serverTime: 9_000,
+    },
+    members: [{ id: "member-1", name: "Alice" }],
+  } as unknown as RoomState;
+
+  const harness = createControllerHarness({
+    getMonotonicNow: () => monotonicNow,
+    onEnsureSharedVideoOpen: () => {
+      // Opening the tab took 4s, and a newer state arrived meanwhile.
+      monotonicNow += 4_000;
+      harness.runtimeState.room.roomState = laterSnapshot;
+    },
+  });
+
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: {
+      roomCode: "ROOM07",
+      sharedVideo: null,
+      playback: {
+        actorId: "peer",
+        seq: 1,
+        url: "https://www.bilibili.com/video/BV1",
+        playState: "playing",
+        currentTime: 42,
+        playbackRate: 1,
+        serverTime: 1_000,
+      },
+      members: [{ id: "member-1", name: "Alice" }],
+    },
+  } satisfies ServerMessage);
+
+  assert.equal(harness.compensateCalls.length, 1);
+  const call = harness.compensateCalls[0];
+  assert.equal(call?.receivedAtMs, 1_000);
+  // The snapshot this handler is responsible for — not the one that overtook it.
+  assert.equal(call?.state.playback?.currentTime, 42);
+});

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -26,6 +26,11 @@ function createControllerHarness(options?: {
     state: RoomState;
     receivedAtMs: number | undefined;
   }> = [];
+  const arrivalMarks: Array<{
+    currentTime: number | undefined;
+    atMs: number;
+    persistCallsSoFar: number;
+  }> = [];
   const roomLifecycleResets: Array<{ action: string; reason: string }> = [];
   let connectCalls = 0;
   let disconnectCalls = 0;
@@ -76,6 +81,13 @@ function createControllerHarness(options?: {
       compensateCalls.push({ state, receivedAtMs });
       return state;
     },
+    markPlaybackArrival: (playback, atMs) => {
+      arrivalMarks.push({
+        currentTime: playback?.currentTime,
+        atMs,
+        persistCallsSoFar: persistReasons.length,
+      });
+    },
     clearPendingLocalShare: (reason) => {
       clearPendingLocalShareReasons.push(reason);
       runtimeState.share.pendingLocalShareUrl = null;
@@ -101,6 +113,7 @@ function createControllerHarness(options?: {
     ensureSharedVideoOpenCalls,
     clearPendingLocalShareReasons,
     compensateCalls,
+    arrivalMarks,
     roomLifecycleResets,
     get connectCalls() {
       return connectCalls;
@@ -871,5 +884,100 @@ test("drops a room state that a later one superseded while it awaited", async ()
   assert.deepEqual(harness.notifyContentMessages, []);
   assert.ok(
     harness.logs.some((line) => line.includes("Dropped superseded room state")),
+  );
+});
+
+test("marks the arrival before the state is observable or anything awaits", async () => {
+  // From the moment the state is stored, a rehydrating content script can read it
+  // and a member delta can rewrap it. Whichever compensates first must find the
+  // arrival already recorded. Reported by Codex review on #210.
+  let monotonicNow = 1_000;
+  const harness = createControllerHarness({
+    getMonotonicNow: () => monotonicNow,
+    persistState: () => {
+      monotonicNow += 300;
+    },
+  });
+
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: {
+      roomCode: "ROOM09",
+      sharedVideo: null,
+      playback: {
+        actorId: "peer",
+        seq: 1,
+        url: "https://www.bilibili.com/video/BV1",
+        playState: "playing",
+        currentTime: 42,
+        playbackRate: 1,
+        serverTime: 1_000,
+      },
+      members: [{ id: "member-1", name: "Alice" }],
+    },
+  } satisfies ServerMessage);
+
+  assert.equal(harness.arrivalMarks.length, 1);
+  assert.equal(harness.arrivalMarks[0]?.atMs, 1_000);
+  assert.equal(harness.arrivalMarks[0]?.currentTime, 42);
+  // Before the first await, so before anything could observe the snapshot.
+  assert.equal(harness.arrivalMarks[0]?.persistCallsSoFar, 0);
+});
+
+test("drops a member delta that a later room state superseded", async () => {
+  // Mirror of the room-state path: this delta carries the *older* playback
+  // snapshot, and a per-actor staleness check will not save the receiver from it.
+  const laterSnapshot = {
+    roomCode: "ROOM10",
+    sharedVideo: null,
+    playback: {
+      actorId: "peer-b",
+      seq: 5,
+      url: "https://www.bilibili.com/video/BV1",
+      playState: "playing" as const,
+      currentTime: 99,
+      playbackRate: 1,
+      serverTime: 9_000,
+    },
+    members: [{ id: "member-1", name: "Alice" }],
+  } as unknown as RoomState;
+
+  const harness = createControllerHarness({
+    persistState: (callCount) => {
+      if (callCount === 1) {
+        harness.runtimeState.room.roomState = laterSnapshot;
+      }
+    },
+  });
+  harness.runtimeState.room.roomCode = "ROOM10";
+  harness.runtimeState.room.roomState = {
+    roomCode: "ROOM10",
+    sharedVideo: null,
+    playback: {
+      actorId: "peer-a",
+      seq: 1,
+      url: "https://www.bilibili.com/video/BV1",
+      playState: "playing",
+      currentTime: 42,
+      playbackRate: 1,
+      serverTime: 1_000,
+    },
+    members: [{ id: "member-1", name: "Alice" }],
+  } as unknown as RoomState;
+
+  await harness.controller.handleServerMessage({
+    type: "room:member-joined",
+    payload: {
+      roomCode: "ROOM10",
+      member: { id: "member-2", name: "Bob" },
+    },
+  } satisfies ServerMessage);
+
+  assert.deepEqual(harness.compensateCalls, []);
+  assert.deepEqual(harness.notifyContentMessages, []);
+  assert.ok(
+    harness.logs.some((line) =>
+      line.includes("Dropped superseded member state"),
+    ),
   );
 });

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -781,6 +781,8 @@ test("anchors an incoming room state on arrival, not after the work it triggers"
 
   assert.equal(harness.compensateCalls.length, 1);
   assert.equal(harness.compensateCalls[0]?.receivedAtMs, 1_000);
+  // Paired with the snapshot this handler is responsible for.
+  assert.equal(harness.compensateCalls[0]?.state.playback?.currentTime, 42);
   // Proof the stamp is not simply "now": the awaited work moved the clock on.
   assert.equal(monotonicNow, 1_800);
 });
@@ -821,18 +823,16 @@ test("member deltas keep the anchor of the snapshot that arrived", async () => {
   assert.equal(harness.compensateCalls[0]?.receivedAtMs, undefined);
 });
 
-test("pairs each room state with its own arrival time when handlers interleave", async () => {
-  // Handlers are started per socket message with `void handleServerMessage(...)`,
-  // so a later state can land in shared state while this one is awaiting. Applying
-  // that newer snapshot with *this* message's arrival time would anchor it too
-  // early — by however long the tab took to open. Reported by Codex review on #210.
-  let monotonicNow = 1_000;
+test("drops a room state that a later one superseded while it awaited", async () => {
+  // The content script's staleness check is per actor, so pushing an overtaken
+  // snapshot from another member moves playback backwards rather than being
+  // ignored. Reported by Codex review on #210.
   const laterSnapshot = {
-    roomCode: "ROOM07",
+    roomCode: "ROOM08",
     sharedVideo: null,
     playback: {
-      actorId: "peer",
-      seq: 9,
+      actorId: "peer-b",
+      seq: 3,
       url: "https://www.bilibili.com/video/BV1",
       playState: "playing" as const,
       currentTime: 99,
@@ -843,10 +843,7 @@ test("pairs each room state with its own arrival time when handlers interleave",
   } as unknown as RoomState;
 
   const harness = createControllerHarness({
-    getMonotonicNow: () => monotonicNow,
     onEnsureSharedVideoOpen: () => {
-      // Opening the tab took 4s, and a newer state arrived meanwhile.
-      monotonicNow += 4_000;
       harness.runtimeState.room.roomState = laterSnapshot;
     },
   });
@@ -854,10 +851,10 @@ test("pairs each room state with its own arrival time when handlers interleave",
   await harness.controller.handleServerMessage({
     type: "room:state",
     payload: {
-      roomCode: "ROOM07",
+      roomCode: "ROOM08",
       sharedVideo: null,
       playback: {
-        actorId: "peer",
+        actorId: "peer-a",
         seq: 1,
         url: "https://www.bilibili.com/video/BV1",
         playState: "playing",
@@ -869,9 +866,10 @@ test("pairs each room state with its own arrival time when handlers interleave",
     },
   } satisfies ServerMessage);
 
-  assert.equal(harness.compensateCalls.length, 1);
-  const call = harness.compensateCalls[0];
-  assert.equal(call?.receivedAtMs, 1_000);
-  // The snapshot this handler is responsible for — not the one that overtook it.
-  assert.equal(call?.state.playback?.currentTime, 42);
+  // Neither compensated (which would repoint the anchor) nor delivered.
+  assert.deepEqual(harness.compensateCalls, []);
+  assert.deepEqual(harness.notifyContentMessages, []);
+  assert.ok(
+    harness.logs.some((line) => line.includes("Dropped superseded room state")),
+  );
 });

--- a/extension/test/toast.test.ts
+++ b/extension/test/toast.test.ts
@@ -52,6 +52,7 @@ test("builds member join and leave toast messages", () => {
     pendingRoomStateHydration: false,
     isCurrentPageShowingSharedVideo: false,
     now: 1000,
+    elapsedSincePreviousStateMs: 1000,
     lastSeekToastByActor: new Map(),
   });
 
@@ -79,6 +80,7 @@ test("keeps member join toasts during initial hydration", () => {
     pendingRoomStateHydration: true,
     isCurrentPageShowingSharedVideo: true,
     now: 1000,
+    elapsedSincePreviousStateMs: 1000,
     lastSeekToastByActor: new Map(),
   });
 
@@ -129,6 +131,7 @@ test("builds seek and rate toast messages for remote playback changes", () => {
     pendingRoomStateHydration: false,
     isCurrentPageShowingSharedVideo: true,
     now: 1000,
+    elapsedSincePreviousStateMs: 1,
     lastSeekToastByActor: new Map(),
   });
 
@@ -183,6 +186,7 @@ test("suppresses playback toasts for a natural-end paused state", () => {
     pendingRoomStateHydration: false,
     isCurrentPageShowingSharedVideo: true,
     now: 1000,
+    elapsedSincePreviousStateMs: 6000,
     lastSeekToastByActor: new Map(),
   });
 
@@ -276,6 +280,7 @@ test("builds English toast messages when the UI language is English", () => {
     pendingRoomStateHydration: false,
     isCurrentPageShowingSharedVideo: true,
     now: 1000,
+    elapsedSincePreviousStateMs: 1,
     lastSeekToastByActor: new Map(),
   });
 
@@ -384,4 +389,118 @@ test("does not auto-continue toast when the pending target is a different video"
 
   assert.equal(result.message, null);
   setLocaleForTests(null);
+});
+
+function playingPeerState(args: {
+  currentTime: number;
+  serverTime: number;
+  playState?: "playing" | "paused";
+  playbackRate?: number;
+}): RoomState {
+  return createRoomState({
+    members: [
+      { id: "self", name: "Me" },
+      { id: "remote", name: "Alice" },
+    ],
+    sharedUrl: "https://www.bilibili.com/video/BV1?p=1",
+    playback: {
+      url: "https://www.bilibili.com/video/BV1?p=1",
+      currentTime: args.currentTime,
+      playState: args.playState ?? "playing",
+      playbackRate: args.playbackRate ?? 1,
+      updatedAt: args.serverTime,
+      serverTime: args.serverTime,
+      actorId: "remote",
+      seq: args.serverTime,
+    },
+  });
+}
+
+function peerToastMessages(args: {
+  previousState: RoomState;
+  nextState: RoomState;
+  elapsedSincePreviousStateMs: number;
+}): string[] {
+  return getRoomStateToastMessages({
+    previousState: args.previousState,
+    nextState: args.nextState,
+    localMemberId: "self",
+    pendingRoomStateHydration: false,
+    isCurrentPageShowingSharedVideo: true,
+    now: 10_000,
+    elapsedSincePreviousStateMs: args.elapsedSincePreviousStateMs,
+    lastSeekToastByActor: new Map(),
+  }).messages;
+}
+
+test("reports a mid-playback seek when both time references agree", () => {
+  setLocaleForTests("zh-CN");
+
+  const messages = peerToastMessages({
+    previousState: playingPeerState({ currentTime: 10, serverTime: 1_000 }),
+    nextState: playingPeerState({ currentTime: 42, serverTime: 3_000 }),
+    elapsedSincePreviousStateMs: 2_000,
+  });
+
+  assert.deepEqual(messages, ["Alice 跳转到 0:42"]);
+});
+
+test("stays silent when only the server's clock moved", () => {
+  setLocaleForTests("zh-CN");
+  // The reported false positive: the peer played steadily for 2.1s, but the
+  // server's clock was stepped ~1.9s in between, so its timestamps claim 4s
+  // passed. Nobody seeked.
+  const messages = peerToastMessages({
+    previousState: playingPeerState({ currentTime: 10, serverTime: 1_000 }),
+    nextState: playingPeerState({ currentTime: 12.1, serverTime: 5_000 }),
+    elapsedSincePreviousStateMs: 2_100,
+  });
+
+  assert.deepEqual(messages, []);
+});
+
+test("stays silent when only this page stalled", () => {
+  setLocaleForTests("zh-CN");
+  // The mirror image: the two states were processed back to back after the main
+  // thread stalled, so locally no time appears to have passed.
+  const messages = peerToastMessages({
+    previousState: playingPeerState({ currentTime: 10, serverTime: 1_000 }),
+    nextState: playingPeerState({ currentTime: 12.1, serverTime: 3_100 }),
+    elapsedSincePreviousStateMs: 0,
+  });
+
+  assert.deepEqual(messages, []);
+});
+
+test("does not report a seek when a peer resumes after a long pause", () => {
+  setLocaleForTests("zh-CN");
+  // Position unchanged across a 30s pause: crediting the elapsed time here would
+  // report the pause itself as a 30s backwards jump.
+  const messages = peerToastMessages({
+    previousState: playingPeerState({
+      currentTime: 10,
+      serverTime: 1_000,
+      playState: "paused",
+    }),
+    nextState: playingPeerState({ currentTime: 10, serverTime: 31_000 }),
+    elapsedSincePreviousStateMs: 30_000,
+  });
+
+  assert.deepEqual(messages, ["Alice 开始播放"]);
+});
+
+test("reports a seek that lands together with a pause", () => {
+  setLocaleForTests("zh-CN");
+
+  const messages = peerToastMessages({
+    previousState: playingPeerState({ currentTime: 10, serverTime: 1_000 }),
+    nextState: playingPeerState({
+      currentTime: 100,
+      serverTime: 3_000,
+      playState: "paused",
+    }),
+    elapsedSincePreviousStateMs: 2_000,
+  });
+
+  assert.deepEqual(messages, ["Alice 暂停了视频", "Alice 跳转到 1:40"]);
 });


### PR DESCRIPTION
## 问题

播放过程中无任何人为操作，接收端反复触发倍速修正（1.05 → 1.06 → 0.84 → 0.89 → 0.96 持续振荡）。

目标位置的外推原式跨了两个钟：

```
目标 = 快照位置 + (本地 now + 时钟偏移 − 服务端打戳)
```

于是两台机器的钟差直接落在外推位置上。漂移控制器无法把它与真实漂移区分开，只能以改倍速作答；钟差每移动一次，目标就被踢一次。

## 判据

第一版按"偏移估计有噪声"来治（中位数 + 死区滤波），**实测证明方向错了**，但那版顺带加的原始样本日志给出了判据：

```
offset=-139ms  sample=324ms   sampleRtt=1ms  out=324ms   in=323ms
offset=-376ms  sample=-893ms  sampleRtt=1ms  out=-893ms  in=-894ms
offset=92ms    sample=1264ms  sampleRtt=1ms  out=1264ms  in=1263ms
```

- `out` 与 `in` 只差 1ms（正好等于往返时延）→ **样本本身完全自洽**，既不是网络不对称，也不是时间戳补记；样本值就等于两钟钟差的真值。
- 该值一分钟内横跨 **−893ms ~ +1264ms**。
- `out` 为负意味着服务端记录的"收到"早于客户端记录的"发出" —— 同一个钟不可能如此。

复现环境是**服务端在 WSL、两个浏览器在 Windows 宿主**：Hyper-V guest 与宿主是两个独立的钟，由 hypervisor 周期性重新同步。所以根本不存在一个稳定的偏移可供估计，任何滤波器都只能降低抖动频率 —— 加了中位数+死区之后 `offset=` 仍在 −139 / −376 / +92 之间跳，每次跨过死区就踢一次目标，倍速修正照旧。

## 改了什么

不再跨钟比较。以"该快照首次到达本地的时刻"为锚，只在本机时钟上做差：

```
目标 = 快照位置 + (单调 now − 锚点) × 速率
```

- 锚点取 `performance.now()` 而非 `Date.now()`，**连本机时钟被步进也免疫**；
- 锚按快照身份（`actorId|seq|playState|url|currentTime|rate`）记忆：新到达状态 elapsed=0，直接透传发送端上报的位置，残余误差只剩单向网络延迟（实测 `ageMs=4~6ms`，比原先的 ±500ms 小两个数量级）；
- 重放旧状态（标签页迟绑定、popup 查询）按真实经过时长外推，迟绑定仍能拿到"现在"的位置。

已核对：`compensateRoomState` 的四个调用点传入的都是未经外推的存储态，锚的身份不会被自己的输出污染。仓库里其余 `serverTime` 用法都是**两个服务端时刻相减**（版本排序、toast 时长），同钟比较，不受影响。

### 代价（写在代码注释里）

不再知道快照到达时已经多旧。**中途加入正在播放的房间**最坏偏一个广播周期（约 2.1s），由接收端一次 seek 收掉（加入时本来就会 seek）。要补回这一段需服务端以"时长"形式给出快照年龄 —— 时长跨钟安全、时刻不安全 —— 属协议层改动，不在本 PR。

Service Worker 重启后恢复的持久化状态没有本会话的锚，按"刚到达"处理；重连后的 `sync:request` 会在一个广播周期内纠正。

### 保留但降级的部分

第一版的中位数滤波与原始样本日志保留，但**降级为 popup 指标与诊断用途，不再参与播放路径**。`CLOCK_OFFSET_DEADBAND_MS` 的注释已改写，避免它继续宣称自己是修复的依据。

## 严重程度边界

WSL 开发环境把这个问题放大了。真实用户（跨机、各自正常 NTP）的偏移通常是几十毫秒且稳定，线上 v1.3.1 的抖动应比本地实测轻。但修法与之无关：任何钟偏或一次 NTP 步进都会触发同一条链路，而 WSL 是本项目的日常回归环境 —— 锚点改掉之后本地实测才可信。

## 放大链条与影响版本（供参考，本 PR 只动客户端外推）

| 层 | 提交 | 首个含它的版本 |
| --- | --- | --- |
| 放大器：catch-up 回差 0.05 + 放宽 target-shifted | #188 | **v1.3.1** |
| 前置条件：rate-only 修正每次都续上自恢复 session | #143 | v1.2.0 |
| 根因：跨钟外推 | `aa60294` | v0.7.0（一直未变） |

v1.3.1 之前同样的钟差只会造成偶发单次速率毛刺（`ignore` 分支会立刻把速率写回基准）；v1.3.1 起才变成持续振荡。**不建议回滚 #188** —— 它修的是"漂移常驻偏离房间约半秒"这个真问题。

## 验证

新增 `extension/test/clock-controller.test.ts`（8 条：新快照透传、重放按真实时长推进、逐条重新锚定、**钟被步进不影响外推位置**、倍速缩放、暂停不外推、暂停快照不污染下一个播放锚、诊断偏移仍照常发布）与 `extension/test/clock-sync.test.ts`（14 条：样本数学、离群不移动、噪声下静止、真实变化仍跟随、慢往返落选、不可能往返时延不夺权、时长淘汰、窗口上界、死区边界、外推/速率/负值/非播放态）。这两处此前零测试覆盖。

完整门禁逐项断言退出码全绿：`format:check` / `lint` / `typecheck` / `build` / `test`（扩展 568/568）/ `audit`。

**仍无真机复现对比** —— 保持 draft，等本地实测：装新包跑同一场景，看 `Playback reconcile` 是否还每 2 秒一条、`appliedRate` 是否长期停在 1.00。第 3 步（控制器死区/迟滞）的参数依赖这轮数据。

🤖 Generated with [Claude Code](https://claude.com/claude-code)