### PR TITLE
docs: 给 fix-issue / add-feature 的预提交序列补上 npm run audit

### DIFF
--- a/.claude/skills/add-feature/SKILL.md
+++ b/.claude/skills/add-feature/SKILL.md
@@ -100,10 +100,14 @@ git switch -c "feat/$BRANCH_SLUG"
 ## 5. 提交前的预提交检查（强制）
 
 ```bash
-npm run format:check && npm run lint && npm run typecheck && npm run build && npm test
+npm run format:check && npm run lint && npm run typecheck && npm run build && npm test && npm run audit
 ```
 
 任一项失败就先修复，**不要跳过**。
+
+`npm run audit` 不被 `npm test` 覆盖，是 CI `verify` job 的同一道依赖闸门，且会在
+本地毫无改动的情况下因新公告而变红——所以要在推送前跑，而不是等 CI 红了再补。不
+适用于本仓库的条目写进 `audit-allowlist.json`，附理由和**必填的过期日期**。
 
 ## 6. 提交、推送、开 PR
 
@@ -152,7 +156,7 @@ git switch main && git pull --ff-only
 ## 硬性规则
 
 - **严禁直接推 main/master**。
-- **严禁跳过** `format:check` / `lint` / `typecheck` / `build` / `test`。
+- **严禁跳过** `format:check` / `lint` / `typecheck` / `build` / `test` / `audit`。
 - **严禁** `--no-verify` / `--no-gpg-sign` 绕过钩子或签名。
 - **严禁** `git add -A` / `git add .`。
 - **不要越界**：不要搭建"未来可能用到"的抽象；三行相似代码胜过过早抽象。

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -47,10 +47,14 @@ git switch -c "fix/issue-$ISSUE_NUM"
 ## 4. 提交前的预提交检查（强制）
 
 ```bash
-npm run format:check && npm run lint && npm run typecheck && npm run build && npm test
+npm run format:check && npm run lint && npm run typecheck && npm run build && npm test && npm run audit
 ```
 
 任一项失败就先修复，**不要跳过**。CLAUDE.md 的 Git 工作流已明确要求这一步。
+
+`npm run audit` 不被 `npm test` 覆盖，是 CI `verify` job 的同一道依赖闸门，且会在
+本地毫无改动的情况下因新公告而变红——所以要在推送前跑，而不是等 CI 红了再补。不
+适用于本仓库的条目写进 `audit-allowlist.json`，附理由和**必填的过期日期**。
 
 ## 5. 提交、推送、开 PR
 
@@ -86,7 +90,7 @@ git switch main && git pull --ff-only
 ## 硬性规则
 
 - **严禁直接推 main/master**。
-- **严禁跳过** `format:check` / `lint` / `typecheck` / `test`。
+- **严禁跳过** `format:check` / `lint` / `typecheck` / `build` / `test` / `audit`。
 - **严禁** `--no-verify` 或 `--no-gpg-sign` 绕过钩子。
 - **严禁** `git add -A` / `git add .`。
 - 除非用户明确授权，否则 `gh pr merge` 前先向用户确认。


### PR DESCRIPTION
## 问题

`fix-issue` 和 `add-feature` 两个技能的「提交前预提交检查（强制）」都只有五项，漏了 `npm run audit`：

```bash
# 改前（两个技能一致）
npm run format:check && npm run lint && npm run typecheck && npm run build && npm test
```

而 AGENTS.md 的权威序列是六项。`npm run audit` **不被 `npm test` 覆盖**，是 CI `verify` job 的同一道依赖闸门，并且会在本地毫无改动的情况下因新公告而变红——漏跑的后果是推上去才被 CI 拦住，而不是本地拦住。

## 改动

四处，两个文件：

| 文件 | 位置 | 改动 |
|---|---|---|
| `fix-issue/SKILL.md` | 第 50 行 | 序列补 `&& npm run audit` |
| `fix-issue/SKILL.md` | 第 93 行 | 「严禁跳过」清单补 `build` / `audit`（此前连 `build` 也漏了） |
| `add-feature/SKILL.md` | 第 103 行 | 序列补 `&& npm run audit` |
| `add-feature/SKILL.md` | 第 159 行 | 「严禁跳过」清单补 `audit` |

各加一段说明：为什么这一项不能省，以及不适用于本仓库的条目走 `audit-allowlist.json` 并附**必填的过期日期**。

## 溯源

发现于处理 #225 评审意见时对同类路径的审计——Codex 在 #225 指出预提交循环的退出码问题后，顺手检查了另外两个技能是否有同类缺陷。

两个技能用的是 `&&` 串联，**没有** #225 里那个退出码反转的问题（`a && b` 在 a 失败时正确返回非零）；它们的问题纯粹是序列不完整。

## 验证

改后两个技能的序列与 AGENTS.md **逐字一致**（脚本比对，非目测）：

```
✓ fix-issue 与 AGENTS.md 逐字一致
✓ add-feature 与 AGENTS.md 逐字一致
```

完整预提交序列六项全绿，逐项断言退出码，未用管道截断：

| 命令 | 结果 |
|---|---|
| `npm run format:check` | exit 0 |
| `npm run lint` | exit 0 |
| `npm run typecheck` | exit 0 |
| `npm run build` | exit 0 |
| `npm test` | exit 0 |
| `npm run audit` | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)