### PR TITLE
fix: 协议层以时长形式给出快照年龄，恢复中途加入时的位置精度 (#212)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,16 @@ background path touches room state or playback timing.
   an age across machines send a _duration_, never a timestamp. Comparing two
   server timestamps to each other is fine (version ordering); comparing two local
   ones is fine (elapsed).
+- **A snapshot age is computed at every send and never stored.** `room:state`
+  carries `playbackAgeMs` so a client joining mid-playback knows how stale the
+  snapshot it was handed already is (`withPlaybackAge` on the server,
+  `resolvePlaybackAnchorAtMs` on the receiver). An age is only true at the instant
+  it is sent, so storing one turns it back into a timestamp — which is why it
+  lives on the `room:state` payload and not on `PlaybackState`, the shape the
+  server persists and clients send back. Every `room:state` send site must stamp
+  it (there are four: bootstrap, `sync:request`, and two in
+  `room-event-consumer`), and the extension strips it before the state reaches
+  storage or a member-delta rewrap.
 - **Record a playback snapshot's arrival before the snapshot is observable.** Once
   it is in `roomSessionState.roomState`, a rehydrating content script
   (`content:get-room-state`) can read it and a member join/leave can rewrap it,

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -66,7 +66,7 @@ Clients send `protocolVersion` inside the `room:create` / `room:join` payload; t
 | -------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `room:created`       | `{ roomCode, memberId, joinToken, memberToken, serverProtocolVersion? }` | Room created; carries the invite and session tokens                                                                                     |
 | `room:joined`        | `{ roomCode, memberId, memberToken, serverProtocolVersion? }`            | Join succeeded; returns the session `memberToken` (a rejoin with a still-valid previous token reuses it, otherwise a new one is issued) |
-| `room:state`         | `RoomState`                                                              | Full room snapshot (after join, on request, on shared-video / playback changes)                                                         |
+| `room:state`         | `RoomState & { playbackAgeMs? }`                                         | Full room snapshot (after join, on request, on shared-video / playback changes)                                                         |
 | `room:member-joined` | `{ roomCode, member: RoomMember }`                                       | Member joined (delta, sent to `protocolVersion >= 2` clients)                                                                           |
 | `room:member-left`   | `{ roomCode, member: RoomMember }`                                       | Member left (delta, sent to `protocolVersion >= 2` clients)                                                                             |
 | `error`              | `{ code: ErrorCode, message }`                                           | Request failed                                                                                                                          |
@@ -76,9 +76,20 @@ Clients send `protocolVersion` inside the `room:create` / `room:join` payload; t
 
 Membership changes are version-gated (`MEMBER_DELTA_PROTOCOL_VERSION = 2` in `server/src/room-event-consumer.ts`): clients with `protocolVersion >= 2` receive `room:member-joined` / `room:member-left` deltas and must apply them to their member list — `room:state` is not re-broadcast for membership changes. Legacy clients (v1 or no version) receive a full `room:state` instead.
 
+### Playback snapshot age
+
+`room:state` carries an optional `playbackAgeMs` alongside the room state: how long ago the server stamped `playback.serverTime`, computed from the server's own two timestamps at the moment of sending. It lets a client joining a room mid-playback start from where the room actually is instead of from the last broadcast's position, which can be up to one broadcast interval (~2.1s) old.
+
+Two rules keep it sound, neither of which the type system enforces:
+
+- **Computed at every send, never stored.** An age is only true at the instant it is sent; a stored one is a timestamp in disguise. That is why it lives on the `room:state` payload (`RoomStatePayload`) rather than inside `PlaybackState`, which the server persists and clients send back in `playback:update`.
+- **A duration, never a timestamp.** A duration is safe across two disagreeing clocks — the receiver only adds it to an anchor of its own. A timestamp would force the receiver to subtract a server time from a local one, which measures the clock disagreement rather than elapsed time (see the playback timing invariants in [AGENTS.md](../../AGENTS.md)).
+
+Receivers subtract it from the message's local arrival time to get the anchor the position is extrapolated from (`extension/src/background/clock-sync.ts`), ignoring values that are absent (legacy server), negative, or implausibly large. Absent means "assume current", the pre-#212 behaviour.
+
 ### Clock synchronization
 
-`sync:ping` / `sync:pong` implement an NTP-style exchange: the client compares `clientSendTime`, `serverReceiveTime`, `serverSendTime`, and its own receive time to estimate the clock offset used when applying `PlaybackState.serverTime`. The extension's `clock-controller.ts` maintains this offset.
+`sync:ping` / `sync:pong` implement an NTP-style exchange: the client compares `clientSendTime`, `serverReceiveTime`, `serverSendTime`, and its own receive time to estimate the clock offset, which the extension's `clock-controller.ts` maintains. As of #210 that offset is a diagnostic shown in the popup, not an input to playback: positions are extrapolated from a local monotonic anchor instead, and `PlaybackState.serverTime` is used only as the server's version tag for a snapshot.
 
 ## Error Codes (`ErrorCode`)
 

--- a/docs/reference/protocol.md
+++ b/docs/reference/protocol.md
@@ -8,8 +8,8 @@
 
 | Constant                   | Location                                | Value | Meaning                                                      |
 | -------------------------- | --------------------------------------- | ----- | ------------------------------------------------------------ |
-| `PROTOCOL_VERSION`         | `packages/protocol/src/types/common.ts` | `3`   | Version sent by the extension in `room:create` / `room:join` |
-| `CURRENT_PROTOCOL_VERSION` | `server/src/messages.ts`                | `3`   | Version the server currently speaks                          |
+| `PROTOCOL_VERSION`         | `packages/protocol/src/types/common.ts` | `4`   | Version sent by the extension in `room:create` / `room:join` |
+| `CURRENT_PROTOCOL_VERSION` | `server/src/messages.ts`                | `4`   | Version the server currently speaks                          |
 | `MIN_PROTOCOL_VERSION`     | `server/src/messages.ts`                | `1`   | Oldest client version the server still accepts               |
 
 Clients send `protocolVersion` inside the `room:create` / `room:join` payload; the server rejects clients below `MIN_PROTOCOL_VERSION` with the `unsupported_protocol_version` error code. Legacy clients that omit `protocolVersion` are treated according to the server's compatibility policy in `server/src/messages.ts`.

--- a/docs/reference/protocol.zh-CN.md
+++ b/docs/reference/protocol.zh-CN.md
@@ -66,7 +66,7 @@
 | -------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
 | `room:created`       | `{ roomCode, memberId, joinToken, memberToken, serverProtocolVersion? }` | 房间已创建，携带邀请与会话 token                                                      |
 | `room:joined`        | `{ roomCode, memberId, memberToken, serverProtocolVersion? }`            | 加入成功，返回本次会话的 `memberToken`（重连携带仍有效的旧 token 时复用，否则新签发） |
-| `room:state`         | `RoomState`                                                              | 房间完整快照（加入后、按请求、共享视频/播放状态变化时）                               |
+| `room:state`         | `RoomState & { playbackAgeMs? }`                                         | 房间完整快照（加入后、按请求、共享视频/播放状态变化时）                               |
 | `room:member-joined` | `{ roomCode, member: RoomMember }`                                       | 成员加入（增量消息，发给 `protocolVersion >= 2` 客户端）                              |
 | `room:member-left`   | `{ roomCode, member: RoomMember }`                                       | 成员离开（增量消息，发给 `protocolVersion >= 2` 客户端）                              |
 | `error`              | `{ code: ErrorCode, message }`                                           | 请求失败                                                                              |
@@ -76,9 +76,20 @@
 
 成员变更按协议版本分流（`server/src/room-event-consumer.ts` 中 `MEMBER_DELTA_PROTOCOL_VERSION = 2`）：`protocolVersion >= 2` 的客户端收到 `room:member-joined` / `room:member-left` 增量，必须据此维护成员列表——成员变更不会重新广播 `room:state`；旧客户端（v1 或未携带版本号）则收到完整 `room:state`。
 
+### 播放快照年龄
+
+`room:state` 在房间状态之外附带可选的 `playbackAgeMs`：服务端在**发送那一刻**用自己的两个时刻相减，得出 `playback.serverTime` 至今过了多久。它让中途加入正在播放房间的客户端从房间的实际位置起播，而不是从最后一次广播的位置起播——后者最坏已旧了一个广播周期（约 2.1s）。
+
+两条规则保证它成立，且都不受类型系统约束：
+
+- **每次下发都重新计算，绝不存储。** 年龄只在发送那一刻为真，存下来的年龄就是伪装成时长的时刻。因此它挂在 `room:state` payload（`RoomStatePayload`）上，而不是放进 `PlaybackState`——后者会被服务端持久化，也会由客户端在 `playback:update` 中回传。
+- **只传时长，不传时刻。** 时长跨两个不一致的钟是安全的：接收端只是把它加到自己的锚上。时刻则不然，接收端必须拿服务端时刻减本地时刻，量到的是钟差而非流逝时间（见 [AGENTS.md](../../AGENTS.md) 的播放计时不变量）。
+
+接收端把它从该消息的本地到达时刻里减去，得到位置外推所用的锚（`extension/src/background/clock-sync.ts`）；缺失（旧服务端）、为负或大得不合理的值一律忽略。缺失即"视为最新"，也就是 #212 之前的行为。
+
 ### 时钟同步
 
-`sync:ping` / `sync:pong` 实现 NTP 式往返：客户端比较 `clientSendTime`、`serverReceiveTime`、`serverSendTime` 与自身接收时间，估算应用 `PlaybackState.serverTime` 时使用的时钟偏移。扩展端由 `clock-controller.ts` 维护该偏移。
+`sync:ping` / `sync:pong` 实现 NTP 式往返：客户端比较 `clientSendTime`、`serverReceiveTime`、`serverSendTime` 与自身接收时间估算时钟偏移，扩展端由 `clock-controller.ts` 维护该偏移。自 #210 起该偏移只是弹窗里展示的诊断值，不再参与播放：位置改由本地单调锚点外推，`PlaybackState.serverTime` 仅作为快照的服务端版本标签使用。
 
 ## 错误码（`ErrorCode`）
 

--- a/docs/reference/protocol.zh-CN.md
+++ b/docs/reference/protocol.zh-CN.md
@@ -8,8 +8,8 @@
 
 | 常量                       | 位置                                    | 当前值 | 含义                                              |
 | -------------------------- | --------------------------------------- | ------ | ------------------------------------------------- |
-| `PROTOCOL_VERSION`         | `packages/protocol/src/types/common.ts` | `3`    | 扩展在 `room:create` / `room:join` 中携带的版本号 |
-| `CURRENT_PROTOCOL_VERSION` | `server/src/messages.ts`                | `3`    | 服务端当前使用的版本                              |
+| `PROTOCOL_VERSION`         | `packages/protocol/src/types/common.ts` | `4`    | 扩展在 `room:create` / `room:join` 中携带的版本号 |
+| `CURRENT_PROTOCOL_VERSION` | `server/src/messages.ts`                | `4`    | 服务端当前使用的版本                              |
 | `MIN_PROTOCOL_VERSION`     | `server/src/messages.ts`                | `1`    | 服务端仍接受的最老客户端版本                      |
 
 客户端在 `room:create` / `room:join` 的 payload 中携带 `protocolVersion`；低于 `MIN_PROTOCOL_VERSION` 的客户端会被以 `unsupported_protocol_version` 错误码拒绝。未携带 `protocolVersion` 的旧客户端按 `server/src/messages.ts` 中的兼容策略处理。

--- a/extension/src/background/clock-controller.ts
+++ b/extension/src/background/clock-controller.ts
@@ -19,12 +19,13 @@ export interface ClockController {
     serverReceiveTime: number,
     serverSendTime: number,
   ): void;
-  compensateRoomState(state: RoomState, receivedAtMs?: number): RoomState;
+  compensateRoomState(state: RoomState, anchorAtMs?: number): RoomState;
   /**
-   * Record when a playback snapshot arrived, before anything else can observe it.
+   * Record when a playback snapshot was current, in local monotonic time, before
+   * anything else can observe it.
    *
    * Anchoring at ingress rather than at the first `compensateRoomState` call takes
-   * the question of which caller has to supply an arrival time out of the picture:
+   * the question of which caller has to supply an anchor out of the picture:
    * a snapshot becomes readable (`content:get-room-state`) and gets rewrapped
    * (member joins/leaves) while its own handler is still persisting state or
    * opening a tab, and any of those paths compensating first would otherwise anchor
@@ -140,19 +141,19 @@ export function createClockController(args: {
    * it, and a replay (a tab binding late, a popup asking for current state) is
    * advanced by the time that genuinely passed since it arrived.
    *
-   * `receivedAtMs` (monotonic, same source as this controller's) is when the
-   * snapshot actually arrived, and callers handling a fresh `room:state` must
-   * pass it: work between arrival and here — persisting state, opening the shared
-   * video's tab — is not instant, and anchoring at this call instead would credit
-   * that time to nobody. The room kept playing through it, so the receiver would
-   * apply a position already that stale as though it were current and then have to
-   * seek. Omit it only when replaying a snapshot that was anchored on arrival.
+   * `anchorAtMs` (monotonic, same source as this controller's) is when the
+   * snapshot's position was true on this machine's clock, and callers handling a
+   * fresh `room:state` must pass it: work between arrival and here — persisting
+   * state, opening the shared video's tab — is not instant, and anchoring at this
+   * call instead would credit that time to nobody. The room kept playing through
+   * it, so the receiver would apply a position already that stale as though it
+   * were current and then have to seek. Omit it only when replaying a snapshot
+   * that was already anchored.
    *
-   * The cost is that we no longer know how stale a snapshot already was when it
-   * reached us — on joining a room mid-playback that can be up to one broadcast
-   * interval, which the receiver closes with a single seek. Recovering it needs
-   * the server to report the snapshot's age as a *duration*, which is safe to
-   * send across disagreeing clocks; `serverTime` is not.
+   * It is arrival time minus the snapshot's age at arrival — see
+   * `resolvePlaybackAnchorAtMs`, which is what recovers the staleness a snapshot
+   * already had when it reached us (up to one broadcast interval, when joining a
+   * room mid-playback).
    */
   function markPlaybackArrival(
     playback: PlaybackState | null | undefined,
@@ -174,6 +175,9 @@ export function createClockController(args: {
     // Only ever earlier. The same snapshot can be presented more than once (a
     // re-broadcast, a replay), and the room has been at that position since the
     // first time it reached us, so the earliest evidence is the best evidence.
+    // With `playbackAgeMs` accounted for, two arrivals of one snapshot resolve to
+    // the same anchor no matter how far apart they land, so this only ever has to
+    // discard a reader's late, unaged guess.
     if (atMs < playbackAnchor.atMs) {
       playbackAnchor = { key, atMs };
     }
@@ -181,7 +185,7 @@ export function createClockController(args: {
 
   function compensateRoomState(
     state: RoomState,
-    receivedAtMs?: number,
+    anchorAtMs?: number,
   ): RoomState {
     if (!state.playback || state.playback.playState !== "playing") {
       playbackAnchor = null;
@@ -192,7 +196,7 @@ export function createClockController(args: {
     // Anchors the snapshot if ingress did not already (a replay of a snapshot from
     // a previous service-worker session has no anchor), and corrects one that a
     // reader established late.
-    markPlaybackArrival(state.playback, receivedAtMs ?? now);
+    markPlaybackArrival(state.playback, anchorAtMs ?? now);
     return extrapolatePlayingRoomState(state, now - playbackAnchor!.atMs);
   }
 

--- a/extension/src/background/clock-sync.ts
+++ b/extension/src/background/clock-sync.ts
@@ -197,6 +197,51 @@ export function updateClockSample(args: {
 }
 
 /**
+ * Largest snapshot age still treated as evidence of a room that is playing right
+ * now. Roughly five broadcast intervals (a playing member re-broadcasts about
+ * every 2.1s).
+ *
+ * Past that, no broadcast has refreshed the snapshot for long enough that the
+ * simplest explanation is not a slow join but a room nobody is playing any more
+ * — its last member closed the tab while the state still read `playing` — or a
+ * server whose clock stepped between stamping the snapshot and sending it.
+ * Crediting the whole gap would then hurl the position forward by however long
+ * that lasted, so fall back to the conservative reading: take the position as
+ * sent, the pre-#212 behaviour. Under a live room this bound is never anywhere
+ * near reached.
+ */
+export const MAX_TRUSTED_PLAYBACK_AGE_MS = 10_000;
+
+/**
+ * Resolve the local monotonic time at which a received snapshot's position was
+ * true, from when it arrived and how old the server said it already was.
+ *
+ * The age is what makes joining a playing room land on the right position: the
+ * server hands a new member the last broadcast snapshot, which is up to one
+ * broadcast interval old, and without this the receiver would take it as
+ * current and start behind. A duration is the only form this can safely take —
+ * a timestamp would have to be compared against this machine's clock, which is
+ * the two-clock comparison `extrapolatePlayingRoomState` exists to avoid.
+ *
+ * Missing (legacy server), non-finite, negative, or beyond
+ * `MAX_TRUSTED_PLAYBACK_AGE_MS` all resolve to the arrival time itself.
+ */
+export function resolvePlaybackAnchorAtMs(
+  receivedAtMs: number,
+  playbackAgeMs: number | undefined,
+): number {
+  if (
+    playbackAgeMs === undefined ||
+    !Number.isFinite(playbackAgeMs) ||
+    playbackAgeMs <= 0 ||
+    playbackAgeMs > MAX_TRUSTED_PLAYBACK_AGE_MS
+  ) {
+    return receivedAtMs;
+  }
+  return receivedAtMs - playbackAgeMs;
+}
+
+/**
  * Advance a playing snapshot by the time that has passed since it was taken.
  *
  * `elapsedMs` is measured locally — see `ClockController.compensateRoomState` —

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -124,8 +124,8 @@ const roomSessionController = createRoomSessionController({
   flushPendingShare,
   ensureSharedVideoOpen: () => tabController.ensureSharedVideoOpen(),
   notifyContentScripts,
-  compensateRoomState: (state, receivedAtMs) =>
-    clockController.compensateRoomState(state, receivedAtMs),
+  compensateRoomState: (state, anchorAtMs) =>
+    clockController.compensateRoomState(state, anchorAtMs),
   markPlaybackArrival: (playback, atMs) =>
     clockController.markPlaybackArrival(playback, atMs),
   clearPendingLocalShare: (reason) =>

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -22,6 +22,7 @@ import {
   getPendingShareToastFor as getRoomPendingShareToastFor,
 } from "./room-manager";
 import { localizeServerError } from "../shared/i18n";
+import { resolvePlaybackAnchorAtMs } from "./clock-sync";
 
 type JoinAttemptResult = "joined" | "failed" | "timeout";
 type PendingMemberDelta = {
@@ -66,7 +67,7 @@ export function createRoomSessionController(args: {
   flushPendingShare: () => void;
   ensureSharedVideoOpen: (state: RoomState) => Promise<void>;
   notifyContentScripts: (message: BackgroundToContentMessage) => Promise<void>;
-  compensateRoomState: (state: RoomState, receivedAtMs?: number) => RoomState;
+  compensateRoomState: (state: RoomState, anchorAtMs?: number) => RoomState;
   markPlaybackArrival: (playback: RoomState["playback"], atMs: number) => void;
   clearPendingLocalShare: (reason: string) => void;
   expirePendingLocalShareIfNeeded: () => void;
@@ -75,8 +76,9 @@ export function createRoomSessionController(args: {
   shareToastTtlMs: number;
   /**
    * Monotonic time source, shared with the clock controller: it stamps when a
-   * `room:state` arrived so that the work before applying it is not credited to
-   * nobody. See `ClockController.compensateRoomState`.
+   * `room:state` arrived so that neither the work before applying it nor the age
+   * it already had on arrival is credited to nobody. See
+   * `ClockController.compensateRoomState`.
    */
   getMonotonicNow?: () => number;
   bootstrapRoomStateTimeoutMs?: number;
@@ -383,9 +385,18 @@ export function createRoomSessionController(args: {
         args.flushPendingShare();
         args.notifyAll();
         return;
-      case "room:state":
-        await handleRoomStateMessage(message.payload, receivedAtMs);
+      case "room:state": {
+        // `playbackAgeMs` is stripped here rather than carried inside: it is only
+        // true at the instant the server sent it, and the room state travels on
+        // into storage and into member-delta rewraps where a stale age would read
+        // as a fresh one.
+        const { playbackAgeMs, ...state } = message.payload;
+        await handleRoomStateMessage(
+          state,
+          resolvePlaybackAnchorAtMs(receivedAtMs, playbackAgeMs),
+        );
         return;
+      }
       case "room:member-joined":
         await handleRoomMemberJoined(
           message.payload.roomCode,
@@ -523,7 +534,7 @@ export function createRoomSessionController(args: {
 
   async function handleRoomStateMessage(
     nextState: RoomState,
-    receivedAtMs: number,
+    playbackAnchorAtMs: number,
   ): Promise<void> {
     args.expirePendingLocalShareIfNeeded();
     const decision = decideIncomingRoomState({
@@ -566,7 +577,7 @@ export function createRoomSessionController(args: {
     // from here a rehydrating content script can read it and a member delta can
     // rewrap it, and whichever of those compensates first must find the arrival
     // already recorded rather than anchoring the snapshot at its own moment.
-    args.markPlaybackArrival(resolvedState.playback, receivedAtMs);
+    args.markPlaybackArrival(resolvedState.playback, playbackAnchorAtMs);
     args.roomSessionState.roomState = resolvedState;
     args.roomSessionState.roomCode = resolvedState.roomCode;
     args.connectionState.lastError = null;
@@ -603,13 +614,13 @@ export function createRoomSessionController(args: {
       return;
     }
 
-    // Anchored on arrival, not on reaching this line: the awaits above can take a
-    // while and the room played on through them. `resolvedState` and its own
-    // arrival time, never a re-read of shared state — a snapshot must only ever be
-    // paired with the arrival that belongs to it.
+    // Anchored where the snapshot was actually current, not on reaching this
+    // line: the awaits above can take a while and the room played on through
+    // them. `resolvedState` and its own anchor, never a re-read of shared state —
+    // a snapshot must only ever be paired with the anchor that belongs to it.
     const compensatedRoomState = args.compensateRoomState(
       resolvedState,
-      receivedAtMs,
+      playbackAnchorAtMs,
     );
     await args.notifyContentScripts({
       type: "background:apply-room-state",

--- a/extension/test/clock-sync.test.ts
+++ b/extension/test/clock-sync.test.ts
@@ -7,6 +7,8 @@ import {
   CLOCK_SAMPLE_MIN_TRUSTED_SIZE,
   CLOCK_SAMPLE_WINDOW_SIZE,
   extrapolatePlayingRoomState,
+  MAX_TRUSTED_PLAYBACK_AGE_MS,
+  resolvePlaybackAnchorAtMs,
   updateClockSample,
   type ClockSample,
 } from "../src/background/clock-sync";
@@ -435,4 +437,46 @@ test("keeps the published offset when nothing in the window is believable", () =
 
   assert.ok(second.sample.rttMs < 0);
   assert.equal(second.clockOffsetMs, 200);
+});
+
+test("a reported snapshot age moves the anchor back before arrival", () => {
+  // The joining case: the server handed over a snapshot that was already one
+  // broadcast interval old, so it was current 2.1s before it reached us.
+  assert.equal(resolvePlaybackAnchorAtMs(10_000, 2_100), 7_900);
+});
+
+test("a legacy server without an age anchors at arrival", () => {
+  assert.equal(resolvePlaybackAnchorAtMs(10_000, undefined), 10_000);
+});
+
+test("a zero age anchors at arrival", () => {
+  assert.equal(resolvePlaybackAnchorAtMs(10_000, 0), 10_000);
+});
+
+test("a negative age cannot push the anchor forward", () => {
+  // Only reachable from a broken or hostile server — the guard rejects these —
+  // but pushing the anchor past arrival would rewind the room on every replay.
+  assert.equal(resolvePlaybackAnchorAtMs(10_000, -5_000), 10_000);
+});
+
+test("a non-finite age is ignored rather than poisoning the anchor", () => {
+  assert.equal(resolvePlaybackAnchorAtMs(10_000, Number.NaN), 10_000);
+  assert.equal(
+    resolvePlaybackAnchorAtMs(10_000, Number.POSITIVE_INFINITY),
+    10_000,
+  );
+});
+
+test("an age past the trust bound falls back to anchoring at arrival", () => {
+  // No broadcast has refreshed this snapshot for five intervals: more likely a
+  // room nobody is playing, or a server clock step, than a very slow join. The
+  // fallback is the conservative one — take the position as sent.
+  assert.equal(
+    resolvePlaybackAnchorAtMs(10_000, MAX_TRUSTED_PLAYBACK_AGE_MS),
+    10_000 - MAX_TRUSTED_PLAYBACK_AGE_MS,
+  );
+  assert.equal(
+    resolvePlaybackAnchorAtMs(10_000, MAX_TRUSTED_PLAYBACK_AGE_MS + 1),
+    10_000,
+  );
 });

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -24,7 +24,7 @@ function createControllerHarness(options?: {
   const clearPendingLocalShareReasons: string[] = [];
   const compensateCalls: Array<{
     state: RoomState;
-    receivedAtMs: number | undefined;
+    anchorAtMs: number | undefined;
   }> = [];
   const arrivalMarks: Array<{
     currentTime: number | undefined;
@@ -77,8 +77,8 @@ function createControllerHarness(options?: {
     notifyContentScripts: async (message) => {
       notifyContentMessages.push(message);
     },
-    compensateRoomState: (state, receivedAtMs) => {
-      compensateCalls.push({ state, receivedAtMs });
+    compensateRoomState: (state, anchorAtMs) => {
+      compensateCalls.push({ state, anchorAtMs });
       return state;
     },
     markPlaybackArrival: (playback, atMs) => {
@@ -288,7 +288,9 @@ test("room session controller confirms pending local share and notifies content 
     "share confirmation received",
   ]);
   assert.equal(harness.runtimeState.room.roomCode, "ROOM03");
-  assert.equal(harness.runtimeState.room.roomState, nextRoomState);
+  // Not identity: the payload's `playbackAgeMs` is stripped before the state is
+  // stored, so what is stored is a copy of everything else.
+  assert.deepEqual(harness.runtimeState.room.roomState, nextRoomState);
   assert.equal(harness.ensureSharedVideoOpenCalls.length, 1);
   assert.equal(
     (
@@ -303,7 +305,7 @@ test("room session controller confirms pending local share and notifies content 
     ).type,
     "background:apply-room-state",
   );
-  assert.equal(
+  assert.deepEqual(
     (
       harness.notifyContentMessages[0] as {
         payload: RoomState;
@@ -794,11 +796,89 @@ test("anchors an incoming room state on arrival, not after the work it triggers"
   } satisfies ServerMessage);
 
   assert.equal(harness.compensateCalls.length, 1);
-  assert.equal(harness.compensateCalls[0]?.receivedAtMs, 1_000);
+  assert.equal(harness.compensateCalls[0]?.anchorAtMs, 1_000);
   // Paired with the snapshot this handler is responsible for.
   assert.equal(harness.compensateCalls[0]?.state.playback?.currentTime, 42);
   // Proof the stamp is not simply "now": the awaited work moved the clock on.
   assert.equal(monotonicNow, 1_800);
+});
+
+test("a snapshot the server reported as stale anchors before it arrived", async () => {
+  // Joining a room mid-playback: the server hands over the last broadcast, which
+  // was already one broadcast interval old. Anchoring at arrival would take that
+  // position as current and start playback ~2.1s behind the room.
+  const monotonicNow = 10_000;
+  const harness = createControllerHarness({
+    getMonotonicNow: () => monotonicNow,
+  });
+
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: {
+      roomCode: "ROOM12",
+      sharedVideo: null,
+      playback: {
+        actorId: "peer",
+        seq: 1,
+        url: "https://www.bilibili.com/video/BV1",
+        playState: "playing",
+        currentTime: 42,
+        playbackRate: 1,
+        serverTime: 1,
+        updatedAt: 1,
+      },
+      members: [{ id: "member-1", name: "Alice" }],
+      playbackAgeMs: 2_100,
+    },
+  } satisfies ServerMessage);
+
+  assert.equal(harness.arrivalMarks[0]?.atMs, 7_900);
+  assert.equal(harness.compensateCalls[0]?.anchorAtMs, 7_900);
+  // Never stored or forwarded: the age is only true at the instant it was sent,
+  // and this state goes on to storage and to member-delta rewraps.
+  assert.ok(
+    !("playbackAgeMs" in (harness.runtimeState.room.roomState ?? {})),
+    "playbackAgeMs must not survive into the stored room state",
+  );
+  assert.ok(
+    !(
+      "playbackAgeMs" in
+      ((
+        harness.notifyContentMessages[0] as { payload: Record<string, unknown> }
+      ).payload ?? {})
+    ),
+    "playbackAgeMs must not be forwarded to content scripts",
+  );
+});
+
+test("a room state without a playback age anchors at arrival", async () => {
+  // Backward compatibility with a server predating #212.
+  const monotonicNow = 10_000;
+  const harness = createControllerHarness({
+    getMonotonicNow: () => monotonicNow,
+  });
+
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: {
+      roomCode: "ROOM13",
+      sharedVideo: null,
+      playback: {
+        actorId: "peer",
+        seq: 1,
+        url: "https://www.bilibili.com/video/BV1",
+        playState: "playing",
+        currentTime: 42,
+        playbackRate: 1,
+        serverTime: 1,
+        updatedAt: 1,
+      },
+      members: [{ id: "member-1", name: "Alice" }],
+    },
+  } satisfies ServerMessage);
+
+  assert.equal(harness.arrivalMarks[0]?.atMs, 10_000);
+  assert.equal(harness.compensateCalls[0]?.anchorAtMs, 10_000);
 });
 
 test("member deltas keep the anchor of the snapshot that arrived", async () => {
@@ -835,7 +915,7 @@ test("member deltas keep the anchor of the snapshot that arrived", async () => {
   } satisfies ServerMessage);
 
   assert.equal(harness.compensateCalls.length, 1);
-  assert.equal(harness.compensateCalls[0]?.receivedAtMs, undefined);
+  assert.equal(harness.compensateCalls[0]?.anchorAtMs, undefined);
 });
 
 test("drops a room state that a later one superseded while it awaited", async () => {

--- a/packages/protocol/src/guards/server-message.ts
+++ b/packages/protocol/src/guards/server-message.ts
@@ -5,6 +5,7 @@ import type {
   RoomMemberJoinedMessage,
   RoomMemberLeftMessage,
   RoomStateMessage,
+  RoomStatePayload,
   ServerMessage,
   SyncPongMessage,
 } from "../types/server-message.js";
@@ -116,9 +117,24 @@ function isRoomJoinedMessage(value: unknown): value is RoomJoinedMessage {
   );
 }
 
+export function isRoomStatePayload(value: unknown): value is RoomStatePayload {
+  if (!isRecord(value) || !isRoomState(value)) {
+    return false;
+  }
+  const { playbackAgeMs } = value;
+  // A negative age is not a duration; rejecting it here keeps receivers from
+  // having to decide what "the snapshot is from the future" means.
+  return (
+    playbackAgeMs === undefined ||
+    (isFiniteNumber(playbackAgeMs) && playbackAgeMs >= 0)
+  );
+}
+
 function isRoomStateMessage(value: unknown): value is RoomStateMessage {
   return (
-    isRecord(value) && value.type === "room:state" && isRoomState(value.payload)
+    isRecord(value) &&
+    value.type === "room:state" &&
+    isRoomStatePayload(value.payload)
   );
 }
 

--- a/packages/protocol/src/types/common.ts
+++ b/packages/protocol/src/types/common.ts
@@ -1,4 +1,4 @@
-export const PROTOCOL_VERSION = 3;
+export const PROTOCOL_VERSION = 4;
 
 export type RoomCode = string;
 export type PlaybackPlayState = "playing" | "paused" | "buffering";

--- a/packages/protocol/src/types/server-message.ts
+++ b/packages/protocol/src/types/server-message.ts
@@ -22,9 +22,34 @@ export interface RoomJoinedMessage {
   };
 }
 
+/**
+ * `room:state` payload: the room state, plus how stale its playback snapshot
+ * already was when the server sent it.
+ *
+ * `playbackAgeMs` deliberately lives here rather than inside `PlaybackState`,
+ * and is deliberately a *duration* rather than a timestamp:
+ *
+ * - A duration is safe to send across two disagreeing clocks — the receiver
+ *   only ever adds it to an anchor of its own. A timestamp is not: subtracting
+ *   a server timestamp from a local one measures the clock disagreement, which
+ *   is not a duration and drifts on its own.
+ * - The age is only true at the instant of sending, so it must be computed per
+ *   send and must never be stored in the room state. Keeping it off
+ *   `PlaybackState` — the shape the server persists and the shape clients send
+ *   in `playback:update` — makes storing it structurally impossible instead of
+ *   a rule someone has to remember.
+ *
+ * Optional for backward compatibility: legacy servers omit it, and receivers
+ * treat a missing value as 0 (the pre-#212 behaviour of assuming a freshly
+ * arrived snapshot is current).
+ */
+export interface RoomStatePayload extends RoomState {
+  playbackAgeMs?: number;
+}
+
 export interface RoomStateMessage {
   type: "room:state";
-  payload: RoomState;
+  payload: RoomStatePayload;
 }
 
 export interface RoomMemberJoinedMessage {

--- a/packages/protocol/test/server-message.test.ts
+++ b/packages/protocol/test/server-message.test.ts
@@ -538,3 +538,87 @@ test("rejects room:joined when serverProtocolVersion is negative", () => {
     false,
   );
 });
+
+function roomStatePayload(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    roomCode: "ABC123",
+    sharedVideo: {
+      videoId: "BV1xx411c7mD",
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=2",
+      title: "Video",
+    },
+    playback: {
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=2",
+      currentTime: 12,
+      playState: "playing",
+      playbackRate: 1,
+      updatedAt: 1,
+      serverTime: 1,
+      actorId: "member-1",
+      seq: 1,
+    },
+    members: [{ id: "member-1", name: "Alice" }],
+    ...overrides,
+  };
+}
+
+test("accepts room:state carrying a playback age", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:state",
+      payload: roomStatePayload({ playbackAgeMs: 2_100 }),
+    }),
+    true,
+  );
+});
+
+test("accepts room:state from a server that omits the playback age", () => {
+  assert.equal(
+    isServerMessage({ type: "room:state", payload: roomStatePayload() }),
+    true,
+  );
+});
+
+test("accepts a zero playback age", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:state",
+      payload: roomStatePayload({ playbackAgeMs: 0 }),
+    }),
+    true,
+  );
+});
+
+test("rejects a negative playback age", () => {
+  // A duration cannot be negative, and a receiver that had to interpret one
+  // would be extrapolating a snapshot from the future.
+  assert.equal(
+    isServerMessage({
+      type: "room:state",
+      payload: roomStatePayload({ playbackAgeMs: -1 }),
+    }),
+    false,
+  );
+});
+
+test("rejects a non-numeric playback age", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:state",
+      payload: roomStatePayload({ playbackAgeMs: "2100" }),
+    }),
+    false,
+  );
+});
+
+test("rejects a non-finite playback age", () => {
+  assert.equal(
+    isServerMessage({
+      type: "room:state",
+      payload: roomStatePayload({ playbackAgeMs: Number.POSITIVE_INFINITY }),
+    }),
+    false,
+  );
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -195,6 +195,10 @@ export async function createSyncServer(
     send,
     instanceId: persistenceConfig.instanceId,
     logEvent,
+    // The same clock the room service stamps `playback.serverTime` with, so the
+    // snapshot age this consumer reports is a difference of two readings from
+    // one time base rather than of two unrelated ones.
+    now,
   });
   const adminCommandConsumer = await createAdminCommandConsumer({
     instanceId: persistenceConfig.instanceId,

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -19,6 +19,7 @@ import {
   CURRENT_PROTOCOL_VERSION,
 } from "./messages.js";
 import { RoomServiceError } from "./room-service.js";
+import { withPlaybackAge } from "./room-state-age.js";
 import type { RoomEventBusMessage } from "./room-event-bus.js";
 import { hasAttachedSocket } from "./types.js";
 import type { LogEvent, SendError, SendMessage, Session } from "./types.js";
@@ -183,9 +184,11 @@ export function createMessageHandler(options: {
       if (!hasAttachedSocket(session)) {
         return;
       }
+      // Aged at the send, not at the read: `getRoomStateForSession` awaits the
+      // store, and the room kept playing through it.
       send(session.socket, {
         type: "room:state",
-        payload: state,
+        payload: withPlaybackAge(state, now()),
       });
     } catch (error) {
       logEvent("room_state_bootstrap_failed", {
@@ -754,7 +757,7 @@ export function createMessageHandler(options: {
             );
             send(socket, {
               type: "room:state",
-              payload: state,
+              payload: withPlaybackAge(state, now()),
             });
           });
           return;

--- a/server/src/messages.ts
+++ b/server/src/messages.ts
@@ -34,4 +34,4 @@ export const UNSUPPORTED_PROTOCOL_VERSION_MESSAGE =
 export const MIN_PROTOCOL_VERSION = 1;
 
 /** Current protocol version this server implements. */
-export const CURRENT_PROTOCOL_VERSION = 3;
+export const CURRENT_PROTOCOL_VERSION = 4;

--- a/server/src/room-event-consumer.ts
+++ b/server/src/room-event-consumer.ts
@@ -6,6 +6,7 @@ import {
 } from "./types.js";
 import type { RoomEventBus, RoomEventBusMessage } from "./room-event-bus.js";
 import type { ServerMessage } from "@bili-syncplay/protocol";
+import { withPlaybackAge } from "./room-state-age.js";
 
 const MEMBER_DELTA_PROTOCOL_VERSION = 2;
 type MemberDeltaMessage = Extract<
@@ -73,7 +74,9 @@ export async function createRoomEventConsumer(options: {
   send: SendMessage;
   instanceId?: string;
   logEvent?: import("./types.js").LogEvent;
+  now?: () => number;
 }): Promise<{ close: () => Promise<void> }> {
+  const now = options.now ?? Date.now;
   const unsubscribe = await options.roomEventBus.subscribe(async (message) => {
     try {
       const localSessions = options.listLocalSessionsByRoom(message.roomCode);
@@ -111,9 +114,12 @@ export async function createRoomEventConsumer(options: {
           if (!roomState || !isMemberDeltaRecipient(session, message)) {
             continue;
           }
+          // A legacy client gets a member delta as a full room state, which
+          // carries the playback snapshot the room has been holding since well
+          // before this join/leave — exactly the case the age exists for.
           options.send(session.socket, {
             type: "room:state",
-            payload: roomState,
+            payload: withPlaybackAge(roomState, now()),
           });
         }
 
@@ -160,7 +166,7 @@ export async function createRoomEventConsumer(options: {
           }
           options.send(session.socket, {
             type: "room:state",
-            payload: state,
+            payload: withPlaybackAge(state, now()),
           });
         }
       }

--- a/server/src/room-state-age.ts
+++ b/server/src/room-state-age.ts
@@ -12,11 +12,21 @@ import type { RoomState, RoomStatePayload } from "@bili-syncplay/protocol";
  * This must be called at each send, never stored: an age is only true at the
  * instant it is sent, and a stored one is just a timestamp in disguise.
  *
- * The clamp covers the one case where the two timestamps are not from the same
- * clock after all: in a multi-node deployment the snapshot may have been
- * stamped by another node, whose clock can sit slightly behind this one's. A
- * negative result is meaningless as a duration (and rejected by the protocol
- * guard), so report the snapshot as current instead.
+ * The clamp exists to satisfy the protocol, not to correct clocks: a negative
+ * duration is meaningless and the guard rejects it, so the floor keeps a
+ * malformed frame off the wire. It is deliberately not a skew filter — bounding
+ * an implausibly *large* age is the receiver's call, since only the receiver
+ * knows what its own extrapolation is worth (`MAX_TRUSTED_PLAYBACK_AGE_MS`).
+ *
+ * Known limitation, multi-node only: `serverTime` may have been stamped by a
+ * different node, so the two readings can come from two clocks after all. A
+ * peer node running behind makes the age negative and the floor reports the
+ * snapshot as current; a peer running ahead inflates it, and only the receiver's
+ * bound catches that. Cluster nodes are NTP-synced to within milliseconds, which
+ * is orders of magnitude below the ~2.1s staleness this recovers, so the trade
+ * is worth taking — closing it properly needs a cluster-wide time source for
+ * `serverTime` itself, which is a change to the playback write path rather than
+ * to this function.
  */
 export function withPlaybackAge(
   state: RoomState,

--- a/server/src/room-state-age.ts
+++ b/server/src/room-state-age.ts
@@ -1,0 +1,32 @@
+import type { RoomState, RoomStatePayload } from "@bili-syncplay/protocol";
+
+/**
+ * Stamp a `room:state` payload with how stale its playback snapshot is.
+ *
+ * Both operands are the server's own clock — `playback.serverTime` was written
+ * by `now()` when the update was accepted — so this subtraction stays inside
+ * one clock. What crosses to the client is the resulting *duration*, which is
+ * what makes it safe: the receiver adds it to an anchor of its own instead of
+ * comparing our timestamps against its own (see `RoomStatePayload`).
+ *
+ * This must be called at each send, never stored: an age is only true at the
+ * instant it is sent, and a stored one is just a timestamp in disguise.
+ *
+ * The clamp covers the one case where the two timestamps are not from the same
+ * clock after all: in a multi-node deployment the snapshot may have been
+ * stamped by another node, whose clock can sit slightly behind this one's. A
+ * negative result is meaningless as a duration (and rejected by the protocol
+ * guard), so report the snapshot as current instead.
+ */
+export function withPlaybackAge(
+  state: RoomState,
+  sentAtMs: number,
+): RoomStatePayload {
+  if (!state.playback) {
+    return state;
+  }
+  return {
+    ...state,
+    playbackAgeMs: Math.max(0, sentAtMs - state.playback.serverTime),
+  };
+}

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -1841,3 +1841,82 @@ test("publish wrapper times out so a hung publish frees its slot", async () => {
   // Underlying publish never rejected, so the failed-event log must stay quiet.
   assert.equal(failedEvents.length, 0);
 });
+
+test("room:state is aged at the send, not at the room-store read", async () => {
+  // The age must cover the store read too: `getRoomStateForSession` awaits, and
+  // the room keeps playing through it. Anchoring at the read would hand the
+  // receiver a position already staler than the age admits.
+  const sentPayloads: Array<Record<string, unknown>> = [];
+  let clock = 10_000;
+  const session = createSession("member-age", {
+    roomCode: "ROOM-AGE",
+    memberId: "member-age",
+    memberToken: "member-token-age",
+    joinedAt: 0,
+  });
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    now: () => clock,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession() {
+        return { room: null };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        // The store read costs 400ms of room time before the send happens.
+        clock += 400;
+        return {
+          roomCode: "ROOM-AGE",
+          sharedVideo: null,
+          playback: {
+            url: "https://www.bilibili.com/video/BV1xx411c7mD",
+            currentTime: 42,
+            playState: "playing",
+            playbackRate: 1,
+            updatedAt: 8_000,
+            serverTime: 8_000,
+            actorId: "member-age",
+            seq: 7,
+          },
+          members: [{ id: "member-age", name: "Alice" }],
+        };
+      },
+    },
+    logEvent() {},
+    send(_socket, message) {
+      if (message.type === "room:state") {
+        sentPayloads.push(
+          message.payload as unknown as Record<string, unknown>,
+        );
+      }
+    },
+    sendError() {
+      throw new Error("sendError should not be called");
+    },
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "sync:request",
+    payload: { memberToken: "member-token-age" },
+  });
+
+  assert.equal(sentPayloads.length, 1);
+  assert.equal(sentPayloads[0].playbackAgeMs, 2_400);
+});

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -952,7 +952,7 @@ test("message handler accepts room:create without protocolVersion (legacy client
   assert.ok(events.includes("room_created"));
   assert.equal(sent.length, 2);
   assert.equal(sent[0].type, "room:created");
-  assert.equal(sent[0].serverProtocolVersion, 3);
+  assert.equal(sent[0].serverProtocolVersion, 4);
   assert.equal(sent[1].type, "room:state");
 });
 
@@ -1145,20 +1145,21 @@ test("message handler accepts room:join with matching protocolVersion and return
     payload: {
       roomCode: "ROOM01",
       joinToken: "join-token-1",
-      protocolVersion: 3,
+      protocolVersion: 4,
     },
   });
 
   assert.equal(sent.length, 2);
   assert.equal(sent[0].type, "room:joined");
-  assert.equal(sent[0].serverProtocolVersion, 3);
+  assert.equal(sent[0].serverProtocolVersion, 4);
   assert.equal(sent[1].type, "room:state");
 });
 
 test("message handler accepts room:join from a still-supported older protocol version", async () => {
   // v2 clients (below CURRENT but >= MIN) stay in the compatibility window: the
   // server accepts them and advertises its CURRENT version. The v3 `naturalEnd`
-  // playback flag is additive, so these older clients simply ignore it.
+  // playback flag and the v4 `room:state.playbackAgeMs` are both additive, so
+  // these older clients simply ignore them.
   const sent: Array<{ type: string; serverProtocolVersion?: number }> = [];
   const session = createSession("older-joiner");
 
@@ -1233,7 +1234,7 @@ test("message handler accepts room:join from a still-supported older protocol ve
 
   assert.equal(session.protocolVersion, 2);
   assert.equal(sent[0].type, "room:joined");
-  assert.equal(sent[0].serverProtocolVersion, 3);
+  assert.equal(sent[0].serverProtocolVersion, 4);
   assert.equal(sent[1].type, "room:state");
 });
 

--- a/server/test/room-event-consumer.test.ts
+++ b/server/test/room-event-consumer.test.ts
@@ -627,3 +627,101 @@ test("room event consumer still reads room state when a local session is present
   assert.equal(roomStateReads, 1);
   assert.equal(delivered, 1);
 });
+
+const PLAYING_SNAPSHOT = {
+  url: "https://www.bilibili.com/video/BV1xx411c7mD",
+  currentTime: 42,
+  playState: "playing" as const,
+  playbackRate: 1,
+  updatedAt: 8_000,
+  serverTime: 8_000,
+  actorId: "member-a",
+  seq: 7,
+};
+
+test("broadcast room state reports how stale its playback snapshot is", async () => {
+  const bus = createInMemoryRoomEventBus();
+  const session = createSession("member-a", "ROOM01");
+  const ages: Array<number | undefined> = [];
+
+  const consumer = await createRoomEventConsumer({
+    roomEventBus: bus,
+    now: () => 10_100,
+    async getRoomStateByCode(roomCode) {
+      return {
+        roomCode,
+        sharedVideo: null,
+        playback: PLAYING_SNAPSHOT,
+        members: [{ id: "member-a", name: "Alice" }],
+      };
+    },
+    listLocalSessionsByRoom() {
+      return [session];
+    },
+    send(_socket, message) {
+      if (message.type === "room:state") {
+        ages.push(message.payload.playbackAgeMs);
+      }
+    },
+  });
+
+  try {
+    await bus.publish({
+      type: "room_state_updated",
+      roomCode: "ROOM01",
+      sourceInstanceId: "instance-b",
+      emittedAt: 1_100,
+    });
+  } finally {
+    await consumer.close();
+  }
+
+  assert.deepEqual(ages, [2_100]);
+});
+
+test("legacy member-delta room state reports how stale its playback snapshot is", async () => {
+  // The snapshot a legacy client receives here is the one the room has held
+  // since well before this join — the case the age exists for.
+  const bus = createInMemoryRoomEventBus();
+  const legacySession = createSession("member-b", "ROOM01", 1);
+  const ages: Array<number | undefined> = [];
+
+  const consumer = await createRoomEventConsumer({
+    roomEventBus: bus,
+    now: () => 10_100,
+    async getRoomStateByCode(roomCode) {
+      return {
+        roomCode,
+        sharedVideo: null,
+        playback: PLAYING_SNAPSHOT,
+        members: [
+          { id: "member-a", name: "Alice" },
+          { id: "member-b", name: "Bob" },
+        ],
+      };
+    },
+    listLocalSessionsByRoom() {
+      return [legacySession];
+    },
+    send(_socket, message) {
+      if (message.type === "room:state") {
+        ages.push(message.payload.playbackAgeMs);
+      }
+    },
+  });
+
+  try {
+    await bus.publish({
+      type: "room_member_joined",
+      roomCode: "ROOM01",
+      sourceInstanceId: "instance-b",
+      emittedAt: 1_100,
+      memberId: "member-a",
+      displayName: "Alice",
+    });
+  } finally {
+    await consumer.close();
+  }
+
+  assert.deepEqual(ages, [2_100]);
+});

--- a/server/test/room-state-age.test.ts
+++ b/server/test/room-state-age.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { PlaybackState, RoomState } from "@bili-syncplay/protocol";
+import { withPlaybackAge } from "../src/room-state-age.js";
+
+function roomState(playback: Partial<PlaybackState> | null): RoomState {
+  return {
+    roomCode: "ROOM01",
+    sharedVideo: null,
+    members: [{ id: "member-1", name: "Alice" }],
+    playback: playback
+      ? {
+          url: "https://www.bilibili.com/video/BV1xx411c7mD",
+          currentTime: 42,
+          playState: "playing",
+          playbackRate: 1,
+          updatedAt: 10_000,
+          serverTime: 10_000,
+          actorId: "member-1",
+          seq: 1,
+          ...playback,
+        }
+      : null,
+  };
+}
+
+test("reports how long ago the snapshot was stamped", () => {
+  const payload = withPlaybackAge(roomState({ serverTime: 10_000 }), 12_100);
+
+  assert.equal(payload.playbackAgeMs, 2_100);
+});
+
+test("a snapshot stamped at this instant has no age", () => {
+  const payload = withPlaybackAge(roomState({ serverTime: 12_100 }), 12_100);
+
+  assert.equal(payload.playbackAgeMs, 0);
+});
+
+test("a snapshot stamped by a node running ahead reports as current", () => {
+  // Multi-node: `serverTime` came from another node, whose clock can sit ahead
+  // of this one's. A negative duration is meaningless (and rejected by the
+  // protocol guard), so report the snapshot as current rather than as one from
+  // the future.
+  const payload = withPlaybackAge(roomState({ serverTime: 12_500 }), 12_100);
+
+  assert.equal(payload.playbackAgeMs, 0);
+});
+
+test("a room with no playback gets no age", () => {
+  const payload = withPlaybackAge(roomState(null), 12_100);
+
+  assert.equal(payload.playbackAgeMs, undefined);
+  assert.equal("playbackAgeMs" in payload, false);
+});
+
+test("the room state is left otherwise untouched", () => {
+  const state = roomState({ serverTime: 10_000 });
+
+  const payload = withPlaybackAge(state, 12_100);
+
+  const { playbackAgeMs, ...rest } = payload;
+  assert.equal(playbackAgeMs, 2_100);
+  assert.deepEqual(rest, state);
+  // The stored state must not gain the field: an age is only true at the instant
+  // it is sent, and a stored one is a timestamp in disguise.
+  assert.equal("playbackAgeMs" in state, false);
+});
+
+test("the age is recomputed per send rather than fixed to the snapshot", () => {
+  const state = roomState({ serverTime: 10_000 });
+
+  assert.equal(withPlaybackAge(state, 11_000).playbackAgeMs, 1_000);
+  assert.equal(withPlaybackAge(state, 13_000).playbackAgeMs, 3_000);
+});


### PR DESCRIPTION
## Summary

#210 把播放外推改成以本地单调锚点为准之后，接收端不再知道一份快照到达时已经多旧了 —— 新到达的状态一律按 `elapsed=0` 处理。稳态没有影响（广播约 2.1s 一次，残余只剩单向网络延迟），但**中途加入正在播放的房间**时，服务端下发的是最后一次广播的快照，最坏已旧了一个广播周期，接收端会以偏后的位置起播，再由一次 seek 收掉。

本 PR 让服务端以**时长**形式把快照年龄告诉接收端：

- `packages/protocol`：`room:state` 的 payload 提升为 `RoomStatePayload = RoomState & { playbackAgeMs?: number }`，新增 `isRoomStatePayload` 守卫（拒绝负数/非有限值）。字段刻意**不放进 `PlaybackState`** —— 那是服务端持久化、且客户端会在 `playback:update` 中回传的形状，放在那里等于把时刻存了下来；放在 payload 上让"不可存储"成为结构性事实而不是需要有人记住的规则。
- `server`：新增 `withPlaybackAge(state, sentAtMs)`，在**每个下发点、发送那一刻**计算 `now() - playback.serverTime`（服务端自己的两个时刻相减）。四个下发点全部覆盖：join/bootstrap、`sync:request`、`room-event-consumer` 的广播、以及旧客户端收到的成员增量全量态。多节点下 `serverTime` 可能来自另一节点，故结果 clamp 到 `>= 0`。
- `extension`：`resolvePlaybackAnchorAtMs(receivedAtMs, playbackAgeMs)` 把年龄从本地到达时刻中减去，得到该快照位置为真的锚点；缺失（旧服务端）、非有限、为负、或超过 `MAX_TRUSTED_PLAYBACK_AGE_MS`（10s ≈ 5 个广播周期）一律退回按到达时刻锚定，即 #212 之前的行为。字段在入口即被剥离，不会流入 `roomSessionState.roomState`、chrome.storage 或成员增量重包。

跨机只传时长不传时刻：时长安全（接收端只是把它加到自己的锚上），时刻则迫使接收端拿服务端时刻减本地时刻 —— 量到的是钟差而非流逝时间，正是 #210 要消除的那一类比较。

顺带修正了 `docs/reference/protocol.md`（中英）中一处 #210 之后已失实的说明："时钟偏移用于应用 `PlaybackState.serverTime`" —— 该偏移现在只是弹窗里的诊断值。

Fixes #212

## Test plan

- [x] `packages/protocol`：6 条守卫用例（携带/省略/0/负数/非数字/非有限）
- [x] `server`：`room-state-age.test.ts`（含"另一节点时钟超前 → 报告为最新"与"逐次下发重新计算"），`message-handler` 一条端到端用例证明年龄覆盖了 store 读取耗时（读取花 400ms → 年龄 2400 而非 2000），`room-event-consumer` 广播与旧客户端两条路径各一条
- [x] `extension`：`resolvePlaybackAnchorAtMs` 六条边界用例；`room-session-controller` 两条 —— 带年龄的快照锚定在到达之前、且 `playbackAgeMs` 既不落库也不下发给 content script；不带年龄时锚定在到达时刻（向后兼容）
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test && npm run audit` 全绿（597 通过 / 0 失败）
- [ ] 手动验证：一台正在播放，另一台中途加入，观察起播位置误差应显著小于一个广播周期

## 兼容性

`PROTOCOL_VERSION` / `CURRENT_PROTOCOL_VERSION` 由 3 递增至 4（`CONTRIBUTING.md:48` 要求每次 wire-shape 变更都递增）；`MIN_PROTOCOL_VERSION` 保持 1，服务端仍安全服务旧客户端。

四种组合均兼容：

| | 旧服务端 | 新服务端 |
|---|---|---|
| **旧客户端** | 不变 | 不变（多出的字段被忽略） |
| **新客户端** | 不变（退回 #210 后行为） | 得到精度改进 |

旧扩展在 socket 入口的 `isServerMessage` 逐字段校验、不拒绝未知键，故新字段不会导致丢帧；它不剥离该字段，会随 `roomState` 进 storage，但无人读取，是惰性数据。移动端 `sync_play_core`（PiliPlus fork，独立仓库）的 `RoomState.tryParse` 同样逐字段读取，不受影响，只是暂未消费该字段。

🤖 Generated with [Claude Code](https://claude.com/claude-code)