### PR TITLE
ci: 给 Docker 构建步骤加 20 分钟超时

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -75,6 +75,11 @@ jobs:
             type=ref,event=pr
 
       - name: Build and push
+        # QEMU 模拟下的 linux/arm64 `npm ci` 会偶发静默挂起（实测 36 分钟零输出，
+        # 取消重跑后同一层 4 分钟跑完）。历次 tag 发布该步骤耗时 2.9~8.6 分钟，
+        # 20 分钟给足余量，又能让挂起在 20 分钟内失败，而不是占满 job 默认的 6 小时。
+        # 命中时按失败处理即可：重跑本工作流，不需要改构建本身。
+        timeout-minutes: 20
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## 背景

发 v1.3.2 时 `Docker Release` 卡了 36 分钟，定位到 QEMU 模拟下的 `linux/arm64` 层：

```
02:38:45  #45 [linux/amd64 stage-1 11/11] RUN rm -rf ...   DONE 0.2s   ← amd64 全部完成
02:38:45  #25 [linux/arm64 builder 8/18] RUN npm ci
03:14:46  ##[error]The operation was canceled.             ← 36 分钟零输出
```

取消后原样重跑，同一条 `npm ci` 真正执行（非 `CACHED`，后续 `9/18`…`18/18` 都跟着跑完）并在 **4 分钟**内完成 —— 偶发挂起，不是必然复现。也排除了缓存驱逐：当时 Actions cache 仅 1.05GB/10GB。

## 改动

给 `Build and push` 步骤加 `timeout-minutes: 20`。

挂起时该步骤原本只受 job 默认的 6 小时超时约束，无人值守会白占一个 runner 大半天。历次 tag 发布该步骤耗时 2.9 / 5.8 / 5.8 / 8.6 分钟，20 分钟给足余量，又能让挂起及早失败。

**不改构建结构** —— 命中时重跑本工作流即可。若后续发现挂起变频繁，再考虑把 arm64 拆到原生 `ubuntu-24.04-arm` runner 上绕开 QEMU，那是另一件事。

## 验证

- `prettier --file-info` 确认该文件按 yaml parser 解析，`format:check` 通过 → YAML 语法有效
- 确认 `timeout-minutes` 与 `uses` 同为 8 空格缩进，落在 `Build and push` 步骤内
- 六项门禁（format/lint/typecheck/build/test/audit）本地全绿
- 本 PR 改了 `.github/workflows/docker-release.yml`，会触发该工作流的 PR 构建（amd64-only，不推送），即为改动本身的实机验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)