### PR TITLE
docs: 新增 review-round 技能，固化单轮评审响应流程

### DIFF
--- a/.claude/skills/review-round/SKILL.md
+++ b/.claude/skills/review-round/SKILL.md
@@ -20,12 +20,12 @@ description: 处理当前 PR 的一轮 Codex 评审反馈。从读取评审信�
 | `round-signal.sh <PR>`    | 无未解决线程时区分「通过」与「没触发」              |
 | `selftest.sh [PR]`        | 对上述防护做判别力测试                              |
 
-改动这些脚本后必须跑 `./scripts/selftest.sh <PR编号>`。
+改动这些脚本后必须跑 `.claude/skills/review-round/scripts/selftest.sh <PR编号>`。
 
 ## 0. 切到该 PR 的 head 分支并校验
 
 ```bash
-./scripts/verify-branch.sh "$PR" --switch
+.claude/skills/review-round/scripts/verify-branch.sh "$PR" --switch
 ```
 
 技能可能从 `main` 或别的分支启动。只比分支名不够：同名本地分支可能落后于远端，那样
@@ -35,7 +35,7 @@ description: 处理当前 PR 的一轮 Codex 评审反馈。从读取评审信�
 ## 1. 读未解决的评审线程（权威信号）
 
 ```bash
-./scripts/list-unresolved.sh "$PR"
+.claude/skills/review-round/scripts/list-unresolved.sh "$PR"
 ```
 
 **不要用 reaction 判断有没有意见。** 本仓库实测：意见最多的 PR221（11 条）和 PR222
@@ -73,10 +73,10 @@ PR 上有多轮评审时列表里既有旧 SHA 也有当前 SHA，无从对应�
 **宁要单一根因修复，不要层叠补丁。** 若修复需要在已有的抑制标志 / 冷却期 / 特例分支
 之上再加一个，停下来重新推导根因——见 AGENTS.md 的 `## Debugging Sync Bugs`。
 
-编辑前先记一份工作树基线，后面要用：
+**编辑前必须先记一份工作树基线**，第 5 步要拿它判断本轮到底改了什么：
 
 ```bash
-git status --porcelain
+.claude/skills/review-round/scripts/has-changes.sh --baseline /tmp/rr-baseline
 ```
 
 ## 4. 审计同类路径（不要只修被标的那一行）
@@ -94,12 +94,16 @@ git status --porcelain
 ## 5. 验证
 
 ```bash
-./scripts/has-changes.sh || echo "本轮无改动，跳到第 7 步"
+.claude/skills/review-round/scripts/has-changes.sh /tmp/rr-baseline || echo "本轮无改动，跳到第 7 步"
 ```
 
-`has-changes.sh` 用 `git status --porcelain`，覆盖已修改、已暂存和**未跟踪**三类。
-只用 `git diff --quiet` 会漏掉新增的测试或文档文件，把有改动的一轮误判成无改动，
-跳过验证和提交却仍去 resolve，改动就此丢失。
+判断的是**相对第 3 步基线的新增**，两个方向都得防住：
+
+- 用 `git status --porcelain` 而非 `git diff --quiet`——后者看不到未跟踪文件，只新增
+  测试或文档的一轮会被误判成无改动，跳过验证和提交却仍去 resolve，改动就此丢失。
+- 但也不能直接看工作树是否非空——技能启动前就存在的无关未提交文件，会让「本轮只需
+  解释或拒绝意见」的轮次误判成有改动，卡在无内容可提交的 `git commit` 上，永远到不了
+  第 7 步。
 
 有改动时：
 
@@ -144,7 +148,9 @@ git status --porcelain
 git add <本轮实际改动的具体文件>   # 严禁 git add -A / git add .
 git diff --cached                  # 核对暂存内容
 git commit -m "fix: ..."
-./scripts/verify-branch.sh "$PR"   # 推送前复验，中途可能被切走
+# 推送前复验（中途可能被切走）。--allow-ahead 是必须的：刚 commit 完本地一定
+# 领先远端 headRefOid，严格相等会让每个有提交的轮次都在 push 前中止。
+.claude/skills/review-round/scripts/verify-branch.sh "$PR" --allow-ahead
 git push origin "HEAD:$(gh pr view "$PR" --json headRefName --jq .headRefName)"
 ```
 
@@ -154,19 +160,19 @@ git push origin "HEAD:$(gh pr view "$PR" --json headRefName --jq .headRefName)"
 ## 7. 回复并 resolve 线程
 
 ```bash
-./scripts/reply-resolve.sh <线程id> "已修。<改在哪、怎么验证的；不采纳则写明理由>" <第1步看到的评论数>
+.claude/skills/review-round/scripts/reply-resolve.sh <线程id> "已修。<改在哪、怎么验证的；不采纳则写明理由>" <第1步看到的评论数>
 ```
 
 脚本会先重读线程：若评论数与第 1 步不一致，说明扫描之后评审者又补了内容，此时**拒绝
 resolve** 并打出最新一条，让你先把它纳入根因分析。确认回复拿到 comment id 之后才
 resolve——只跑 `resolveReviewThread` 会把线程静默关掉，评审者看不到改在哪。
 
-收尾用 `./scripts/list-unresolved.sh "$PR" --count` 确认归零。
+收尾用 `.claude/skills/review-round/scripts/list-unresolved.sh "$PR" --count` 确认归零。
 
 ## 8. 本轮结束——**不要合并**
 
 ```bash
-./scripts/round-signal.sh "$PR"
+.claude/skills/review-round/scripts/round-signal.sh "$PR"
 ```
 
 输出 `PASSED` / `REVIEWING` / `NOT-TRIGGERED`。

--- a/.claude/skills/review-round/SKILL.md
+++ b/.claude/skills/review-round/SKILL.md
@@ -22,9 +22,16 @@ description: 处理当前 PR 的一轮 Codex 评审反馈。从读取评审信�
 
 改动这些脚本后必须跑 `.claude/skills/review-round/scripts/selftest.sh <PR编号>`。
 
-## 0. 切到该 PR 的 head 分支并校验
+## 0. 确定 PR 编号，切到它的 head 分支并校验
+
+后面每个代码块都用 `$PR`，**先把它定下来**（Bash 工具不保留 shell 状态，每次新开的
+代码块都要重新赋值，或直接把编号写进命令）：
 
 ```bash
+PR=<编号>                                    # 用户指定了就用指定的
+PR=$(gh pr view --json number --jq .number)  # 否则取当前分支对应的 PR
+[ -n "$PR" ] || { echo "无法确定 PR 编号"; exit 1; }
+
 .claude/skills/review-round/scripts/verify-branch.sh "$PR" --switch
 ```
 

--- a/.claude/skills/review-round/SKILL.md
+++ b/.claude/skills/review-round/SKILL.md
@@ -10,6 +10,27 @@ description: 处理当前 PR 的一轮 Codex 评审反馈。从读取评审信�
 > Bash 工具**不保留 shell 状态**，变量不跨代码块存活。下面每个代码块都自带
 > `PR=` / `REPO=` 两行，照抄时把 `PR=` 改成实际编号。
 
+## 0. 切到该 PR 的 head 分支并校验（动任何文件之前）
+
+技能可能从 `main` 或别的分支上被启动。后续步骤只读 `HEAD` 和你填的 PR 编号，**没有
+任何一步保证当前分支就是这个 PR 的 head**——第 6 步那个无目标的 `git push` 于是会
+把修复推到当前分支上，最坏情况直接推 `main`。
+
+```bash
+PR=<编号>; REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+HEAD_REF=$(gh pr view "$PR" --json headRefName --jq .headRefName)
+CUR=$(git rev-parse --abbrev-ref HEAD)
+echo "PR#$PR head=$HEAD_REF  当前分支=$CUR"
+
+case "$HEAD_REF" in
+  main | master) echo "拒绝：该 PR 的 head 是 $HEAD_REF"; exit 1 ;;
+esac
+[ "$CUR" = "$HEAD_REF" ] || git switch "$HEAD_REF"
+[ "$(git rev-parse --abbrev-ref HEAD)" = "$HEAD_REF" ] || { echo "切换失败"; exit 1; }
+```
+
+提交和推送前（第 6 步）再校验一次——中途可能因为别的操作切走了。
+
 ## 1. 读未解决的评审线程（权威信号）
 
 **不要用 reaction 判断有没有意见。** 本仓库实测：意见最多的 PR221（11 条）和
@@ -23,43 +44,67 @@ REST 的 `pulls/$PR/comments` 也不行：它不返回解决状态，第 2 轮�
 PR=<编号>; REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 read -r OWNER NAME <<<"${REPO%%/*} ${REPO##*/}"
 
-gh api graphql -f query='
-  query($owner:String!,$repo:String!,$pr:Int!){
-    repository(owner:$owner,name:$repo){
-      pullRequest(number:$pr){
-        reviewThreads(first:100){
-          nodes{ id isResolved path line originalLine
-                 comments(first:50){ totalCount
-                   nodes{author{login} body} } }
+CUR=null
+while :; do
+  RESP=$(gh api graphql -f query='
+    query($owner:String!,$repo:String!,$pr:Int!,$after:String){
+      repository(owner:$owner,name:$repo){
+        pullRequest(number:$pr){
+          reviewThreads(first:100, after:$after){
+            pageInfo{ hasNextPage endCursor }
+            nodes{ id isResolved path line originalLine
+                   comments(first:100){ totalCount
+                     nodes{ author{login} body
+                            pullRequestReview{ commit{oid} submittedAt } } } }
+          }
         }
       }
-    }
-  }' -F owner="$OWNER" -F repo="$NAME" -F pr="$PR" \
-  --jq '.data.repository.pullRequest.reviewThreads.nodes[]
-        | select(.isResolved==false)
-        | "\n=== \(.path):\(.line // .originalLine)  id=\(.id)  评论数=\(.comments.totalCount)",
-          (.comments.nodes[] | "  [\(.author.login)] \(.body
-            | gsub("!\\[[^]]*\\]\\([^)]*\\)";"") | gsub("\n";" ") | .[0:400])")'
+    }' -F owner="$OWNER" -F repo="$NAME" -F pr="$PR" -F after="$CUR")
+
+  echo "$RESP" | node -e '
+    let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+      const t=JSON.parse(s).data.repository.pullRequest.reviewThreads;
+      for(const n of t.nodes){
+        if(n.isResolved) continue;
+        console.log(`\n═══ ${n.path}:${n.line ?? n.originalLine}  id=${n.id}  评论数=${n.comments.totalCount}`);
+        for(const c of n.comments.nodes){
+          const sha=c.pullRequestReview?.commit?.oid?.slice(0,7) ?? "?";
+          // 完整正文，只剥徽章图片，不截断
+          console.log(`[${c.author.login} @${sha}] ${c.body.replace(/!\[[^\]]*\]\([^)]*\)/g,"")}`);
+        }
+        if(n.comments.totalCount > n.comments.nodes.length)
+          console.log(`  ⚠ 该线程还有 ${n.comments.totalCount-n.comments.nodes.length} 条评论未取出，需翻页`);
+      }
+    });'
+
+  NEXT=$(echo "$RESP" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const p=JSON.parse(s).data.repository.pullRequest.reviewThreads.pageInfo;process.stdout.write(p.hasNextPage?p.endCursor:"")})')
+  [ -z "$NEXT" ] && break
+  CUR="$NEXT"
+done
 ```
 
-`line` 常为 `null`（意见挂在已变动的行上），必须回退到 `originalLine`；Codex 的
-正文以徽章图片开头，不剥掉会吃掉大半个截断窗口。
+这个查询里有四处都不能省：
 
-**必须读完线程里的每一条评论，不能只取第一条。** 评审者会在同一线程里追加条件、
-纠正原意见或回答你的提问；只看首条会照着已被推翻的说法改，然后 resolve 掉。你自己
-在第 7 步的回复也会进入该线程，所以第 2 轮起线程普遍是多条。若 `totalCount > 50`
-需翻页取全。
+- **`line` 常为 `null`**（意见挂在已变动的行上），必须回退到 `originalLine`。
+- **正文不截断。** 只剥掉开头的徽章图片。评审者常把适用条件、反例、纠正写在后半段，
+  按固定字数切片会静默丢掉它们，然后你照着半条意见改完就 resolve 了。
+- **读完线程里的每一条评论。** 评审者会在同一线程追加条件或推翻原意见；你自己在第 7
+  步的回复也会进该线程，所以第 2 轮起线程普遍是多条。单线程评论超过 100 条时上面会
+  打出告警，此时需要对 `comments` 再翻页。
+- **必须翻页。** 线程超过 100 条时 `first:100` 只返回第一页，剩下的未解决意见完全不
+  可见——命令会输出「零条未解决」，于是你把还有反馈的一轮当成通过或没触发。
 
-**有未解决线程 → 进第 2 步。一条都没有 → 进第 8 步判断是通过还是没触发。**
-
-## 2. 核对评审针对的是当前 HEAD
+## 2. 核对每条线程对应的是当前 HEAD
 
 评审可能是上一次 push 的产物。对着旧提交的意见照改会白改甚至改错。
 
+**判定要按线程逐条做，不能只看全局 review 列表。** PR 上同时存在多轮评审时，全局列表
+里既有旧 SHA 也有当前 SHA，而线程本身若不带 commit 信息就无从对应——本仓库 PR225 实测
+就同时挂着 `2ab3b09` 和 `938c337` 两轮的线程。第 1 步的输出已经把每条评论标成
+`[作者 @sha]`，直接拿它和当前 HEAD 比：
+
 ```bash
-PR=<编号>; REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
-git rev-parse HEAD
-gh api "repos/$REPO/pulls/$PR/reviews" --jq '.[] | "\(.user.login) \(.state) commit=\(.commit_id)"'
+git rev-parse --short HEAD
 ```
 
 `commit_id` 与当前 HEAD 不一致 → 这轮意见是旧的，先确认哪些仍然成立。
@@ -141,24 +186,66 @@ gh api "repos/$REPO/pulls/$PR/reviews" --jq '.[] | "\(.user.login) \(.state) com
 
 - **严禁 `npm run typecheck | tail`** 这类写法：管道让退出码变成 `tail` 的，失败被吞成绿。
 
-## 6. 提交、推送
+## 6. 提交、推送（可能整步跳过）
+
+**这一步不是无条件的。** 若本轮所有意见都已过时、不成立、或只需解释而无需改文件，
+此时 `git commit` 会以 "nothing to commit" 失败——而技能开头要求任一步失败就停，
+于是永远走不到第 7 步去回复和 resolve，线程就那么挂着。先判断有没有改动：
 
 ```bash
-git add <具体文件>          # 严禁 git add -A / git add .
-git commit -m "fix: ..."
-git push
+if git diff --quiet && git diff --cached --quiet; then
+  echo "本轮无代码改动，跳过第 5-6 步，直接进第 7 步回复线程"
+else
+  # …第 5 步验证…然后提交
+  git add <本轮实际改动的具体文件>   # 严禁 git add -A / git add .
+  git commit -m "fix: ..."
+  HEAD_REF=$(gh pr view "$PR" --json headRefName --jq .headRefName)
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "$HEAD_REF" ] || { echo "分支不对，拒绝推送"; exit 1; }
+  git push origin "HEAD:$HEAD_REF"
+fi
 ```
+
+**推送前必须复验分支**（第 0 步之后可能被切走），且显式写出 `origin "HEAD:$HEAD_REF"`
+而不是裸 `git push`。
+
+**动手前先审计工作树。** 显式列出文件名并不足以隔离改动：如果用户在技能启动前就对同
+一个文件有未提交的修改，`git add <文件>` 会把那些改动和本轮修复一起提交。所以在第 3
+步开始编辑之前先记录：
+
+```bash
+git status --short          # 记下哪些文件本来就是脏的
+git stash list
+```
+
+对本来就脏的文件，提交前用 `git add -p` 按 hunk 只暂存本轮的补丁，并用
+`git diff --cached` 逐项确认暂存内容里没有别人的改动。
 
 ## 7. 回复并 resolve 线程
 
-逐条回复说明如何处理的，再用第 1 步取到的线程 `id` 标记已解决：
+**先回复，确认回复成功，再 resolve。** 只跑 `resolveReviewThread` 会把线程静默关掉，
+评审者看不到改在哪、验证结果如何、或哪条为什么不采纳。回复用
+`addPullRequestReviewThreadReply`：
 
 ```bash
 THREAD_ID=<第 1 步输出的 id>
+BODY="已修。<改在哪、怎么验证的；不采纳则写明理由>"
+
+# 1) 先发回复，并确认拿到了 id（失败就不要往下走）
+REPLY=$(gh api graphql -f query='
+  mutation($id:ID!,$body:String!){
+    addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$id, body:$body}){
+      comment{ id }
+    }
+  }' -F id="$THREAD_ID" -F body="$BODY" --jq '.data.addPullRequestReviewThreadReply.comment.id')
+[ -n "$REPLY" ] || { echo "回复失败，不 resolve"; exit 1; }
+
+# 2) 回复成功后才 resolve
 gh api graphql -f query='
   mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){thread{isResolved}} }
-' -F id="$THREAD_ID"
+' -F id="$THREAD_ID" --jq '.data.resolveReviewThread.thread.isResolved'
 ```
+
+收尾再查一次未解决线程数应为 0，确认回复确实进了线程（该线程 `totalCount` 应 +1）。
 
 ## 8. 本轮结束——**不要合并**
 

--- a/.claude/skills/review-round/SKILL.md
+++ b/.claude/skills/review-round/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: review-round
+description: 处理当前 PR 的一轮 Codex 评审反馈。从读取评审信号、逐条定位根因、修复、验证、回复线程到推送的完整单轮流程。当用户请求"处理评审意见"、"处理下一轮反馈"、"看看 Codex 说了什么"或类似单轮评审响应任务时触发。不负责合并。
+---
+
+# review-round — 处理一轮 Codex 评审反馈
+
+处理**一轮**评审。以 `$1` 作为 PR 编号；省略时用当前分支对应的 PR。
+任何一步失败都先修复再进下一步，**不要跳步**。
+
+## 1. 读取评审信号（reaction 才是完成信号）
+
+**Codex 用 PR 的 reaction 表态，不是用 review 或 comment。** 只查 `gh pr view --comments`
+会漏判：通过时 reviews 接口是空的，你会误以为「还没反馈」而空等。
+
+```bash
+PR="${1:-$(gh pr view --json number --jq .number)}"
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+
+# 完成信号：reaction
+gh api "repos/$REPO/issues/$PR/reactions" --jq '.[] | "\(.content) by \(.user.login)"'
+```
+
+| reaction          | 含义                                   | 该做什么                          |
+| ----------------- | -------------------------------------- | --------------------------------- |
+| （空）            | **没触发**，不是「没问题」             | 别空等，评论 `@codex review` 触发 |
+| 👀 `eyes`         | 正在评审                               | 等                                |
+| 👍 `+1`           | 已评审、**无意见**                     | 本轮结束，跳到第 7 步             |
+| 有 comment/review | 有问题（此时通常也会有对应的评审内容） | 进入第 2 步                       |
+
+## 2. 核对评审针对的是当前 HEAD
+
+评审可能是上一次 push 的产物。对着旧提交的意见照着改会白改甚至改错。
+
+```bash
+git rev-parse HEAD
+gh api "repos/$REPO/pulls/$PR/reviews" --jq '.[] | "\(.user.login) \(.state) commit=\(.commit_id)"'
+```
+
+`commit_id` 与当前 HEAD 不一致 → 这轮意见是旧的，先确认哪些仍然成立，别机械照做。
+
+## 3. 列出全部未解决意见
+
+```bash
+gh pr view "$PR" --comments
+gh api "repos/$REPO/pulls/$PR/comments" --jq '.[] | "\(.path):\(.line) \(.body[0:200])"'
+```
+
+逐条列出，标注严重级别（P1/P2）。**先把清单摆出来再动手改**，不要边看边改。
+
+## 4. 逐条陈述根因，再改
+
+对每一条意见：
+
+- 用一句话陈述**根因**，而不是复述现象。
+- 点名证明它的代码路径或日志行。
+- 然后才编辑。
+
+**宁要单一根因修复，不要层叠补丁。** 若修复需要在已有的抑制标志 / 冷却期 / 特例分支
+之上再加一个，停下来重新推导根因——见 AGENTS.md 的 `## Debugging Sync Bugs`。
+
+## 5. 审计同类路径（不要只修被标的那一行）
+
+被标出的往往只是同一类问题的一个实例。
+
+- grep 出被改签名的**全部调用点**，含 `server/src/app.ts` 与各 `index.ts` 适配层。
+  TypeScript 接受声明了**更少**参数的函数，所以「适配层忘记转发末位参数」**不会**报错。
+- 状态清理 / reset 函数：grep 每一处相关状态，逐一确认。
+- 异步 Redis / 锁操作：确认都 `await` 且包了 `try/catch`。
+- 协议相关改动：走 AGENTS.md 的 `## Protocol Changes` 清单（版本号有
+  `PROTOCOL_VERSION` 和 `CURRENT_PROTOCOL_VERSION` **两个**常量要同步提升）。
+
+逐个列出「已处理 / 不适用及原因」，再进下一步。
+
+## 6. 验证（宣称改好之前）
+
+- 每个编辑过的区域**重读确认改动确实落地**——静默失败的字符串替换在本仓库发生过多次。
+- 新增的回归测试必须在**修复前的代码上失败**：把修复 stash 掉（或从事先的副本还原）
+  跑一遍，确认变红。一直是绿的测试什么也没守住。
+- 跑完整预提交序列，**逐项断言退出码**：
+
+```bash
+for step in format:check lint typecheck build test audit; do
+  npm run "$step" > "/tmp/$step.log" 2>&1
+  code=$?
+  echo "$step exit=$code"
+  [ $code -ne 0 ] && { tail -40 "/tmp/$step.log"; break; }
+done
+```
+
+**严禁 `npm run typecheck | tail`** 这类写法：管道让退出码变成 `tail` 的，失败会被吞成绿。
+
+## 7. 提交、推送、回复线程
+
+```bash
+git add <具体文件>          # 严禁 git add -A / git add .
+git commit -m "fix: ..."
+git push
+```
+
+推送后逐条回复评审线程说明如何处理的，已解决的用 GraphQL 标记 resolved：
+
+```bash
+gh api graphql -f query='
+  query($owner:String!,$repo:String!,$pr:Int!){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$pr){
+        reviewThreads(first:50){nodes{id isResolved path line}}
+      }
+    }
+  }' -F owner=<owner> -F repo=<repo> -F pr="$PR"
+
+gh api graphql -f query='
+  mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){thread{isResolved}} }
+' -F id=<threadId>
+```
+
+## 8. 本轮结束——**不要合并**
+
+- push 之后 Codex **不必然**自动重审。再查一次 reactions；仍为空就评论 `@codex review` 触发。
+- 通过标志是 👍 reaction，**不要把沉默当通过**。
+- 合并需要用户**针对这个 PR** 的明确授权。关于发版的含糊表述不是合并授权。
+
+## 硬性规则
+
+- **严禁**在没有用户明确指令的情况下 `gh pr merge`。
+- **严禁**只修被标的那一行而不审计同类路径。
+- **严禁**把检查命令管道给 `tail`/`head` 后据此判断成败。
+- **严禁** `git add -A` / `git add .`。
+- **严禁**用 `git checkout <file>` / `git restore <file>` 回退探针——会连同该文件其它
+  未提交改动一起冲掉。先 `cp` 备份或用 `git stash`。
+- 未真正跑过的检查，**不得**声称已验证。

--- a/.claude/skills/review-round/SKILL.md
+++ b/.claude/skills/review-round/SKILL.md
@@ -29,19 +29,26 @@ gh api graphql -f query='
       pullRequest(number:$pr){
         reviewThreads(first:100){
           nodes{ id isResolved path line originalLine
-                 comments(first:1){nodes{author{login} body}} }
+                 comments(first:50){ totalCount
+                   nodes{author{login} body} } }
         }
       }
     }
   }' -F owner="$OWNER" -F repo="$NAME" -F pr="$PR" \
   --jq '.data.repository.pullRequest.reviewThreads.nodes[]
         | select(.isResolved==false)
-        | "\(.path):\(.line // .originalLine)\t\(.id)\t\(.comments.nodes[0].body
-            | gsub("!\\[[^]]*\\]\\([^)]*\\)";"") | gsub("\n";" ") | .[0:300])"'
+        | "\n=== \(.path):\(.line // .originalLine)  id=\(.id)  评论数=\(.comments.totalCount)",
+          (.comments.nodes[] | "  [\(.author.login)] \(.body
+            | gsub("!\\[[^]]*\\]\\([^)]*\\)";"") | gsub("\n";" ") | .[0:400])")'
 ```
 
 `line` 常为 `null`（意见挂在已变动的行上），必须回退到 `originalLine`；Codex 的
 正文以徽章图片开头，不剥掉会吃掉大半个截断窗口。
+
+**必须读完线程里的每一条评论，不能只取第一条。** 评审者会在同一线程里追加条件、
+纠正原意见或回答你的提问；只看首条会照着已被推翻的说法改，然后 resolve 掉。你自己
+在第 7 步的回复也会进入该线程，所以第 2 轮起线程普遍是多条。若 `totalCount > 50`
+需翻页取全。
 
 **有未解决线程 → 进第 2 步。一条都没有 → 进第 8 步判断是通过还是没触发。**
 
@@ -64,6 +71,9 @@ gh api "repos/$REPO/pulls/$PR/reviews" --jq '.[] | "\(.user.login) \(.state) com
 - 用一句话陈述**根因**，而不是复述现象。
 - 点名证明它的代码路径或日志行。
 - 然后才编辑。
+- **每次 Edit/Write 之后立刻重读改动区域**，确认改动真的落地了，再动下一处。
+  字符串替换静默失败在本仓库发生过多次；拖到第 5 步才发现，意味着中间的同类路径
+  审计全部建立在一处并不存在的改动上，还可能整条意见被漏改。
 
 **宁要单一根因修复，不要层叠补丁。** 若修复需要在已有的抑制标志 / 冷却期 / 特例
 分支之上再加一个，停下来重新推导根因——见 AGENTS.md 的 `## Debugging Sync Bugs`。
@@ -84,7 +94,8 @@ gh api "repos/$REPO/pulls/$PR/reviews" --jq '.[] | "\(.user.login) \(.state) com
 
 ## 5. 验证（宣称改好之前）
 
-- 每个编辑过的区域**重读确认改动确实落地**——静默失败的字符串替换在本仓库发生过多次。
+- 第 3 步已要求每次编辑后立刻重读；这里再对全部改动做一次提交前复核，确认没有
+  被后续编辑覆盖掉。
 - 新增的回归测试必须在**修复前的代码上失败**。回退修复时**只回退源文件**：
 
   ```bash
@@ -104,14 +115,29 @@ gh api "repos/$REPO/pulls/$PR/reviews" --jq '.[] | "\(.user.login) \(.state) com
   for step in format:check lint typecheck build test audit; do
     npm run "$step" > "/tmp/rr-$step.log" 2>&1
     code=$?
-    echo "$step exit=$code"
-    if [ $code -ne 0 ]; then tail -40 "/tmp/rr-$step.log"; fail="$step"; break; fi
+    echo "$step exit=$code  log=/tmp/rr-$step.log"
+    if [ $code -ne 0 ]; then
+      echo "===== $step 完整输出 ====="
+      cat "/tmp/rr-$step.log"        # 完整输出，不截断
+      fail="$step"
+      break
+    fi
   done
-  [ -n "$fail" ] && echo "FAILED: $fail" || echo "ALL-GREEN"
+  if [ -n "$fail" ]; then
+    echo "FAILED: $fail"
+    exit 1                           # 必须以非零退出码结束
+  fi
+  echo "ALL-GREEN"
   ```
 
-  循环末尾必须显式打出 `FAILED` / `ALL-GREEN`：`[ $code -ne 0 ] && { …; break; }`
-  这种写法的循环退出码是**反的**（全绿返回 1、失败返回 0），照它判会得出相反结论。
+  两处都不能省：
+
+  - **失败必须 `exit 1`。** 只打印 `FAILED` 而让代码块以 0 结束，依赖工具退出状态
+    的执行者会带着未通过的检查继续提交推送。反过来，`[ $code -ne 0 ] && { …; }`
+    这种写法的退出码是**反的**（全绿返回 1、失败返回 0），照它判会得出相反结论。
+  - **失败时 `cat` 完整日志，不要 `tail -40`。** AGENTS.md 要求报告真实命令输出而
+    非摘要；截断会藏掉更早的失败上下文和警告。成功时输出量太大不便全贴，但日志路径
+    已经打出来了——需要核对时直接读那个文件，不要凭 `exit=0` 一句话下结论。
 
 - **严禁 `npm run typecheck | tail`** 这类写法：管道让退出码变成 `tail` 的，失败被吞成绿。
 
@@ -140,13 +166,35 @@ gh api graphql -f query='
 
 ```bash
 PR=<编号>; REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
-gh api "repos/$REPO/issues/$PR/reactions" --jq '.[] | "\(.content) \(.created_at) \(.user.login)"'
-git log -1 --format=%cI    # 最后一次提交时间
+BOT=chatgpt-codex-connector[bot]
+SHA=$(git rev-parse HEAD)
+
+# 基准 = 当前 HEAD 被 push 上去的时刻（该 SHA 触发的最早一次 workflow run）
+PUSHED=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA" \
+  --jq '[.workflow_runs[].created_at] | sort | .[0]')
+echo "head=$SHA pushed≈$PUSHED"
+
+# 注意：gh api 不支持 --arg（那是 jq 自己的 flag，--jq 不透传），
+# 且本机没有可用于管道的独立 jq，所以变量用 shell 插值进 jq 表达式。
+gh api "repos/$REPO/issues/$PR/reactions" \
+  --jq "[.[] | select(.user.login==\"$BOT\") | select(.created_at > \"$PUSHED\")]
+        | if length==0 then \"（本轮无 Codex reaction）\"
+          else (.[]|\"\(.content) \(.created_at)\") end"
 ```
 
-- **reaction 会长期留存且不带 commit 引用**，第 2 轮读到的很可能是第 1 轮的旧
-  reaction。只有 `created_at` **晚于最后一次 push** 的 reaction 才算本轮信号。
-- 👀 = 评审中，等；👍（且够新）= 本轮通过、无意见。
+两个过滤条件缺一不可：
+
+- **必须按机器人账号过滤。** 该接口返回所有人的 reaction；维护者或其他自动化在当前
+  提交之后点一个 👍，会被误读成「Codex 通过」而提前结束本轮。
+- **新鲜度基准要用 push 时刻，不能用 `git log -1 --format=%cI`。** 后者是提交的
+  _创建_ 时间：提交先在本地生成、上一轮的旧 reaction 随后到达、再 push 这个提交，
+  旧 reaction 仍晚于提交时间，会被当成本轮信号。reaction 不带 commit 引用且长期
+  留存，所以只能用一个真正代表「这次远端更新」的边界。若该 SHA 尚无 workflow run
+  （CI 还没起来），说明本轮结果根本还没到，直接按「没触发」处理。
+
+判定：
+
+- 👀 = 评审中，等；👍（本轮、来自机器人）= 通过、无意见。
 - 没有任何本轮信号 = **没触发**，不等于没问题。评论 `@codex review` 触发，别空等。
 - 合并需要用户**针对这个 PR** 的明确授权。关于发版的含糊表述不是合并授权。
 

--- a/.claude/skills/review-round/SKILL.md
+++ b/.claude/skills/review-round/SKILL.md
@@ -5,92 +5,117 @@ description: 处理当前 PR 的一轮 Codex 评审反馈。从读取评审信�
 
 # review-round — 处理一轮 Codex 评审反馈
 
-处理**一轮**评审。以 `$1` 作为 PR 编号；省略时用当前分支对应的 PR。
-任何一步失败都先修复再进下一步，**不要跳步**。
+处理**一轮**评审。任何一步失败都先修复再进下一步，**不要跳步**。
 
-## 1. 读取评审信号（reaction 才是完成信号）
+> Bash 工具**不保留 shell 状态**，变量不跨代码块存活。下面每个代码块都自带
+> `PR=` / `REPO=` 两行，照抄时把 `PR=` 改成实际编号。
 
-**Codex 用 PR 的 reaction 表态，不是用 review 或 comment。** 只查 `gh pr view --comments`
-会漏判：通过时 reviews 接口是空的，你会误以为「还没反馈」而空等。
+## 1. 读未解决的评审线程（权威信号）
+
+**不要用 reaction 判断有没有意见。** 本仓库实测：意见最多的 PR221（11 条）和
+PR222（14 条）**reaction 完全为空**；而 PR220、PR224 有 👍 但 reviews 和
+comments 都是 0。两种信号各自都会漏判，必须以线程为准。
+
+REST 的 `pulls/$PR/comments` 也不行：它不返回解决状态，第 2 轮会把上一轮已修好
+并已 resolve 的意见重新摆上清单。用 GraphQL：
 
 ```bash
-PR="${1:-$(gh pr view --json number --jq .number)}"
-REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+PR=<编号>; REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+read -r OWNER NAME <<<"${REPO%%/*} ${REPO##*/}"
 
-# 完成信号：reaction
-gh api "repos/$REPO/issues/$PR/reactions" --jq '.[] | "\(.content) by \(.user.login)"'
+gh api graphql -f query='
+  query($owner:String!,$repo:String!,$pr:Int!){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$pr){
+        reviewThreads(first:100){
+          nodes{ id isResolved path line originalLine
+                 comments(first:1){nodes{author{login} body}} }
+        }
+      }
+    }
+  }' -F owner="$OWNER" -F repo="$NAME" -F pr="$PR" \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+        | select(.isResolved==false)
+        | "\(.path):\(.line // .originalLine)\t\(.id)\t\(.comments.nodes[0].body
+            | gsub("!\\[[^]]*\\]\\([^)]*\\)";"") | gsub("\n";" ") | .[0:300])"'
 ```
 
-| reaction          | 含义                                   | 该做什么                          |
-| ----------------- | -------------------------------------- | --------------------------------- |
-| （空）            | **没触发**，不是「没问题」             | 别空等，评论 `@codex review` 触发 |
-| 👀 `eyes`         | 正在评审                               | 等                                |
-| 👍 `+1`           | 已评审、**无意见**                     | 本轮结束，跳到第 7 步             |
-| 有 comment/review | 有问题（此时通常也会有对应的评审内容） | 进入第 2 步                       |
+`line` 常为 `null`（意见挂在已变动的行上），必须回退到 `originalLine`；Codex 的
+正文以徽章图片开头，不剥掉会吃掉大半个截断窗口。
+
+**有未解决线程 → 进第 2 步。一条都没有 → 进第 8 步判断是通过还是没触发。**
 
 ## 2. 核对评审针对的是当前 HEAD
 
-评审可能是上一次 push 的产物。对着旧提交的意见照着改会白改甚至改错。
+评审可能是上一次 push 的产物。对着旧提交的意见照改会白改甚至改错。
 
 ```bash
+PR=<编号>; REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 git rev-parse HEAD
 gh api "repos/$REPO/pulls/$PR/reviews" --jq '.[] | "\(.user.login) \(.state) commit=\(.commit_id)"'
 ```
 
-`commit_id` 与当前 HEAD 不一致 → 这轮意见是旧的，先确认哪些仍然成立，别机械照做。
+`commit_id` 与当前 HEAD 不一致 → 这轮意见是旧的，先确认哪些仍然成立。
 
-## 3. 列出全部未解决意见
+## 3. 逐条陈述根因，再改
 
-```bash
-gh pr view "$PR" --comments
-gh api "repos/$REPO/pulls/$PR/comments" --jq '.[] | "\(.path):\(.line) \(.body[0:200])"'
-```
-
-逐条列出，标注严重级别（P1/P2）。**先把清单摆出来再动手改**，不要边看边改。
-
-## 4. 逐条陈述根因，再改
-
-对每一条意见：
+先把第 1 步的清单摆出来并标注严重级别（P1/P2），**不要边看边改**。对每一条：
 
 - 用一句话陈述**根因**，而不是复述现象。
 - 点名证明它的代码路径或日志行。
 - 然后才编辑。
 
-**宁要单一根因修复，不要层叠补丁。** 若修复需要在已有的抑制标志 / 冷却期 / 特例分支
-之上再加一个，停下来重新推导根因——见 AGENTS.md 的 `## Debugging Sync Bugs`。
+**宁要单一根因修复，不要层叠补丁。** 若修复需要在已有的抑制标志 / 冷却期 / 特例
+分支之上再加一个，停下来重新推导根因——见 AGENTS.md 的 `## Debugging Sync Bugs`。
 
-## 5. 审计同类路径（不要只修被标的那一行）
+## 4. 审计同类路径（不要只修被标的那一行）
 
 被标出的往往只是同一类问题的一个实例。
 
 - grep 出被改签名的**全部调用点**，含 `server/src/app.ts` 与各 `index.ts` 适配层。
-  TypeScript 接受声明了**更少**参数的函数，所以「适配层忘记转发末位参数」**不会**报错。
+  注意 TypeScript 的边界：把少声明参数的函数**赋值**给回调类型不报错（多出的末位
+  参数被静默忽略），但适配层若仍调用下游函数而少传参，`TS2554` 会报出来。真正无
+  声的是前者——新参数压根没被接住、也没往下传。
 - 状态清理 / reset 函数：grep 每一处相关状态，逐一确认。
 - 异步 Redis / 锁操作：确认都 `await` 且包了 `try/catch`。
-- 协议相关改动：走 AGENTS.md 的 `## Protocol Changes` 清单（版本号有
-  `PROTOCOL_VERSION` 和 `CURRENT_PROTOCOL_VERSION` **两个**常量要同步提升）。
+- 协议相关改动：走 AGENTS.md 的 `## Protocol Changes` 清单。
 
 逐个列出「已处理 / 不适用及原因」，再进下一步。
 
-## 6. 验证（宣称改好之前）
+## 5. 验证（宣称改好之前）
 
 - 每个编辑过的区域**重读确认改动确实落地**——静默失败的字符串替换在本仓库发生过多次。
-- 新增的回归测试必须在**修复前的代码上失败**：把修复 stash 掉（或从事先的副本还原）
-  跑一遍，确认变红。一直是绿的测试什么也没守住。
-- 跑完整预提交序列，**逐项断言退出码**：
+- 新增的回归测试必须在**修复前的代码上失败**。回退修复时**只回退源文件**：
 
-```bash
-for step in format:check lint typecheck build test audit; do
-  npm run "$step" > "/tmp/$step.log" 2>&1
-  code=$?
-  echo "$step exit=$code"
-  [ $code -ne 0 ] && { tail -40 "/tmp/$step.log"; break; }
-done
-```
+  ```bash
+  cp <源文件> /tmp/fix.bak          # 事前备份
+  # …验证…
+  cp /tmp/fix.bak <源文件>          # 还原
+  ```
 
-**严禁 `npm run typecheck | tail`** 这类写法：管道让退出码变成 `tail` 的，失败会被吞成绿。
+  **不要整仓 `git stash`**：新测试若追加在已跟踪的测试文件里会被一起 stash 走，
+  测试因「找不到用例」而退出非零，看着是红的，其实什么都没验证。确认失败原因是
+  **断言失败**，不是用例不存在。
 
-## 7. 提交、推送、回复线程
+- 跑完整预提交序列，逐项断言退出码：
+
+  ```bash
+  fail=""
+  for step in format:check lint typecheck build test audit; do
+    npm run "$step" > "/tmp/rr-$step.log" 2>&1
+    code=$?
+    echo "$step exit=$code"
+    if [ $code -ne 0 ]; then tail -40 "/tmp/rr-$step.log"; fail="$step"; break; fi
+  done
+  [ -n "$fail" ] && echo "FAILED: $fail" || echo "ALL-GREEN"
+  ```
+
+  循环末尾必须显式打出 `FAILED` / `ALL-GREEN`：`[ $code -ne 0 ] && { …; break; }`
+  这种写法的循环退出码是**反的**（全绿返回 1、失败返回 0），照它判会得出相反结论。
+
+- **严禁 `npm run typecheck | tail`** 这类写法：管道让退出码变成 `tail` 的，失败被吞成绿。
+
+## 6. 提交、推送
 
 ```bash
 git add <具体文件>          # 严禁 git add -A / git add .
@@ -98,35 +123,40 @@ git commit -m "fix: ..."
 git push
 ```
 
-推送后逐条回复评审线程说明如何处理的，已解决的用 GraphQL 标记 resolved：
+## 7. 回复并 resolve 线程
+
+逐条回复说明如何处理的，再用第 1 步取到的线程 `id` 标记已解决：
 
 ```bash
-gh api graphql -f query='
-  query($owner:String!,$repo:String!,$pr:Int!){
-    repository(owner:$owner,name:$repo){
-      pullRequest(number:$pr){
-        reviewThreads(first:50){nodes{id isResolved path line}}
-      }
-    }
-  }' -F owner=<owner> -F repo=<repo> -F pr="$PR"
-
+THREAD_ID=<第 1 步输出的 id>
 gh api graphql -f query='
   mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){thread{isResolved}} }
-' -F id=<threadId>
+' -F id="$THREAD_ID"
 ```
 
 ## 8. 本轮结束——**不要合并**
 
-- push 之后 Codex **不必然**自动重审。再查一次 reactions；仍为空就评论 `@codex review` 触发。
-- 通过标志是 👍 reaction，**不要把沉默当通过**。
+判断「通过」还是「没触发」，两者都表现为没有未解决线程：
+
+```bash
+PR=<编号>; REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+gh api "repos/$REPO/issues/$PR/reactions" --jq '.[] | "\(.content) \(.created_at) \(.user.login)"'
+git log -1 --format=%cI    # 最后一次提交时间
+```
+
+- **reaction 会长期留存且不带 commit 引用**，第 2 轮读到的很可能是第 1 轮的旧
+  reaction。只有 `created_at` **晚于最后一次 push** 的 reaction 才算本轮信号。
+- 👀 = 评审中，等；👍（且够新）= 本轮通过、无意见。
+- 没有任何本轮信号 = **没触发**，不等于没问题。评论 `@codex review` 触发，别空等。
 - 合并需要用户**针对这个 PR** 的明确授权。关于发版的含糊表述不是合并授权。
 
 ## 硬性规则
 
 - **严禁**在没有用户明确指令的情况下 `gh pr merge`。
+- **严禁**只凭 reaction 判断有没有意见——以未解决线程为准。
 - **严禁**只修被标的那一行而不审计同类路径。
 - **严禁**把检查命令管道给 `tail`/`head` 后据此判断成败。
 - **严禁** `git add -A` / `git add .`。
-- **严禁**用 `git checkout <file>` / `git restore <file>` 回退探针——会连同该文件其它
-  未提交改动一起冲掉。先 `cp` 备份或用 `git stash`。
+- **严禁**用 `git checkout <file>` / `git restore <file>` 回退探针——会连同该文件
+  其它未提交改动一起冲掉。先 `cp` 备份或 `git stash push -- <仅源文件路径>`。
 - 未真正跑过的检查，**不得**声称已验证。

--- a/.claude/skills/review-round/SKILL.md
+++ b/.claude/skills/review-round/SKILL.md
@@ -7,151 +7,114 @@ description: 处理当前 PR 的一轮 Codex 评审反馈。从读取评审信�
 
 处理**一轮**评审。任何一步失败都先修复再进下一步，**不要跳步**。
 
-> Bash 工具**不保留 shell 状态**，变量不跨代码块存活。下面每个代码块都自带
-> `PR=` / `REPO=` 两行，照抄时把 `PR=` 改成实际编号。
+易错的多步操作都在 `scripts/` 下，**不要把它们抄成一次性命令**——脚本里带着错误处理、
+翻页和判别力测试，散写在对话里的版本必然会丢掉其中某一项（这份技能的前三轮评审共
+20 条意见，绝大多数正是这么来的）。
 
-## 0. 切到该 PR 的 head 分支并校验（动任何文件之前）
+| 脚本                      | 作用                                                |
+| ------------------------- | --------------------------------------------------- |
+| `verify-branch.sh <PR>`   | 校验本地分支名 **和** SHA 与 PR head 一致；拒 fork  |
+| `list-unresolved.sh <PR>` | 翻页列出全部未解决线程，正文不截断，标注所属 commit |
+| `has-changes.sh`          | 判断本轮有无改动（含未跟踪文件）                    |
+| `reply-resolve.sh`        | 重读线程 → 回复 → 确认 → resolve                    |
+| `round-signal.sh <PR>`    | 无未解决线程时区分「通过」与「没触发」              |
+| `selftest.sh [PR]`        | 对上述防护做判别力测试                              |
 
-技能可能从 `main` 或别的分支上被启动。后续步骤只读 `HEAD` 和你填的 PR 编号，**没有
-任何一步保证当前分支就是这个 PR 的 head**——第 6 步那个无目标的 `git push` 于是会
-把修复推到当前分支上，最坏情况直接推 `main`。
+改动这些脚本后必须跑 `./scripts/selftest.sh <PR编号>`。
+
+## 0. 切到该 PR 的 head 分支并校验
 
 ```bash
-PR=<编号>; REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
-HEAD_REF=$(gh pr view "$PR" --json headRefName --jq .headRefName)
-CUR=$(git rev-parse --abbrev-ref HEAD)
-echo "PR#$PR head=$HEAD_REF  当前分支=$CUR"
-
-case "$HEAD_REF" in
-  main | master) echo "拒绝：该 PR 的 head 是 $HEAD_REF"; exit 1 ;;
-esac
-[ "$CUR" = "$HEAD_REF" ] || git switch "$HEAD_REF"
-[ "$(git rev-parse --abbrev-ref HEAD)" = "$HEAD_REF" ] || { echo "切换失败"; exit 1; }
+./scripts/verify-branch.sh "$PR" --switch
 ```
 
-提交和推送前（第 6 步）再校验一次——中途可能因为别的操作切走了。
+技能可能从 `main` 或别的分支启动。只比分支名不够：同名本地分支可能落后于远端，那样
+你会基于旧代码处理反馈、把针对当前提交的意见误判成过时，直到 push 被非快进拒绝才
+暴露。脚本同时校验 `headRefOid`，并拒绝 `main`/`master` 与 fork PR。
 
 ## 1. 读未解决的评审线程（权威信号）
 
-**不要用 reaction 判断有没有意见。** 本仓库实测：意见最多的 PR221（11 条）和
-PR222（14 条）**reaction 完全为空**；而 PR220、PR224 有 👍 但 reviews 和
-comments 都是 0。两种信号各自都会漏判，必须以线程为准。
-
-REST 的 `pulls/$PR/comments` 也不行：它不返回解决状态，第 2 轮会把上一轮已修好
-并已 resolve 的意见重新摆上清单。用 GraphQL：
-
 ```bash
-PR=<编号>; REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
-read -r OWNER NAME <<<"${REPO%%/*} ${REPO##*/}"
-
-CUR=null
-while :; do
-  RESP=$(gh api graphql -f query='
-    query($owner:String!,$repo:String!,$pr:Int!,$after:String){
-      repository(owner:$owner,name:$repo){
-        pullRequest(number:$pr){
-          reviewThreads(first:100, after:$after){
-            pageInfo{ hasNextPage endCursor }
-            nodes{ id isResolved path line originalLine
-                   comments(first:100){ totalCount
-                     nodes{ author{login} body
-                            pullRequestReview{ commit{oid} submittedAt } } } }
-          }
-        }
-      }
-    }' -F owner="$OWNER" -F repo="$NAME" -F pr="$PR" -F after="$CUR")
-
-  echo "$RESP" | node -e '
-    let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
-      const t=JSON.parse(s).data.repository.pullRequest.reviewThreads;
-      for(const n of t.nodes){
-        if(n.isResolved) continue;
-        console.log(`\n═══ ${n.path}:${n.line ?? n.originalLine}  id=${n.id}  评论数=${n.comments.totalCount}`);
-        for(const c of n.comments.nodes){
-          const sha=c.pullRequestReview?.commit?.oid?.slice(0,7) ?? "?";
-          // 完整正文，只剥徽章图片，不截断
-          console.log(`[${c.author.login} @${sha}] ${c.body.replace(/!\[[^\]]*\]\([^)]*\)/g,"")}`);
-        }
-        if(n.comments.totalCount > n.comments.nodes.length)
-          console.log(`  ⚠ 该线程还有 ${n.comments.totalCount-n.comments.nodes.length} 条评论未取出，需翻页`);
-      }
-    });'
-
-  NEXT=$(echo "$RESP" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const p=JSON.parse(s).data.repository.pullRequest.reviewThreads.pageInfo;process.stdout.write(p.hasNextPage?p.endCursor:"")})')
-  [ -z "$NEXT" ] && break
-  CUR="$NEXT"
-done
+./scripts/list-unresolved.sh "$PR"
 ```
 
-这个查询里有四处都不能省：
+**不要用 reaction 判断有没有意见。** 本仓库实测：意见最多的 PR221（11 条）和 PR222
+（14 条）reaction 完全为空；而 PR220、PR224 有 👍 但 reviews 和 comments 都是 0。
+两种信号各自都会漏判，必须以线程为准。REST 的 `pulls/$PR/comments` 也不行——它不返回
+解决状态，第 2 轮会把上一轮已 resolve 的意见重新摆上清单。
 
-- **`line` 常为 `null`**（意见挂在已变动的行上），必须回退到 `originalLine`。
-- **正文不截断。** 只剥掉开头的徽章图片。评审者常把适用条件、反例、纠正写在后半段，
-  按固定字数切片会静默丢掉它们，然后你照着半条意见改完就 resolve 了。
-- **读完线程里的每一条评论。** 评审者会在同一线程追加条件或推翻原意见；你自己在第 7
-  步的回复也会进该线程，所以第 2 轮起线程普遍是多条。单线程评论超过 100 条时上面会
-  打出告警，此时需要对 `comments` 再翻页。
-- **必须翻页。** 线程超过 100 条时 `first:100` 只返回第一页，剩下的未解决意见完全不
-  可见——命令会输出「零条未解决」，于是你把还有反馈的一轮当成通过或没触发。
+脚本已经处理掉这几件事，看输出即可：正文完整不截断（只剥 shields.io 徽章，保留评审者
+贴的截图）、读完线程里每一条评论、按游标翻页取全、每条评论标注 `[作者 @sha]`。
+API 或解析失败时脚本以非零退出——**「没读到」绝不能被当成「没有」**。
+
+**有未解决线程 → 进第 2 步。一条都没有 → 进第 8 步。**
 
 ## 2. 核对每条线程对应的是当前 HEAD
-
-评审可能是上一次 push 的产物。对着旧提交的意见照改会白改甚至改错。
-
-**判定要按线程逐条做，不能只看全局 review 列表。** PR 上同时存在多轮评审时，全局列表
-里既有旧 SHA 也有当前 SHA，而线程本身若不带 commit 信息就无从对应——本仓库 PR225 实测
-就同时挂着 `2ab3b09` 和 `938c337` 两轮的线程。第 1 步的输出已经把每条评论标成
-`[作者 @sha]`，直接拿它和当前 HEAD 比：
 
 ```bash
 git rev-parse --short HEAD
 ```
 
-`commit_id` 与当前 HEAD 不一致 → 这轮意见是旧的，先确认哪些仍然成立。
+拿它和第 1 步输出里每条评论的 `@sha` 比。**要逐线程比，不能只看全局 review 列表**：
+PR 上有多轮评审时列表里既有旧 SHA 也有当前 SHA，无从对应。本仓库 PR225 实测就同时
+挂着 `2ab3b09` 和 `938c337` 两轮的线程。`@sha` 不是当前 HEAD 的，先确认那条是否仍成立。
 
 ## 3. 逐条陈述根因，再改
 
-先把第 1 步的清单摆出来并标注严重级别（P1/P2），**不要边看边改**。对每一条：
+先把清单摆出来并标注严重级别（P1/P2），**不要边看边改**。对每一条：
 
 - 用一句话陈述**根因**，而不是复述现象。
 - 点名证明它的代码路径或日志行。
 - 然后才编辑。
 - **每次 Edit/Write 之后立刻重读改动区域**，确认改动真的落地了，再动下一处。
-  字符串替换静默失败在本仓库发生过多次；拖到第 5 步才发现，意味着中间的同类路径
-  审计全部建立在一处并不存在的改动上，还可能整条意见被漏改。
+  静默失败的字符串替换在本仓库发生过多次；拖到第 5 步才发现，意味着中间的审计全部
+  建立在一处并不存在的改动上。
 
-**宁要单一根因修复，不要层叠补丁。** 若修复需要在已有的抑制标志 / 冷却期 / 特例
-分支之上再加一个，停下来重新推导根因——见 AGENTS.md 的 `## Debugging Sync Bugs`。
+**宁要单一根因修复，不要层叠补丁。** 若修复需要在已有的抑制标志 / 冷却期 / 特例分支
+之上再加一个，停下来重新推导根因——见 AGENTS.md 的 `## Debugging Sync Bugs`。
+
+编辑前先记一份工作树基线，后面要用：
+
+```bash
+git status --porcelain
+```
 
 ## 4. 审计同类路径（不要只修被标的那一行）
 
 被标出的往往只是同一类问题的一个实例。
 
 - grep 出被改签名的**全部调用点**，含 `server/src/app.ts` 与各 `index.ts` 适配层。
-  注意 TypeScript 的边界：把少声明参数的函数**赋值**给回调类型不报错（多出的末位
-  参数被静默忽略），但适配层若仍调用下游函数而少传参，`TS2554` 会报出来。真正无
-  声的是前者——新参数压根没被接住、也没往下传。
+  编译器的边界见 AGENTS.md 的 `## Protocol Changes` 第 2 条。
 - 状态清理 / reset 函数：grep 每一处相关状态，逐一确认。
 - 异步 Redis / 锁操作：确认都 `await` 且包了 `try/catch`。
 - 协议相关改动：走 AGENTS.md 的 `## Protocol Changes` 清单。
 
 逐个列出「已处理 / 不适用及原因」，再进下一步。
 
-## 5. 验证（宣称改好之前）
+## 5. 验证
 
-- 第 3 步已要求每次编辑后立刻重读；这里再对全部改动做一次提交前复核，确认没有
-  被后续编辑覆盖掉。
+```bash
+./scripts/has-changes.sh || echo "本轮无改动，跳到第 7 步"
+```
+
+`has-changes.sh` 用 `git status --porcelain`，覆盖已修改、已暂存和**未跟踪**三类。
+只用 `git diff --quiet` 会漏掉新增的测试或文档文件，把有改动的一轮误判成无改动，
+跳过验证和提交却仍去 resolve，改动就此丢失。
+
+有改动时：
+
+- 对全部改动做提交前复核，确认没有被后续编辑覆盖掉。
 - 新增的回归测试必须在**修复前的代码上失败**。回退修复时**只回退源文件**：
 
   ```bash
-  cp <源文件> /tmp/fix.bak          # 事前备份
+  cp <源文件> /tmp/fix.bak    # 事前备份
   # …验证…
-  cp /tmp/fix.bak <源文件>          # 还原
+  cp /tmp/fix.bak <源文件>    # 还原
   ```
 
-  **不要整仓 `git stash`**：新测试若追加在已跟踪的测试文件里会被一起 stash 走，
-  测试因「找不到用例」而退出非零，看着是红的，其实什么都没验证。确认失败原因是
-  **断言失败**，不是用例不存在。
+  **不要整仓 `git stash`**：新测试若追加在已跟踪的测试文件里会被一起 stash 走，测试
+  因「找不到用例」而退出非零，看着是红的，其实什么都没验证。确认失败原因是**断言
+  失败**，不是用例不存在。
 
 - 跑完整预提交序列，逐项断言退出码：
 
@@ -162,136 +125,68 @@ git rev-parse --short HEAD
     code=$?
     echo "$step exit=$code  log=/tmp/rr-$step.log"
     if [ $code -ne 0 ]; then
-      echo "===== $step 完整输出 ====="
-      cat "/tmp/rr-$step.log"        # 完整输出，不截断
-      fail="$step"
-      break
+      echo "===== $step 完整输出 ====="; cat "/tmp/rr-$step.log"
+      fail="$step"; break
     fi
   done
-  if [ -n "$fail" ]; then
-    echo "FAILED: $fail"
-    exit 1                           # 必须以非零退出码结束
-  fi
+  if [ -n "$fail" ]; then echo "FAILED: $fail"; exit 1; fi
   echo "ALL-GREEN"
   ```
 
-  两处都不能省：
+  失败必须 `exit 1`，否则依赖退出状态的执行者会带着未通过的检查继续提交。
+  `[ $code -ne 0 ] && { …; break; }` 那种写法的循环退出码是**反的**（全绿返回 1、
+  失败返回 0）。失败时 `cat` 完整日志而非 `tail -40`——AGENTS.md 要求报告真实输出。
+  **严禁 `npm run typecheck | tail`**：管道让退出码变成 `tail` 的。
 
-  - **失败必须 `exit 1`。** 只打印 `FAILED` 而让代码块以 0 结束，依赖工具退出状态
-    的执行者会带着未通过的检查继续提交推送。反过来，`[ $code -ne 0 ] && { …; }`
-    这种写法的退出码是**反的**（全绿返回 1、失败返回 0），照它判会得出相反结论。
-  - **失败时 `cat` 完整日志，不要 `tail -40`。** AGENTS.md 要求报告真实命令输出而
-    非摘要；截断会藏掉更早的失败上下文和警告。成功时输出量太大不便全贴，但日志路径
-    已经打出来了——需要核对时直接读那个文件，不要凭 `exit=0` 一句话下结论。
-
-- **严禁 `npm run typecheck | tail`** 这类写法：管道让退出码变成 `tail` 的，失败被吞成绿。
-
-## 6. 提交、推送（可能整步跳过）
-
-**这一步不是无条件的。** 若本轮所有意见都已过时、不成立、或只需解释而无需改文件，
-此时 `git commit` 会以 "nothing to commit" 失败——而技能开头要求任一步失败就停，
-于是永远走不到第 7 步去回复和 resolve，线程就那么挂着。先判断有没有改动：
+## 6. 提交、推送
 
 ```bash
-if git diff --quiet && git diff --cached --quiet; then
-  echo "本轮无代码改动，跳过第 5-6 步，直接进第 7 步回复线程"
-else
-  # …第 5 步验证…然后提交
-  git add <本轮实际改动的具体文件>   # 严禁 git add -A / git add .
-  git commit -m "fix: ..."
-  HEAD_REF=$(gh pr view "$PR" --json headRefName --jq .headRefName)
-  [ "$(git rev-parse --abbrev-ref HEAD)" = "$HEAD_REF" ] || { echo "分支不对，拒绝推送"; exit 1; }
-  git push origin "HEAD:$HEAD_REF"
-fi
+git add <本轮实际改动的具体文件>   # 严禁 git add -A / git add .
+git diff --cached                  # 核对暂存内容
+git commit -m "fix: ..."
+./scripts/verify-branch.sh "$PR"   # 推送前复验，中途可能被切走
+git push origin "HEAD:$(gh pr view "$PR" --json headRefName --jq .headRefName)"
 ```
 
-**推送前必须复验分支**（第 0 步之后可能被切走），且显式写出 `origin "HEAD:$HEAD_REF"`
-而不是裸 `git push`。
-
-**动手前先审计工作树。** 显式列出文件名并不足以隔离改动：如果用户在技能启动前就对同
-一个文件有未提交的修改，`git add <文件>` 会把那些改动和本轮修复一起提交。所以在第 3
-步开始编辑之前先记录：
-
-```bash
-git status --short          # 记下哪些文件本来就是脏的
-git stash list
-```
-
-对本来就脏的文件，提交前用 `git add -p` 按 hunk 只暂存本轮的补丁，并用
-`git diff --cached` 逐项确认暂存内容里没有别人的改动。
+对第 3 步基线里**本来就脏**的文件，用 `git add -p` 按 hunk 只暂存本轮补丁——显式写
+文件名并不足以隔离改动，用户在技能启动前的未提交修改会被一起提交。
 
 ## 7. 回复并 resolve 线程
 
-**先回复，确认回复成功，再 resolve。** 只跑 `resolveReviewThread` 会把线程静默关掉，
-评审者看不到改在哪、验证结果如何、或哪条为什么不采纳。回复用
-`addPullRequestReviewThreadReply`：
-
 ```bash
-THREAD_ID=<第 1 步输出的 id>
-BODY="已修。<改在哪、怎么验证的；不采纳则写明理由>"
-
-# 1) 先发回复，并确认拿到了 id（失败就不要往下走）
-REPLY=$(gh api graphql -f query='
-  mutation($id:ID!,$body:String!){
-    addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$id, body:$body}){
-      comment{ id }
-    }
-  }' -F id="$THREAD_ID" -F body="$BODY" --jq '.data.addPullRequestReviewThreadReply.comment.id')
-[ -n "$REPLY" ] || { echo "回复失败，不 resolve"; exit 1; }
-
-# 2) 回复成功后才 resolve
-gh api graphql -f query='
-  mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){thread{isResolved}} }
-' -F id="$THREAD_ID" --jq '.data.resolveReviewThread.thread.isResolved'
+./scripts/reply-resolve.sh <线程id> "已修。<改在哪、怎么验证的；不采纳则写明理由>" <第1步看到的评论数>
 ```
 
-收尾再查一次未解决线程数应为 0，确认回复确实进了线程（该线程 `totalCount` 应 +1）。
+脚本会先重读线程：若评论数与第 1 步不一致，说明扫描之后评审者又补了内容，此时**拒绝
+resolve** 并打出最新一条，让你先把它纳入根因分析。确认回复拿到 comment id 之后才
+resolve——只跑 `resolveReviewThread` 会把线程静默关掉，评审者看不到改在哪。
+
+收尾用 `./scripts/list-unresolved.sh "$PR" --count` 确认归零。
 
 ## 8. 本轮结束——**不要合并**
 
-判断「通过」还是「没触发」，两者都表现为没有未解决线程：
-
 ```bash
-PR=<编号>; REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
-BOT=chatgpt-codex-connector[bot]
-SHA=$(git rev-parse HEAD)
-
-# 基准 = 当前 HEAD 被 push 上去的时刻（该 SHA 触发的最早一次 workflow run）
-PUSHED=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA" \
-  --jq '[.workflow_runs[].created_at] | sort | .[0]')
-echo "head=$SHA pushed≈$PUSHED"
-
-# 注意：gh api 不支持 --arg（那是 jq 自己的 flag，--jq 不透传），
-# 且本机没有可用于管道的独立 jq，所以变量用 shell 插值进 jq 表达式。
-gh api "repos/$REPO/issues/$PR/reactions" \
-  --jq "[.[] | select(.user.login==\"$BOT\") | select(.created_at > \"$PUSHED\")]
-        | if length==0 then \"（本轮无 Codex reaction）\"
-          else (.[]|\"\(.content) \(.created_at)\") end"
+./scripts/round-signal.sh "$PR"
 ```
 
-两个过滤条件缺一不可：
+输出 `PASSED` / `REVIEWING` / `NOT-TRIGGERED`。
 
-- **必须按机器人账号过滤。** 该接口返回所有人的 reaction；维护者或其他自动化在当前
-  提交之后点一个 👍，会被误读成「Codex 通过」而提前结束本轮。
-- **新鲜度基准要用 push 时刻，不能用 `git log -1 --format=%cI`。** 后者是提交的
-  _创建_ 时间：提交先在本地生成、上一轮的旧 reaction 随后到达、再 push 这个提交，
-  旧 reaction 仍晚于提交时间，会被当成本轮信号。reaction 不带 commit 引用且长期
-  留存，所以只能用一个真正代表「这次远端更新」的边界。若该 SHA 尚无 workflow run
-  （CI 还没起来），说明本轮结果根本还没到，直接按「没触发」处理。
+reaction 长期留存且不带 commit 引用，所以脚本用「当前 HEAD 触发的最早一次 workflow
+run 的 `created_at`」作为推送时刻基准，并且只认 Codex 机器人的 reaction。该 SHA 尚无
+run 时直接判 `NOT-TRIGGERED`——此时若拿空字符串当阈值，`created_at > ""` 会选中所有
+历史 reaction，旧的 👍 就成了「本轮通过」。
 
-判定：
-
-- 👀 = 评审中，等；👍（本轮、来自机器人）= 通过、无意见。
-- 没有任何本轮信号 = **没触发**，不等于没问题。评论 `@codex review` 触发，别空等。
-- 合并需要用户**针对这个 PR** 的明确授权。关于发版的含糊表述不是合并授权。
+`NOT-TRIGGERED` **不等于没问题**：评论 `@codex review` 触发，别空等。
+合并需要用户**针对这个 PR** 的明确授权，关于发版的含糊表述不是合并授权。
 
 ## 硬性规则
 
 - **严禁**在没有用户明确指令的情况下 `gh pr merge`。
 - **严禁**只凭 reaction 判断有没有意见——以未解决线程为准。
+- **严禁**把脚本抄成一次性命令。要改行为就改脚本，并跑 `selftest.sh`。
 - **严禁**只修被标的那一行而不审计同类路径。
 - **严禁**把检查命令管道给 `tail`/`head` 后据此判断成败。
 - **严禁** `git add -A` / `git add .`。
-- **严禁**用 `git checkout <file>` / `git restore <file>` 回退探针——会连同该文件
-  其它未提交改动一起冲掉。先 `cp` 备份或 `git stash push -- <仅源文件路径>`。
+- **严禁**用 `git checkout <file>` / `git restore <file>` 回退探针——会连同该文件其它
+  未提交改动一起冲掉。先 `cp` 备份或 `git stash push -- <仅源文件路径>`。
 - 未真正跑过的检查，**不得**声称已验证。

--- a/.claude/skills/review-round/scripts/has-changes.sh
+++ b/.claude/skills/review-round/scripts/has-changes.sh
@@ -1,29 +1,50 @@
 #!/usr/bin/env bash
-# 用法: has-changes.sh
+# 用法:
+#   has-changes.sh --baseline <文件>    # 第 3 步开始编辑前，记录基线
+#   has-changes.sh <基线文件>           # 第 5 步，判断本轮相对基线是否产生改动
 #
-# 判断本轮有没有产生实际改动。有则退出 0，无则退出 1。
-# 顺带打出工作树里本来就存在的脏文件，供第 6 步按 hunk 暂存时对照。
+# 有本轮改动退出 0，无则退出 1。
 
 source "$(dirname "$0")/lib.sh"
 
-# 第三轮第 2 条：git diff --quiet 和 git diff --cached --quiet 都忽略未跟踪文件。
-# 评审响应若只新增测试 / 文档 / 辅助文件，会被误判成「无代码改动」而跳过验证、
-# 提交和推送，却仍继续回复并 resolve——改动就此丢失。
-# git status --porcelain 覆盖已修改、已暂存和未跟踪（?? 前缀）三类。
-STATUS=$(git status --porcelain)
+if [ "${1:-}" = "--baseline" ]; then
+  OUT=${2:?用法: has-changes.sh --baseline <文件>}
+  git status --porcelain >"$OUT"
+  echo "基线已记录到 $OUT（$(wc -l <"$OUT") 条既有条目）"
+  exit 0
+fi
 
-if [ -z "$STATUS" ]; then
-  echo "NO-CHANGES（本轮无需改文件，跳过验证与提交，直接回复线程）"
+BASE=${1:?用法: has-changes.sh <基线文件>（先用 --baseline 生成）}
+[ -f "$BASE" ] || die "基线文件不存在：$BASE。第 3 步开始编辑前必须先跑 --baseline。"
+
+# 必须用 git status --porcelain：git diff --quiet 和 git diff --cached --quiet 都
+# 忽略未跟踪文件，只新增测试/文档的一轮会被误判成「无改动」而跳过验证与提交。
+CURRENT=$(git status --porcelain)
+
+# 但也不能直接看工作树是否非空：技能启动前就存在的无关未提交文件会让「本轮只需
+# 解释或拒绝意见」的轮次误判成有改动，进而卡在无内容可提交的 git commit 上，
+# 永远到不了回复线程那一步。所以要跟基线比。
+NEW=$(comm -13 <(sort "$BASE") <(printf '%s\n' "$CURRENT" | sort) | sed '/^$/d')
+
+if [ -z "$NEW" ]; then
+  echo "NO-CHANGES（相对基线无本轮改动，跳过验证与提交，直接回复线程）"
+  PRE=$(sed '/^$/d' "$BASE" | wc -l)
+  [ "$PRE" -gt 0 ] && echo "（工作树里有 $PRE 条基线中就存在的既有改动，与本轮无关）"
   exit 1
 fi
 
-echo "HAS-CHANGES:"
-printf '%s\n' "$STATUS"
+echo "HAS-CHANGES（相对基线新增）:"
+printf '%s\n' "$NEW"
 
-UNTRACKED=$(printf '%s\n' "$STATUS" | grep -c '^??' || true)
-[ "$UNTRACKED" -gt 0 ] && echo "（其中 $UNTRACKED 个未跟踪文件——git diff 看不到它们）"
+UNTRACKED=$(printf '%s\n' "$NEW" | grep -c '^??' || true)
+[ "$UNTRACKED" -gt 0 ] && echo "（其中 $UNTRACKED 个未跟踪条目——git diff 看不到它们）"
+
+if [ -s "$BASE" ]; then
+  echo
+  echo "⚠ 基线中已有既有改动，提交时对这些文件用 git add -p 按 hunk 只暂存本轮补丁："
+  sed '/^$/d' "$BASE"
+fi
 
 echo
-echo "提交前用 git add <具体文件> 或 git add -p 只暂存本轮补丁，"
-echo "再用 git diff --cached 核对暂存内容里没有混入既有的无关改动。"
+echo "提交前用 git diff --cached 核对暂存内容里没有混入基线中的既有改动。"
 exit 0

--- a/.claude/skills/review-round/scripts/has-changes.sh
+++ b/.claude/skills/review-round/scripts/has-changes.sh
@@ -1,48 +1,71 @@
 #!/usr/bin/env bash
 # 用法:
-#   has-changes.sh --baseline <文件>    # 第 3 步开始编辑前，记录基线
+#   has-changes.sh --baseline <文件>    # 第 3 步开始编辑前，记录基线快照
 #   has-changes.sh <基线文件>           # 第 5 步，判断本轮相对基线是否产生改动
 #
 # 有本轮改动退出 0，无则退出 1。
 
 source "$(dirname "$0")/lib.sh"
 
+# 快照必须包含**内容**，不能只有 porcelain 的状态行。
+#
+# 只比状态行时：待修文件在基线里已经是 ` M path`（或落在基线已有的 `?? dir/` 下），
+# 本轮继续修改它并不会改变那一行，比对结果为空 → 判 NO-CHANGES → 跳过验证、提交和
+# 推送，却仍去回复并 resolve——修复就只留在工作树里，永远没提交。
+#
+# 三类都要覆盖：已跟踪文件的内容变更、未跟踪文件的新增与内容变更、以及删除。
+snapshot() {
+  echo "---STATUS---"
+  git status --porcelain
+  echo "---TRACKED-DIFF---"
+  git diff HEAD # 已暂存 + 未暂存的内容变更
+  echo "---UNTRACKED---"
+  git ls-files --others --exclude-standard -z |
+    sort -z |
+    while IFS= read -r -d '' f; do
+      printf '%s  %s\n' "$(sha1sum "$f" | cut -d' ' -f1)" "$f"
+    done
+}
+
+baseline_status() {
+  sed -n '/^---STATUS---$/,/^---TRACKED-DIFF---$/p' "$1" | sed '1d;$d;/^$/d'
+}
+
 if [ "${1:-}" = "--baseline" ]; then
   OUT=${2:?用法: has-changes.sh --baseline <文件>}
-  git status --porcelain >"$OUT"
-  echo "基线已记录到 $OUT（$(wc -l <"$OUT") 条既有条目）"
+  snapshot >"$OUT"
+  echo "基线快照已记录到 $OUT（工作树已有 $(baseline_status "$OUT" | wc -l) 条既有条目）"
   exit 0
 fi
 
 BASE=${1:?用法: has-changes.sh <基线文件>（先用 --baseline 生成）}
 [ -f "$BASE" ] || die "基线文件不存在：$BASE。第 3 步开始编辑前必须先跑 --baseline。"
 
-# 必须用 git status --porcelain：git diff --quiet 和 git diff --cached --quiet 都
-# 忽略未跟踪文件，只新增测试/文档的一轮会被误判成「无改动」而跳过验证与提交。
-CURRENT=$(git status --porcelain)
+CUR="/tmp/rr-snapshot.$$"
+trap 'rm -f "$CUR"' EXIT
+snapshot >"$CUR"
 
-# 但也不能直接看工作树是否非空：技能启动前就存在的无关未提交文件会让「本轮只需
-# 解释或拒绝意见」的轮次误判成有改动，进而卡在无内容可提交的 git commit 上，
-# 永远到不了回复线程那一步。所以要跟基线比。
-NEW=$(comm -13 <(sort "$BASE") <(printf '%s\n' "$CURRENT" | sort) | sed '/^$/d')
-
-if [ -z "$NEW" ]; then
-  echo "NO-CHANGES（相对基线无本轮改动，跳过验证与提交，直接回复线程）"
-  PRE=$(sed '/^$/d' "$BASE" | wc -l)
+if diff -q "$BASE" "$CUR" >/dev/null 2>&1; then
+  echo "NO-CHANGES（内容与基线完全一致，跳过验证与提交，直接回复线程）"
+  PRE=$(baseline_status "$BASE" | wc -l)
   [ "$PRE" -gt 0 ] && echo "（工作树里有 $PRE 条基线中就存在的既有改动，与本轮无关）"
   exit 1
 fi
 
-echo "HAS-CHANGES（相对基线新增）:"
-printf '%s\n' "$NEW"
+echo "HAS-CHANGES（相对基线的内容差异，前 40 行）:"
+# diff 在文件不同时返回 1，set -e + pipefail 会就地终止脚本——「有改动」反而以
+# 退出码 1 报出，与「无改动」撞在一起，语义完全颠倒。必须显式吞掉这个退出码。
+diff "$BASE" "$CUR" | head -40 || true
 
-UNTRACKED=$(printf '%s\n' "$NEW" | grep -c '^??' || true)
-[ "$UNTRACKED" -gt 0 ] && echo "（其中 $UNTRACKED 个未跟踪条目——git diff 看不到它们）"
+echo
+echo "当前工作树状态："
+git status --porcelain
 
-if [ -s "$BASE" ]; then
+BASE_STATUS=$(baseline_status "$BASE")
+if [ -n "$BASE_STATUS" ]; then
   echo
-  echo "⚠ 基线中已有既有改动，提交时对这些文件用 git add -p 按 hunk 只暂存本轮补丁："
-  sed '/^$/d' "$BASE"
+  echo "⚠ 下列条目在基线中就已存在，提交时对它们用 git add -p 按 hunk 只暂存本轮补丁："
+  printf '%s\n' "$BASE_STATUS"
 fi
 
 echo

--- a/.claude/skills/review-round/scripts/has-changes.sh
+++ b/.claude/skills/review-round/scripts/has-changes.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# 用法: has-changes.sh
+#
+# 判断本轮有没有产生实际改动。有则退出 0，无则退出 1。
+# 顺带打出工作树里本来就存在的脏文件，供第 6 步按 hunk 暂存时对照。
+
+source "$(dirname "$0")/lib.sh"
+
+# 第三轮第 2 条：git diff --quiet 和 git diff --cached --quiet 都忽略未跟踪文件。
+# 评审响应若只新增测试 / 文档 / 辅助文件，会被误判成「无代码改动」而跳过验证、
+# 提交和推送，却仍继续回复并 resolve——改动就此丢失。
+# git status --porcelain 覆盖已修改、已暂存和未跟踪（?? 前缀）三类。
+STATUS=$(git status --porcelain)
+
+if [ -z "$STATUS" ]; then
+  echo "NO-CHANGES（本轮无需改文件，跳过验证与提交，直接回复线程）"
+  exit 1
+fi
+
+echo "HAS-CHANGES:"
+printf '%s\n' "$STATUS"
+
+UNTRACKED=$(printf '%s\n' "$STATUS" | grep -c '^??' || true)
+[ "$UNTRACKED" -gt 0 ] && echo "（其中 $UNTRACKED 个未跟踪文件——git diff 看不到它们）"
+
+echo
+echo "提交前用 git add <具体文件> 或 git add -p 只暂存本轮补丁，"
+echo "再用 git diff --cached 核对暂存内容里没有混入既有的无关改动。"
+exit 0

--- a/.claude/skills/review-round/scripts/lib.sh
+++ b/.claude/skills/review-round/scripts/lib.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# review-round 各脚本的公共库。用 `source` 引入，不要直接执行。
+#
+# 本机没有可用于管道的 jq，所有 JSON 解析走 node。
+# gh api 不支持 --arg（那是 jq 自己的 flag，--jq 不透传）。
+
+set -euo pipefail
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "缺少依赖：$1"
+}
+
+need gh
+need git
+need node
+
+# 解析仓库坐标，导出 REPO / OWNER / NAME
+resolve_repo() {
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner) ||
+    die "无法解析仓库（gh 未登录？不在 git 仓库内？）"
+  [ -n "$REPO" ] || die "仓库名为空"
+  OWNER=${REPO%%/*}
+  NAME=${REPO##*/}
+  export REPO OWNER NAME
+}
+
+# gh api graphql 包装：任何一层失败都必须终止，绝不把「没读到」当成「没有」。
+#
+# 这是第三轮评审的第 1 条：原先赋值失败后循环仍继续，node 解析报错但 NEXT 为空，
+# 随后 break 让整个代码块以 0 退出，执行者会把「根本没读到线程」误判成「没有未解决
+# 线程」并继续回复或判定本轮状态。
+gql() {
+  local query=$1
+  shift
+  local resp status
+  set +e
+  resp=$(gh api graphql -f query="$query" "$@" 2>&1)
+  status=$?
+  set -e
+  [ $status -eq 0 ] || die "GraphQL 请求失败（exit=$status）：$resp"
+
+  # HTTP 200 但 body 里带 errors 的情况，gh 不一定以非零退出
+  printf '%s' "$resp" | node -e '
+    let s = "";
+    process.stdin.on("data", (d) => (s += d)).on("end", () => {
+      let j;
+      try { j = JSON.parse(s); }
+      catch { console.error("响应不是合法 JSON：" + s.slice(0, 300)); process.exit(1); }
+      if (j.errors) { console.error("GraphQL 返回 errors：" + JSON.stringify(j.errors)); process.exit(1); }
+      if (!j.data) { console.error("响应缺少 data 字段：" + s.slice(0, 300)); process.exit(1); }
+      process.stdout.write(s);
+    });
+  ' || die "GraphQL 响应校验失败"
+}
+
+# 只剥 shields.io 徽章，保留评审者贴的截图等真实图片。
+#
+# 第三轮第 5 条：原先的全局 /!\[[^\]]*\]\([^)]*\)/g 会删掉正文里的每一张图片，
+# 包括失败截图和示意图，而注释却说「只剥徽章」。
+export BADGE_STRIP_JS='
+  (body) => body
+    .replace(/!\[[^\]]*\]\(https:\/\/img\.shields\.io\/[^)]*\)/g, "")
+    .replace(/<\/?sub>/g, "")
+'

--- a/.claude/skills/review-round/scripts/list-unresolved.sh
+++ b/.claude/skills/review-round/scripts/list-unresolved.sh
@@ -60,7 +60,7 @@ while :; do
         lines.push(`\n═══ ${n.path}:${n.line ?? n.originalLine}  id=${n.id}  评论数=${n.comments.totalCount}`);
         for (const c of n.comments.nodes) {
           const sha = c.pullRequestReview?.commit?.oid?.slice(0, 7) ?? "?";
-          lines.push(`[${c.author.login} @${sha}] ${strip(c.body)}`);
+          lines.push(`[${c.author?.login ?? "ghost"} @${sha}] ${strip(c.body)}`);
         }
         if (n.comments.pageInfo.hasNextPage)
           lines.push("  ⚠ 该线程评论超过 100 条，仍有未取出的内容");

--- a/.claude/skills/review-round/scripts/list-unresolved.sh
+++ b/.claude/skills/review-round/scripts/list-unresolved.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# 用法: list-unresolved.sh <PR编号> [--count]
+#
+# 列出全部未解决评审线程。翻页取全、正文不截断、每条评论标注所属评审 commit。
+# --count 只输出未解决线程数（供脚本判断用）。
+#
+# 任何一层失败都以非零退出（见 lib.sh 的 gql）——「没读到」绝不能被当成「没有」。
+
+source "$(dirname "$0")/lib.sh"
+
+PR=${1:?用法: list-unresolved.sh <PR编号> [--count]}
+MODE=${2:-}
+
+resolve_repo
+
+QUERY='
+query($owner:String!,$repo:String!,$pr:Int!,$after:String,$size:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$pr){
+      reviewThreads(first:$size, after:$after){
+        pageInfo{ hasNextPage endCursor }
+        nodes{
+          id isResolved path line originalLine
+          comments(first:100){
+            totalCount
+            pageInfo{ hasNextPage }
+            nodes{ author{login} body pullRequestReview{ commit{oid} submittedAt } }
+          }
+        }
+      }
+    }
+  }
+}'
+
+# 页大小可覆盖，仅供 selftest 强制触发翻页用
+PAGE_SIZE=${RR_PAGE_SIZE:-100}
+
+CURSOR=null
+COUNT=0
+PAGES=0
+OUT=""
+META="/tmp/rr-meta.$$"
+trap 'rm -f "$META"' EXIT
+
+while :; do
+  RESP=$(gql "$QUERY" -F owner="$OWNER" -F repo="$NAME" -F pr="$PR" \
+    -F after="$CURSOR" -F size="$PAGE_SIZE")
+
+  # 正文走 stdout，「计数 + 游标」走 stderr 写进文件。
+  # 不要用 \x00 之类做行内分隔符：bash 的 $'\x00' 求值为空串，命令替换也会丢掉
+  # NUL，模式退化成 `*` 后游标恒为空——翻页会在第一页就静默停下。
+  PAGE=$(printf '%s' "$RESP" | node -e '
+    const strip = eval(process.env.BADGE_STRIP_JS);
+    let s = "";
+    process.stdin.on("data", (d) => (s += d)).on("end", () => {
+      const t = JSON.parse(s).data.repository.pullRequest.reviewThreads;
+      const unresolved = t.nodes.filter((n) => !n.isResolved);
+      const lines = [];
+      for (const n of unresolved) {
+        lines.push(`\n═══ ${n.path}:${n.line ?? n.originalLine}  id=${n.id}  评论数=${n.comments.totalCount}`);
+        for (const c of n.comments.nodes) {
+          const sha = c.pullRequestReview?.commit?.oid?.slice(0, 7) ?? "?";
+          lines.push(`[${c.author.login} @${sha}] ${strip(c.body)}`);
+        }
+        if (n.comments.pageInfo.hasNextPage)
+          lines.push("  ⚠ 该线程评论超过 100 条，仍有未取出的内容");
+      }
+      process.stdout.write(lines.join("\n"));
+      process.stderr.write(unresolved.length + " " + (t.pageInfo.hasNextPage ? t.pageInfo.endCursor : "-") + "\n");
+    });
+  ' 2>"$META") || die "解析线程失败"
+
+  read -r N NEXT <"$META" || die "读取分页元信息失败"
+  [ -n "${N:-}" ] || die "分页元信息为空——不能把「没读到」当成「没有」"
+
+  COUNT=$((COUNT + N))
+  PAGES=$((PAGES + 1))
+  OUT="$OUT$PAGE"
+
+  [ "$NEXT" = "-" ] && break
+  CURSOR="$NEXT"
+done
+
+if [ "$MODE" = "--count" ]; then
+  echo "$COUNT"
+else
+  [ "$COUNT" -eq 0 ] && echo "（无未解决线程）" || printf '%s\n' "$OUT"
+  echo
+  echo "未解决线程数: $COUNT"
+fi

--- a/.claude/skills/review-round/scripts/reply-resolve.sh
+++ b/.claude/skills/review-round/scripts/reply-resolve.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# 用法: reply-resolve.sh <线程id> <回复正文> <第1步看到的评论数>
+#
+# 顺序固定：重读线程 → 比对评论数 → 发回复 → 确认回复成功 → 才 resolve。
+# 任何一环失败都不 resolve，线程宁可留着也不能被静默关闭。
+
+source "$(dirname "$0")/lib.sh"
+
+THREAD_ID=${1:?用法: reply-resolve.sh <线程id> <回复正文> <已见评论数>}
+BODY=${2:?缺少回复正文}
+SEEN=${3:?缺少「第 1 步看到的评论数」——用于检测扫描后是否有新评论}
+
+# 第三轮第 7 条：评审者可能在第 1 步扫描之后、修复期间往同一线程补充条件或指出修复
+# 方向有误。若照最初保存的内容直接回复并 resolve，新反馈从未进入根因分析就被关掉了。
+RESP=$(gql '
+  query($id:ID!){
+    node(id:$id){
+      ... on PullRequestReviewThread {
+        isResolved
+        comments(first:100){ totalCount nodes{ author{login} body } }
+      }
+    }
+  }' -F id="$THREAD_ID")
+
+read -r NOW RESOLVED <<<"$(printf '%s' "$RESP" | node -e '
+  let s = "";
+  process.stdin.on("data", (d) => (s += d)).on("end", () => {
+    const n = JSON.parse(s).data.node;
+    process.stdout.write(`${n.comments.totalCount} ${n.isResolved}`);
+  });
+')"
+
+if [ "$RESOLVED" = "true" ]; then
+  echo "线程 ${THREAD_ID:0:20} 已是 resolved，跳过"
+  exit 0
+fi
+
+if [ "$NOW" -ne "$SEEN" ]; then
+  echo "拒绝 resolve：该线程评论数由 $SEEN 变为 $NOW，扫描之后有新反馈。" >&2
+  printf '%s' "$RESP" | node -e '
+    const strip = eval(process.env.BADGE_STRIP_JS);
+    let s = "";
+    process.stdin.on("data", (d) => (s += d)).on("end", () => {
+      const c = JSON.parse(s).data.node.comments.nodes;
+      const last = c[c.length - 1];
+      console.error(`最新一条 [${last.author.login}]: ${strip(last.body).slice(0, 500)}`);
+    });
+  '
+  die "先把新增内容纳入根因分析，再重跑本脚本"
+fi
+
+REPLY=$(gql '
+  mutation($id:ID!,$body:String!){
+    addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$id, body:$body}){
+      comment{ id }
+    }
+  }' -F id="$THREAD_ID" -F body="$BODY" |
+  node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{process.stdout.write(JSON.parse(s).data.addPullRequestReviewThreadReply?.comment?.id ?? "")})')
+
+[ -n "$REPLY" ] || die "回复未成功（没拿到 comment id），不执行 resolve"
+
+STATE=$(gql '
+  mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ isResolved } } }
+  ' -F id="$THREAD_ID" |
+  node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{process.stdout.write(String(JSON.parse(s).data.resolveReviewThread.thread.isResolved))})')
+
+[ "$STATE" = "true" ] || die "resolve 未生效"
+echo "OK: ${THREAD_ID:0:20} 已回复并 resolved"

--- a/.claude/skills/review-round/scripts/reply-resolve.sh
+++ b/.claude/skills/review-round/scripts/reply-resolve.sh
@@ -32,8 +32,9 @@ read -r TOTAL RESOLVED MINE <<<"$(printf '%s' "$RESP" | BODY="$BODY" ME="$ME" no
   let s = "";
   process.stdin.on("data", (d) => (s += d)).on("end", () => {
     const n = JSON.parse(s).data.node;
+    // author 可为 null（账号已注销）——直接解引用会抛异常，整条流程被一条历史评论卡死
     const mine = n.comments.nodes.some(
-      (c) => c.author.login === process.env.ME && c.body.trim() === process.env.BODY.trim(),
+      (c) => (c.author?.login ?? "ghost") === process.env.ME && c.body.trim() === process.env.BODY.trim(),
     );
     process.stdout.write(`${n.comments.totalCount} ${n.isResolved} ${mine}`);
   });
@@ -55,7 +56,24 @@ resolve_now() {
 
 # 重试路径：回复已发但上次 resolve 失败。若不识别这种情况，按原 SEEN 重跑会因评论数
 # 变多而被拒，改用新计数重跑又会再发一条重复回复。
+#
+# 但幂等分支**不能**绕过新评论保护：上次回复成功、resolve 失败之后，评审者可能又补了
+# 内容。此时总数会超过 SEEN+1，直接 resolve 会把没分析过的反馈一起关掉。
+# 只有「唯一的增量就是脚本自己那条回复」才允许直接补 resolve。
 if [ "$MINE" = "true" ]; then
+  if [ "$TOTAL" -ne "$((SEEN + 1))" ]; then
+    echo "拒绝 resolve：回复已发，但评论数为 $TOTAL（期望 $((SEEN + 1))），说明之后还有新反馈。" >&2
+    printf '%s' "$RESP" | node -e '
+      const strip = eval(process.env.BADGE_STRIP_JS);
+      let s = "";
+      process.stdin.on("data", (d) => (s += d)).on("end", () => {
+        const c = JSON.parse(s).data.node.comments.nodes;
+        const last = c[c.length - 1];
+        console.error(`最新一条 [${last.author?.login ?? "ghost"}]: ${strip(last.body).slice(0, 500)}`);
+      });
+    '
+    die "先把新增内容纳入根因分析，再重跑本脚本"
+  fi
   echo "检测到本脚本的同一条回复已存在（上次 resolve 未完成），跳过发送，仅补做 resolve"
   resolve_now
   echo "OK: ${THREAD_ID:0:20} 已 resolved（复用既有回复）"
@@ -72,7 +90,7 @@ if [ "$TOTAL" -ne "$SEEN" ]; then
     process.stdin.on("data", (d) => (s += d)).on("end", () => {
       const c = JSON.parse(s).data.node.comments.nodes;
       const last = c[c.length - 1];
-      console.error(`最新一条 [${last.author.login}]: ${strip(last.body).slice(0, 500)}`);
+      console.error(`最新一条 [${last.author?.login ?? "ghost"}]: ${strip(last.body).slice(0, 500)}`);
     });
   '
   die "先把新增内容纳入根因分析，再重跑本脚本"

--- a/.claude/skills/review-round/scripts/reply-resolve.sh
+++ b/.claude/skills/review-round/scripts/reply-resolve.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # 用法: reply-resolve.sh <线程id> <回复正文> <第1步看到的评论数>
 #
-# 顺序固定：重读线程 → 比对评论数 → 发回复 → 确认回复成功 → 才 resolve。
-# 任何一环失败都不 resolve，线程宁可留着也不能被静默关闭。
+# 顺序固定：重读线程 → 比对评论数 → 发回复 → 确认成功 → 才 resolve。
+# 幂等：若本脚本的同一条回复已经发出过（上次 resolve 失败等），重跑不会重复发，
+# 直接补做 resolve。
 
 source "$(dirname "$0")/lib.sh"
 
@@ -10,23 +11,31 @@ THREAD_ID=${1:?用法: reply-resolve.sh <线程id> <回复正文> <已见评论�
 BODY=${2:?缺少回复正文}
 SEEN=${3:?缺少「第 1 步看到的评论数」——用于检测扫描后是否有新评论}
 
-# 第三轮第 7 条：评审者可能在第 1 步扫描之后、修复期间往同一线程补充条件或指出修复
-# 方向有误。若照最初保存的内容直接回复并 resolve，新反馈从未进入根因分析就被关掉了。
-RESP=$(gql '
-  query($id:ID!){
-    node(id:$id){
-      ... on PullRequestReviewThread {
-        isResolved
-        comments(first:100){ totalCount nodes{ author{login} body } }
-      }
-    }
-  }' -F id="$THREAD_ID")
+ME=$(gh api user --jq .login) || die "无法确定当前登录用户"
 
-read -r NOW RESOLVED <<<"$(printf '%s' "$RESP" | node -e '
+read_thread() {
+  gql '
+    query($id:ID!){
+      node(id:$id){
+        ... on PullRequestReviewThread {
+          isResolved
+          comments(first:100){ totalCount nodes{ author{login} body } }
+        }
+      }
+    }' -F id="$THREAD_ID"
+}
+
+RESP=$(read_thread)
+
+# 一次解析出：总数、是否已解决、本脚本此前是否已发过同一条回复
+read -r TOTAL RESOLVED MINE <<<"$(printf '%s' "$RESP" | BODY="$BODY" ME="$ME" node -e '
   let s = "";
   process.stdin.on("data", (d) => (s += d)).on("end", () => {
     const n = JSON.parse(s).data.node;
-    process.stdout.write(`${n.comments.totalCount} ${n.isResolved}`);
+    const mine = n.comments.nodes.some(
+      (c) => c.author.login === process.env.ME && c.body.trim() === process.env.BODY.trim(),
+    );
+    process.stdout.write(`${n.comments.totalCount} ${n.isResolved} ${mine}`);
   });
 ')"
 
@@ -35,8 +44,28 @@ if [ "$RESOLVED" = "true" ]; then
   exit 0
 fi
 
-if [ "$NOW" -ne "$SEEN" ]; then
-  echo "拒绝 resolve：该线程评论数由 $SEEN 变为 $NOW，扫描之后有新反馈。" >&2
+resolve_now() {
+  local state
+  state=$(gql '
+    mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ isResolved } } }
+    ' -F id="$THREAD_ID" |
+    node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{process.stdout.write(String(JSON.parse(s).data.resolveReviewThread.thread.isResolved))})')
+  [ "$state" = "true" ] || die "resolve 未生效"
+}
+
+# 重试路径：回复已发但上次 resolve 失败。若不识别这种情况，按原 SEEN 重跑会因评论数
+# 变多而被拒，改用新计数重跑又会再发一条重复回复。
+if [ "$MINE" = "true" ]; then
+  echo "检测到本脚本的同一条回复已存在（上次 resolve 未完成），跳过发送，仅补做 resolve"
+  resolve_now
+  echo "OK: ${THREAD_ID:0:20} 已 resolved（复用既有回复）"
+  exit 0
+fi
+
+# 评审者可能在第 1 步扫描之后、修复期间往同一线程补充条件或指出修复方向有误。
+# 照最初保存的内容直接回复并 resolve，新反馈从未进入根因分析就被关掉了。
+if [ "$TOTAL" -ne "$SEEN" ]; then
+  echo "拒绝 resolve：该线程评论数由 $SEEN 变为 $TOTAL，扫描之后有新反馈。" >&2
   printf '%s' "$RESP" | node -e '
     const strip = eval(process.env.BADGE_STRIP_JS);
     let s = "";
@@ -59,10 +88,5 @@ REPLY=$(gql '
 
 [ -n "$REPLY" ] || die "回复未成功（没拿到 comment id），不执行 resolve"
 
-STATE=$(gql '
-  mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ isResolved } } }
-  ' -F id="$THREAD_ID" |
-  node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{process.stdout.write(String(JSON.parse(s).data.resolveReviewThread.thread.isResolved))})')
-
-[ "$STATE" = "true" ] || die "resolve 未生效"
+resolve_now
 echo "OK: ${THREAD_ID:0:20} 已回复并 resolved"

--- a/.claude/skills/review-round/scripts/round-signal.sh
+++ b/.claude/skills/review-round/scripts/round-signal.sh
@@ -43,20 +43,31 @@ fi
 echo "head=${SHA:0:7} pushed≈$PUSHED"
 
 FRESH=$(gh api "repos/$REPO/issues/$PR/reactions" \
-  --jq "[.[] | select(.user.login==\"$BOT\") | select(.created_at > \"$PUSHED\")] | map(.content) | join(\",\")") ||
+  --jq "[.[] | select(.user.login==\"$BOT\") | select(.created_at > \"$PUSHED\")]
+        | sort_by(.created_at) | last | if . == null then \"\" else \"\(.content) \(.created_at)\" end") ||
   die "读取 reaction 失败"
 
-case "$FRESH" in
-*"+1"*)
-  echo "PASSED（本轮 Codex 👍，无意见）"
+# 必须取**时间上最新**的那一条，不能「只要存在 +1 就判通过」。
+# 同一 HEAD 上可能先有 +1、之后在不改代码的情况下原地触发新一轮评审并产生更新的
+# eyes（本仓库就是这么触发重审的）。按内容存在性判定会让旧的 +1 永久压过新的 eyes，
+# 明明还在评审中却报 PASSED。
+read -r KIND WHEN <<<"$FRESH"
+
+case "${KIND:-}" in
+"+1")
+  echo "PASSED（本轮最新信号是 👍 @$WHEN，无意见）"
   exit 0
   ;;
-*eyes*)
-  echo "REVIEWING（Codex 👀 评审中，等）"
+eyes)
+  echo "REVIEWING（本轮最新信号是 👀 @$WHEN，评审中，等）"
   exit 0
+  ;;
+"")
+  echo "NOT-TRIGGERED（本轮无 Codex reaction——不等于没问题，评论 @codex review 触发）"
+  exit 1
   ;;
 *)
-  echo "NOT-TRIGGERED（本轮无 Codex reaction——不等于没问题，评论 @codex review 触发）"
+  echo "UNKNOWN（本轮最新信号是 $KIND @$WHEN，人工确认）"
   exit 1
   ;;
 esac

--- a/.claude/skills/review-round/scripts/round-signal.sh
+++ b/.claude/skills/review-round/scripts/round-signal.sh
@@ -16,13 +16,26 @@ SHA=$(git rev-parse HEAD)
 # 基准必须是「当前 HEAD 被推上去的时刻」，不能用 git log 的提交创建时间：
 # 提交先在本地生成、上一轮的旧 reaction 随后到达、再 push 这个提交时，
 # 旧 reaction 仍晚于提交时间而被误判为本轮信号。
-PUSHED=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA" \
-  --jq '[.workflow_runs[].created_at] | sort | .[0]' 2>/dev/null || true)
+# 请求失败必须保持非零，绝不能和「查询成功但没有 run」混为一谈：
+# 把网络故障、权限不足、服务错误降级成 NOT-TRIGGERED，会让执行者反复发
+# @codex review，而不是停下来修访问问题。
+set +e
+RUNS=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA" 2>&1)
+RC=$?
+set -e
+[ $RC -eq 0 ] || die "读取 Actions runs 失败（exit=$RC），这不是「未触发」，请先排查访问问题：$RUNS"
 
-# 第三轮第 3 条：run 尚未创建或 Actions 被禁用时 PUSHED 为空，而 jq 里
-# `.created_at > ""` 对任何非空字符串都为真，会把该 PR 上所有历史 reaction
-# 全部选中——旧的 👍 于是被当成当前 HEAD 已通过。必须显式分支。
-if [ -z "$PUSHED" ] || [ "$PUSHED" = "null" ]; then
+PUSHED=$(printf '%s' "$RUNS" | node -e '
+  let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+    const runs = JSON.parse(s).workflow_runs || [];
+    const times = runs.map(r=>r.created_at).sort();
+    process.stdout.write(times[0] ?? "");
+  });') || die "解析 Actions runs 响应失败"
+
+# 查询成功但确实没有 run（尚未创建或 Actions 被禁用）：此时无法确定推送时刻。
+# 不能拿空字符串当阈值——jq 里 `.created_at > ""` 对任何非空字符串都为真，会把
+# 该 PR 上所有历史 reaction 全部选中，旧的 👍 于是被当成当前 HEAD 已通过。
+if [ -z "$PUSHED" ]; then
   echo "NOT-TRIGGERED（${SHA:0:7} 尚无 workflow run，无法确定推送时刻，按未触发处理）"
   exit 1
 fi

--- a/.claude/skills/review-round/scripts/round-signal.sh
+++ b/.claude/skills/review-round/scripts/round-signal.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# 用法: round-signal.sh <PR编号>
+#
+# 在没有未解决线程时，区分「本轮通过」与「根本没触发」。
+# 输出 PASSED / REVIEWING / NOT-TRIGGERED，并以对应退出码结束（0/0/1）。
+
+source "$(dirname "$0")/lib.sh"
+
+PR=${1:?用法: round-signal.sh <PR编号>}
+BOT="chatgpt-codex-connector[bot]"
+
+resolve_repo
+
+SHA=$(git rev-parse HEAD)
+
+# 基准必须是「当前 HEAD 被推上去的时刻」，不能用 git log 的提交创建时间：
+# 提交先在本地生成、上一轮的旧 reaction 随后到达、再 push 这个提交时，
+# 旧 reaction 仍晚于提交时间而被误判为本轮信号。
+PUSHED=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA" \
+  --jq '[.workflow_runs[].created_at] | sort | .[0]' 2>/dev/null || true)
+
+# 第三轮第 3 条：run 尚未创建或 Actions 被禁用时 PUSHED 为空，而 jq 里
+# `.created_at > ""` 对任何非空字符串都为真，会把该 PR 上所有历史 reaction
+# 全部选中——旧的 👍 于是被当成当前 HEAD 已通过。必须显式分支。
+if [ -z "$PUSHED" ] || [ "$PUSHED" = "null" ]; then
+  echo "NOT-TRIGGERED（${SHA:0:7} 尚无 workflow run，无法确定推送时刻，按未触发处理）"
+  exit 1
+fi
+
+echo "head=${SHA:0:7} pushed≈$PUSHED"
+
+FRESH=$(gh api "repos/$REPO/issues/$PR/reactions" \
+  --jq "[.[] | select(.user.login==\"$BOT\") | select(.created_at > \"$PUSHED\")] | map(.content) | join(\",\")") ||
+  die "读取 reaction 失败"
+
+case "$FRESH" in
+*"+1"*)
+  echo "PASSED（本轮 Codex 👍，无意见）"
+  exit 0
+  ;;
+*eyes*)
+  echo "REVIEWING（Codex 👀 评审中，等）"
+  exit 0
+  ;;
+*)
+  echo "NOT-TRIGGERED（本轮无 Codex reaction——不等于没问题，评论 @codex review 触发）"
+  exit 1
+  ;;
+esac

--- a/.claude/skills/review-round/scripts/selftest.sh
+++ b/.claude/skills/review-round/scripts/selftest.sh
@@ -75,11 +75,20 @@ rm -rf "$TMP"
 echo "== 4. GraphQL 失败必须终止，不能被当成「没有线程」 =="
 grep -q 'j.errors' "$HERE/lib.sh" && ok "lib.sh 检查响应体里的 errors" || no "lib.sh 未检查 errors"
 grep -q 'set -euo pipefail' "$HERE/lib.sh" && ok "lib.sh 启用 set -euo pipefail" || no "缺少 set -euo pipefail"
-(source "$HERE/lib.sh" && gql 'query{ bogusField }' >/dev/null 2>&1) &&
-  no "非法查询竟然成功了" || ok "非法 GraphQL 查询以非零退出"
+
+# 先用一个合法查询确认依赖 / 认证 / 网络都可用。否则 gh 缺失或未登录时，
+# lib.sh 会在执行非法查询之前就 die，而 `|| ok` 仍把它记成「非法查询以非零退出」——
+# 关键防护根本没被测到，selftest 却报全绿。
+if (source "$HERE/lib.sh" && gql 'query{ viewer{ login } }' >/dev/null 2>&1); then
+  ok "前置条件可用（gh 已登录、网络可达）"
+  (source "$HERE/lib.sh" && gql 'query{ bogusField }' >/dev/null 2>&1) &&
+    no "非法查询竟然成功了" || ok "非法 GraphQL 查询以非零退出"
+else
+  no "前置条件不可用（gh 缺失/未登录/网络不可达）——GraphQL 防护未被测试，不能算通过"
+fi
 
 echo "== 5. resolve 前必须比对评论数 =="
-grep -q 'NOW" -ne "\$SEEN' "$HERE/reply-resolve.sh" &&
+grep -q 'TOTAL" -ne "\$SEEN' "$HERE/reply-resolve.sh" &&
   ok "reply-resolve.sh 比对扫描后是否有新评论" || no "缺少评论数比对"
 grep -q '不执行 resolve' "$HERE/reply-resolve.sh" &&
   ok "回复失败时不 resolve" || no "缺少回复失败保护"
@@ -88,7 +97,50 @@ echo "== 6. 分支校验必须比 SHA 而非只比分支名 =="
 grep -q 'headRefOid' "$HERE/verify-branch.sh" && ok "verify-branch.sh 读取 headRefOid" || no "未校验 SHA"
 grep -q 'isCrossRepository' "$HERE/verify-branch.sh" && ok "检测 fork PR" || no "未检测 fork"
 
-echo "== 7. 翻页一致性（需传入一个真实 PR 编号）=="
+echo "== 7. has-changes 必须按基线判断，而非工作树是否非空 =="
+TMP2=$(mktemp -d)
+(
+  cd "$TMP2" && git init -q
+  git config user.email t@t && git config user.name t && git config commit.gpgsign false
+  git commit -q --allow-empty -m init || exit 9
+  echo pre >preexisting.txt # 技能启动前就存在的无关脏文件
+  "$HERE/has-changes.sh" --baseline /tmp/rr-selftest-base >/dev/null
+  # 本轮什么都没改
+  "$HERE/has-changes.sh" /tmp/rr-selftest-base >/dev/null 2>&1
+  [ $? -eq 1 ] || exit 1 # 应判 NO-CHANGES
+  echo new >thisround.txt # 本轮新增
+  "$HERE/has-changes.sh" /tmp/rr-selftest-base >/dev/null 2>&1
+  [ $? -eq 0 ] || exit 2 # 应判 HAS-CHANGES
+)
+case $? in
+0) ok "脏工作树下：无本轮改动判 NO-CHANGES，有则判 HAS-CHANGES" ;;
+1) no "既有脏文件被误判成本轮改动（会卡在无内容可提交的 commit）" ;;
+2) no "本轮新增未被识别" ;;
+*) no "基线测试环境异常" ;;
+esac
+rm -rf "$TMP2" /tmp/rr-selftest-base
+
+echo "== 8. verify-branch 必须允许提交后本地领先 =="
+grep -q 'allow-ahead' "$HERE/verify-branch.sh" &&
+  ok "verify-branch.sh 支持 --allow-ahead（否则有提交的轮次都会在 push 前中止）" ||
+  no "缺少 --allow-ahead"
+grep -q 'git fetch origin "\$HEAD_REF"' "$HERE/verify-branch.sh" &&
+  [ "$(grep -n 'git fetch origin' "$HERE/verify-branch.sh" | cut -d: -f1)" -lt \
+    "$(grep -n 'git switch "\$HEAD_REF"' "$HERE/verify-branch.sh" | cut -d: -f1)" ] &&
+  ok "fetch 在 switch 之前（新建的 PR 分支本地没有 origin/ref，否则 switch 必失败）" ||
+  no "fetch 仍在 switch 之后"
+
+echo "== 9. round-signal 不得把 API 错误降级为未触发 =="
+grep -q '这不是「未触发」' "$HERE/round-signal.sh" &&
+  ok "Actions API 请求失败时 die 而非报 NOT-TRIGGERED" || no "仍在吞掉 API 错误"
+grep -q '2>/dev/null || true' "$HERE/round-signal.sh" &&
+  no "仍有 2>/dev/null || true 吞错误" || ok "已移除吞错误的写法"
+
+echo "== 10. reply-resolve 部分失败后可安全重试 =="
+grep -q 'MINE" = "true"' "$HERE/reply-resolve.sh" &&
+  ok "识别已存在的自身回复，重跑只补 resolve 不重复发" || no "缺少幂等重试路径"
+
+echo "== 11. 翻页一致性（需传入一个真实 PR 编号）=="
 if [ -n "${1:-}" ]; then
   BIG=$("$HERE/list-unresolved.sh" "$1" --count 2>/dev/null)
   ONE=$(RR_PAGE_SIZE=1 "$HERE/list-unresolved.sh" "$1" --count 2>/dev/null)

--- a/.claude/skills/review-round/scripts/selftest.sh
+++ b/.claude/skills/review-round/scripts/selftest.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# 用法: selftest.sh
+#
+# 对各脚本的关键防护做判别力测试：每条都构造出「防护若不存在就会走错」的输入，
+# 断言脚本给出正确结果。只读，不改仓库、不动 GitHub 状态。
+
+set -uo pipefail
+HERE=$(cd "$(dirname "$0")" && pwd)
+PASS=0
+FAIL=0
+
+ok() {
+  echo "  ✓ $1"
+  PASS=$((PASS + 1))
+}
+no() {
+  echo "  ✗ $1"
+  FAIL=$((FAIL + 1))
+}
+
+echo "== 1. 徽章剥离：只删 shields.io，保留评审者的截图 =="
+BADGE_STRIP_JS='
+  (body) => body
+    .replace(/!\[[^\]]*\]\(https:\/\/img\.shields\.io\/[^)]*\)/g, "")
+    .replace(/<\/?sub>/g, "")
+' node -e '
+  const strip = eval(process.env.BADGE_STRIP_JS);
+  const body = "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> 标题**\n见截图：![failure](https://user-images.githubusercontent.com/x/shot.png)";
+  const out = strip(body);
+  const badgeGone = !out.includes("img.shields.io");
+  const shotKept = out.includes("user-images.githubusercontent.com");
+  process.exit(badgeGone && shotKept ? 0 : 1);
+' && ok "徽章被剥离且截图被保留" || no "徽章/截图处理不正确"
+
+# 对照组：旧的全局正则应当把截图也删掉（证明这条测试确实抓得住回归）
+node -e '
+  const body = "![b](https://img.shields.io/x) 见截图：![f](https://user-images.githubusercontent.com/x/shot.png)";
+  const old = body.replace(/!\[[^\]]*\]\([^)]*\)/g, "");
+  process.exit(old.includes("user-images") ? 1 : 0);
+' && ok "对照组：旧的全局正则确实会删掉截图（测试有判别力）" || no "对照组未复现旧行为"
+
+echo "== 2. 空推送时刻：jq 的 > \"\" 会选中所有历史 reaction =="
+node -e '
+  // 复现 jq 语义：任何非空字符串 > "" 为真
+  const reactions = [{created_at:"2020-01-01T00:00:00Z"},{created_at:"2026-07-27T00:00:00Z"}];
+  const withEmpty = reactions.filter(r => r.created_at > "");
+  process.exit(withEmpty.length === reactions.length ? 0 : 1);
+' && ok "已确认空阈值会全选——故 round-signal.sh 必须显式分支" || no "空阈值语义与预期不符"
+
+grep -q 'if \[ -z "$PUSHED" \]' "$HERE/round-signal.sh" &&
+  ok "round-signal.sh 对空 PUSHED 有显式分支" ||
+  no "round-signal.sh 缺少空 PUSHED 分支"
+
+echo "== 3. 改动判断必须覆盖未跟踪文件 =="
+TMP=$(mktemp -d)
+(
+  cd "$TMP" && git init -q
+  git config user.email t@t && git config user.name t
+  git config commit.gpgsign false # 全局启用了 SSH 签名，临时仓库里签不了
+  git commit -q --allow-empty -m init || exit 9
+  echo x >untracked.md
+  git diff --quiet && git diff --cached --quiet
+)
+RC=$?
+case $RC in
+0) ok "对照组：git diff 系列确实看不到未跟踪文件（旧写法会误判无改动）" ;;
+9) no "对照组仓库初始化失败（提交没成功，该结论不可信）" ;;
+*) no "对照组未复现旧行为（exit=$RC）" ;;
+esac
+[ -n "$(cd "$TMP" && git status --porcelain)" ] &&
+  ok "git status --porcelain 能看到未跟踪文件" ||
+  no "porcelain 未覆盖未跟踪文件"
+rm -rf "$TMP"
+
+echo "== 4. GraphQL 失败必须终止，不能被当成「没有线程」 =="
+grep -q 'j.errors' "$HERE/lib.sh" && ok "lib.sh 检查响应体里的 errors" || no "lib.sh 未检查 errors"
+grep -q 'set -euo pipefail' "$HERE/lib.sh" && ok "lib.sh 启用 set -euo pipefail" || no "缺少 set -euo pipefail"
+(source "$HERE/lib.sh" && gql 'query{ bogusField }' >/dev/null 2>&1) &&
+  no "非法查询竟然成功了" || ok "非法 GraphQL 查询以非零退出"
+
+echo "== 5. resolve 前必须比对评论数 =="
+grep -q 'NOW" -ne "\$SEEN' "$HERE/reply-resolve.sh" &&
+  ok "reply-resolve.sh 比对扫描后是否有新评论" || no "缺少评论数比对"
+grep -q '不执行 resolve' "$HERE/reply-resolve.sh" &&
+  ok "回复失败时不 resolve" || no "缺少回复失败保护"
+
+echo "== 6. 分支校验必须比 SHA 而非只比分支名 =="
+grep -q 'headRefOid' "$HERE/verify-branch.sh" && ok "verify-branch.sh 读取 headRefOid" || no "未校验 SHA"
+grep -q 'isCrossRepository' "$HERE/verify-branch.sh" && ok "检测 fork PR" || no "未检测 fork"
+
+echo "== 7. 翻页一致性（需传入一个真实 PR 编号）=="
+if [ -n "${1:-}" ]; then
+  BIG=$("$HERE/list-unresolved.sh" "$1" --count 2>/dev/null)
+  ONE=$(RR_PAGE_SIZE=1 "$HERE/list-unresolved.sh" "$1" --count 2>/dev/null)
+  if [ -n "$BIG" ] && [ "$BIG" = "$ONE" ]; then
+    ok "PR#$1 每页 1 条与默认页大小结果一致（=$BIG），游标循环有效"
+  else
+    no "翻页结果不一致：默认=$BIG 每页1条=$ONE"
+  fi
+  # 判别力说明：若游标逻辑坏掉（例如用 \x00 做分隔符导致第一页就 break），
+  # 每页 1 条只会数到第一个线程，与默认页大小必然不等，这条断言会失败。
+else
+  echo "  – 跳过（用法: selftest.sh <PR编号> 可启用）"
+fi
+
+echo
+echo "通过 $PASS 条，失败 $FAIL 条"
+[ "$FAIL" -eq 0 ]

--- a/.claude/skills/review-round/scripts/selftest.sh
+++ b/.claude/skills/review-round/scripts/selftest.sh
@@ -140,7 +140,52 @@ echo "== 10. reply-resolve 部分失败后可安全重试 =="
 grep -q 'MINE" = "true"' "$HERE/reply-resolve.sh" &&
   ok "识别已存在的自身回复，重跑只补 resolve 不重复发" || no "缺少幂等重试路径"
 
-echo "== 11. 翻页一致性（需传入一个真实 PR 编号）=="
+echo "== 11. 基线必须比内容：已脏文件被继续修改要能识别 =="
+TMP3=$(mktemp -d)
+(
+  cd "$TMP3" && git init -q
+  git config user.email t@t && git config user.name t && git config commit.gpgsign false
+  echo v1 >tracked.txt && git add tracked.txt
+  git commit -q -m init || exit 9
+  echo v2 >tracked.txt # 技能启动前，该文件已经是 " M"
+  "$HERE/has-changes.sh" --baseline /tmp/rr-st2 >/dev/null
+  "$HERE/has-changes.sh" /tmp/rr-st2 >/dev/null 2>&1
+  [ $? -eq 1 ] || exit 1 # 尚未动手，应判 NO-CHANGES
+  echo v3 >tracked.txt   # 本轮继续修改同一个已脏文件——porcelain 状态行不变
+  "$HERE/has-changes.sh" /tmp/rr-st2 >/dev/null 2>&1
+  [ $? -eq 0 ] || exit 2 # 必须判 HAS-CHANGES
+)
+case $? in
+0) ok "已脏文件的后续内容修改能被识别（只比状态行会漏，导致修复不被提交）" ;;
+1) no "基线阶段被误判成有改动" ;;
+2) no "已脏文件的后续修改被漏判——修复会只留在工作树" ;;
+*) no "内容快照测试环境异常" ;;
+esac
+rm -rf "$TMP3" /tmp/rr-st2
+
+echo "== 12. 幂等重试不得绕过新评论保护 =="
+grep -q 'TOTAL" -ne "\$((SEEN + 1))' "$HERE/reply-resolve.sh" &&
+  ok "幂等分支要求增量恰为脚本自己那一条回复" || no "幂等分支仍会绕过新评论检查"
+
+echo "== 13. reaction 按时间取最新，而非存在性 =="
+grep -q 'sort_by(.created_at) | last' "$HERE/round-signal.sh" &&
+  ok "取时间上最新的 reaction" || no "仍按内容存在性判定"
+node -e '
+  // 同一 HEAD：先 +1，之后原地触发重审产生更新的 eyes
+  const rs = [
+    {content:"+1",   created_at:"2026-07-27T10:00:00Z"},
+    {content:"eyes", created_at:"2026-07-27T11:00:00Z"},
+  ];
+  const latest = rs.sort((a,b)=>a.created_at.localeCompare(b.created_at)).at(-1);
+  process.exit(latest.content === "eyes" ? 0 : 1);
+' && ok "对照组：旧 +1 与新 eyes 并存时取到 eyes（存在性判定会错报 PASSED）" ||
+  no "最新信号选择逻辑不正确"
+
+echo "== 14. author 为 null 不得中断解析 =="
+grep -c 'author\.login' "$HERE/list-unresolved.sh" "$HERE/reply-resolve.sh" |
+  grep -qv ':0' && no "仍有裸 .author.login 解引用" || ok "全部改为可选访问 + ghost 占位"
+
+echo "== 15. 翻页一致性（需传入一个真实 PR 编号）=="
 if [ -n "${1:-}" ]; then
   BIG=$("$HERE/list-unresolved.sh" "$1" --count 2>/dev/null)
   ONE=$(RR_PAGE_SIZE=1 "$HERE/list-unresolved.sh" "$1" --count 2>/dev/null)

--- a/.claude/skills/review-round/scripts/verify-branch.sh
+++ b/.claude/skills/review-round/scripts/verify-branch.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
-# 用法: verify-branch.sh <PR编号> [--switch]
+# 用法: verify-branch.sh <PR编号> [--switch] [--allow-ahead]
+#
+#   --switch       允许自行切换到 PR 的 head 分支（编辑前用）
+#   --allow-ahead  允许本地领先远端（提交之后、推送之前用）
 #
 # 在动任何文件之前，确认本地就是这个 PR 的 head——分支名 *和* SHA 都要对。
-# --switch 允许脚本自行切换分支；不传则只校验、不一致就报错退出。
 
 source "$(dirname "$0")/lib.sh"
 
-PR=${1:?用法: verify-branch.sh <PR编号> [--switch]}
-MODE=${2:-}
+PR=${1:?用法: verify-branch.sh <PR编号> [--switch] [--allow-ahead]}
+shift || true
+
+DO_SWITCH=0
+ALLOW_AHEAD=0
+for arg in "$@"; do
+  case "$arg" in
+  --switch) DO_SWITCH=1 ;;
+  --allow-ahead) ALLOW_AHEAD=1 ;;
+  *) die "未知参数：$arg" ;;
+  esac
+done
 
 resolve_repo
 
@@ -19,9 +31,7 @@ read -r HEAD_REF HEAD_OID CROSS HEAD_OWNER <<<"$(printf '%s' "$META" | node -e '
   process.stdin.on("data", (d) => (s += d)).on("end", () => {
     const j = JSON.parse(s);
     process.stdout.write([
-      j.headRefName,
-      j.headRefOid,
-      String(j.isCrossRepository),
+      j.headRefName, j.headRefOid, String(j.isCrossRepository),
       j.headRepositoryOwner?.login ?? "?",
     ].join(" "));
   });
@@ -29,21 +39,24 @@ read -r HEAD_REF HEAD_OID CROSS HEAD_OWNER <<<"$(printf '%s' "$META" | node -e '
 
 echo "PR#$PR head=$HEAD_REF@${HEAD_OID:0:7} owner=$HEAD_OWNER cross_repo=$CROSS"
 
-# 第三轮第 4 条：PR 来自 fork 时 origin 指向基础仓库，headRefName 只有分支名，
-# 推送会打到基础仓库的同名分支或直接因权限失败，PR head 不会更新。
-# 本仓库不存在 fork PR，与其写一套没法验证的 fork 推送逻辑，不如显式拒绝。
-if [ "$CROSS" = "true" ]; then
-  die "该 PR 来自 fork（$HEAD_OWNER），本脚本不支持跨仓库推送。请手动配置 fork remote 后再操作。"
-fi
+# fork PR：origin 指向基础仓库，headRefName 只有分支名，推送会打到基础仓库的同名
+# 分支或因权限失败，PR head 不会更新。本仓库不存在 fork PR，显式拒绝而不是写一套
+# 无法在此验证的跨仓库推送逻辑。
+[ "$CROSS" = "true" ] &&
+  die "该 PR 来自 fork（$HEAD_OWNER），本脚本不支持跨仓库推送。请手动配置 fork remote。"
 
 case "$HEAD_REF" in
 main | master) die "该 PR 的 head 是 $HEAD_REF，拒绝在其上直接操作" ;;
 esac
 
-CUR=$(git rev-parse --abbrev-ref HEAD)
+# fetch 必须在切换之前：PR 分支若是上次 fetch 之后才创建的，本地既没有同名分支也没有
+# origin/$HEAD_REF，两个 git switch 都会以 "invalid reference: origin/xxx" 失败。
+# --track 只设置跟踪配置，不会自行下载缺失的引用。
+git fetch origin "$HEAD_REF" --quiet || die "fetch origin/$HEAD_REF 失败"
 
+CUR=$(git rev-parse --abbrev-ref HEAD)
 if [ "$CUR" != "$HEAD_REF" ]; then
-  if [ "$MODE" = "--switch" ]; then
+  if [ "$DO_SWITCH" -eq 1 ]; then
     echo "当前在 $CUR，切换到 $HEAD_REF"
     git switch "$HEAD_REF" >/dev/null 2>&1 ||
       git switch -c "$HEAD_REF" --track "origin/$HEAD_REF" >/dev/null 2>&1 ||
@@ -53,18 +66,29 @@ if [ "$CUR" != "$HEAD_REF" ]; then
   fi
 fi
 
-# 第三轮第 6 条：只比分支名不够——同名本地分支可能落后于远端（协作者或上一轮自动化
-# 已推新提交）。此时会基于旧代码处理反馈，甚至把针对当前远端提交的意见判成过时，
-# 直到最后 push 被非快进拒绝才暴露。
-git fetch origin "$HEAD_REF" --quiet || die "fetch origin/$HEAD_REF 失败"
 LOCAL_OID=$(git rev-parse HEAD)
 
-if [ "$LOCAL_OID" != "$HEAD_OID" ]; then
-  echo "本地 HEAD=${LOCAL_OID:0:7}  PR head=${HEAD_OID:0:7}" >&2
-  if git merge-base --is-ancestor "$LOCAL_OID" "$HEAD_OID" 2>/dev/null; then
-    die "本地落后于 PR head，先 git pull --ff-only 再重来（否则会基于旧代码处理反馈）"
-  fi
-  die "本地 HEAD 与 PR head 不一致且非快进关系，请人工确认后再继续"
+if [ "$LOCAL_OID" = "$HEAD_OID" ]; then
+  echo "OK: 分支 $HEAD_REF 与 SHA ${HEAD_OID:0:7} 均一致"
+  exit 0
 fi
 
-echo "OK: 分支 $HEAD_REF 与 SHA ${HEAD_OID:0:7} 均一致"
+echo "本地 HEAD=${LOCAL_OID:0:7}  PR head=${HEAD_OID:0:7}" >&2
+
+# 本地落后：会基于旧代码处理反馈，甚至把针对当前远端提交的意见误判成过时。
+if git merge-base --is-ancestor "$LOCAL_OID" "$HEAD_OID" 2>/dev/null; then
+  die "本地落后于 PR head，先 git pull --ff-only 再重来"
+fi
+
+# 本地领先：提交之后、推送之前的正常状态。严格相等会让每个有提交的轮次都在 push
+# 前中止，所以推送前的复验要用 --allow-ahead。
+if git merge-base --is-ancestor "$HEAD_OID" "$LOCAL_OID" 2>/dev/null; then
+  AHEAD=$(git rev-list --count "$HEAD_OID..$LOCAL_OID")
+  if [ "$ALLOW_AHEAD" -eq 1 ]; then
+    echo "OK: 本地领先远端 $AHEAD 个提交（待推送），分支 $HEAD_REF 正确"
+    exit 0
+  fi
+  die "本地领先远端 $AHEAD 个提交。编辑前应与远端一致；若这是提交后的推送前复验，请加 --allow-ahead。"
+fi
+
+die "本地 HEAD 与 PR head 已分叉（互非祖先），请人工确认后再继续"

--- a/.claude/skills/review-round/scripts/verify-branch.sh
+++ b/.claude/skills/review-round/scripts/verify-branch.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# 用法: verify-branch.sh <PR编号> [--switch]
+#
+# 在动任何文件之前，确认本地就是这个 PR 的 head——分支名 *和* SHA 都要对。
+# --switch 允许脚本自行切换分支；不传则只校验、不一致就报错退出。
+
+source "$(dirname "$0")/lib.sh"
+
+PR=${1:?用法: verify-branch.sh <PR编号> [--switch]}
+MODE=${2:-}
+
+resolve_repo
+
+META=$(gh pr view "$PR" --json headRefName,headRefOid,headRepositoryOwner,isCrossRepository) ||
+  die "读取 PR #$PR 元数据失败"
+
+read -r HEAD_REF HEAD_OID CROSS HEAD_OWNER <<<"$(printf '%s' "$META" | node -e '
+  let s = "";
+  process.stdin.on("data", (d) => (s += d)).on("end", () => {
+    const j = JSON.parse(s);
+    process.stdout.write([
+      j.headRefName,
+      j.headRefOid,
+      String(j.isCrossRepository),
+      j.headRepositoryOwner?.login ?? "?",
+    ].join(" "));
+  });
+')"
+
+echo "PR#$PR head=$HEAD_REF@${HEAD_OID:0:7} owner=$HEAD_OWNER cross_repo=$CROSS"
+
+# 第三轮第 4 条：PR 来自 fork 时 origin 指向基础仓库，headRefName 只有分支名，
+# 推送会打到基础仓库的同名分支或直接因权限失败，PR head 不会更新。
+# 本仓库不存在 fork PR，与其写一套没法验证的 fork 推送逻辑，不如显式拒绝。
+if [ "$CROSS" = "true" ]; then
+  die "该 PR 来自 fork（$HEAD_OWNER），本脚本不支持跨仓库推送。请手动配置 fork remote 后再操作。"
+fi
+
+case "$HEAD_REF" in
+main | master) die "该 PR 的 head 是 $HEAD_REF，拒绝在其上直接操作" ;;
+esac
+
+CUR=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$CUR" != "$HEAD_REF" ]; then
+  if [ "$MODE" = "--switch" ]; then
+    echo "当前在 $CUR，切换到 $HEAD_REF"
+    git switch "$HEAD_REF" >/dev/null 2>&1 ||
+      git switch -c "$HEAD_REF" --track "origin/$HEAD_REF" >/dev/null 2>&1 ||
+      die "切换到 $HEAD_REF 失败"
+  else
+    die "当前分支是 $CUR，不是 PR 的 head（$HEAD_REF）。加 --switch 允许自动切换。"
+  fi
+fi
+
+# 第三轮第 6 条：只比分支名不够——同名本地分支可能落后于远端（协作者或上一轮自动化
+# 已推新提交）。此时会基于旧代码处理反馈，甚至把针对当前远端提交的意见判成过时，
+# 直到最后 push 被非快进拒绝才暴露。
+git fetch origin "$HEAD_REF" --quiet || die "fetch origin/$HEAD_REF 失败"
+LOCAL_OID=$(git rev-parse HEAD)
+
+if [ "$LOCAL_OID" != "$HEAD_OID" ]; then
+  echo "本地 HEAD=${LOCAL_OID:0:7}  PR head=${HEAD_OID:0:7}" >&2
+  if git merge-base --is-ancestor "$LOCAL_OID" "$HEAD_OID" 2>/dev/null; then
+    die "本地落后于 PR head，先 git pull --ff-only 再重来（否则会基于旧代码处理反馈）"
+  fi
+  die "本地 HEAD 与 PR head 不一致且非快进关系，请人工确认后再继续"
+fi
+
+echo "OK: 分支 $HEAD_REF 与 SHA ${HEAD_OID:0:7} 均一致"


### PR DESCRIPTION
## 背景

来自 `/insights` 报告的建议：`code_review_response` 是最高频的意图类别（31 个会话），而「读评审 → 定位根因 → 修 → 验证 → 回复线程 → 推送」这个循环一直靠人工记忆执行。本 PR 把它固化为 `.claude/skills/review-round/SKILL.md`，与既有的 `fix-issue` / `add-feature` 同风格（中文、编号步骤、末尾硬性规则）。

纯文档改动，不涉及任何代码行为。

## 相对最初草案的四处修正

**1. 评审信号源（最关键）**

草案第 1 步用 `gh pr view --comments` 读反馈。这会漏判：Codex 通过时 reviews 接口是空的，只有一个 👍 reaction。在 #224 上实测：

| 接口 | 结果 |
|---|---|
| `pulls/224/reviews` | 空 |
| `issues/224/reactions` | `+1 by chatgpt-codex-connector[bot]` |

照草案执行会判成「还没反馈」然后无限空等。已改为查 reactions，并给出对照表：空 = **没触发**（不等于没问题，需 `@codex review`）、👀 = 评审中、👍 = 通过无意见。

**2. 新增「核对评审针对的是当前 HEAD」**

草案没有这一步。评审可能是上一次 push 的产物，`commit_id` 与 HEAD 不符时照着改是白改甚至改错。

**3. 验证环节扩充**

草案的 `npm run typecheck && npm test` 不足：`npm run audit` 是 CI `verify` job 的同一道依赖闸门，不被 `npm test` 覆盖，且会因新公告在无本地改动时变红。已改为完整六项序列并**逐项断言退出码**，同时明写禁止把检查命令管道给 `tail`/`head`——管道让退出码变成 `tail` 的，失败会被吞成绿。

**4. 协议版本号不重复列条目**

改为指向 AGENTS.md 的 `## Protocol Changes` 清单（#224 已合入，那里写明了 `PROTOCOL_VERSION` 与 `CURRENT_PROTOCOL_VERSION` 是两个需同步提升的常量），避免两处文档漂移。

另补了草案缺失的：修复后审计同类调用点、回归测试须在修复前代码上确实失败、push 后 Codex 不必然自动重审。

## 关于 gitignore

`.gitignore` 的 `/.claude/*` 覆盖整个目录，既有的 `fix-issue` / `add-feature` 两个技能同样是强制加入的，本 PR 沿用 `git add -f`，只暂存了这一个文件。

## 验证

完整预提交序列，逐项断言退出码（未用管道截断）：

| 命令 | 结果 |
|---|---|
| `npm run format:check` | exit 0 |
| `npm run lint` | exit 0 |
| `npm run typecheck` | exit 0 |
| `npm run build` | exit 0 |
| `npm test` | exit 0 |
| `npm run audit` | exit 0 |

另单独校验了 SKILL.md 的 frontmatter 在 prettier 处理后完好（`name` / `description` 均可解析）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)