### PR TITLE
docs: 补充完成前验证、协议变更与同步调试三节规则

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,22 @@
 - This file is for AI agents, coding assistants, and repository automations working in this codebase.
 - Human contribution rules live in [CONTRIBUTING.md](./CONTRIBUTING.md). This file only adds agent-specific execution constraints and decision rules.
 
+## Verification Before Claiming Done
+
+- Never report an edit as complete without re-reading the changed region. After
+  every Edit/Write, re-read the file (or grep the exact new string) to confirm
+  the change actually landed — silent no-op string replacements have happened
+  repeatedly.
+- After any fix, run the full test suite AND typecheck before saying it works.
+  Report the actual command output, not a summary. Never pipe a check into
+  `tail`/`head` to judge it: the pipe reports the tail's exit code, so a failure
+  reads as green.
+- Never use `git checkout <file>` or `git restore <file>` to revert a probe — it
+  destroys uncommitted work in that same file. Copy the file aside first (`cp`)
+  and restore from the copy, or use `git stash`.
+- Never use `git add -A`; stage explicit paths so build artifacts and patch
+  files don't get committed.
+
 ## Language Rules
 
 - Agents must respond in Chinese throughout the entire interaction unless the user explicitly requests another language.
@@ -38,6 +54,28 @@ turns red. Findings that do not apply to this repository go in
 ### Protocol Package (`packages/protocol/`)
 
 Always export through the package root to preserve import stability.
+
+## Protocol Changes
+
+Checklist to run before opening any PR that touches the sync protocol:
+
+1. Did the wire format change? If yes, bump the version — and note there are
+   **two** constants that must move together, with nothing enforcing that they
+   agree: `PROTOCOL_VERSION` in `packages/protocol/src/types/common.ts` (what
+   the extension sends) and `CURRENT_PROTOCOL_VERSION` in
+   `server/src/messages.ts` (what the server implements and reports back).
+2. Grep for ALL call sites of any changed function signature, including
+   `server/src/app.ts` and the `index.ts` adapters. TypeScript accepts a
+   function that declares _fewer_ parameters than the target type expects, so an
+   adapter that quietly stops forwarding a trailing argument still typechecks —
+   the compiler will not flag it for you.
+3. New enum values or new fields: the server accepts clients all the way down to
+   `MIN_PROTOCOL_VERSION` (currently `1`), so confirm an older client's guards
+   tolerate them, or gate the behaviour behind a version check.
+   `MEMBER_DELTA_PROTOCOL_VERSION` in `server/src/room-event-consumer.ts` is the
+   pattern to copy.
+4. Update `docs/reference/protocol.md` and `docs/reference/protocol.zh-CN.md` in
+   the same PR.
 
 ## Structural Constraints
 
@@ -173,13 +211,23 @@ of a large interface, its parameter should say so (`Pick<RoomStore,
 (`ws.WebSocket`, `chrome.tabs.Tab`, `HTMLVideoElement`, `IncomingMessage`);
 prefer one shared constructor over per-call-site casts.
 
+## Debugging Sync Bugs
+
+- Prefer a single root-cause fix over layered patches. If a fix requires adding
+  a new suppression flag, cooldown, or special case on top of an existing one,
+  stop and re-derive the root cause instead.
+- State the hypothesis, name the exact log lines / code path that prove it, and
+  confirm before writing code.
+- Every sync fix needs a regression test that FAILS on the pre-fix code — verify
+  this by reverting the fix (stash it, or restore from a copy taken beforehand)
+  and running the test. A test that stays green either way guards nothing.
+
 ## Agent Execution Rules
 
 - Do not perform destructive git operations such as `git reset --hard`, force-pushes, or overwriting unrelated uncommitted user changes unless explicitly requested.
 - Do not change secrets, `.env` files, release credentials, or production deployment settings unless explicitly requested.
 - Do not update versions, lockfiles, or release artifacts unless the task clearly requires it.
-- Prefer the smallest relevant verification command first; if validation was not run, say so explicitly.
-- Do not claim a change was verified if the relevant checks were not actually run.
+- While iterating, prefer the smallest relevant verification command first; if validation was not run, say so explicitly. Claiming a change works is a different bar — see [Verification Before Claiming Done](#verification-before-claiming-done).
 - Keep changes scoped to the task. Avoid opportunistic edits in unrelated files.
 - When code changes affect developer workflow, architecture, or shared rules, update the relevant documentation files in the same change.
 - When reviewing code, report findings first, with concrete file references and impact, before giving summary commentary.


### PR DESCRIPTION
## 背景

来自 `/insights` 使用洞察报告的建议：把一直靠人工把关、且反复在 Codex 评审中被抓到的三类规则固化进 `AGENTS.md`（`CLAUDE.md` 通过 `@AGENTS.md` 继承）。纯文档改动，不涉及任何行为。

## 改动

三个新章节：

| 章节 | 位置 | 内容 |
|---|---|---|
| `## Verification Before Claiming Done` | `## Purpose` 之后、`## Language Rules` 之前 | 编辑后重读确认落地；宣称修好前跑完整测试+类型检查并贴真实输出；禁止 `git checkout/restore <file>` 回退探针；禁止 `git add -A` |
| `## Protocol Changes` | Architecture 之后 | 协议 PR 开单前的四步清单 |
| `## Debugging Sync Bugs` | Testing Focus 之后 | 宁要单一根因修复不要层叠补丁；先陈述假设再写码；回归测试须在修复前代码上确实失败 |

同时删去 `## Agent Execution Rules` 中与第一节语义重复的一条，并把「迭代中用最小验证命令」与「宣称完成须全量验证」明确区分为两个标准。

## 已对照代码核实并修正的断言

原建议文案有四处与当前代码不符，已按实际情况改写：

1. **协议版本号是两个常量，不是一个。** `PROTOCOL_VERSION`（`packages/protocol/src/types/common.ts:1`，扩展发送）与 `CURRENT_PROTOCOL_VERSION`（`server/src/messages.ts:37`，服务端实现并回报）各自独立定义、无任何机制保证一致，须同步提升。二者现均为 `4`。
2. **「parameter bivariance」用词不准。** 双变指参数*类型*的兼容性；真正让「丢参」逃过类型检查的是 TS 允许把声明了更少参数的函数赋给期望更多参数的类型。已按实际机制表述。
3. **「older v2 clients」已过期。** `MIN_PROTOCOL_VERSION = 1`（`server/src/messages.ts:34`），服务端仍接受低至 v1 的客户端。同时补上现成的版本门控范例 `MEMBER_DELTA_PROTOCOL_VERSION`（`server/src/room-event-consumer.ts:11`）。
4. **点名协议文档实际路径**：`docs/reference/protocol.md` 与 `docs/reference/protocol.zh-CN.md`。

另补两条与既有实践一致的细节：检查命令不得管道给 `tail`/`head`（退出码会被吞成绿）；回退探针须先 `cp` 备份再还原，因为 `git checkout <file>` 会连同该文件其它未提交改动一起冲掉。

## 验证

完整预提交序列，逐项断言退出码（未用管道截断）：

| 命令 | 结果 |
|---|---|
| `npm run format:check` | exit 0 |
| `npm run lint` | exit 0 |
| `npm run typecheck` | exit 0 |
| `npm run build` | exit 0 |
| `npm test` | exit 0 — node:test 1073 passed / 0 failed，admin-ui vitest 15 files / 70 tests passed |
| `npm run audit` | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)