### PR TITLE
perf(server): 房间索引对账改由独立定时器驱动并单独计量

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,14 +66,14 @@ Cross-area helpers: normalized video URL handling (`url.ts`, wrapping the protoc
 
 `app.ts` is runtime assembly only; `index.ts` (room node) and `global-admin-index.ts` (dedicated admin process) are the two entrypoints.
 
-| Layer               | Modules                                                                                            | Responsibility                                                      |
-| ------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Config              | `config/*`                                                                                         | Env / config-file parsing (the only place env vars are read)        |
-| Bootstrap           | `bootstrap/*`                                                                                      | Provider selection and dependency wiring                            |
-| Session handling    | `ws-session-handler.ts`, `message-handler.ts`, `rate-limit.ts`, `security.ts`, `origin.ts`         | Handshake checks, message validation, auth, rate limits             |
-| Room domain         | `room-service.ts`, `room-store.ts`, `playback-authority.ts`, `room-reaper.ts`                      | Room lifecycle, playback-state authority, expiry cleanup            |
-| Multi-node plumbing | `redis-*.ts`, `room-event-bus.ts`, `admin-command-bus.ts`, `runtime-store.ts`, `node-heartbeat.ts` | Redis-backed stores, cross-node fanout, command routing, heartbeats |
-| Admin               | `admin/*`, `admin-panel.ts`, `admin-session-store.ts`                                              | Admin panel UI, routes, sessions, events, audit logs                |
+| Layer               | Modules                                                                                                   | Responsibility                                                                 |
+| ------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Config              | `config/*`                                                                                                | Env / config-file parsing (the only place env vars are read)                   |
+| Bootstrap           | `bootstrap/*`                                                                                             | Provider selection and dependency wiring                                       |
+| Session handling    | `ws-session-handler.ts`, `message-handler.ts`, `rate-limit.ts`, `security.ts`, `origin.ts`                | Handshake checks, message validation, auth, rate limits                        |
+| Room domain         | `room-service.ts`, `room-store.ts`, `playback-authority.ts`, `room-reaper.ts`, `room-index-reconciler.ts` | Room lifecycle, playback-state authority, expiry cleanup, room index reconcile |
+| Multi-node plumbing | `redis-*.ts`, `room-event-bus.ts`, `admin-command-bus.ts`, `runtime-store.ts`, `node-heartbeat.ts`        | Redis-backed stores, cross-node fanout, command routing, heartbeats            |
+| Admin               | `admin/*`, `admin-panel.ts`, `admin-session-store.ts`                                                     | Admin panel UI, routes, sessions, events, audit logs                           |
 
 Every store and bus has a `memory` and a `redis` provider behind the same interface; the [multi-node guide](./operations/multi-node.md) describes which providers must be enabled for a multi-node topology.
 

--- a/docs/architecture.zh-CN.md
+++ b/docs/architecture.zh-CN.md
@@ -66,14 +66,14 @@ flowchart LR
 
 `app.ts` 只负责运行时装配；`index.ts`（Room Node）和 `global-admin-index.ts`（独立管理进程）是两个入口。
 
-| 层次       | 模块                                                                                               | 职责                                           |
-| ---------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| 配置       | `config/*`                                                                                         | 环境变量 / 配置文件解析（读取 env 的唯一位置） |
-| Bootstrap  | `bootstrap/*`                                                                                      | provider 选择与依赖装配                        |
-| 会话处理   | `ws-session-handler.ts`、`message-handler.ts`、`rate-limit.ts`、`security.ts`、`origin.ts`         | 握手检查、消息校验、鉴权、限流                 |
-| 房间领域   | `room-service.ts`、`room-store.ts`、`playback-authority.ts`、`room-reaper.ts`                      | 房间生命周期、播放状态权威、过期清理           |
-| 多节点管道 | `redis-*.ts`、`room-event-bus.ts`、`admin-command-bus.ts`、`runtime-store.ts`、`node-heartbeat.ts` | Redis 后端存储、跨节点广播、命令路由、心跳     |
-| 管理后台   | `admin/*`、`admin-panel.ts`、`admin-session-store.ts`                                              | 管理面板 UI、路由、会话、事件、审计日志        |
+| 层次       | 模块                                                                                                      | 职责                                               |
+| ---------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| 配置       | `config/*`                                                                                                | 环境变量 / 配置文件解析（读取 env 的唯一位置）     |
+| Bootstrap  | `bootstrap/*`                                                                                             | provider 选择与依赖装配                            |
+| 会话处理   | `ws-session-handler.ts`、`message-handler.ts`、`rate-limit.ts`、`security.ts`、`origin.ts`                | 握手检查、消息校验、鉴权、限流                     |
+| 房间领域   | `room-service.ts`、`room-store.ts`、`playback-authority.ts`、`room-reaper.ts`、`room-index-reconciler.ts` | 房间生命周期、播放状态权威、过期清理、房间索引对账 |
+| 多节点管道 | `redis-*.ts`、`room-event-bus.ts`、`admin-command-bus.ts`、`runtime-store.ts`、`node-heartbeat.ts`        | Redis 后端存储、跨节点广播、命令路由、心跳         |
+| 管理后台   | `admin/*`、`admin-panel.ts`、`admin-session-store.ts`                                                     | 管理面板 UI、路由、会话、事件、审计日志            |
 
 每个 store 和 bus 都在同一接口后提供 `memory` 和 `redis` 两种实现；多节点拓扑需要启用哪些 provider 见[多节点部署指南](./operations/multi-node.zh-CN.md)。
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,7 +16,9 @@ import {
 import { createAdminCommandConsumer } from "./admin-command-consumer.js";
 import { createMessageHandler } from "./message-handler.js";
 import { createNodeHeartbeat } from "./node-heartbeat.js";
+import { ROOM_INDEX_RECONCILE_INTERVAL_MS } from "./redis-room-store.js";
 import { createRoomEventConsumer } from "./room-event-consumer.js";
+import { createRoomIndexReconciler } from "./room-index-reconciler.js";
 import { type RoomStore } from "./room-store.js";
 import { createRoomReaper } from "./room-reaper.js";
 import { createRoomService } from "./room-service.js";
@@ -258,6 +260,16 @@ export async function createSyncServer(
     logEvent,
     now,
   });
+  // Only the Redis store keeps an index that can drift from the room bodies;
+  // the in-memory one has nothing to reconcile.
+  const reconcileRoomIndex = roomStore.reconcileRoomIndex;
+  const roomIndexReconciler = reconcileRoomIndex
+    ? createRoomIndexReconciler({
+        intervalMs: ROOM_INDEX_RECONCILE_INTERVAL_MS,
+        reconcileRoomIndex: () => reconcileRoomIndex(),
+        logEvent,
+      })
+    : null;
   const nodeHeartbeatRuntimeStore = {
     ...localRuntimeStore,
     heartbeatNode: (
@@ -369,6 +381,12 @@ export async function createSyncServer(
             name: "stop_room_reaper",
             run: () => {
               roomReaper.stop();
+            },
+          },
+          {
+            name: "stop_room_index_reconciler",
+            run: () => {
+              roomIndexReconciler?.stop();
             },
           },
           {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,9 +16,7 @@ import {
 import { createAdminCommandConsumer } from "./admin-command-consumer.js";
 import { createMessageHandler } from "./message-handler.js";
 import { createNodeHeartbeat } from "./node-heartbeat.js";
-import { ROOM_INDEX_RECONCILE_INTERVAL_MS } from "./redis-room-store.js";
 import { createRoomEventConsumer } from "./room-event-consumer.js";
-import { createRoomIndexReconciler } from "./room-index-reconciler.js";
 import { type RoomStore } from "./room-store.js";
 import { createRoomReaper } from "./room-reaper.js";
 import { createRoomService } from "./room-service.js";
@@ -98,6 +96,7 @@ export async function createSyncServer(
   const {
     serviceVersion,
     roomStore,
+    roomIndexReconciler,
     localRuntimeStore,
     sharedRuntimeStore,
     runtimeStore,
@@ -260,16 +259,6 @@ export async function createSyncServer(
     logEvent,
     now,
   });
-  // Only the Redis store keeps an index that can drift from the room bodies;
-  // the in-memory one has nothing to reconcile.
-  const reconcileRoomIndex = roomStore.reconcileRoomIndex;
-  const roomIndexReconciler = reconcileRoomIndex
-    ? createRoomIndexReconciler({
-        intervalMs: ROOM_INDEX_RECONCILE_INTERVAL_MS,
-        reconcileRoomIndex: () => reconcileRoomIndex(),
-        logEvent,
-      })
-    : null;
   const nodeHeartbeatRuntimeStore = {
     ...localRuntimeStore,
     heartbeatNode: (
@@ -379,15 +368,7 @@ export async function createSyncServer(
         [
           {
             name: "stop_room_reaper",
-            run: () => {
-              roomReaper.stop();
-            },
-          },
-          {
-            name: "stop_room_index_reconciler",
-            run: () => {
-              roomIndexReconciler?.stop();
-            },
+            run: () => roomReaper.stop(),
           },
           {
             name: "stop_node_heartbeat",
@@ -506,6 +487,7 @@ export async function createSyncServer(
           },
           ...createSharedServerShutdownSteps({
             roomStore,
+            roomIndexReconciler,
             eventStore,
             runtimeStore: maybeClosableRuntimeStore,
             runtimeStoreStepName: "close_shared_runtime_store",

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -33,6 +33,11 @@ import {
   type RoomEventBus,
   type RoomEventBusMessage,
 } from "../room-event-bus.js";
+import { ROOM_INDEX_RECONCILE_INTERVAL_MS } from "../redis-room-store.js";
+import {
+  createRoomIndexReconciler,
+  type RoomIndexReconciler,
+} from "../room-index-reconciler.js";
 import { createInMemoryRoomStore, type RoomStore } from "../room-store.js";
 import {
   instrumentRoomStore,
@@ -112,9 +117,15 @@ type BootstrapLoggingHooks = {
 
 export type ServerBootstrapContext = {
   serviceVersion: string;
-  // Maintainable rather than plain RoomStore so app.ts can see the optional
-  // reconcileRoomIndex hook without probing for it structurally.
+  // Maintainable rather than plain RoomStore so the reconcile hook is visible
+  // without probing for it structurally.
   roomStore: MaintainableRoomStore;
+  // Built here rather than in each entry point so every server that shares
+  // this Redis keeps the index converging. The standalone global admin reads
+  // rooms but writes none, so an entry point that forgot to start this would
+  // serve a listing and a count that silently drift from what the room nodes
+  // wrote — with nothing failing to say so. Null when the store keeps no index.
+  roomIndexReconciler: RoomIndexReconciler | null;
   localRuntimeStore: RuntimeStore;
   sharedRuntimeStore: RuntimeStore;
   runtimeStore: RuntimeStore;
@@ -278,7 +289,7 @@ export async function createServerBootstrapContext(
     roomStore: rawRoomStore,
     serviceVersion,
   });
-  const roomStore =
+  const roomStore: MaintainableRoomStore =
     persistenceConfig.provider === "redis" &&
     dependencies.roomStore === undefined
       ? instrumentRoomStore(rawRoomStore, metricsCollector)
@@ -390,9 +401,21 @@ export async function createServerBootstrapContext(
     });
   }
 
+  // Only the Redis store keeps an index that can drift from the room bodies;
+  // the in-memory one has nothing to reconcile.
+  const reconcileRoomIndex = roomStore.reconcileRoomIndex;
+  const roomIndexReconciler = reconcileRoomIndex
+    ? createRoomIndexReconciler({
+        intervalMs: ROOM_INDEX_RECONCILE_INTERVAL_MS,
+        reconcileRoomIndex: () => reconcileRoomIndex(),
+        logEvent,
+      })
+    : null;
+
   return {
     serviceVersion,
     roomStore,
+    roomIndexReconciler,
     localRuntimeStore,
     sharedRuntimeStore,
     runtimeStore,
@@ -405,7 +428,16 @@ export async function createServerBootstrapContext(
 }
 
 export function createSharedServerShutdownSteps(args: {
-  roomStore: RoomStore;
+  // Maintainable, not plain RoomStore: this function probes for close(), so
+  // the parameter should say the hook is expected rather than leave callers
+  // passing something the declared type claims cannot have one.
+  roomStore: MaintainableRoomStore;
+  // Required, not optional: an entry point that forgets it would silently stop
+  // reconciling the index, and nothing at runtime would say so. Making it
+  // mandatory turns that omission into a compile error — which is why the
+  // standalone global admin regressed here in the first place. Pass the
+  // context's value; null when the store keeps no index.
+  roomIndexReconciler: RoomIndexReconciler | null;
   eventStore: GlobalEventStore;
   runtimeStore?: RuntimeStore | null;
   runtimeStoreStepName?: string;
@@ -414,6 +446,12 @@ export function createSharedServerShutdownSteps(args: {
   closeAdminServices: () => Promise<void>;
 }): ShutdownStep[] {
   const steps: ShutdownStep[] = [
+    // Must precede close_room_store: stop() waits out the pass in flight, and
+    // a SCAN/GET/EVAL still in the air would otherwise race redis.quit().
+    {
+      name: "stop_room_index_reconciler",
+      run: () => args.roomIndexReconciler?.stop(),
+    },
     {
       name: "close_room_store",
       run: () =>

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -34,7 +34,10 @@ import {
   type RoomEventBusMessage,
 } from "../room-event-bus.js";
 import { createInMemoryRoomStore, type RoomStore } from "../room-store.js";
-import { instrumentRoomStore } from "../room-store-instrumentation.js";
+import {
+  instrumentRoomStore,
+  type MaintainableRoomStore,
+} from "../room-store-instrumentation.js";
 import {
   createInMemoryRuntimeStore,
   type RuntimeStore,
@@ -109,7 +112,9 @@ type BootstrapLoggingHooks = {
 
 export type ServerBootstrapContext = {
   serviceVersion: string;
-  roomStore: RoomStore;
+  // Maintainable rather than plain RoomStore so app.ts can see the optional
+  // reconcileRoomIndex hook without probing for it structurally.
+  roomStore: MaintainableRoomStore;
   localRuntimeStore: RuntimeStore;
   sharedRuntimeStore: RuntimeStore;
   runtimeStore: RuntimeStore;

--- a/server/src/global-admin-app.ts
+++ b/server/src/global-admin-app.ts
@@ -55,6 +55,7 @@ export async function createGlobalAdminServer(
   const {
     serviceVersion,
     roomStore,
+    roomIndexReconciler,
     runtimeStore,
     adminCommandBus,
     roomEventBus,
@@ -118,6 +119,7 @@ export async function createGlobalAdminServer(
           },
           ...createSharedServerShutdownSteps({
             roomStore,
+            roomIndexReconciler,
             eventStore,
             runtimeStore,
             adminCommandBus,

--- a/server/src/redis-room-store.ts
+++ b/server/src/redis-room-store.ts
@@ -235,11 +235,11 @@ return deletedCount
 // single long-running script.
 const REPAIR_CHUNK_SIZE = 500;
 
-// How long a completed reconcile is trusted. It repeats rather than running
-// once per process because a node still on an older build — mid rolling
-// upgrade, sharing this Redis — writes rooms this set never hears about, and
-// reaps rooms whose membership nobody removes.
-const RECONCILE_INTERVAL_MS = 900_000;
+// How often the index is reconciled against the room bodies. It repeats
+// rather than running once per process because a node still on an older build
+// — mid rolling upgrade, sharing this Redis — writes rooms this set never
+// hears about, and reaps rooms whose membership nobody removes.
+export const ROOM_INDEX_RECONCILE_INTERVAL_MS = 900_000;
 
 // SCAN MATCH takes a glob, so a namespace carrying glob metacharacters — a
 // plain string as far as the config layer is concerned, e.g. "tenant[1]" —
@@ -329,11 +329,17 @@ export async function createRedisRoomStore(
   redisUrl: string,
   options: {
     namespace?: string;
-    // Injectable only so the reconcile cooldown is testable without waiting it
-    // out; every other timestamp in this module stays on Date.now.
+    // Injectable only so a test can place rooms either side of the expiry
+    // cutoff without waiting; every other timestamp in this module stays on
+    // Date.now.
     now?: () => number;
   } = {},
-): Promise<RoomStore & { close: () => Promise<void> }> {
+): Promise<
+  RoomStore & {
+    close: () => Promise<void>;
+    reconcileRoomIndex: () => Promise<void>;
+  }
+> {
   const redis = new Redis(redisUrl, {
     lazyConnect: true,
     maxRetriesPerRequest: 1,
@@ -469,36 +475,27 @@ export async function createRedisRoomStore(
   }
 
   let reconcile: Promise<void> | null = null;
-  let lastReconciledAt = 0;
+  let bootstrapReconciled = false;
 
   async function runReconcile(): Promise<void> {
     await reconcileFromRoomBodies();
     await pruneOrphanedMembers();
-    lastReconciledAt = now();
   }
 
-  // Started here but deliberately not awaited: createSyncServer resolves
-  // before httpServer.listen, so awaiting a keyspace walk would delay
-  // readiness and can trip deployment health checks on a Redis shared with
-  // other services. Only reads depend on the result, so they await it instead.
-  function ensureReconciled(): Promise<void> {
+  // De-duplicates concurrent passes: the periodic timer and a read still
+  // waiting on the first pass must not walk the keyspace twice at once.
+  // Cleared once settled, and rethrown on failure so a read that depends on
+  // this fails loudly rather than reporting a count built on a set known to be
+  // incomplete. The identity checks keep a late settlement from discarding a
+  // newer attempt that already replaced this one.
+  function reconcileRoomIndex(): Promise<void> {
     if (reconcile) {
       return reconcile;
     }
-    if (
-      lastReconciledAt !== 0 &&
-      now() - lastReconciledAt < RECONCILE_INTERVAL_MS
-    ) {
-      return Promise.resolve();
-    }
 
-    // Cleared once settled so the cooldown governs the next run, and rethrown
-    // on failure so a read fails loudly rather than reporting a list or count
-    // built on a set known to be incomplete. The identity checks keep a late
-    // settlement from discarding a newer attempt that already replaced this
-    // one.
     const pending = runReconcile().then(
       () => {
+        bootstrapReconciled = true;
         if (reconcile === pending) {
           reconcile = null;
         }
@@ -514,7 +511,26 @@ export async function createRedisRoomStore(
     return pending;
   }
 
-  void ensureReconciled().catch(() => undefined);
+  // Reads wait for the *first* pass only. That one is the migration: until it
+  // lands, a database written before this set existed answers every count and
+  // listing with rooms missing, so a read that skipped it would be wrong.
+  // Every later pass exists to pick up rooms a node on an older build wrote
+  // mid rolling upgrade — nothing a caller is holding depends on it, so making
+  // callers wait only charged one unlucky read per interval for a keyspace
+  // walk. `createRoomIndexReconciler` drives those on its own timer instead,
+  // where the cost is attributable and nobody is blocked by it.
+  function ensureBootstrapReconciled(): Promise<void> {
+    if (bootstrapReconciled) {
+      return Promise.resolve();
+    }
+    return reconcileRoomIndex();
+  }
+
+  // Started here but deliberately not awaited: createSyncServer resolves
+  // before httpServer.listen, so awaiting a keyspace walk would delay
+  // readiness and can trip deployment health checks on a Redis shared with
+  // other services. Only reads depend on the result, so they await it instead.
+  void reconcileRoomIndex().catch(() => undefined);
 
   async function fetchRooms(
     query: Pick<
@@ -527,7 +543,7 @@ export async function createRedisRoomStore(
       | "sortOrder"
     >,
   ) {
-    await ensureReconciled();
+    await ensureBootstrapReconciled();
 
     // Members are the room codes; ordering here is irrelevant because rooms
     // are re-sorted below by query.sortBy once their bodies are loaded.
@@ -701,12 +717,12 @@ export async function createRedisRoomStore(
       );
     },
     async deleteExpiredRooms(currentTime) {
-      // The reaper is the only caller that runs on its own timer, so it is
-      // what guarantees the reconcile keeps happening. Leaving that to
-      // listings and metric scrapes would mean a deployment with neither
-      // never picks up rooms an older node wrote, and those rooms — absent
-      // from this set — would never be reaped.
-      await ensureReconciled();
+      // Candidates come from the index, so on a database that predates it the
+      // reaper would see nothing until the migration pass lands. It waits for
+      // that one pass only — keeping it waiting on every later pass put a
+      // keyspace walk inside one reaper tick per interval, which is what made
+      // this operation's histogram bimodal.
+      await ensureBootstrapReconciled();
       const deletedCount = await redis.eval(
         DELETE_EXPIRED_ROOMS_LUA,
         1,
@@ -734,7 +750,7 @@ export async function createRedisRoomStore(
     // and none of them loads a room body — which matters because the metrics
     // collector calls this on every scrape.
     async countRooms(query: Pick<RoomListQuery, "keyword" | "includeExpired">) {
-      await ensureReconciled();
+      await ensureBootstrapReconciled();
 
       if (!query.keyword) {
         return query.includeExpired
@@ -759,6 +775,11 @@ export async function createRedisRoomStore(
         return false;
       }
     },
+    // Outside the RoomStore contract: only this implementation keeps an index
+    // that can drift from the room bodies. `createRoomIndexReconciler` owns
+    // the schedule; exposing it here is what lets that timer's cost land on
+    // its own histogram label instead of on whichever read triggered it.
+    reconcileRoomIndex,
     async close() {
       await redis.quit();
     },

--- a/server/src/room-index-reconciler.ts
+++ b/server/src/room-index-reconciler.ts
@@ -2,7 +2,8 @@ import { clampTimerIntervalMs } from "./timers.js";
 import type { LogEvent } from "./types.js";
 
 export type RoomIndexReconciler = {
-  stop: () => void;
+  /** Resolves once the pass in flight, if any, has settled. */
+  stop: () => Promise<void>;
   runNow: () => Promise<boolean>;
 };
 
@@ -38,13 +39,22 @@ export function createRoomIndexReconciler(options: {
     }
   }
 
+  // A pass in flight when shutdown starts must be waited out, not just
+  // unscheduled: the steps that follow close the room store, and a SCAN/GET/
+  // EVAL still in the air would then race `redis.quit()` and issue commands on
+  // a closed connection. Same shape as `runtime-index-reaper`.
+  let pendingPass: Promise<boolean> | null = null;
+
   const intervalId = setInterval(() => {
-    void runNow();
+    pendingPass = runNow();
   }, clampTimerIntervalMs(options.intervalMs));
 
   return {
-    stop() {
+    async stop() {
       clearInterval(intervalId);
+      // runNow never rejects, so awaiting it cannot fail the shutdown step.
+      await pendingPass;
+      pendingPass = null;
     },
     runNow,
   };

--- a/server/src/room-index-reconciler.ts
+++ b/server/src/room-index-reconciler.ts
@@ -1,0 +1,51 @@
+import { clampTimerIntervalMs } from "./timers.js";
+import type { LogEvent } from "./types.js";
+
+export type RoomIndexReconciler = {
+  stop: () => void;
+  runNow: () => Promise<boolean>;
+};
+
+/**
+ * Drives the Redis room store's index reconcile on its own timer.
+ *
+ * The pass used to run lazily, charged to whichever read first arrived after
+ * a cooldown lapsed. That made a background maintenance walk look like tail
+ * latency on `delete_expired_rooms` or `count_rooms` — and left it invisible
+ * whenever the caller that paid for it was not instrumented. Here it has one
+ * schedule, one owner, and one histogram label.
+ */
+export function createRoomIndexReconciler(options: {
+  intervalMs: number;
+  reconcileRoomIndex: () => Promise<void>;
+  logEvent: LogEvent;
+}): RoomIndexReconciler {
+  /** Resolves false when the pass failed; the timer path ignores the result. */
+  async function runNow(): Promise<boolean> {
+    try {
+      await options.reconcileRoomIndex();
+      return true;
+    } catch (error) {
+      // Swallowed rather than rethrown: an unhandled rejection out of a timer
+      // takes the process down, and a failed pass is not fatal — reads still
+      // answer from the index as it stands, and the next tick retries.
+      options.logEvent("room_index_reconcile_failed", {
+        result: "error",
+        reason: "room_index_reconcile_failed",
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  }
+
+  const intervalId = setInterval(() => {
+    void runNow();
+  }, clampTimerIntervalMs(options.intervalMs));
+
+  return {
+    stop() {
+      clearInterval(intervalId);
+    },
+    runNow,
+  };
+}

--- a/server/src/room-reaper.ts
+++ b/server/src/room-reaper.ts
@@ -2,7 +2,8 @@ import { clampTimerIntervalMs } from "./timers.js";
 import type { LogEvent } from "./types.js";
 
 export type RoomReaper = {
-  stop: () => void;
+  /** Resolves once the sweep in flight, if any, has settled. */
+  stop: () => Promise<void>;
   runNow: () => Promise<number>;
 };
 
@@ -34,13 +35,21 @@ export function createRoomReaper(options: {
     }
   }
 
+  // Same reason as `room-index-reconciler`: shutdown closes the room store
+  // right after this timer is stopped, so a sweep still in flight would race
+  // `redis.quit()` and issue its EVAL on a closed connection.
+  let pendingSweep: Promise<number> | null = null;
+
   const intervalId = setInterval(() => {
-    void runNow();
+    pendingSweep = runNow();
   }, clampTimerIntervalMs(options.intervalMs));
 
   return {
-    stop() {
+    async stop() {
       clearInterval(intervalId);
+      // runNow never rejects, so awaiting it cannot fail the shutdown step.
+      await pendingSweep;
+      pendingSweep = null;
     },
     runNow,
   };

--- a/server/src/room-store-instrumentation.ts
+++ b/server/src/room-store-instrumentation.ts
@@ -12,17 +12,20 @@ type RoomStoreMetricsCollector = Pick<
  * the in-memory store is synchronous and would just add noise.
  */
 /**
- * Redis 版实现额外带一个 RoomStore 契约之外的 close() 钩子,关服时按结构探测
- * (见 server-bootstrap 的 hasClose)。把它写进类型里,包装前后都不必强转。
+ * Redis 版实现额外带两个 RoomStore 契约之外的钩子:关服用的 close() (按结构
+ * 探测,见 server-bootstrap 的 hasClose),以及索引对账 reconcileRoomIndex()
+ * (由 createRoomIndexReconciler 定时驱动)。把它们写进类型里,包装前后都不必
+ * 强转。
  */
-export type CloseableRoomStore = RoomStore & {
+export type MaintainableRoomStore = RoomStore & {
   close?: () => Promise<void>;
+  reconcileRoomIndex?: () => Promise<void>;
 };
 
 export function instrumentRoomStore(
-  roomStore: CloseableRoomStore,
+  roomStore: MaintainableRoomStore,
   metricsCollector: RoomStoreMetricsCollector,
-): CloseableRoomStore {
+): MaintainableRoomStore {
   function measure<Args extends unknown[], Result>(
     operation: string,
     run: (...args: Args) => Promise<Result>,
@@ -59,11 +62,19 @@ export function instrumentRoomStore(
     isReady: measure("is_ready", () => roomStore.isReady()),
   };
 
-  // close() must survive wrapping or server.close() would leak the Redis
-  // connection.
+  // Both hooks must survive wrapping: losing close() would leak the Redis
+  // connection, and losing reconcileRoomIndex() would silently stop the index
+  // from ever converging again — a rolling upgrade's rooms would go unreaped
+  // with nothing failing.
+  const hooks: Pick<MaintainableRoomStore, "close" | "reconcileRoomIndex"> = {};
   if (typeof roomStore.close === "function") {
-    const close = roomStore.close.bind(roomStore);
-    return Object.assign(instrumented, { close });
+    hooks.close = roomStore.close.bind(roomStore);
   }
-  return instrumented;
+  if (typeof roomStore.reconcileRoomIndex === "function") {
+    hooks.reconcileRoomIndex = measure(
+      "reconcile_room_index",
+      roomStore.reconcileRoomIndex.bind(roomStore),
+    );
+  }
+  return Object.assign(instrumented, hooks);
 }

--- a/server/test/graceful-shutdown.test.ts
+++ b/server/test/graceful-shutdown.test.ts
@@ -13,6 +13,14 @@ import {
 } from "../src/app.js";
 import { createGlobalAdminServer } from "../src/global-admin-app.js";
 import {
+  createSharedServerShutdownSteps,
+  runShutdownSteps,
+} from "../src/bootstrap/server-bootstrap.js";
+import { createInMemoryAdminCommandBus } from "../src/admin-command-bus.js";
+import { createInMemoryRoomEventBus } from "../src/room-event-bus.js";
+import { createInMemoryRoomStore } from "../src/room-store.js";
+import type { GlobalEventStore } from "../src/admin/global-event-store.js";
+import {
   installGracefulShutdown,
   type GracefulShutdownHandle,
   type ShutdownCloseTarget,
@@ -462,4 +470,51 @@ test("handlers are detached after shutdown and by the returned detach", async ()
   await flush();
   assert.equal(other.signalTarget.listenerCount("SIGTERM"), 0);
   assert.equal(other.signalTarget.listenerCount("SIGINT"), 0);
+});
+
+// Neither entry point's shutdown touches these beyond a structural close()
+// probe, so an inert implementation of the real contract is honest here — no
+// cast needed, and a field added to either type surfaces as a type error.
+const inertEventStore: GlobalEventStore = {
+  append: (input) => ({
+    id: "evt-test",
+    timestamp: input.timestamp ?? "1970-01-01T00:00:00.000Z",
+    event: input.event,
+    roomCode: null,
+    sessionId: null,
+    remoteAddress: null,
+    origin: null,
+    result: null,
+    details: { ...input.data },
+  }),
+  query: () => ({ items: [], total: 0 }),
+  totalCountsByEvent: () => ({}),
+  countsByEventInWindow: () => ({}),
+};
+
+test("the reconciler is stopped before the room store it talks to is closed", async () => {
+  const order: string[] = [];
+  const steps = createSharedServerShutdownSteps({
+    roomStore: {
+      ...createInMemoryRoomStore({ now: () => 0 }),
+      close: async () => {
+        order.push("close_room_store");
+      },
+    },
+    roomIndexReconciler: {
+      runNow: async () => true,
+      stop: async () => {
+        order.push("stop_room_index_reconciler");
+      },
+    },
+    eventStore: inertEventStore,
+    adminCommandBus: createInMemoryAdminCommandBus(() => 0),
+    roomEventBus: createInMemoryRoomEventBus(),
+    closeAdminServices: async () => undefined,
+  });
+
+  assert.deepEqual(await runShutdownSteps(steps, () => undefined), []);
+
+  // Reversing these two lets a SCAN/GET/EVAL in flight hit a closed connection.
+  assert.deepEqual(order, ["stop_room_index_reconciler", "close_room_store"]);
 });

--- a/server/test/redis-room-store.test.ts
+++ b/server/test/redis-room-store.test.ts
@@ -314,7 +314,7 @@ test("redis room listing prunes members whose room body is gone", async (t) => {
   }
 });
 
-test("redis room reconcile sweeps orphans again once the cooldown lapses", async (t) => {
+test("redis room reconcile sweeps orphans again when the reconciler drives it", async (t) => {
   if (!REDIS_URL) {
     t.skip("REDIS_URL is not configured.");
     return;
@@ -337,16 +337,52 @@ test("redis room reconcile sweeps orphans again once the cooldown lapses", async
     await redis.zadd(roomsKey, "+inf", "LATEGH");
     assert.equal(await store.countRooms({ includeExpired: true }), 1);
 
-    clock += 60_000;
+    // No amount of elapsed time makes a read reconcile any more: the pass used
+    // to be triggered by whichever read first arrived after a cooldown lapsed,
+    // which charged one unlucky caller per interval for a keyspace walk and
+    // hid the cost under that caller's metric label.
+    clock += 900_000 * 4;
     assert.equal(await store.countRooms({ includeExpired: true }), 1);
+    assert.equal(await redis.zcard(roomsKey), 1);
 
-    clock += 900_000;
+    // createRoomIndexReconciler calls exactly this on its own timer.
+    await store.reconcileRoomIndex();
     assert.equal(await store.countRooms({ includeExpired: true }), 0);
     assert.equal(await redis.zcard(roomsKey), 0);
   } finally {
     await redis.del(roomsKey);
     await redis.quit();
     await store.close();
+  }
+});
+
+test("redis room store still reconciles once before answering the first read", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = uniqueNamespace("bootstrapreconcile");
+  const roomsKey = `${namespace}:rooms-by-expiry`;
+  const redis = await connect();
+
+  let store: Store | null = null;
+  try {
+    // A room body written before this index existed: the migration pass is the
+    // only thing that can put it in the set, so a read that skipped waiting on
+    // it would answer with the room missing.
+    await redis.set(
+      `${namespace}:room:OLDBLD`,
+      legacyRoomBody("OLDBLD", { expiresAt: null, lastActiveAt: 5 }),
+    );
+
+    store = await createRedisRoomStore(REDIS_URL, { namespace });
+    assert.equal(await store.countRooms({ includeExpired: true }), 1);
+    assert.equal(await redis.zscore(roomsKey, "OLDBLD"), "inf");
+  } finally {
+    await redis.del(`${namespace}:room:OLDBLD`, roomsKey);
+    await redis.quit();
+    await store?.close();
   }
 });
 
@@ -661,7 +697,7 @@ test("redis room save rolls the room body back when indexing fails", async (t) =
   }
 });
 
-test("redis room reaper triggers the reconcile itself", async (t) => {
+test("redis room reaper waits for the migration pass before its first sweep", async (t) => {
   if (!REDIS_URL) {
     t.skip("REDIS_URL is not configured.");
     return;
@@ -688,6 +724,53 @@ test("redis room reaper triggers the reconcile itself", async (t) => {
     assert.equal(await redis.zscore(roomsKey, "NOREAD"), null);
   } finally {
     await redis.del(`${namespace}:room:NOREAD`, roomsKey);
+    await redis.quit();
+    await store?.close();
+  }
+});
+
+test("redis room reaper does not reconcile again after the migration pass", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = uniqueNamespace("reapnoreconcile");
+  const roomsKey = `${namespace}:rooms-by-expiry`;
+  const redis = await connect();
+  let clock = 1_000_000;
+
+  let store: Store | null = null;
+  try {
+    store = await createRedisRoomStore(REDIS_URL, {
+      namespace,
+      now: () => clock,
+    });
+    // Settle the migration pass first, so what follows can only be a later one.
+    assert.equal(await store.deleteExpiredRooms(100), 0);
+
+    // Written straight to Redis afterwards, exactly as a node on an older
+    // build would: expired, but with no membership for the reaper's range
+    // query to find. A reaper tick that still reconciled would pick it up —
+    // and pay for a keyspace walk to do so, which is the spike this change
+    // removes from delete_expired_rooms.
+    await redis.set(
+      `${namespace}:room:LATEBD`,
+      legacyRoomBody("LATEBD", { expiresAt: 70, lastActiveAt: 65 }),
+    );
+
+    // Well past the interval the pass used to be re-triggered on, so a tick
+    // that still reconciled would be free to do so here.
+    clock += 900_000 * 4;
+    assert.equal(await store.deleteExpiredRooms(100), 0);
+    assert.equal(await redis.exists(`${namespace}:room:LATEBD`), 1);
+
+    // The reconciler's timer is what collects it, one tick later.
+    await store.reconcileRoomIndex();
+    assert.equal(await store.deleteExpiredRooms(100), 1);
+    assert.equal(await redis.exists(`${namespace}:room:LATEBD`), 0);
+  } finally {
+    await redis.del(`${namespace}:room:LATEBD`, roomsKey);
     await redis.quit();
     await store?.close();
   }

--- a/server/test/room-index-reconciler.test.ts
+++ b/server/test/room-index-reconciler.test.ts
@@ -47,26 +47,72 @@ test("room index reconciler swallows a failed pass and logs it", async () => {
 
 test("room index reconciler fires on its interval and stops on stop()", async () => {
   let calls = 0;
+  // Waits for the second pass rather than asserting a count after a fixed
+  // window: Node does not replay setInterval ticks missed while the event loop
+  // was stalled, so a short wall-clock window makes a correct implementation
+  // fail under load. The test times out if the timer never fires.
+  let secondPass!: () => void;
+  const sawTwoPasses = new Promise<void>((resolve) => {
+    secondPass = resolve;
+  });
   const reconciler = createRoomIndexReconciler({
     intervalMs: 5,
     reconcileRoomIndex: async () => {
       calls += 1;
+      if (calls === 2) {
+        secondPass();
+      }
     },
     logEvent: () => undefined,
   });
 
-  await delay(40);
-  const whileRunning = calls;
-  reconciler.stop();
+  try {
+    // The timer is what replaces the old read-path trigger; if it never fired,
+    // the index would only ever be reconciled once per process.
+    await sawTwoPasses;
+  } finally {
+    await reconciler.stop();
+  }
+
+  // And it must stop, or shutdown leaves a handle keeping the process alive.
   const atStop = calls;
   await delay(40);
-
-  // The timer is what replaces the old read-path trigger; if it never fired,
-  // the index would only ever be reconciled once per process.
-  assert.ok(
-    whileRunning >= 2,
-    `expected repeated passes, saw ${String(whileRunning)}`,
-  );
-  // And it must stop, or shutdown leaves a handle keeping the process alive.
   assert.equal(calls, atStop);
+});
+
+test("room index reconciler stop() waits for the pass in flight", async () => {
+  let settled = false;
+  let announceStarted!: () => void;
+  let releasePass!: () => void;
+  const started = new Promise<void>((resolve) => {
+    announceStarted = resolve;
+  });
+  const blocked = new Promise<void>((resolve) => {
+    releasePass = resolve;
+  });
+
+  const reconciler = createRoomIndexReconciler({
+    intervalMs: 5,
+    reconcileRoomIndex: async () => {
+      announceStarted();
+      await blocked;
+      // Crossing a macrotask is what gives this test its teeth: awaiting a
+      // stop() that does not track the pass resumes on the microtask queue,
+      // which drains before this timer fires, so `settled` is still false.
+      // Without it both implementations happen to settle in the right order
+      // and the test passes either way.
+      await delay(0);
+      settled = true;
+    },
+    logEvent: () => undefined,
+  });
+
+  await started;
+  const stopped = reconciler.stop();
+  // Shutdown closes the room store right after this step; returning before the
+  // pass settles would leave a SCAN/GET/EVAL racing redis.quit().
+  assert.equal(settled, false);
+  releasePass();
+  await stopped;
+  assert.equal(settled, true);
 });

--- a/server/test/room-index-reconciler.test.ts
+++ b/server/test/room-index-reconciler.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { createRoomIndexReconciler } from "../src/room-index-reconciler.js";
+
+test("room index reconciler runs the pass through the injected hook", async () => {
+  let calls = 0;
+  const reconciler = createRoomIndexReconciler({
+    intervalMs: 60_000,
+    reconcileRoomIndex: async () => {
+      calls += 1;
+    },
+    logEvent: () => undefined,
+  });
+
+  try {
+    assert.equal(await reconciler.runNow(), true);
+    assert.equal(calls, 1);
+  } finally {
+    reconciler.stop();
+  }
+});
+
+test("room index reconciler swallows a failed pass and logs it", async () => {
+  const logged: Array<{ event: string; data: Record<string, unknown> }> = [];
+  const reconciler = createRoomIndexReconciler({
+    intervalMs: 60_000,
+    reconcileRoomIndex: () => Promise.reject(new Error("scan failed")),
+    logEvent: (event, data) => {
+      logged.push({ event, data });
+    },
+  });
+
+  try {
+    // Rethrowing here would surface out of the timer callback as an unhandled
+    // rejection and take the process down on a Redis hiccup.
+    assert.equal(await reconciler.runNow(), false);
+    assert.deepEqual(
+      logged.map((entry) => entry.event),
+      ["room_index_reconcile_failed"],
+    );
+    assert.equal(logged[0]?.data.error, "scan failed");
+  } finally {
+    reconciler.stop();
+  }
+});
+
+test("room index reconciler fires on its interval and stops on stop()", async () => {
+  let calls = 0;
+  const reconciler = createRoomIndexReconciler({
+    intervalMs: 5,
+    reconcileRoomIndex: async () => {
+      calls += 1;
+    },
+    logEvent: () => undefined,
+  });
+
+  await delay(40);
+  const whileRunning = calls;
+  reconciler.stop();
+  const atStop = calls;
+  await delay(40);
+
+  // The timer is what replaces the old read-path trigger; if it never fired,
+  // the index would only ever be reconciled once per process.
+  assert.ok(
+    whileRunning >= 2,
+    `expected repeated passes, saw ${String(whileRunning)}`,
+  );
+  // And it must stop, or shutdown leaves a handle keeping the process alive.
+  assert.equal(calls, atStop);
+});

--- a/server/test/room-reaper.test.ts
+++ b/server/test/room-reaper.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 import { createInMemoryRoomStore } from "../src/room-store.js";
 import { createRoomReaper } from "../src/room-reaper.js";
 
@@ -28,6 +29,42 @@ test("room reaper deletes expired rooms through the store interface", async () =
     assert.equal(deletedCount, 1);
     assert.equal(await store.getRoom("ROOM01"), null);
   } finally {
-    reaper.stop();
+    await reaper.stop();
   }
+});
+
+test("room reaper stop() waits for the sweep in flight", async () => {
+  let settled = false;
+  let announceStarted!: () => void;
+  let releaseSweep!: () => void;
+  const started = new Promise<void>((resolve) => {
+    announceStarted = resolve;
+  });
+  const blocked = new Promise<void>((resolve) => {
+    releaseSweep = resolve;
+  });
+
+  const reaper = createRoomReaper({
+    intervalMs: 5,
+    deleteExpiredRooms: async () => {
+      announceStarted();
+      await blocked;
+      // Crossing a macrotask is what gives this test its teeth — see the
+      // matching note in room-index-reconciler.test.ts.
+      await delay(0);
+      settled = true;
+      return 0;
+    },
+    logEvent: () => undefined,
+    now: () => 10,
+  });
+
+  await started;
+  const stopped = reaper.stop();
+  // close_room_store runs right after this shutdown step; returning before the
+  // sweep settles would leave its EVAL racing redis.quit().
+  assert.equal(settled, false);
+  releaseSweep();
+  await stopped;
+  assert.equal(settled, true);
 });

--- a/server/test/room-store-instrumentation.test.ts
+++ b/server/test/room-store-instrumentation.test.ts
@@ -105,3 +105,65 @@ test("instrumented room store adds no close hook when the underlying store has n
 
   assert.equal("close" in store, false);
 });
+
+test("instrumented room store measures the reconcile hook under its own label", async () => {
+  const recorder = createRecorder();
+  let reconciled = 0;
+  const store = instrumentRoomStore(
+    {
+      ...createInMemoryRoomStore({ now: () => 0 }),
+      async reconcileRoomIndex() {
+        reconciled += 1;
+      },
+    },
+    recorder.collector,
+  );
+
+  // Dropping this hook while wrapping would stop the index from ever
+  // converging again, with nothing failing to say so.
+  const reconcileRoomIndex = store.reconcileRoomIndex;
+  assert.ok(reconcileRoomIndex);
+  await reconcileRoomIndex();
+
+  assert.equal(reconciled, 1);
+  // Its own label is the point of the change: charged to the reconcile, not
+  // to whichever read used to trigger it.
+  assert.deepEqual(
+    recorder.durations.map((entry) => entry.operation),
+    ["reconcile_room_index"],
+  );
+  assert.deepEqual(recorder.failures, []);
+});
+
+test("instrumented room store reports a failed reconcile and rethrows", async () => {
+  const recorder = createRecorder();
+  const store = instrumentRoomStore(
+    {
+      ...createInMemoryRoomStore({ now: () => 0 }),
+      async reconcileRoomIndex() {
+        throw new Error("scan failed");
+      },
+    },
+    recorder.collector,
+  );
+
+  const reconcileRoomIndex = store.reconcileRoomIndex;
+  assert.ok(reconcileRoomIndex);
+  await assert.rejects(reconcileRoomIndex(), /scan failed/);
+
+  assert.deepEqual(recorder.failures, ["reconcile_room_index"]);
+  assert.deepEqual(
+    recorder.durations.map((entry) => entry.operation),
+    ["reconcile_room_index"],
+  );
+});
+
+test("instrumented room store adds no reconcile hook when the underlying store has none", () => {
+  const recorder = createRecorder();
+  const store = instrumentRoomStore(
+    createInMemoryRoomStore({ now: () => 0 }),
+    recorder.collector,
+  );
+
+  assert.equal("reconcileRoomIndex" in store, false);
+});


### PR DESCRIPTION
## 问题

线上 Grafana 的 `Redis room store P95（按操作）` 面板上，`delete_expired_rooms` 出现稳定的周期性尖峰（~97ms 与 ~242ms 两档）。抓线上 `/metrics` 原始直方图定位到根因。

进程已跑 23h31m，`delete_expired_rooms` 共 1410 次（正好 = 84660s / 60s 的 reaper 间隔），桶分布：

| 区间 | 次数 |
|---|---|
| ≤ 1ms | 1292 |
| 1–5ms | 99 |
| **5–50ms** | **0** |
| 50–100ms | 12 |
| 100–250ms | 7 |
| > 250ms | 0 |

5ms 到 50ms 之间零样本——双峰，不是长尾抖动，慢的 19 次走的是另一条路径。

那条路径是 `ensureReconciled()`：对账 15 分钟一轮，冷却一到**谁先调谁付钱**。`countRooms`（每次抓取都调）和 reaper 抢同一个触发点，reaper 抢到约 20%（23.5h 里 94 轮对账 × 20% ≈ 19，与观测吻合）。排除了"删房间本身慢"——1410 次里 456 次真的删掉了房间，但只有 19 次慢。

顺带说明：图上那两档高度是 `histogram_quantile` 的插值假象（97.5 = 0.05 + 0.05×0.95，242.5 = 0.1 + 0.15×0.95，基线 950µs = 0.001×0.95），因为窗口内只有 1 个样本。真实耗时只能读出落在哪个桶。

## 改动

- **读路径只等首轮。** 首轮是迁移，不等它则老库上的计数与枚举会漏房间；之后每轮只为接住滚动升级期间老节点写的房间，没有调用方依赖它。
- **`createRoomIndexReconciler`（新）** 按 15 分钟自行驱动后续各轮。失败记 `room_index_reconcile_failed` 而不外抛——定时器回调里的 unhandled rejection 会带崩进程，而一轮失败不致命，下一跳重试。
- **对账走 `reconcile_room_index` 独立 label**，不再冒充触发它的那个操作的尾延迟。

行为权衡：首轮之后，老节点写入但未入索引的房间会缺席列表/计数/过期清理，直到 timer 跑到。延迟上界没变（改动前也是 15 分钟冷却），变的只是谁承担对账开销。

指标收集器仍持有未插桩的 store——那是 `server-bootstrap.ts:269-270` 注释写明的刻意设计（不让抓取污染操作直方图）；对账不再由抓取触发后，`countRooms` 本身也不再慢。

## 验证

预提交序列全绿：`format:check` / `lint` / `typecheck` / `build` / `test` / `audit`，逐项断言退出码，未走管道截断。测试 1147 项全过、**0 skip**（本地 Redis 在跑，集成测试真执行）。

判别力已验证（`cp` 备份还原，未用 `git checkout`）：

| 回退的东西 | 变红的测试 |
|---|---|
| 恢复"读路径按冷却触发对账" | `reconcile sweeps orphans again when the reconciler drives it`、`reaper does not reconcile again after the migration pass` |
| 删掉 instrumentation 的钩子透传 | `measures the reconcile hook under its own label`、`reports a failed reconcile and rethrows` |

其中第二条测试最初没有判别力（没跨过 15 分钟窗口，对 pre-fix 代码是绿的），加了时钟推进才抓得住。

## 部署说明

线上当前跑的是 1.3.1 标签之后、1.3.2 之前的 main 构建（`build_info` 自报 1.3.1，但已含引入该对账的 #209）。本修复需重新部署才生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)