### PR TITLE
docs: 收紧协议清单里 TypeScript 参数个数的断言

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,10 +65,13 @@ Checklist to run before opening any PR that touches the sync protocol:
    the extension sends) and `CURRENT_PROTOCOL_VERSION` in
    `server/src/messages.ts` (what the server implements and reports back).
 2. Grep for ALL call sites of any changed function signature, including
-   `server/src/app.ts` and the `index.ts` adapters. TypeScript accepts a
-   function that declares _fewer_ parameters than the target type expects, so an
-   adapter that quietly stops forwarding a trailing argument still typechecks —
-   the compiler will not flag it for you.
+   `server/src/app.ts` and the `index.ts` adapters. Know exactly where the
+   compiler stops helping: it _does_ flag a call that passes too few arguments
+   (`TS2554`), including inside an adapter that forwards. What it accepts
+   silently is a function that _declares_ fewer parameters than the type it is
+   assigned to — a callback written against the old signature keeps
+   typechecking, never receives the new trailing argument, and drops it without
+   a word. That is the case grep has to catch, because `tsc` never will.
 3. New enum values or new fields: the server accepts clients all the way down to
    `MIN_PROTOCOL_VERSION` (currently `1`), so confirm an older client's guards
    tolerate them, or gate the behaviour behind a version check.


### PR DESCRIPTION
## 背景

#224 合入的 `## Protocol Changes` 第 2 条写的是：

> TypeScript accepts a function that declares _fewer_ parameters than the target type expects, so an adapter that quietly stops forwarding a trailing argument still typechecks — the compiler will not flag it for you.

前半句成立，**后半句不成立**。「转发时少传参」恰恰是编译器抓得住的情形。

## 实测

`tsc 6.0.3`，`--strict`，三种写法：

| 情形 | 代码 | 结果 |
|---|---|---|
| 1 | 少声明参数的函数赋值给回调类型，**不往下转发** | **无报错** |
| 2 | 适配层仍调用下游，但少传一个参数 | `TS2554: Expected 3 arguments, but got 2` |
| 3 | 既赋值给回调类型，转发时又少传参 | `TS2554` |

```ts
// 情形 1 —— 唯一真正无声的
type Handler = (a: number, b: string, c: boolean) => void;
const adapter1: Handler = (a, b) => { console.log(a, b); };   // 无报错

// 情形 2 —— 编译器抓得住
export function adapter2(a: number, b: string, c: boolean): void {
  target(a, b);                                                // TS2554
}
```

## 为什么值得改

原措辞把「无声」的范围说宽了，两个方向都会误导：可能对 `tsc` 已经能报的情形做无谓的全量 grep，也可能反过来误判 grep 真正需要兜住的边界在哪。

改后点明编译器停止帮忙的**确切位置**：调用少传参会报 `TS2554`；真正无声的是按旧签名写的回调——它仍然通过类型检查，永远收不到新增的末位参数，且不发一言地丢掉。**那才是 grep 必须兜住的情形。**

检查项本身（grep 全部调用点，含 `server/src/app.ts` 与各 `index.ts` 适配层）不变，只是把理由说准。

## 溯源

这处偏差是在给 #225 做推送前敌意自审时被子代理发现的（[详见 #225 的自审记录](https://github.com/sky1wu/Bili-SyncPlay/pull/225#issuecomment-5092050576)），同一轮自审还在 #225 里抓到两个 P1。

## 验证

预提交序列六项全绿，逐项断言退出码，未用管道截断：

| 命令 | 结果 |
|---|---|
| `npm run format:check` | exit 0 |
| `npm run lint` | exit 0 |
| `npm run typecheck` | exit 0 |
| `npm run build` | exit 0 |
| `npm test` | exit 0 |
| `npm run audit` | exit 0 |

TS 行为的三个情形均在 `/tmp` 下用本仓库的 `tsc` 实跑确认，临时文件已删。

🤖 Generated with [Claude Code](https://claude.com/claude-code)