### PR TITLE
chore: release 1.3.2

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-exclude='../packages/**' test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.1"
+    "@bili-syncplay/protocol": "1.3.2"
   },
   "devDependencies": {
     "@types/chrome": "^0.2.2",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["alarms", "storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "workspaces": [
         "packages/*",
         "server",
@@ -28,9 +28,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.1"
+        "@bili-syncplay/protocol": "1.3.2"
       },
       "devDependencies": {
         "@types/chrome": "^0.2.2",
@@ -5701,10 +5701,10 @@
     },
     "packages/admin-ui": {
       "name": "@bili-syncplay/admin-ui",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
-        "@bili-syncplay/protocol": "1.3.1",
+        "@bili-syncplay/protocol": "1.3.2",
         "@tanstack/react-query": "^5.101.2",
         "antd": "^6.5.1",
         "dayjs": "^1.11.21",
@@ -5727,7 +5727,7 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "devDependencies": {
         "@types/node": "^24.0.0",
         "typescript": "^6.0.3"
@@ -5735,9 +5735,9 @@
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.1",
+        "@bili-syncplay/protocol": "1.3.2",
         "ioredis": "^5.10.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/admin-ui",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
-    "@bili-syncplay/protocol": "1.3.1",
+    "@bili-syncplay/protocol": "1.3.2",
     "@tanstack/react-query": "^5.101.2",
     "antd": "^6.5.1",
     "dayjs": "^1.11.21",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.1",
+    "@bili-syncplay/protocol": "1.3.2",
     "ioredis": "^5.10.0",
     "ws": "^8.21.0"
   },


### PR DESCRIPTION
自 v1.3.1 起累计 8 个 commit，集中在多节点服务端的容量与正确性，以及一条影响所有接收端的播放外推时基修复。无新增用户可见功能，按 patch 发布。

## 主要变更

**播放同步**
- 播放位置外推改以本地单调锚点为准，消除钟差驱动的倍速抖动（#210）
- 协议层以时长形式给出快照年龄，恢复中途加入时的位置精度（#212 / #214）

**服务端容量与正确性**
- 房间索引不再泄漏已过期房间的条目（#204）
- 房间索引合并为单一有序集合（#209）
- 无本地接收者时跳过房间状态读取，updateRoom 改 Lua CAS（#206）
- 暴露进程 CPU 指标并计量 sync:request 耗时（#203）

**工程**
- 三个包的 test/ 纳入 typecheck 并修掉暴露的类型错误（#213）
- 解除依赖审计门禁对 CI 的阻塞（#205）

## 变更范围

仅版本号：根 / protocol / admin-ui / server / extension 的 package.json、extension/public/manifest.json、package-lock.json。

## 验证

`format:check`、`lint`、`typecheck`、`build`、`test`（14 文件 / 65 用例）、`audit` 六项本地全部通过。

合并后打 `v1.3.2` 标签触发 release.yml 与 docker-release.yml。

🤖 Generated with [Claude Code](https://claude.com/claude-code)