### PR TITLE
docs: 精简 AGENTS.md 中可由代码推导的内容

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,52 +9,9 @@
 
 - Agents must respond in Chinese throughout the entire interaction unless the user explicitly requests another language.
 
-## Project Overview
-
-Bili-SyncPlay is a monorepo for synchronized Bilibili video playback across multiple users. It consists of:
-
-- **`packages/protocol/`** — Shared TypeScript types, type guards, and URL normalization utilities
-- **`packages/admin-ui/`** — Admin console (React + Vite + Ant Design, served at `/admin-next`; `/admin` 302-redirects to it)
-- **`extension/`** — Chrome/Edge browser extension (service worker + content scripts + popup)
-- **`server/`** — Node.js WebSocket server with admin API
-
 ## Commands
 
-```bash
-# Install dependencies
-npm install
-
-# Build all packages (protocol → server + extension, in dependency order)
-npm run build
-
-# Development server (watch mode)
-npm run dev:server
-
-# Admin console dev server (Vite, proxies /api to localhost:8787)
-npm run dev:admin-ui
-
-# Build extension only (Chrome/Edge → extension/dist)
-npm run build:extension
-
-# Build the Firefox target (event-page background → extension/dist-firefox)
-npm run build:extension:firefox
-
-# Code quality checks
-npm run lint
-npm run lint:fix
-npm run format:check
-npm run typecheck
-
-# Testing
-npm test
-npm run coverage
-
-# Release
-npm run build:release          # Package Chrome + Firefox (zip + xpi)
-npm run build:release:chrome   # Chrome/Edge zip only
-npm run build:release:firefox  # Firefox zip + xpi only
-npm run release:version        # Bump version numbers
-```
+Everyday commands are the `package.json` scripts — read them from there.
 
 **Before every commit**, run in order:
 
@@ -78,30 +35,9 @@ turns red. Findings that do not apply to this repository go in
 4. Server broadcasts to all room members
 5. Other clients receive the message and apply playback state to their video player
 
-### Key Extension Controllers (`extension/src/background/`)
-
-| Controller                   | Responsibility                                         |
-| ---------------------------- | ------------------------------------------------------ |
-| `socket-controller.ts`       | WebSocket connection, reconnection, health checks      |
-| `room-session-controller.ts` | Room create/join/leave/state                           |
-| `share-controller.ts`        | Shared video and pending local shares                  |
-| `clock-controller.ts`        | NTP-style clock offset for playback sync               |
-| `tab-controller.ts`          | Bilibili tab tracking, shared vs. local page switching |
-| `message-controller.ts`      | Routes popup/content messages to handlers              |
-
-The `background/index.ts` entry file only bootstraps and wires controllers — keep it thin.
-
-### Server (`server/src/`)
-
-- `app.ts` — HTTP/WebSocket setup and message routing
-- `config/` — Centralized environment parsing (`ALLOWED_ORIGINS`, `PORT`, `REDIS_URL`)
-- `admin/` — Admin panel, command bus, event store, session management
-
-Optional Redis support enables multi-node deployments.
-
 ### Protocol Package (`packages/protocol/`)
 
-Single source of truth for `ClientMessage`, `ServerMessage`, domain types (`RoomState`, `SharedVideo`, `PlaybackState`, `RoomMember`), type guards, and URL normalization. Always export through the package root to preserve import stability.
+Always export through the package root to preserve import stability.
 
 ## Structural Constraints
 


### PR DESCRIPTION
## 背景

`CLAUDE.md` 通过 `@AGENTS.md` 把整个 AGENTS.md 引入每次会话的常驻上下文。其中有相当一部分内容是"读 `ls` / `package.json` / 源码就能复原"的，等于每次会话都为可推导信息付一次 token。

## 改动

删除 5 段共 66 行：

| 位置 | 内容 | 为什么可删 |
| --- | --- | --- |
| `## Project Overview` | 四个包的目录清单 | `ls packages/` + `package.json` 的 workspaces 字段即可得 |
| `## Commands` 的代码块 | `npm run …` 逐条罗列 | 已逐条核对，全部是 `package.json` 里的 scripts |
| `### Key Extension Controllers` | controller 表格 | `ls extension/src/background/` 即可得；其中"index.ts 只做 bootstrap"一句已由 Structural Constraints 覆盖 |
| `### Server (server/src/)` | 文件清单 + Redis 一句 | `ls server/src/` 即可得；"env 解析留在 config 层"的约束在 Structural Constraints 里已有 |
| `### Protocol Package` | 类型枚举句 | 类型清单看源码即可；保留了 "Always export through the package root" 这句指令 |

补一句 `Everyday commands are the package.json scripts — read them from there.` 作为指路。

## 保留不动

所有**不可推导**的内容：提交前检查序列与 `npm run audit` 说明、Data Flow、Structural Constraints、**Playback timing invariants**、"测试目录必须进 typecheck"一节、Engineering / Git / Commit Conventions / Review Feedback / Testing Focus / Agent Execution Rules。

## 效果

13,190 → 10,553 字符，每次会话约省 660 tokens 常驻上下文。纯文档改动，不涉及任何源码。

## 验证

完整预提交序列全绿（逐项断言退出码，未用管道）：`format:check` / `lint` / `typecheck` / `build` / `test` / `audit` 均为 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)