### PR TITLE
fix(server): steady tick 不再刷新播放否决窗口

### DIFF
--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -1388,16 +1388,6 @@ export function createRoomService(options: {
         );
       }
 
-      if (authorityKind) {
-        recordPlaybackAuthority({
-          roomCode: access.persistedRoom.code,
-          actorId: nextPlayback.actorId,
-          kind: authorityKind,
-          source: "playback:update",
-        });
-      }
-
-      const nextAuthority = getPlaybackAuthority(access.persistedRoom.code);
       // Skip steady timeupdate ticks so the admin event store keeps user
       // operations visible without being flooded by ~every-2s broadcasts:
       // log when playState, playbackRate, or syncIntent changes, or when
@@ -1431,6 +1421,36 @@ export function createRoomService(options: {
           0.01 &&
         !nextPlayback.syncIntent &&
         Math.abs(actualTimeDelta - expectedTimeDelta) < 1;
+
+      // A steady tick must not refresh the authority window. It carries no new
+      // intent by definition — same playState, same rate, no syncIntent, and a
+      // currentTime that only advanced as far as the previous rate predicts —
+      // yet recording it used to push the 1.2s veto window forward in full,
+      // which is what `decidePlaybackAcceptance` reads to drop other members'
+      // updates as `authority-window-follow`.
+      //
+      // That turned a repeated `paused` frame into a rolling veto: a peer that
+      // hard-seeks across a shared-video switch leaks its just-applied pause
+      // back as two identical frames, and the second one extends the window
+      // far enough to swallow every `playing` the sharer emits while its own
+      // autoplay-next starts up — the room sticks at paused with nobody having
+      // paused anything. Only the frame that actually changes something may
+      // claim the veto.
+      //
+      // The gate is deliberately the same predicate as the applied-event log
+      // below: a frame that is not worth an audit entry is not worth a veto,
+      // and keeping one predicate means the log stays an accurate record of
+      // which frames can move the authority.
+      if (authorityKind && !isSteadyTick) {
+        recordPlaybackAuthority({
+          roomCode: access.persistedRoom.code,
+          actorId: nextPlayback.actorId,
+          kind: authorityKind,
+          source: "playback:update",
+        });
+      }
+
+      const nextAuthority = getPlaybackAuthority(access.persistedRoom.code);
       if (!isSteadyTick) {
         logEvent("playback_update_applied", {
           roomCode: access.persistedRoom.code,

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -1736,6 +1736,174 @@ test("room service accepts a legal cross-actor playback update after authority e
   assert.equal(finalState.playback?.actorId, guest.memberId);
 });
 
+test("room service does not let a steady paused tick claim the authority window", async () => {
+  // Reproduces the autoplay-next stall seen in production: the sharer switches
+  // to the next video, which starts out paused at the remembered position, and
+  // a peer that hard-seeks to that position leaks the pause it just applied
+  // back into the room as repeated frames. Those frames change nothing, so
+  // they must not hand the peer a veto over the sharer's own start-up.
+  let currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: createActiveRoomRegistry(),
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOM31",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  const guest = createSession("guest");
+  const joined = await service.joinRoomForSession(
+    guest,
+    created.room.code,
+    created.room.joinToken,
+    "Bob",
+  );
+
+  await service.shareVideoForSession(
+    owner,
+    created.memberToken,
+    createSharedVideo(),
+    createPlayback(owner.memberId ?? owner.id, {
+      playState: "paused",
+      currentTime: 49,
+    }),
+  );
+
+  // Past the share's own authority window, so nothing but the guest's frames
+  // can decide the outcome below.
+  currentTime = 2_500;
+  const echo = await service.updatePlaybackForSession(
+    guest,
+    joined.memberToken,
+    createPlayback(guest.memberId ?? guest.id, {
+      playState: "paused",
+      currentTime: 49,
+      seq: 1,
+    }),
+  );
+  assert.equal(echo.ignored, false);
+
+  currentTime = 2_600;
+  const repeatedEcho = await service.updatePlaybackForSession(
+    guest,
+    joined.memberToken,
+    createPlayback(guest.memberId ?? guest.id, {
+      playState: "paused",
+      currentTime: 49,
+      seq: 2,
+    }),
+  );
+  assert.equal(repeatedEcho.ignored, false);
+  assert.equal(service.getPlaybackAuthority(created.room.code), null);
+
+  currentTime = 2_700;
+  const sharerStartsPlaying = await service.updatePlaybackForSession(
+    owner,
+    created.memberToken,
+    createPlayback(owner.memberId ?? owner.id, {
+      playState: "playing",
+      currentTime: 49,
+      seq: 2,
+    }),
+  );
+
+  assert.equal(sharerStartsPlaying.ignored, false);
+  const finalState = await service.getRoomStateForSession(
+    owner,
+    created.memberToken,
+    "sync:request",
+  );
+  assert.equal(finalState.playback?.playState, "playing");
+  assert.equal(finalState.playback?.actorId, owner.memberId);
+});
+
+test("room service still lets a real pause claim the authority window", async () => {
+  // Counterpart to the steady-tick test above: a frame that actually changes
+  // playState is a genuine intent and must keep vetoing a competing play, or
+  // the steady-tick gate would have simply disabled pause dominance.
+  let currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: createActiveRoomRegistry(),
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOM32",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  const guest = createSession("guest");
+  const joined = await service.joinRoomForSession(
+    guest,
+    created.room.code,
+    created.room.joinToken,
+    "Bob",
+  );
+
+  await service.shareVideoForSession(
+    owner,
+    created.memberToken,
+    createSharedVideo(),
+    createPlayback(owner.memberId ?? owner.id, {
+      playState: "playing",
+      currentTime: 40,
+    }),
+  );
+
+  currentTime = 2_500;
+  const realPause = await service.updatePlaybackForSession(
+    guest,
+    joined.memberToken,
+    createPlayback(guest.memberId ?? guest.id, {
+      playState: "paused",
+      currentTime: 40,
+      seq: 1,
+    }),
+  );
+  assert.equal(realPause.ignored, false);
+  assert.equal(
+    service.getPlaybackAuthority(created.room.code)?.actorId,
+    guest.memberId,
+  );
+  assert.equal(service.getPlaybackAuthority(created.room.code)?.kind, "pause");
+
+  currentTime = 2_600;
+  const competingPlay = await service.updatePlaybackForSession(
+    owner,
+    created.memberToken,
+    createPlayback(owner.memberId ?? owner.id, {
+      playState: "playing",
+      currentTime: 40,
+      seq: 2,
+    }),
+  );
+
+  assert.equal(competingPlay.ignored, true);
+  const finalState = await service.getRoomStateForSession(
+    owner,
+    created.memberToken,
+    "sync:request",
+  );
+  assert.equal(finalState.playback?.playState, "paused");
+  assert.equal(finalState.playback?.actorId, guest.memberId);
+});
+
 test("room service consults shared kick blocks when rejoining through another node", async () => {
   const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
   const service = createRoomService({


### PR DESCRIPTION
## 问题

`playback:update` 每次被接受都会刷新 1.2s 的 playback authority（`room-service.ts` 原 :1391），**包括 `playState` / `playbackRate` / `syncIntent` 全部未变、`currentTime` 也只按原速率推进的重复帧**。这类帧不携带任何新意图，却能把 `decidePlaybackAcceptance` 用来丢弃其他成员更新（`authority-window-follow`）的否决窗口整体后移——重复的 `paused` 帧因此变成了滚动否决。

雪上加霜的是，这些帧正好落在 #106 引入的 steady-tick 日志门槛之下，刷新窗口时**不留任何日志**，排查时只能看到"起播被拒"却找不到否决权的来源。

## 线上表现

分享者自动连播换片后，新视频停在记忆进度（49s）且尚未起播，房间态天然是 `paused`。观众跨视频 hard-seek 到该位置时，缓冲耗时超过扩展端 700ms 的回声抑制窗，把刚应用的 `paused` 当作本地状态泄漏回房间，连发两帧。第二帧把否决窗口续到 `authorityUntil=…521822`，正好盖住分享者随后 220ms 内发出的全部 7 次 `playing`：

```
seq=60..66  playState=playing  ct≈49.0
reason=authority-window-follow  authorityKind=pause
authorityActorId=<观众>  currentPlayState=paused
```

结果：房间卡死在暂停，而没有任何人执行过暂停。

## 改动

只有真正改变了状态的帧才能取得否决权。门槛直接复用下方 `playback_update_applied` 已有的 `isSteadyTick` 判定，把它的计算上移到 `recordPlaybackAuthority` 之前——不值得记一条审计的帧，也不值得拥有否决权，并且这样一来日志始终是"哪些帧能移动 authority"的准确记录。

由于 steady tick 要求 `playState` 相同，受影响的只有 `kind="pause"` 的重复帧；`play`（playState 必变）、`ratechange`（rate 必变）、`seek`（带 `syncIntent` 或时间跳变 ≥2.5s）都不会被门掉。

## 测试

新增两条，互为判别力对照：

- `does not let a steady paused tick claim the authority window` —— 复现线上链路（share paused@49 → 观众两帧 steady paused → 分享者 playing）。**回退本次修复后该测试失败**，已验证。
- `still lets a real pause claim the authority window` —— 真正改变 `playState` 的 pause 仍然否决竞争中的 play。回退修复后该测试**依然通过**，证明这不是把 pause dominance 整个关掉。

`npm run format:check && lint && typecheck && build && test && audit` 全绿。

## 不在本 PR 范围

- **扩展端回声泄漏（根因）**：远端写入的播放态目前靠 700ms 固定窗抑制回声，跨视频 hard-seek 的缓冲天然会超过它。需要改为归属标记 + 真实 gesture 清除。
- **`buffering` 被算作 `currentIsStopLike`**（`playback-authority.ts:32-34`）：缓冲是各客户端各自的瞬态，不是停止意图；房间越卡越容易锁死在暂停。这条语义自初版就在，改动面大。

两项都会另开 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)