### PR TITLE
fix: sync:request 只在后台无缓存房间态时才转发 (#229)

### DIFF
--- a/extension/src/background/message-controller.ts
+++ b/extension/src/background/message-controller.ts
@@ -108,16 +108,26 @@ export function createMessageController(args: {
   persistProfileState: () => Promise<void>;
   notifyPageShareButtonSettings: () => Promise<void>;
   notifyAll: () => void;
-  /** Local clock for the authoritative-refresh window. Injected by tests. */
-  now?: () => number;
+  /**
+   * Monotonic time source for the authoritative-refresh window. Must not be the
+   * wall clock — see `lastRoomStateRefreshAt`.
+   */
+  getMonotonicNow?: () => number;
 }): MessageController {
-  const nowOf = () => args.now?.() ?? Date.now();
+  const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
   /**
    * When this session last asked the server for authoritative room state, or
-   * `null` if it never has. Only ever compared against another local reading,
-   * so it is an elapsed duration and never crosses machines. A wall clock is
-   * enough here — a clock step costs at most one extra or one late refresh,
-   * unlike playback anchoring which must stay monotonic.
+   * `null` if it never has. Read from a monotonic clock, never the wall clock:
+   * `Date.now()` moves when the clock is stepped, and a *backward* step makes
+   * `now - lastRoomStateRefreshAt` negative — which compares as "well inside
+   * the window" and would freeze the refresh for the entire duration of the
+   * step, exactly when a missed push most needs recovering from. Only ever
+   * compared against another reading of the same clock, so it stays an elapsed
+   * duration and never crosses machines.
+   *
+   * Resetting to `null` on an MV3 worker restart is correct and matches
+   * `performance.now()`'s own epoch resetting with the worker: the next call
+   * re-establishes authority instead of trusting a reading from a dead epoch.
    */
   let lastRoomStateRefreshAt: number | null = null;
 
@@ -669,7 +679,7 @@ export function createMessageController(args: {
         // funnels through — so a stuck hydration loop costs 6 requests/min
         // total no matter how many tabs are spinning, against a limiter that
         // allows 36/min. The pre-fix loop sent ~171/min from a single tab.
-        const now = nowOf();
+        const now = monotonicNow();
         const cachedRoomStateIsAuthoritative =
           args.roomSessionState.roomState !== null &&
           !args.roomSessionState.awaitingFreshRoomState &&

--- a/extension/src/background/message-controller.ts
+++ b/extension/src/background/message-controller.ts
@@ -14,15 +14,6 @@ import type {
   SharedVideo,
 } from "@bili-syncplay/protocol";
 
-/**
- * How long a cached `roomState` is trusted before one `sync:request` is let
- * through to re-establish authority. Bounds how long a client can hold a
- * snapshot the server silently failed to push (see the call site for why that
- * is unobservable locally), while capping a stuck hydration loop at 6
- * requests/min per browser session — the limiter allows 36/min.
- */
-const AUTHORITATIVE_REFRESH_INTERVAL_MS = 10_000;
-
 type RuntimeMessage = PopupToBackgroundMessage | ContentToBackgroundMessage;
 type QueueSharedVideoResult = { ok: true } | { ok: false; error: string };
 
@@ -108,29 +99,7 @@ export function createMessageController(args: {
   persistProfileState: () => Promise<void>;
   notifyPageShareButtonSettings: () => Promise<void>;
   notifyAll: () => void;
-  /**
-   * Monotonic time source for the authoritative-refresh window. Must not be the
-   * wall clock — see `lastRoomStateRefreshAt`.
-   */
-  getMonotonicNow?: () => number;
 }): MessageController {
-  const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
-  /**
-   * When this session last asked the server for authoritative room state, or
-   * `null` if it never has. Read from a monotonic clock, never the wall clock:
-   * `Date.now()` moves when the clock is stepped, and a *backward* step makes
-   * `now - lastRoomStateRefreshAt` negative — which compares as "well inside
-   * the window" and would freeze the refresh for the entire duration of the
-   * step, exactly when a missed push most needs recovering from. Only ever
-   * compared against another reading of the same clock, so it stays an elapsed
-   * duration and never crosses machines.
-   *
-   * Resetting to `null` on an MV3 worker restart is correct and matches
-   * `performance.now()`'s own epoch resetting with the worker: the next call
-   * re-establishes authority instead of trusting a reading from a dead epoch.
-   */
-  let lastRoomStateRefreshAt: number | null = null;
-
   async function updatePageShareButtonEnabled(enabled: boolean): Promise<void> {
     args.settingsState.pageShareButtonEnabled = enabled;
     await args.persistProfileState();
@@ -644,54 +613,33 @@ export function createMessageController(args: {
         }
         sendResponse({ ok: true });
         return;
-      case "content:get-room-state": {
+      case "content:get-room-state":
         if (args.roomSessionState.roomCode && !args.connectionState.connected) {
           void args.socketController.connect();
         }
-        // Only ask the server when this message cannot be answered locally.
-        // `content:get-room-state` conflates "hand me the state you have" with
-        // "go refresh it", and content-side hydration retries call it in a loop
-        // for the former reason — a tab sitting on the shared video whose
-        // player has not produced a `<video>` element yet re-hydrates every
-        // 350ms (`room-state-apply-controller`), and each pass used to forward a
-        // `sync:request` even though the cached state was returned in the very
-        // same response. That loop alone saturated the per-session limiter
-        // (6 per 10s), which is how 72% of all `sync:request` got rejected
-        // upstream (#229).
+        // Deliberately unconditional. Every earlier attempt at #229 tried to
+        // decide locally whether the cached `roomState` was still authoritative,
+        // and each attempt stranded a client on a stale snapshot in some path:
+        // the server can silently fail to push (`sendRoomStateToSession` on
+        // bootstrap, and the `room_event_consume_failed` catch in
+        // `room-event-consumer.ts`, both swallow the error without retrying,
+        // closing the socket, or telling the client), and a dropped refresh is
+        // indistinguishable from a satisfied one because nothing acknowledges
+        // it. There is no local predicate for "I have not missed a push", so
+        // suppressing here can only trade one bug for another.
         //
-        // Cache authority DECAYS — it is not a property the cache either has or
-        // lacks. Two of its three terms are locally observable: an absent
-        // `roomState` means there is nothing to answer with, and
-        // `awaitingFreshRoomState` means the reconnect handshake has not yet
-        // delivered an authoritative snapshot. The third is not observable at
-        // all: the server can silently fail to push. Both
-        // `sendRoomStateToSession` (bootstrap) and the `room_event_consume_failed`
-        // catch in `room-event-consumer.ts` swallow the error without retrying,
-        // closing the socket, or telling the client — and the member-delta
-        // branch also drops the push when `getRoomStateByCode` returns null.
-        // A client left holding a pre-pause or pre-switch snapshot has no local
-        // signal that anything went wrong.
-        //
-        // So the cache is trusted only inside a bounded staleness window; past
-        // it exactly one request goes through and re-arms the window. That
-        // ceiling is what keeps #229 fixed: this timestamp lives in the
-        // background, which is per browser session — the same object every tab
-        // funnels through — so a stuck hydration loop costs 6 requests/min
-        // total no matter how many tabs are spinning, against a limiter that
-        // allows 36/min. The pre-fix loop sent ~171/min from a single tab.
-        const now = monotonicNow();
-        const cachedRoomStateIsAuthoritative =
-          args.roomSessionState.roomState !== null &&
-          !args.roomSessionState.awaitingFreshRoomState &&
-          lastRoomStateRefreshAt !== null &&
-          now - lastRoomStateRefreshAt < AUTHORITATIVE_REFRESH_INTERVAL_MS;
+        // The flood #229 reported was never caused by forwarding — it was
+        // caused by the CALLER spinning: a tab whose player had not produced a
+        // `<video>` element re-hydrated every 350ms for the life of the tab.
+        // That is fixed where it lives: the element is now awaited by event
+        // (`onVideoElementBound`) instead of polled, and the remaining waits
+        // back off (`room-state-apply-controller`). Both bound this send
+        // without giving up any recovery path.
         if (
           args.connectionState.connected &&
           args.roomSessionState.roomCode &&
-          args.roomSessionState.memberToken &&
-          !cachedRoomStateIsAuthoritative
+          args.roomSessionState.memberToken
         ) {
-          lastRoomStateRefreshAt = now;
           args.sendToServer({
             type: "sync:request",
             payload: { memberToken: args.roomSessionState.memberToken },
@@ -714,7 +662,6 @@ export function createMessageController(args: {
               },
         );
         return;
-      }
       case "content:debug-log":
         args.diagnosticsController.log(
           "content",

--- a/extension/src/background/message-controller.ts
+++ b/extension/src/background/message-controller.ts
@@ -14,6 +14,15 @@ import type {
   SharedVideo,
 } from "@bili-syncplay/protocol";
 
+/**
+ * How long a cached `roomState` is trusted before one `sync:request` is let
+ * through to re-establish authority. Bounds how long a client can hold a
+ * snapshot the server silently failed to push (see the call site for why that
+ * is unobservable locally), while capping a stuck hydration loop at 6
+ * requests/min per browser session — the limiter allows 36/min.
+ */
+const AUTHORITATIVE_REFRESH_INTERVAL_MS = 10_000;
+
 type RuntimeMessage = PopupToBackgroundMessage | ContentToBackgroundMessage;
 type QueueSharedVideoResult = { ok: true } | { ok: false; error: string };
 
@@ -99,7 +108,19 @@ export function createMessageController(args: {
   persistProfileState: () => Promise<void>;
   notifyPageShareButtonSettings: () => Promise<void>;
   notifyAll: () => void;
+  /** Local clock for the authoritative-refresh window. Injected by tests. */
+  now?: () => number;
 }): MessageController {
+  const nowOf = () => args.now?.() ?? Date.now();
+  /**
+   * When this session last asked the server for authoritative room state, or
+   * `null` if it never has. Only ever compared against another local reading,
+   * so it is an elapsed duration and never crosses machines. A wall clock is
+   * enough here — a clock step costs at most one extra or one late refresh,
+   * unlike playback anchoring which must stay monotonic.
+   */
+  let lastRoomStateRefreshAt: number | null = null;
+
   async function updatePageShareButtonEnabled(enabled: boolean): Promise<void> {
     args.settingsState.pageShareButtonEnabled = enabled;
     await args.persistProfileState();
@@ -613,7 +634,7 @@ export function createMessageController(args: {
         }
         sendResponse({ ok: true });
         return;
-      case "content:get-room-state":
+      case "content:get-room-state": {
         if (args.roomSessionState.roomCode && !args.connectionState.connected) {
           void args.socketController.connect();
         }
@@ -628,25 +649,39 @@ export function createMessageController(args: {
         // (6 per 10s), which is how 72% of all `sync:request` got rejected
         // upstream (#229).
         //
-        // An *authoritative* cached `roomState` needs no poll to stay current:
-        // the server pushes `room:state` on every change. A reconnect re-sends
-        // `room:join` (`socket-controller`'s open handler) whose handshake
-        // delivers a fresh snapshot, and `awaitingFreshRoomState` marks that
-        // window — during it the cache is explicitly NOT authoritative, so the
-        // request must still go through. That is not merely belt-and-braces:
-        // the server drops a failed bootstrap snapshot silently
-        // (`sendRoomStateToSession` logs `room_state_bootstrap_failed` and does
-        // not retry) while the client deliberately keeps the flag set
-        // (`expireBootstrapRoomStateWait`), so a `sync:request` from a
-        // hydration retry is the ONLY way out of that state. The retries are
-        // bounded by the hydration backoff, so this cannot re-open the flood.
+        // Cache authority DECAYS — it is not a property the cache either has or
+        // lacks. Two of its three terms are locally observable: an absent
+        // `roomState` means there is nothing to answer with, and
+        // `awaitingFreshRoomState` means the reconnect handshake has not yet
+        // delivered an authoritative snapshot. The third is not observable at
+        // all: the server can silently fail to push. Both
+        // `sendRoomStateToSession` (bootstrap) and the `room_event_consume_failed`
+        // catch in `room-event-consumer.ts` swallow the error without retrying,
+        // closing the socket, or telling the client — and the member-delta
+        // branch also drops the push when `getRoomStateByCode` returns null.
+        // A client left holding a pre-pause or pre-switch snapshot has no local
+        // signal that anything went wrong.
+        //
+        // So the cache is trusted only inside a bounded staleness window; past
+        // it exactly one request goes through and re-arms the window. That
+        // ceiling is what keeps #229 fixed: this timestamp lives in the
+        // background, which is per browser session — the same object every tab
+        // funnels through — so a stuck hydration loop costs 6 requests/min
+        // total no matter how many tabs are spinning, against a limiter that
+        // allows 36/min. The pre-fix loop sent ~171/min from a single tab.
+        const now = nowOf();
+        const cachedRoomStateIsAuthoritative =
+          args.roomSessionState.roomState !== null &&
+          !args.roomSessionState.awaitingFreshRoomState &&
+          lastRoomStateRefreshAt !== null &&
+          now - lastRoomStateRefreshAt < AUTHORITATIVE_REFRESH_INTERVAL_MS;
         if (
           args.connectionState.connected &&
           args.roomSessionState.roomCode &&
           args.roomSessionState.memberToken &&
-          (!args.roomSessionState.roomState ||
-            args.roomSessionState.awaitingFreshRoomState)
+          !cachedRoomStateIsAuthoritative
         ) {
+          lastRoomStateRefreshAt = now;
           args.sendToServer({
             type: "sync:request",
             payload: { memberToken: args.roomSessionState.memberToken },
@@ -669,6 +704,7 @@ export function createMessageController(args: {
               },
         );
         return;
+      }
       case "content:debug-log":
         args.diagnosticsController.log(
           "content",

--- a/extension/src/background/message-controller.ts
+++ b/extension/src/background/message-controller.ts
@@ -617,10 +617,27 @@ export function createMessageController(args: {
         if (args.roomSessionState.roomCode && !args.connectionState.connected) {
           void args.socketController.connect();
         }
+        // Only ask the server when this message cannot be answered locally.
+        // `content:get-room-state` conflates "hand me the state you have" with
+        // "go refresh it", and content-side hydration retries call it in a loop
+        // for the former reason — a tab sitting on the shared video whose
+        // player has not produced a `<video>` element yet re-hydrates every
+        // 350ms (`room-state-apply-controller`), and each pass used to forward a
+        // `sync:request` even though the cached state was returned in the very
+        // same response. That loop alone saturated the per-session limiter
+        // (6 per 10s), which is how 72% of all `sync:request` got rejected
+        // upstream (#229).
+        //
+        // A cached `roomState` needs no poll to stay current: the server pushes
+        // `room:state` on every change, and a reconnect re-sends `room:join`
+        // (`socket-controller`'s open handler) whose handshake delivers a fresh
+        // snapshot — the window in between is exactly what
+        // `awaitingFreshRoomState` marks.
         if (
           args.connectionState.connected &&
           args.roomSessionState.roomCode &&
-          args.roomSessionState.memberToken
+          args.roomSessionState.memberToken &&
+          !args.roomSessionState.roomState
         ) {
           args.sendToServer({
             type: "sync:request",

--- a/extension/src/background/message-controller.ts
+++ b/extension/src/background/message-controller.ts
@@ -628,16 +628,24 @@ export function createMessageController(args: {
         // (6 per 10s), which is how 72% of all `sync:request` got rejected
         // upstream (#229).
         //
-        // A cached `roomState` needs no poll to stay current: the server pushes
-        // `room:state` on every change, and a reconnect re-sends `room:join`
-        // (`socket-controller`'s open handler) whose handshake delivers a fresh
-        // snapshot — the window in between is exactly what
-        // `awaitingFreshRoomState` marks.
+        // An *authoritative* cached `roomState` needs no poll to stay current:
+        // the server pushes `room:state` on every change. A reconnect re-sends
+        // `room:join` (`socket-controller`'s open handler) whose handshake
+        // delivers a fresh snapshot, and `awaitingFreshRoomState` marks that
+        // window — during it the cache is explicitly NOT authoritative, so the
+        // request must still go through. That is not merely belt-and-braces:
+        // the server drops a failed bootstrap snapshot silently
+        // (`sendRoomStateToSession` logs `room_state_bootstrap_failed` and does
+        // not retry) while the client deliberately keeps the flag set
+        // (`expireBootstrapRoomStateWait`), so a `sync:request` from a
+        // hydration retry is the ONLY way out of that state. The retries are
+        // bounded by the hydration backoff, so this cannot re-open the flood.
         if (
           args.connectionState.connected &&
           args.roomSessionState.roomCode &&
           args.roomSessionState.memberToken &&
-          !args.roomSessionState.roomState
+          (!args.roomSessionState.roomState ||
+            args.roomSessionState.awaitingFreshRoomState)
         ) {
           args.sendToServer({
             type: "sync:request",

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -144,6 +144,9 @@ const syncController = createSyncController({
 const playbackBindingController = createPlaybackBindingController({
   runtimeState,
   videoBindIntervalMs: VIDEO_BIND_INTERVAL_MS,
+  // Hydration defers room state it cannot apply until a `<video>` exists; this
+  // is the event that says one now does, so it no longer has to poll for it.
+  onVideoElementBound: () => syncController.notifyVideoElementBound(),
   userGestureGraceMs: USER_GESTURE_GRACE_MS,
   initialRoomStatePauseHoldMs: INITIAL_ROOM_STATE_PAUSE_HOLD_MS,
   bufferSignalWindowMs: BUFFER_SIGNAL_WINDOW_MS,

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -100,6 +100,7 @@ const roomStateController = createRoomStateController({
     syncController.resetPlaybackSyncState(reason),
   scheduleHydrationRetry: (delayMs) =>
     syncController.scheduleHydrationRetry(delayMs),
+  resetHydrationRetry: () => syncController.resetHydrationRetry(),
 });
 const syncController = createSyncController({
   runtimeState,

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -27,6 +27,11 @@ export interface PlaybackBindingController {
 export function createPlaybackBindingController(args: {
   runtimeState: ContentRuntimeState;
   videoBindIntervalMs: number;
+  /**
+   * Called when a `<video>` element is bound for the first time or replaced.
+   * Lets hydration wait for the element by event rather than polling for it.
+   */
+  onVideoElementBound?: () => void;
   userGestureGraceMs: number;
   initialRoomStatePauseHoldMs: number;
   /**
@@ -1169,6 +1174,12 @@ export function createPlaybackBindingController(args: {
       // whose paused state we never observed transitioning. The pause
       // classifiers use this timestamp to avoid reporting either as a user pause.
       args.runtimeState.lastVideoElementBoundAt = nowOf();
+      // This poll is the one place that learns a `<video>` exists. Hydration
+      // used to discover it by polling `document.querySelector("video")` on its
+      // own 350ms timer — the same query this loop already runs at 250ms — and
+      // every one of those passes also hit the server (#229). Telling it here
+      // removes the duplicate poller instead of slowing it down.
+      args.onVideoElementBound?.();
     }
   }
 

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -24,15 +24,21 @@ import type { ContentRuntimeState } from "./runtime-state";
  * never produced a `<video>` used to re-hydrate every 350ms for the life of the
  * tab, and each pass reached the server (#229).
  *
- * A high ceiling costs nothing in responsiveness because the retry is no longer
- * how the common waits end. The `<video>` element arrives by event
- * (`notifyVideoElementBound`, which also clears the streak), and a room state
- * arrives as a push. What is left is a genuine safety net, so it is sized to be
- * cheap rather than prompt: 30s caps a stuck tab at 2 wakeups/min against a
- * limiter that allows 36/min, leaving room for many tabs in one browser
- * session — they share a single WebSocket, so they share one limiter.
+ * The ceiling is a real latency, not a formality: it is the worst case before a
+ * wait that has NO terminating event notices the world changed. Only one of
+ * these waits has such an event — `notifyVideoElementBound` for the `<video>`
+ * element. The page-bridge identity behind `no-current-video` has none and
+ * cannot cheaply get one: `getSharedVideo()` derives from `location`, the
+ * document title and the DOM on every call, so there is no update to hook, and
+ * adding a watcher would recreate the duplicate poller this change removed.
+ *
+ * So it is sized as if every wait were timer-only. 10s means a stuck tab wakes
+ * 6 times/min; the limiter allows 36/min per browser session (tabs share one
+ * WebSocket, so they share one limiter), leaving headroom for six simultaneously
+ * stuck tabs before anything is rejected. For comparison the pre-fix spin sent
+ * ~171/min from a single tab.
  */
-const HYDRATION_RETRY_MAX_DELAY_MS = 30_000;
+const HYDRATION_RETRY_MAX_DELAY_MS = 10_000;
 
 /**
  * Base delay for the hydration re-armed by a `<video>` element binding. Short
@@ -49,6 +55,7 @@ export interface RoomStateApplyController {
   hydrateRoomState(): Promise<void>;
   scheduleHydrationRetry(delayMs?: number): void;
   notifyVideoElementBound(): void;
+  resetHydrationRetry(): void;
   destroy(): void;
 }
 
@@ -974,6 +981,26 @@ export function createRoomStateApplyController(args: {
     }
   }
 
+  /**
+   * Drop everything the hydration retry accumulated for the previous room.
+   *
+   * Both streaks measure "how long has *this* wait been failing", so they are
+   * meaningless across a room switch — and actively harmful: a tab that
+   * saturated them on the old room would either have the new room's 150ms
+   * bootstrap retry stretched to the ceiling, or have it refused outright by
+   * the single-timer guard because the old room's timer is still armed. The new
+   * room would then sit behind the hydration gate, suppressing broadcasts and
+   * holding a pause, if its bootstrap push happened to be lost.
+   */
+  function resetHydrationRetry(): void {
+    if (hydrateRetryTimer !== null) {
+      window.clearTimeout(hydrateRetryTimer);
+      hydrateRetryTimer = null;
+    }
+    hydrateRetryAttempt = 0;
+    boundVideoAttempt = 0;
+  }
+
   function destroy(): void {
     destroyed = true;
     hydrateRetryAttempt = 0;
@@ -990,6 +1017,7 @@ export function createRoomStateApplyController(args: {
     hydrateRoomState,
     scheduleHydrationRetry,
     notifyVideoElementBound,
+    resetHydrationRetry,
     destroy,
   };
 }

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -149,6 +149,12 @@ export function createRoomStateApplyController(args: {
   const ignoredRoomStateLogState = { key: null as string | null, at: 0 };
   const nowOf = () => args.getNow?.() ?? Date.now();
   let hydrateRetryTimer: number | null = null;
+  /**
+   * When the pending retry is due, or `null` when none is armed. Kept beside
+   * the timer id — and only ever cleared through `clearHydrationRetryTimer` —
+   * so `preemptHydrationRetry` can refuse to push the deadline later.
+   */
+  let hydrateRetryDeadline: number | null = null;
   let hydrateRetryAttempt = 0;
   let boundVideoAttempt = 0;
   let destroyed = false;
@@ -336,6 +342,14 @@ export function createRoomStateApplyController(args: {
    * as soon as one hydration cycle finishes without arming another retry
    * (see {@link hydrateRoomState}), so an isolated retry always starts fast.
    */
+  function clearHydrationRetryTimer(): void {
+    if (hydrateRetryTimer !== null) {
+      window.clearTimeout(hydrateRetryTimer);
+      hydrateRetryTimer = null;
+    }
+    hydrateRetryDeadline = null;
+  }
+
   /**
    * Arm the single hydration retry timer at `baseDelayMs` backed off by
    * `attempt` doublings. Returns whether it armed, so the caller only advances
@@ -349,11 +363,52 @@ export function createRoomStateApplyController(args: {
       baseDelayMs * 2 ** attempt,
       HYDRATION_RETRY_MAX_DELAY_MS,
     );
+    hydrateRetryDeadline = nowOf() + backedOffDelayMs;
     hydrateRetryTimer = window.setTimeout(() => {
       hydrateRetryTimer = null;
+      hydrateRetryDeadline = null;
       void hydrateRoomState();
     }, backedOffDelayMs);
     return true;
+  }
+
+  /**
+   * Replace the pending retry only when the replacement fires *sooner*.
+   *
+   * The armed deadline must never move later, or a repeating event starves the
+   * timer: a player rebuilding its `<video>` reports a bind every ~250ms, and
+   * once the bind backoff passes that interval each bind cancelled the pending
+   * timer and armed a longer one, so the callback never ran at all and the
+   * pending room state was held forever. Refusing to postpone makes the
+   * deadline monotonically non-increasing until it fires, which bounds the wait
+   * by whatever armed it first no matter how often the event repeats.
+   *
+   * `nowOf()` is a wall clock here, and unlike the refresh window it removed in
+   * an earlier round, a step is benign in both directions: a step forward at
+   * worst preempts a timer that was going to fire anyway, and a step backward at
+   * worst declines to preempt and leaves the already-armed `setTimeout` — which
+   * is itself immune to clock steps — to fire on schedule. Neither can strand
+   * the hydration, because nothing is ever cancelled without a replacement.
+   */
+  function preemptHydrationRetry(
+    baseDelayMs: number,
+    attempt: number,
+  ): boolean {
+    if (destroyed || hydrateRetryTimer === null) {
+      return false;
+    }
+    const backedOffDelayMs = Math.min(
+      baseDelayMs * 2 ** attempt,
+      HYDRATION_RETRY_MAX_DELAY_MS,
+    );
+    if (
+      hydrateRetryDeadline !== null &&
+      nowOf() + backedOffDelayMs >= hydrateRetryDeadline
+    ) {
+      return false;
+    }
+    clearHydrationRetryTimer();
+    return armHydrationRetry(baseDelayMs, attempt);
   }
 
   function scheduleHydrationRetry(delayMs = 350): void {
@@ -854,10 +909,7 @@ export function createRoomStateApplyController(args: {
     if (destroyed) {
       return;
     }
-    if (hydrateRetryTimer !== null) {
-      window.clearTimeout(hydrateRetryTimer);
-      hydrateRetryTimer = null;
-    }
+    clearHydrationRetryTimer();
     try {
       await runHydrationCycle();
     } finally {
@@ -968,17 +1020,37 @@ export function createRoomStateApplyController(args: {
    * bind every time, and hydrating inline on each one would run up to four a
    * second at the 250ms bind interval. So they back off on `boundVideoAttempt`,
    * which — like the wait streak — clears once a cycle ends without re-arming.
+   *
+   * Goes through {@link preemptHydrationRetry} rather than cancel-and-re-arm,
+   * so a bind can only ever pull the hydration *earlier*. Cancelling
+   * unconditionally starved it outright: once the bind backoff passed the
+   * ~250ms bind interval, every bind cancelled the pending timer and armed a
+   * longer one, so the callback never ran and the pending state was held for
+   * as long as the player kept rebuilding.
    */
   function notifyVideoElementBound(): void {
     if (destroyed || hydrateRetryTimer === null) {
       return;
     }
-    window.clearTimeout(hydrateRetryTimer);
-    hydrateRetryTimer = null;
-    hydrateRetryAttempt = 0;
-    if (armHydrationRetry(BOUND_VIDEO_HYDRATION_DELAY_MS, boundVideoAttempt)) {
-      boundVideoAttempt += 1;
+    // Counted on every notification, not only on the ones that win: the streak
+    // measures how often this element has been rebinding, and a rebuild loop
+    // reports just as many binds whether or not each one manages to preempt.
+    // Advancing it only on wins let a storm hold the delay near the base value
+    // and kept hydration running ~1.6x/s — bounded, but still above the
+    // limiter's budget.
+    const attempt = boundVideoAttempt;
+    boundVideoAttempt += 1;
+    if (!preemptHydrationRetry(BOUND_VIDEO_HYDRATION_DELAY_MS, attempt)) {
+      // Declined because this bind would fire no sooner than what is already
+      // armed — the signature of a rebind storm rather than of the element
+      // finally arriving. Nothing is reset, so the wait streak goes on growing,
+      // which is what makes the storm decay.
+      return;
     }
+    // The preemption won, so this bind really did carry news. The wait streak
+    // it accumulated is spent: a wait that follows must start over rather than
+    // resume at the ceiling.
+    hydrateRetryAttempt = 0;
   }
 
   /**
@@ -993,10 +1065,7 @@ export function createRoomStateApplyController(args: {
    * holding a pause, if its bootstrap push happened to be lost.
    */
   function resetHydrationRetry(): void {
-    if (hydrateRetryTimer !== null) {
-      window.clearTimeout(hydrateRetryTimer);
-      hydrateRetryTimer = null;
-    }
+    clearHydrationRetryTimer();
     hydrateRetryAttempt = 0;
     boundVideoAttempt = 0;
   }
@@ -1005,10 +1074,7 @@ export function createRoomStateApplyController(args: {
     destroyed = true;
     hydrateRetryAttempt = 0;
     boundVideoAttempt = 0;
-    if (hydrateRetryTimer !== null) {
-      window.clearTimeout(hydrateRetryTimer);
-      hydrateRetryTimer = null;
-    }
+    clearHydrationRetryTimer();
     clearDeferredRemotePaused();
   }
 

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -15,6 +15,24 @@ import {
 } from "./player-binding";
 import type { ContentRuntimeState } from "./runtime-state";
 
+/**
+ * Ceiling for the exponential hydration-retry backoff.
+ *
+ * Deliberately much lower than a "this tab is idle" timeout would be: a
+ * hydration retry is the ONLY path that re-applies room state once a slow
+ * player finally produces its `<video>` element (binding one merely records
+ * `lastVideoElementBoundAt`, it does not re-apply), so the ceiling is also the
+ * worst-case delay before such a tab catches up with the room. 5s keeps that
+ * visible-but-tolerable while still cutting a stuck tab's wakeups from ~171/min
+ * to ~12/min.
+ *
+ * The server-side flood this bounds is already gone by the time we get here —
+ * the background only forwards `sync:request` when it has no cached room state
+ * (`message-controller`) — so this ceiling only has to bound local work, and
+ * does not need to be as aggressive as the 30s floated in #229.
+ */
+const HYDRATION_RETRY_MAX_DELAY_MS = 5_000;
+
 export interface RoomStateApplyController {
   applyRoomState(
     state: RoomState,
@@ -115,6 +133,7 @@ export function createRoomStateApplyController(args: {
   const ignoredRoomStateLogState = { key: null as string | null, at: 0 };
   const nowOf = () => args.getNow?.() ?? Date.now();
   let hydrateRetryTimer: number | null = null;
+  let hydrateRetryAttempt = 0;
   let destroyed = false;
   const remotePauseDebounceMs = args.remotePauseDebounceMs ?? 0;
   const scheduleDeferTimer = (cb: () => void, ms: number): number | null => {
@@ -288,14 +307,31 @@ export function createRoomStateApplyController(args: {
     }
   }
 
+  /**
+   * Back off consecutive hydration retries instead of re-arming the caller's
+   * fixed delay forever. Every wait this retry serves — the page bridge, the
+   * `<video>` element, the room state itself — is unbounded: none of them is
+   * guaranteed to arrive, and a tab whose player never produces a `<video>`
+   * used to re-hydrate every 350ms for the lifetime of the tab (#229).
+   *
+   * The delay the caller passes is the *first* interval; each consecutive retry
+   * doubles it up to {@link HYDRATION_RETRY_MAX_DELAY_MS}. The counter resets
+   * as soon as one hydration cycle finishes without arming another retry
+   * (see {@link hydrateRoomState}), so an isolated retry always starts fast.
+   */
   function scheduleHydrationRetry(delayMs = 350): void {
     if (destroyed || hydrateRetryTimer !== null) {
       return;
     }
+    const backedOffDelayMs = Math.min(
+      delayMs * 2 ** hydrateRetryAttempt,
+      HYDRATION_RETRY_MAX_DELAY_MS,
+    );
+    hydrateRetryAttempt += 1;
     const timer = window.setTimeout(() => {
       hydrateRetryTimer = null;
       void hydrateRoomState();
-    }, delayMs);
+    }, backedOffDelayMs);
     hydrateRetryTimer = timer;
   }
 
@@ -795,7 +831,20 @@ export function createRoomStateApplyController(args: {
       window.clearTimeout(hydrateRetryTimer);
       hydrateRetryTimer = null;
     }
+    try {
+      await runHydrationCycle();
+    } finally {
+      // A cycle that ends without arming another retry is not part of a retry
+      // loop, so the next isolated retry starts from its caller's delay again.
+      // Checked here rather than at the cycle's several exits because the retry
+      // can be armed from deep inside `applyRoomState`.
+      if (!destroyed && hydrateRetryTimer === null) {
+        hydrateRetryAttempt = 0;
+      }
+    }
+  }
 
+  async function runHydrationCycle(): Promise<void> {
     const response = await args.requestRoomStateHydration();
     if (destroyed || response === null) {
       if (!destroyed) args.runtimeState.hydrationReady = true;
@@ -871,6 +920,7 @@ export function createRoomStateApplyController(args: {
 
   function destroy(): void {
     destroyed = true;
+    hydrateRetryAttempt = 0;
     if (hydrateRetryTimer !== null) {
       window.clearTimeout(hydrateRetryTimer);
       hydrateRetryTimer = null;

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -143,6 +143,7 @@ export function createRoomStateApplyController(args: {
   const nowOf = () => args.getNow?.() ?? Date.now();
   let hydrateRetryTimer: number | null = null;
   let hydrateRetryAttempt = 0;
+  let boundVideoAttempt = 0;
   let destroyed = false;
   const remotePauseDebounceMs = args.remotePauseDebounceMs ?? 0;
   const scheduleDeferTimer = (cb: () => void, ms: number): number | null => {
@@ -328,20 +329,30 @@ export function createRoomStateApplyController(args: {
    * as soon as one hydration cycle finishes without arming another retry
    * (see {@link hydrateRoomState}), so an isolated retry always starts fast.
    */
-  function scheduleHydrationRetry(delayMs = 350): void {
+  /**
+   * Arm the single hydration retry timer at `baseDelayMs` backed off by
+   * `attempt` doublings. Returns whether it armed, so the caller only advances
+   * its own streak when it actually consumed one.
+   */
+  function armHydrationRetry(baseDelayMs: number, attempt: number): boolean {
     if (destroyed || hydrateRetryTimer !== null) {
-      return;
+      return false;
     }
     const backedOffDelayMs = Math.min(
-      delayMs * 2 ** hydrateRetryAttempt,
+      baseDelayMs * 2 ** attempt,
       HYDRATION_RETRY_MAX_DELAY_MS,
     );
-    hydrateRetryAttempt += 1;
-    const timer = window.setTimeout(() => {
+    hydrateRetryTimer = window.setTimeout(() => {
       hydrateRetryTimer = null;
       void hydrateRoomState();
     }, backedOffDelayMs);
-    hydrateRetryTimer = timer;
+    return true;
+  }
+
+  function scheduleHydrationRetry(delayMs = 350): void {
+    if (armHydrationRetry(delayMs, hydrateRetryAttempt)) {
+      hydrateRetryAttempt += 1;
+    }
   }
 
   async function applyRoomState(
@@ -846,9 +857,12 @@ export function createRoomStateApplyController(args: {
       // A cycle that ends without arming another retry is not part of a retry
       // loop, so the next isolated retry starts from its caller's delay again.
       // Checked here rather than at the cycle's several exits because the retry
-      // can be armed from deep inside `applyRoomState`.
+      // can be armed from deep inside `applyRoomState`. Clears both streaks:
+      // reaching here means the hydration made progress, which is exactly what
+      // ends a rebind storm too.
       if (!destroyed && hydrateRetryTimer === null) {
         hydrateRetryAttempt = 0;
+        boundVideoAttempt = 0;
       }
     }
   }
@@ -934,14 +948,19 @@ export function createRoomStateApplyController(args: {
    * ordinary playback also rebinds, and hydrating on every rebind would put the
    * `sync:request` back on a timer — the opposite of the point.
    *
-   * Re-arms the retry at {@link BOUND_VIDEO_HYDRATION_DELAY_MS} rather than
-   * hydrating inline, so the existing backoff still governs it. That matters
-   * for a player that rebuilds its element repeatedly: each rebuild reports a
-   * bind, and an inline hydration would run one per rebuild — up to four a
-   * second at the 250ms bind interval. Going through the scheduler means a
-   * rebuild storm decays like any other unbounded wait, while the ordinary
-   * single bind still lands within a few hundred ms. The streak is not reset
-   * here; a hydration that actually applies clears it via `hydrateRoomState`.
+   * A binding and a fruitless wait are two different sequences, so they get two
+   * streaks. The wait streak is *spent* here: the element it was waiting for
+   * exists, so the pending room state must apply promptly no matter how long
+   * the wait ran. Sharing one counter meant a two-minute wait had grown it to
+   * ~10, and the nominal 50ms below became `50 * 2**10`, capped at the 30s
+   * ceiling — half a minute of suppressed broadcasts and a held pause *after*
+   * the video was usable.
+   *
+   * Repeated bindings that still fail to apply are the second sequence, and are
+   * unbounded in their own right: a player rebuilding its element reports a
+   * bind every time, and hydrating inline on each one would run up to four a
+   * second at the 250ms bind interval. So they back off on `boundVideoAttempt`,
+   * which — like the wait streak — clears once a cycle ends without re-arming.
    */
   function notifyVideoElementBound(): void {
     if (destroyed || hydrateRetryTimer === null) {
@@ -949,12 +968,16 @@ export function createRoomStateApplyController(args: {
     }
     window.clearTimeout(hydrateRetryTimer);
     hydrateRetryTimer = null;
-    scheduleHydrationRetry(BOUND_VIDEO_HYDRATION_DELAY_MS);
+    hydrateRetryAttempt = 0;
+    if (armHydrationRetry(BOUND_VIDEO_HYDRATION_DELAY_MS, boundVideoAttempt)) {
+      boundVideoAttempt += 1;
+    }
   }
 
   function destroy(): void {
     destroyed = true;
     hydrateRetryAttempt = 0;
+    boundVideoAttempt = 0;
     if (hydrateRetryTimer !== null) {
       window.clearTimeout(hydrateRetryTimer);
       hydrateRetryTimer = null;

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -75,6 +75,11 @@ export function createRoomStateApplyController(args: {
    */
   remotePauseDebounceMs?: number;
   getNow?: () => number;
+  /**
+   * Monotonic time source for the hydration retry deadline. Must not be the
+   * wall clock — see {@link preemptHydrationRetry}.
+   */
+  getMonotonicNow?: () => number;
   debugLog: (message: string) => void;
   shouldLogHeartbeat: (
     state: { key: string | null; at: number },
@@ -148,6 +153,7 @@ export function createRoomStateApplyController(args: {
 }): RoomStateApplyController {
   const ignoredRoomStateLogState = { key: null as string | null, at: 0 };
   const nowOf = () => args.getNow?.() ?? Date.now();
+  const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
   let hydrateRetryTimer: number | null = null;
   /**
    * When the pending retry is due, or `null` when none is armed. Kept beside
@@ -363,11 +369,13 @@ export function createRoomStateApplyController(args: {
       baseDelayMs * 2 ** attempt,
       HYDRATION_RETRY_MAX_DELAY_MS,
     );
-    hydrateRetryDeadline = nowOf() + backedOffDelayMs;
+    hydrateRetryDeadline = monotonicNow() + backedOffDelayMs;
     hydrateRetryTimer = window.setTimeout(() => {
       hydrateRetryTimer = null;
       hydrateRetryDeadline = null;
-      void hydrateRoomState();
+      // Not `hydrateRoomState`: this is a consecutive retry, so it must keep
+      // the streaks that make it back off.
+      void runHydration();
     }, backedOffDelayMs);
     return true;
   }
@@ -383,12 +391,14 @@ export function createRoomStateApplyController(args: {
    * deadline monotonically non-increasing until it fires, which bounds the wait
    * by whatever armed it first no matter how often the event repeats.
    *
-   * `nowOf()` is a wall clock here, and unlike the refresh window it removed in
-   * an earlier round, a step is benign in both directions: a step forward at
-   * worst preempts a timer that was going to fire anyway, and a step backward at
-   * worst declines to preempt and leaves the already-armed `setTimeout` — which
-   * is itself immune to clock steps — to fire on schedule. Neither can strand
-   * the hydration, because nothing is ever cancelled without a replacement.
+   * Both readings come from a monotonic clock, never the wall clock. The
+   * deadline is a `nowOf()`-style reading captured when the timer was armed, so
+   * a *backward* wall-clock step would shrink `now + delay` and make the
+   * candidate look earlier than a deadline it is not — the comparison would
+   * preempt, cancel a timer that was about to fire, and restart the full delay,
+   * up to the 10s ceiling once the bind streak has grown. `setTimeout` itself is
+   * immune to clock steps, so the deadline that is compared against it must be
+   * too.
    */
   function preemptHydrationRetry(
     baseDelayMs: number,
@@ -403,7 +413,7 @@ export function createRoomStateApplyController(args: {
     );
     if (
       hydrateRetryDeadline !== null &&
-      nowOf() + backedOffDelayMs >= hydrateRetryDeadline
+      monotonicNow() + backedOffDelayMs >= hydrateRetryDeadline
     ) {
       return false;
     }
@@ -905,7 +915,31 @@ export function createRoomStateApplyController(args: {
     args.acceptInitialRoomStateHydration();
   }
 
+  /**
+   * Hydration driven from outside this controller — a first load, or an SPA
+   * navigation within the same room.
+   *
+   * Such a call is a fresh start, so it drops the retry state first. Both
+   * streaks describe how long the *previous* page's wait had been failing, and
+   * that page is gone: inheriting them would make the new page's very first
+   * retry wait at the ceiling. Nothing wakes it early either — Bilibili reuses
+   * the same `<video>` element across an SPA navigation, so no bind is reported
+   * — leaving the new page behind the hydration gate with broadcasts suppressed
+   * and a pause held (#229).
+   *
+   * The streak is meant to grow only across *consecutive timer-driven* retries,
+   * which is why the timer callback goes to {@link runHydration} instead.
+   */
   async function hydrateRoomState(): Promise<void> {
+    if (destroyed) {
+      return;
+    }
+    resetHydrationRetry();
+    await runHydration();
+  }
+
+  /** One hydration attempt, preserving the retry streaks. */
+  async function runHydration(): Promise<void> {
     if (destroyed) {
       return;
     }

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -18,20 +18,28 @@ import type { ContentRuntimeState } from "./runtime-state";
 /**
  * Ceiling for the exponential hydration-retry backoff.
  *
- * Deliberately much lower than a "this tab is idle" timeout would be: a
- * hydration retry is the ONLY path that re-applies room state once a slow
- * player finally produces its `<video>` element (binding one merely records
- * `lastVideoElementBoundAt`, it does not re-apply), so the ceiling is also the
- * worst-case delay before such a tab catches up with the room. 5s keeps that
- * visible-but-tolerable while still cutting a stuck tab's wakeups from ~171/min
- * to ~12/min.
+ * Every wait this retry serves is unbounded — the page bridge, the `<video>`
+ * element, the room state itself — and none is guaranteed to arrive, so the
+ * retry must decay rather than re-arm a fixed delay forever: a tab whose player
+ * never produced a `<video>` used to re-hydrate every 350ms for the life of the
+ * tab, and each pass reached the server (#229).
  *
- * The server-side flood this bounds is already gone by the time we get here —
- * the background only forwards `sync:request` when it has no cached room state
- * (`message-controller`) — so this ceiling only has to bound local work, and
- * does not need to be as aggressive as the 30s floated in #229.
+ * A high ceiling costs nothing in responsiveness because the retry is no longer
+ * how the common waits end. The `<video>` element arrives by event
+ * (`notifyVideoElementBound`, which also clears the streak), and a room state
+ * arrives as a push. What is left is a genuine safety net, so it is sized to be
+ * cheap rather than prompt: 30s caps a stuck tab at 2 wakeups/min against a
+ * limiter that allows 36/min, leaving room for many tabs in one browser
+ * session — they share a single WebSocket, so they share one limiter.
  */
-const HYDRATION_RETRY_MAX_DELAY_MS = 5_000;
+const HYDRATION_RETRY_MAX_DELAY_MS = 30_000;
+
+/**
+ * Base delay for the hydration re-armed by a `<video>` element binding. Short
+ * enough to read as immediate, but routed through the backoff so a player that
+ * rebuilds its element in a loop cannot drive one hydration per rebuild.
+ */
+const BOUND_VIDEO_HYDRATION_DELAY_MS = 50;
 
 export interface RoomStateApplyController {
   applyRoomState(
@@ -40,6 +48,7 @@ export interface RoomStateApplyController {
   ): Promise<void>;
   hydrateRoomState(): Promise<void>;
   scheduleHydrationRetry(delayMs?: number): void;
+  notifyVideoElementBound(): void;
   destroy(): void;
 }
 
@@ -918,6 +927,31 @@ export function createRoomStateApplyController(args: {
     scheduleHydrationRetry(1500);
   }
 
+  /**
+   * The `<video>` element a deferred hydration was waiting for now exists.
+   *
+   * A no-op unless a retry is actually pending: a player rebuild during
+   * ordinary playback also rebinds, and hydrating on every rebind would put the
+   * `sync:request` back on a timer — the opposite of the point.
+   *
+   * Re-arms the retry at {@link BOUND_VIDEO_HYDRATION_DELAY_MS} rather than
+   * hydrating inline, so the existing backoff still governs it. That matters
+   * for a player that rebuilds its element repeatedly: each rebuild reports a
+   * bind, and an inline hydration would run one per rebuild — up to four a
+   * second at the 250ms bind interval. Going through the scheduler means a
+   * rebuild storm decays like any other unbounded wait, while the ordinary
+   * single bind still lands within a few hundred ms. The streak is not reset
+   * here; a hydration that actually applies clears it via `hydrateRoomState`.
+   */
+  function notifyVideoElementBound(): void {
+    if (destroyed || hydrateRetryTimer === null) {
+      return;
+    }
+    window.clearTimeout(hydrateRetryTimer);
+    hydrateRetryTimer = null;
+    scheduleHydrationRetry(BOUND_VIDEO_HYDRATION_DELAY_MS);
+  }
+
   function destroy(): void {
     destroyed = true;
     hydrateRetryAttempt = 0;
@@ -932,6 +966,7 @@ export function createRoomStateApplyController(args: {
     applyRoomState,
     hydrateRoomState,
     scheduleHydrationRetry,
+    notifyVideoElementBound,
     destroy,
   };
 }

--- a/extension/src/content/room-state-controller.ts
+++ b/extension/src/content/room-state-controller.ts
@@ -32,6 +32,7 @@ export function createRoomStateController(args: {
   debugLog: (message: string) => void;
   resetPlaybackSyncState: (reason: string) => void;
   scheduleHydrationRetry: (delayMs?: number) => void;
+  resetHydrationRetry: () => void;
 }): RoomStateController {
   let lastWaitingRoomStateLogRoomCode: string | null = null;
 
@@ -128,6 +129,11 @@ export function createRoomStateController(args: {
       args.resetPlaybackSyncState(
         `room changed ${previousRoomCode} -> ${payload.roomCode}`,
       );
+      // The hydration retry's backoff streaks measure how long the *previous*
+      // room's wait had been failing. Carrying them over would either stretch
+      // the 150ms bootstrap retry below to the ceiling, or have the old room's
+      // still-armed timer refuse it outright via the single-timer guard.
+      args.resetHydrationRetry();
       args.toastState.lastRoomState = null;
       args.runtimeState.hasReceivedInitialRoomState = false;
       args.runtimeState.pendingRoomStateHydration = true;

--- a/extension/src/content/room-state-controller.ts
+++ b/extension/src/content/room-state-controller.ts
@@ -154,6 +154,11 @@ export function createRoomStateController(args: {
       if (previousRoomCode) {
         args.resetPlaybackSyncState(`room cleared from ${previousRoomCode}`);
       }
+      // Leaving is the other half of a room switch, and the common one:
+      // `roomChanged` above needs both codes non-null, but leaving then joining
+      // reports `ROOM01 -> null -> ROOM02`, so neither call satisfies it and the
+      // retry state would survive into the new room untouched.
+      args.resetHydrationRetry();
       clearRoomScopedSharedVideoState();
       args.toastState.lastRoomState = null;
       args.runtimeState.pendingRoomStateHydration = false;

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -64,6 +64,7 @@ export interface SyncController {
   ): Promise<void>;
   hydrateRoomState(): Promise<void>;
   scheduleHydrationRetry(delayMs?: number): void;
+  notifyVideoElementBound(): void;
   destroy(): void;
 }
 
@@ -1655,6 +1656,7 @@ export function createSyncController(args: {
     applyRoomState: recordRoomConfirmedBroadcast,
     hydrateRoomState: roomStateApplyController.hydrateRoomState,
     scheduleHydrationRetry: roomStateApplyController.scheduleHydrationRetry,
+    notifyVideoElementBound: roomStateApplyController.notifyVideoElementBound,
     destroy() {
       softApply.destroy();
       roomStateApplyController.destroy();

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -65,6 +65,7 @@ export interface SyncController {
   hydrateRoomState(): Promise<void>;
   scheduleHydrationRetry(delayMs?: number): void;
   notifyVideoElementBound(): void;
+  resetHydrationRetry(): void;
   destroy(): void;
 }
 
@@ -1657,6 +1658,7 @@ export function createSyncController(args: {
     hydrateRoomState: roomStateApplyController.hydrateRoomState,
     scheduleHydrationRetry: roomStateApplyController.scheduleHydrationRetry,
     notifyVideoElementBound: roomStateApplyController.notifyVideoElementBound,
+    resetHydrationRetry: roomStateApplyController.resetHydrationRetry,
     destroy() {
       softApply.destroy();
       roomStateApplyController.destroy();

--- a/extension/test/message-controller.test.ts
+++ b/extension/test/message-controller.test.ts
@@ -66,11 +66,6 @@ function createControllerHarness(
     hasActivePendingLocalShare?: boolean;
     hasActivePendingManualShare?: boolean;
     activePendingLocalShareUrl?: string | null;
-    /**
-     * Skip the injected clock so the controller falls back to its production
-     * default. Only the clock-source test needs this.
-     */
-    omitMonotonicClock?: boolean;
   } = {},
 ) {
   const calls = {
@@ -137,8 +132,6 @@ function createControllerHarness(
     pageShareButtonEnabled: true,
   };
 
-  // Monotonic reading, as `performance.now()` would give (not a wall clock).
-  let clock = 1_000_000;
   const controller = createMessageController({
     connectionState,
     roomSessionState,
@@ -287,7 +280,6 @@ function createControllerHarness(
     notifyAll() {
       calls.notifyAll += 1;
     },
-    ...(overrides.omitMonotonicClock ? {} : { getMonotonicNow: () => clock }),
   });
 
   return {
@@ -297,9 +289,6 @@ function createControllerHarness(
     roomSessionState,
     popupState,
     settingsState,
-    advanceClock(ms: number) {
-      clock += ms;
-    },
     syncRequests: () =>
       calls.sendToServer.filter(
         (message) => (message as { type?: string }).type === "sync:request",
@@ -1678,7 +1667,7 @@ test("message controller forwards content playback updates only for the active s
 
 const GET_ROOM_STATE = { type: "content:get-room-state" } as const;
 
-/** Send one `content:get-room-state`, which also arms the refresh window. */
+/** Send one `content:get-room-state` and return the response. */
 async function getRoomState(
   harness: ReturnType<typeof createControllerHarness>,
 ): Promise<unknown> {
@@ -1693,64 +1682,25 @@ async function getRoomState(
   return response;
 }
 
-test("message controller answers content:get-room-state from cache within the refresh window", async () => {
-  // Regression for #229: content-side hydration retries call this message in a
-  // loop while waiting for a `<video>` element, and forwarding a `sync:request`
-  // on every pass saturated the per-session rate limiter (6 per 10s).
-  const harness = createControllerHarness();
-  await getRoomState(harness);
-  assert.equal(harness.syncRequests().length, 1, "first call arms the window");
+test("message controller always refreshes room state on content:get-room-state", async () => {
+  // #229 was fixed by stopping the CALLER from spinning, not by suppressing the
+  // forward here. Suppressing it locally is what stranded clients on stale
+  // snapshots: the server can silently fail to push, and a dropped
+  // `sync:request` is indistinguishable from a satisfied one, so no local
+  // predicate can decide the cache is still authoritative. A cached room state
+  // present or absent, this must reach the server every time.
+  const cached = createControllerHarness();
+  await getRoomState(cached);
+  const response = await getRoomState(cached);
 
-  // A tight hydration retry loop inside the window must add nothing.
-  harness.advanceClock(350);
-  const response = await getRoomState(harness);
-  harness.advanceClock(350);
-  await getRoomState(harness);
-
-  assert.equal(
-    harness.syncRequests().length,
-    1,
-    "an authoritative cache must be served locally, without a sync:request",
-  );
+  assert.deepEqual(cached.syncRequests(), [
+    { type: "sync:request", payload: { memberToken: "member-token-1" } },
+    { type: "sync:request", payload: { memberToken: "member-token-1" } },
+  ]);
   assert.equal((response as { ok: boolean }).ok, true);
   assert.equal((response as { roomCode: string }).roomCode, "ROOM01");
-});
 
-test("message controller refreshes room state once the trust window expires", async () => {
-  // The server can silently fail to push `room:state` (`room_event_consume_failed`
-  // in room-event-consumer.ts, and a null `getRoomStateByCode`), leaving the
-  // client with a stale snapshot and no local signal. Cache authority therefore
-  // has to expire rather than be permanent.
-  const harness = createControllerHarness();
-  await getRoomState(harness);
-  harness.advanceClock(9_999);
-  await getRoomState(harness);
-  assert.equal(
-    harness.syncRequests().length,
-    1,
-    "still inside the window: no extra request",
-  );
-
-  harness.advanceClock(2);
-  await getRoomState(harness);
-  assert.equal(
-    harness.syncRequests().length,
-    2,
-    "past the window: exactly one refresh goes through",
-  );
-
-  // The refresh re-arms the window rather than leaving it open.
-  harness.advanceClock(350);
-  await getRoomState(harness);
-  assert.equal(harness.syncRequests().length, 2);
-});
-
-test("message controller keeps requesting a sync while it has no cached room state", async () => {
-  // With nothing to answer from, the trust window must not apply at all: a
-  // client that has never received room state would otherwise be throttled to
-  // one attempt per window while it has no state to show. The retry rate here
-  // is bounded by the content-side hydration backoff instead.
-  const harness = createControllerHarness({
+  const uncached = createControllerHarness({
     roomSessionState: {
       roomCode: "ROOM01",
       memberToken: "member-token-1",
@@ -1759,78 +1709,19 @@ test("message controller keeps requesting a sync while it has no cached room sta
       roomState: null,
     },
   });
-  await getRoomState(harness);
-  harness.advanceClock(350);
-  await getRoomState(harness);
-
-  assert.deepEqual(harness.syncRequests(), [
-    { type: "sync:request", payload: { memberToken: "member-token-1" } },
-    { type: "sync:request", payload: { memberToken: "member-token-1" } },
-  ]);
+  const uncachedResponse = await getRoomState(uncached);
+  assert.equal(uncached.syncRequests().length, 1);
+  assert.equal((uncachedResponse as { ok: boolean }).ok, false);
 });
 
-test("message controller re-requests a sync while awaiting fresh room state after reconnect", async () => {
-  // During the reconnect handshake `awaitingFreshRoomState` marks the cache as
-  // stale, and the server drops a failed bootstrap snapshot silently
-  // (`sendRoomStateToSession` logs `room_state_bootstrap_failed` without
-  // retrying) while the client deliberately keeps the flag set
-  // (`expireBootstrapRoomStateWait`) — so this `sync:request` is the only way
-  // out of that state, and it must not wait for the trust window to expire.
-  const harness = createControllerHarness();
-  await getRoomState(harness);
-  assert.equal(harness.syncRequests().length, 1);
-
-  // Well inside the window, so only the flag can let this one through.
-  harness.roomSessionState.awaitingFreshRoomState = true;
-  harness.advanceClock(350);
+test("message controller does not request a sync while offline", async () => {
+  // The remaining guards: without a live socket there is nobody to ask, and the
+  // reconnect is kicked off instead.
+  const harness = createControllerHarness({
+    connectionState: { connected: false, lastError: null },
+  });
   await getRoomState(harness);
 
-  assert.deepEqual(
-    harness.syncRequests(),
-    [
-      { type: "sync:request", payload: { memberToken: "member-token-1" } },
-      { type: "sync:request", payload: { memberToken: "member-token-1" } },
-    ],
-    "a non-authoritative cache must still reach the server",
-  );
-});
-
-test("message controller measures the refresh window on a monotonic clock", async () => {
-  // `Date.now()` is not ordered: an NTP correction or a manual change steps it,
-  // and a *backward* step makes `now - lastRoomStateRefreshAt` negative — which
-  // compares as "well inside the window" and would freeze the recovery refresh
-  // for the whole duration of the step, precisely when a silently missed push
-  // most needs recovering from. The window must therefore come from
-  // `performance.now()`.
-  const realDateNow = Date.now;
-  const realPerformanceNow = performance.now;
-  let monotonic = 5_000;
-  let wallClock = 1_700_000_000_000;
-  Date.now = () => wallClock;
-  performance.now = () => monotonic;
-  try {
-    const harness = createControllerHarness({ omitMonotonicClock: true });
-    await getRoomState(harness);
-    assert.equal(
-      harness.syncRequests().length,
-      1,
-      "first call arms the window",
-    );
-
-    // The wall clock jumps an hour backwards while real time moves past the
-    // window. A `Date.now()`-based window would see -3_600_000ms elapsed and
-    // stay "authoritative"; a monotonic one sees 10_001ms and refreshes.
-    wallClock -= 3_600_000;
-    monotonic += 10_001;
-    await getRoomState(harness);
-
-    assert.equal(
-      harness.syncRequests().length,
-      2,
-      "a backward wall-clock step must not extend the trust window",
-    );
-  } finally {
-    Date.now = realDateNow;
-    performance.now = realPerformanceNow;
-  }
+  assert.deepEqual(harness.syncRequests(), []);
+  assert.equal(harness.calls.connect, 1);
 });

--- a/extension/test/message-controller.test.ts
+++ b/extension/test/message-controller.test.ts
@@ -66,6 +66,11 @@ function createControllerHarness(
     hasActivePendingLocalShare?: boolean;
     hasActivePendingManualShare?: boolean;
     activePendingLocalShareUrl?: string | null;
+    /**
+     * Skip the injected clock so the controller falls back to its production
+     * default. Only the clock-source test needs this.
+     */
+    omitMonotonicClock?: boolean;
   } = {},
 ) {
   const calls = {
@@ -132,6 +137,7 @@ function createControllerHarness(
     pageShareButtonEnabled: true,
   };
 
+  // Monotonic reading, as `performance.now()` would give (not a wall clock).
   let clock = 1_000_000;
   const controller = createMessageController({
     connectionState,
@@ -281,7 +287,7 @@ function createControllerHarness(
     notifyAll() {
       calls.notifyAll += 1;
     },
-    now: () => clock,
+    ...(overrides.omitMonotonicClock ? {} : { getMonotonicNow: () => clock }),
   });
 
   return {
@@ -1787,4 +1793,44 @@ test("message controller re-requests a sync while awaiting fresh room state afte
     ],
     "a non-authoritative cache must still reach the server",
   );
+});
+
+test("message controller measures the refresh window on a monotonic clock", async () => {
+  // `Date.now()` is not ordered: an NTP correction or a manual change steps it,
+  // and a *backward* step makes `now - lastRoomStateRefreshAt` negative — which
+  // compares as "well inside the window" and would freeze the recovery refresh
+  // for the whole duration of the step, precisely when a silently missed push
+  // most needs recovering from. The window must therefore come from
+  // `performance.now()`.
+  const realDateNow = Date.now;
+  const realPerformanceNow = performance.now;
+  let monotonic = 5_000;
+  let wallClock = 1_700_000_000_000;
+  Date.now = () => wallClock;
+  performance.now = () => monotonic;
+  try {
+    const harness = createControllerHarness({ omitMonotonicClock: true });
+    await getRoomState(harness);
+    assert.equal(
+      harness.syncRequests().length,
+      1,
+      "first call arms the window",
+    );
+
+    // The wall clock jumps an hour backwards while real time moves past the
+    // window. A `Date.now()`-based window would see -3_600_000ms elapsed and
+    // stay "authoritative"; a monotonic one sees 10_001ms and refreshes.
+    wallClock -= 3_600_000;
+    monotonic += 10_001;
+    await getRoomState(harness);
+
+    assert.equal(
+      harness.syncRequests().length,
+      2,
+      "a backward wall-clock step must not extend the trust window",
+    );
+  } finally {
+    Date.now = realDateNow;
+    performance.now = realPerformanceNow;
+  }
 });

--- a/extension/test/message-controller.test.ts
+++ b/extension/test/message-controller.test.ts
@@ -1709,3 +1709,41 @@ test("message controller still requests a sync when it has no cached room state"
     [{ type: "sync:request", payload: { memberToken: "member-token-1" } }],
   );
 });
+
+test("message controller re-requests a sync while awaiting fresh room state after reconnect", async () => {
+  // The cache-hit short circuit must key on the state being *authoritative*,
+  // not merely present. During the reconnect handshake `awaitingFreshRoomState`
+  // marks the cache as stale, and the server drops a failed bootstrap snapshot
+  // silently (`sendRoomStateToSession` logs `room_state_bootstrap_failed`
+  // without retrying) while the client deliberately keeps the flag set
+  // (`expireBootstrapRoomStateWait`) — so this `sync:request` is the only way
+  // out of that state.
+  const harness = createControllerHarness({
+    roomSessionState: {
+      roomCode: "ROOM01",
+      memberToken: "member-token-1",
+      memberId: "member-1",
+      displayName: "Alice",
+      roomState: {
+        roomCode: "ROOM01",
+        sharedVideo: null,
+        playback: null,
+        members: [],
+      },
+      awaitingFreshRoomState: true,
+    },
+  });
+  await harness.controller.handleRuntimeMessage(
+    { type: "content:get-room-state" },
+    createSender({ id: 123 }),
+    () => undefined,
+  );
+
+  assert.deepEqual(
+    harness.calls.sendToServer.filter(
+      (message) => (message as { type?: string }).type === "sync:request",
+    ),
+    [{ type: "sync:request", payload: { memberToken: "member-token-1" } }],
+    "a non-authoritative cache must still reach the server",
+  );
+});

--- a/extension/test/message-controller.test.ts
+++ b/extension/test/message-controller.test.ts
@@ -132,6 +132,7 @@ function createControllerHarness(
     pageShareButtonEnabled: true,
   };
 
+  let clock = 1_000_000;
   const controller = createMessageController({
     connectionState,
     roomSessionState,
@@ -280,6 +281,7 @@ function createControllerHarness(
     notifyAll() {
       calls.notifyAll += 1;
     },
+    now: () => clock,
   });
 
   return {
@@ -289,6 +291,13 @@ function createControllerHarness(
     roomSessionState,
     popupState,
     settingsState,
+    advanceClock(ms: number) {
+      clock += ms;
+    },
+    syncRequests: () =>
+      calls.sendToServer.filter(
+        (message) => (message as { type?: string }).type === "sync:request",
+      ),
   };
 }
 
@@ -1661,32 +1670,80 @@ test("message controller forwards content playback updates only for the active s
   assert.deepEqual(inactiveHarness.calls.sendToServer, []);
 });
 
-test("message controller answers content:get-room-state from cache without polling the server", async () => {
-  // Regression for #229: content-side hydration retries call this message in a
-  // loop while waiting for a `<video>` element, and forwarding a `sync:request`
-  // on every pass saturated the per-session rate limiter (6 per 10s).
-  const harness = createControllerHarness();
+const GET_ROOM_STATE = { type: "content:get-room-state" } as const;
+
+/** Send one `content:get-room-state`, which also arms the refresh window. */
+async function getRoomState(
+  harness: ReturnType<typeof createControllerHarness>,
+): Promise<unknown> {
   let response: unknown;
   await harness.controller.handleRuntimeMessage(
-    { type: "content:get-room-state" },
+    GET_ROOM_STATE,
     createSender({ id: 123 }),
     (value) => {
       response = value;
     },
   );
+  return response;
+}
 
-  assert.deepEqual(
-    harness.calls.sendToServer.filter(
-      (message) => (message as { type?: string }).type === "sync:request",
-    ),
-    [],
-    "a cached room state must be served locally, without a sync:request",
+test("message controller answers content:get-room-state from cache within the refresh window", async () => {
+  // Regression for #229: content-side hydration retries call this message in a
+  // loop while waiting for a `<video>` element, and forwarding a `sync:request`
+  // on every pass saturated the per-session rate limiter (6 per 10s).
+  const harness = createControllerHarness();
+  await getRoomState(harness);
+  assert.equal(harness.syncRequests().length, 1, "first call arms the window");
+
+  // A tight hydration retry loop inside the window must add nothing.
+  harness.advanceClock(350);
+  const response = await getRoomState(harness);
+  harness.advanceClock(350);
+  await getRoomState(harness);
+
+  assert.equal(
+    harness.syncRequests().length,
+    1,
+    "an authoritative cache must be served locally, without a sync:request",
   );
   assert.equal((response as { ok: boolean }).ok, true);
   assert.equal((response as { roomCode: string }).roomCode, "ROOM01");
 });
 
-test("message controller still requests a sync when it has no cached room state", async () => {
+test("message controller refreshes room state once the trust window expires", async () => {
+  // The server can silently fail to push `room:state` (`room_event_consume_failed`
+  // in room-event-consumer.ts, and a null `getRoomStateByCode`), leaving the
+  // client with a stale snapshot and no local signal. Cache authority therefore
+  // has to expire rather than be permanent.
+  const harness = createControllerHarness();
+  await getRoomState(harness);
+  harness.advanceClock(9_999);
+  await getRoomState(harness);
+  assert.equal(
+    harness.syncRequests().length,
+    1,
+    "still inside the window: no extra request",
+  );
+
+  harness.advanceClock(2);
+  await getRoomState(harness);
+  assert.equal(
+    harness.syncRequests().length,
+    2,
+    "past the window: exactly one refresh goes through",
+  );
+
+  // The refresh re-arms the window rather than leaving it open.
+  harness.advanceClock(350);
+  await getRoomState(harness);
+  assert.equal(harness.syncRequests().length, 2);
+});
+
+test("message controller keeps requesting a sync while it has no cached room state", async () => {
+  // With nothing to answer from, the trust window must not apply at all: a
+  // client that has never received room state would otherwise be throttled to
+  // one attempt per window while it has no state to show. The retry rate here
+  // is bounded by the content-side hydration backoff instead.
   const harness = createControllerHarness({
     roomSessionState: {
       roomCode: "ROOM01",
@@ -1696,54 +1753,38 @@ test("message controller still requests a sync when it has no cached room state"
       roomState: null,
     },
   });
-  await harness.controller.handleRuntimeMessage(
-    { type: "content:get-room-state" },
-    createSender({ id: 123 }),
-    () => undefined,
-  );
+  await getRoomState(harness);
+  harness.advanceClock(350);
+  await getRoomState(harness);
 
-  assert.deepEqual(
-    harness.calls.sendToServer.filter(
-      (message) => (message as { type?: string }).type === "sync:request",
-    ),
-    [{ type: "sync:request", payload: { memberToken: "member-token-1" } }],
-  );
+  assert.deepEqual(harness.syncRequests(), [
+    { type: "sync:request", payload: { memberToken: "member-token-1" } },
+    { type: "sync:request", payload: { memberToken: "member-token-1" } },
+  ]);
 });
 
 test("message controller re-requests a sync while awaiting fresh room state after reconnect", async () => {
-  // The cache-hit short circuit must key on the state being *authoritative*,
-  // not merely present. During the reconnect handshake `awaitingFreshRoomState`
-  // marks the cache as stale, and the server drops a failed bootstrap snapshot
-  // silently (`sendRoomStateToSession` logs `room_state_bootstrap_failed`
-  // without retrying) while the client deliberately keeps the flag set
+  // During the reconnect handshake `awaitingFreshRoomState` marks the cache as
+  // stale, and the server drops a failed bootstrap snapshot silently
+  // (`sendRoomStateToSession` logs `room_state_bootstrap_failed` without
+  // retrying) while the client deliberately keeps the flag set
   // (`expireBootstrapRoomStateWait`) — so this `sync:request` is the only way
-  // out of that state.
-  const harness = createControllerHarness({
-    roomSessionState: {
-      roomCode: "ROOM01",
-      memberToken: "member-token-1",
-      memberId: "member-1",
-      displayName: "Alice",
-      roomState: {
-        roomCode: "ROOM01",
-        sharedVideo: null,
-        playback: null,
-        members: [],
-      },
-      awaitingFreshRoomState: true,
-    },
-  });
-  await harness.controller.handleRuntimeMessage(
-    { type: "content:get-room-state" },
-    createSender({ id: 123 }),
-    () => undefined,
-  );
+  // out of that state, and it must not wait for the trust window to expire.
+  const harness = createControllerHarness();
+  await getRoomState(harness);
+  assert.equal(harness.syncRequests().length, 1);
+
+  // Well inside the window, so only the flag can let this one through.
+  harness.roomSessionState.awaitingFreshRoomState = true;
+  harness.advanceClock(350);
+  await getRoomState(harness);
 
   assert.deepEqual(
-    harness.calls.sendToServer.filter(
-      (message) => (message as { type?: string }).type === "sync:request",
-    ),
-    [{ type: "sync:request", payload: { memberToken: "member-token-1" } }],
+    harness.syncRequests(),
+    [
+      { type: "sync:request", payload: { memberToken: "member-token-1" } },
+      { type: "sync:request", payload: { memberToken: "member-token-1" } },
+    ],
     "a non-authoritative cache must still reach the server",
   );
 });

--- a/extension/test/message-controller.test.ts
+++ b/extension/test/message-controller.test.ts
@@ -1660,3 +1660,52 @@ test("message controller forwards content playback updates only for the active s
 
   assert.deepEqual(inactiveHarness.calls.sendToServer, []);
 });
+
+test("message controller answers content:get-room-state from cache without polling the server", async () => {
+  // Regression for #229: content-side hydration retries call this message in a
+  // loop while waiting for a `<video>` element, and forwarding a `sync:request`
+  // on every pass saturated the per-session rate limiter (6 per 10s).
+  const harness = createControllerHarness();
+  let response: unknown;
+  await harness.controller.handleRuntimeMessage(
+    { type: "content:get-room-state" },
+    createSender({ id: 123 }),
+    (value) => {
+      response = value;
+    },
+  );
+
+  assert.deepEqual(
+    harness.calls.sendToServer.filter(
+      (message) => (message as { type?: string }).type === "sync:request",
+    ),
+    [],
+    "a cached room state must be served locally, without a sync:request",
+  );
+  assert.equal((response as { ok: boolean }).ok, true);
+  assert.equal((response as { roomCode: string }).roomCode, "ROOM01");
+});
+
+test("message controller still requests a sync when it has no cached room state", async () => {
+  const harness = createControllerHarness({
+    roomSessionState: {
+      roomCode: "ROOM01",
+      memberToken: "member-token-1",
+      memberId: "member-1",
+      displayName: "Alice",
+      roomState: null,
+    },
+  });
+  await harness.controller.handleRuntimeMessage(
+    { type: "content:get-room-state" },
+    createSender({ id: 123 }),
+    () => undefined,
+  );
+
+  assert.deepEqual(
+    harness.calls.sendToServer.filter(
+      (message) => (message as { type?: string }).type === "sync:request",
+    ),
+    [{ type: "sync:request", payload: { memberToken: "member-token-1" } }],
+  );
+});

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -449,6 +449,7 @@ test("playback binding controller keeps hydration guard after direct room switch
     scheduleHydrationRetry: (delayMs) => {
       hydrationRetries.push(delayMs ?? 0);
     },
+    resetHydrationRetry: () => {},
   });
 
   const controller = createPlaybackBindingController({

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -4121,3 +4121,49 @@ test("playback binding controller re-samples the seek origin after a forced paus
     dom.restore();
   }
 });
+
+test("playback binding controller reports a newly bound video element once", () => {
+  // This poll is the only place that learns a `<video>` exists. Hydration relies
+  // on being told, instead of running a second `document.querySelector("video")`
+  // timer of its own that also hit the server on every pass (#229).
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 1_000;
+  let bindings = 0;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    onVideoElementBound: () => {
+      bindings += 1;
+    },
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getNow: () => 1_100,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    assert.equal(bindings, 1, "first bind must be reported");
+
+    // The bind loop runs every 250ms; re-binding the same element must not
+    // re-report, otherwise hydration would be driven on a timer again.
+    controller.attachPlaybackListeners();
+    assert.equal(bindings, 1, "same element must not re-report");
+  } finally {
+    dom.restore();
+  }
+});

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -1393,3 +1393,101 @@ test("legacy remote paused (no userInitiated field) still goes through the debou
     win.restore();
   }
 });
+
+test("backs off consecutive hydration retries instead of re-arming a flat delay", async () => {
+  const win = installWindowTimerStub();
+  try {
+    // Regression for #229: a tab whose player never produces a `<video>`
+    // element re-armed the hydration retry at a flat 350ms for the lifetime of
+    // the tab. Each pass also forwarded a `sync:request`, which is how a single
+    // stuck tab saturated the server's per-session limiter.
+    const roomState = createRoomStateWithPlayback({
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      currentTime: 42,
+      playState: "paused",
+      actorId: "remote-member",
+      seq: 5,
+    });
+    const harness = createController({
+      video: createStubVideo(false),
+      now: 30_000,
+      currentVideo: null,
+      requestRoomStateHydration: async () => ({
+        ok: true,
+        roomState,
+        memberId: "local-member",
+        roomCode: "ROOM01",
+      }),
+    });
+    harness.runtimeState.pendingRoomStateHydration = true;
+    harness.runtimeState.lastUserGestureAt = 29_500;
+
+    // Six consecutive cycles that each re-arm the retry (the page bridge never
+    // becomes ready), driven directly rather than through the timer stub.
+    for (let i = 0; i < 6; i += 1) {
+      await harness.controller.hydrateRoomState();
+    }
+
+    assert.deepEqual(
+      win.scheduled.map((timer) => timer.ms),
+      [350, 700, 1400, 2800, 5000, 5000],
+      "consecutive retries must double up to the 5s ceiling",
+    );
+  } finally {
+    win.restore();
+  }
+});
+
+test("resets hydration retry backoff once a cycle completes without retrying", async () => {
+  const win = installWindowTimerStub();
+  try {
+    const roomState = createRoomStateWithPlayback({
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      currentTime: 42,
+      playState: "paused",
+      actorId: "remote-member",
+      seq: 5,
+    });
+    let bridgeReady = false;
+    const harness = createController({
+      video: createStubVideo(false),
+      now: 30_000,
+      // `currentVideo` null keeps the page bridge "not ready" and re-arms the
+      // retry; returning the shared video lets the cycle complete cleanly.
+      currentVideo: null,
+      requestRoomStateHydration: async () =>
+        bridgeReady
+          ? null
+          : {
+              ok: true,
+              roomState,
+              memberId: "local-member",
+              roomCode: "ROOM01",
+            },
+    });
+    harness.runtimeState.pendingRoomStateHydration = true;
+    harness.runtimeState.lastUserGestureAt = 29_500;
+
+    await harness.controller.hydrateRoomState();
+    await harness.controller.hydrateRoomState();
+    assert.deepEqual(
+      win.scheduled.map((timer) => timer.ms),
+      [350, 700],
+    );
+
+    // A cycle that arms no retry clears the streak...
+    bridgeReady = true;
+    await harness.controller.hydrateRoomState();
+    assert.equal(win.scheduled.length, 2, "clean cycle must not arm a retry");
+
+    // ...so the next isolated retry starts from its caller's delay again.
+    bridgeReady = false;
+    await harness.controller.hydrateRoomState();
+    assert.deepEqual(
+      win.scheduled.map((timer) => timer.ms),
+      [350, 700, 350],
+    );
+  } finally {
+    win.restore();
+  }
+});

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -1430,8 +1430,8 @@ test("backs off consecutive hydration retries instead of re-arming a flat delay"
 
     assert.deepEqual(
       win.scheduled.map((timer) => timer.ms),
-      [350, 700, 1400, 2800, 5000, 5000],
-      "consecutive retries must double up to the 5s ceiling",
+      [350, 700, 1400, 2800, 5600, 11200],
+      "consecutive retries must double toward the ceiling",
     );
   } finally {
     win.restore();
@@ -1486,6 +1486,147 @@ test("resets hydration retry backoff once a cycle completes without retrying", a
     assert.deepEqual(
       win.scheduled.map((timer) => timer.ms),
       [350, 700, 350],
+    );
+  } finally {
+    win.restore();
+  }
+});
+
+test("video element binding ends the hydration wait instead of a retry timer", async () => {
+  const win = installWindowTimerStub();
+  try {
+    // The retry that waits for a `<video>` element used to be a second poller
+    // over the same `document.querySelector("video")` the binding loop already
+    // runs — and every pass of it reached the server (#229). The element now
+    // arrives as an event.
+    const roomState = createRoomStateWithPlayback({
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      currentTime: 42,
+      playState: "paused",
+      actorId: "remote-member",
+      seq: 5,
+    });
+    let hydrations = 0;
+    const harness = createController({
+      video: createStubVideo(false),
+      now: 30_000,
+      currentVideo: null,
+      requestRoomStateHydration: async () => {
+        hydrations += 1;
+        return {
+          ok: true,
+          roomState,
+          memberId: "local-member",
+          roomCode: "ROOM01",
+        };
+      },
+    });
+    harness.runtimeState.pendingRoomStateHydration = true;
+    harness.runtimeState.lastUserGestureAt = 29_500;
+
+    await harness.controller.hydrateRoomState();
+    assert.equal(hydrations, 1);
+    assert.equal(win.scheduled.length, 1, "a retry is pending");
+
+    // Binding cancels the pending retry and re-arms a near-immediate one.
+    harness.controller.notifyVideoElementBound();
+    assert.deepEqual(
+      win.cleared,
+      [win.scheduled[0].id],
+      "the pending retry timer must be cancelled, not left to fire too",
+    );
+    assert.equal(win.scheduled.length, 2);
+    assert.equal(
+      win.scheduled[1].ms,
+      100,
+      "re-armed through the backoff (50ms base, one retry already elapsed)",
+    );
+
+    win.scheduled[1].cb();
+    await Promise.resolve();
+    assert.equal(hydrations, 2, "binding must drive the hydration");
+  } finally {
+    win.restore();
+  }
+});
+
+test("video element binding is a no-op when no hydration is waiting", async () => {
+  const win = installWindowTimerStub();
+  try {
+    // A player rebuild during ordinary playback also rebinds. Hydrating on every
+    // rebind would put `sync:request` back on a timer.
+    let hydrations = 0;
+    const harness = createController({
+      video: createStubVideo(false),
+      now: 30_000,
+      requestRoomStateHydration: async () => {
+        hydrations += 1;
+        return null;
+      },
+    });
+
+    harness.controller.notifyVideoElementBound();
+    await Promise.resolve();
+
+    assert.equal(hydrations, 0);
+    assert.equal(win.scheduled.length, 0);
+  } finally {
+    win.restore();
+  }
+});
+
+test("repeated video rebinds decay instead of hydrating once per rebind", async () => {
+  const win = installWindowTimerStub();
+  try {
+    // A player that rebuilds its element in a loop reports a bind every time.
+    // Routing those through the backoff is what stops them from becoming one
+    // `sync:request` per rebuild at the 250ms bind interval (#229).
+    const roomState = createRoomStateWithPlayback({
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      currentTime: 42,
+      playState: "paused",
+      actorId: "remote-member",
+      seq: 5,
+    });
+    const harness = createController({
+      video: createStubVideo(false),
+      now: 30_000,
+      currentVideo: null,
+      requestRoomStateHydration: async () => ({
+        ok: true,
+        roomState,
+        memberId: "local-member",
+        roomCode: "ROOM01",
+      }),
+    });
+    harness.runtimeState.pendingRoomStateHydration = true;
+    harness.runtimeState.lastUserGestureAt = 29_500;
+
+    await harness.controller.hydrateRoomState();
+
+    // `hydrateRoomState` is async, so let it finish arming the next retry
+    // before the following rebind is reported.
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    const bindArmedDelays: number[] = [];
+    for (let i = 0; i < 4; i += 1) {
+      const before = win.scheduled.length;
+      harness.controller.notifyVideoElementBound();
+      assert.equal(
+        win.scheduled.length,
+        before + 1,
+        `rebind ${i} must re-arm exactly one hydration`,
+      );
+      const armed = win.scheduled[win.scheduled.length - 1];
+      bindArmedDelays.push(armed.ms);
+      armed.cb();
+      await settle();
+    }
+
+    assert.deepEqual(
+      bindArmedDelays,
+      [100, 400, 1600, 6400],
+      "successive rebinds must back off, not re-fire at the base delay",
     );
   } finally {
     win.restore();

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -1538,8 +1538,8 @@ test("video element binding ends the hydration wait instead of a retry timer", a
     assert.equal(win.scheduled.length, 2);
     assert.equal(
       win.scheduled[1].ms,
-      100,
-      "re-armed through the backoff (50ms base, one retry already elapsed)",
+      50,
+      "a first binding must not inherit the wait's backoff",
     );
 
     win.scheduled[1].cb();
@@ -1625,8 +1625,77 @@ test("repeated video rebinds decay instead of hydrating once per rebind", async 
 
     assert.deepEqual(
       bindArmedDelays,
-      [100, 400, 1600, 6400],
-      "successive rebinds must back off, not re-fire at the base delay",
+      [50, 100, 200, 400],
+      "successive rebinds must back off on their own streak",
+    );
+  } finally {
+    win.restore();
+  }
+});
+
+test("a video binding after a long wait hydrates promptly, not at the ceiling", async () => {
+  const win = installWindowTimerStub();
+  try {
+    // The wait streak and the rebind streak are different sequences. A page
+    // bridge that stays unready for minutes drives the wait streak to
+    // saturation; if the binding inherited it, `50 * 2**n` would clamp to the
+    // 30s ceiling and the room state would sit unapplied for half a minute
+    // AFTER the video became usable — with broadcasts suppressed and the
+    // initial pause still held throughout.
+    const roomState = createRoomStateWithPlayback({
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      currentTime: 42,
+      playState: "paused",
+      actorId: "remote-member",
+      seq: 5,
+    });
+    const harness = createController({
+      video: createStubVideo(false),
+      now: 30_000,
+      currentVideo: null,
+      requestRoomStateHydration: async () => ({
+        ok: true,
+        roomState,
+        memberId: "local-member",
+        roomCode: "ROOM01",
+      }),
+    });
+    harness.runtimeState.pendingRoomStateHydration = true;
+    harness.runtimeState.lastUserGestureAt = 29_500;
+
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Drive the wait to the ceiling: 350ms doubling reaches 30s by the 8th.
+    await harness.controller.hydrateRoomState();
+    for (let i = 0; i < 11; i += 1) {
+      const armed = win.scheduled[win.scheduled.length - 1];
+      armed.cb();
+      await settle();
+    }
+    const saturated = win.scheduled[win.scheduled.length - 1];
+    assert.equal(
+      saturated.ms,
+      30_000,
+      "precondition: the wait streak must be saturated",
+    );
+
+    harness.controller.notifyVideoElementBound();
+    const afterBind = win.scheduled[win.scheduled.length - 1];
+    assert.equal(
+      afterBind.ms,
+      50,
+      "the element arrived, so the wait's accumulated penalty is spent",
+    );
+
+    // If that hydration still cannot apply, what it is waiting for now is
+    // something else (the page bridge here) — a new wait, which must start its
+    // own backoff rather than resume the spent one at the ceiling.
+    afterBind.cb();
+    await settle();
+    assert.equal(
+      win.scheduled[win.scheduled.length - 1].ms,
+      350,
+      "the wait that follows a binding restarts its backoff",
     );
   } finally {
     win.restore();

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -1430,8 +1430,8 @@ test("backs off consecutive hydration retries instead of re-arming a flat delay"
 
     assert.deepEqual(
       win.scheduled.map((timer) => timer.ms),
-      [350, 700, 1400, 2800, 5600, 11200],
-      "consecutive retries must double toward the ceiling",
+      [350, 700, 1400, 2800, 5600, 10_000],
+      "consecutive retries must double up to the ceiling",
     );
   } finally {
     win.restore();
@@ -1665,7 +1665,7 @@ test("a video binding after a long wait hydrates promptly, not at the ceiling", 
 
     const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
 
-    // Drive the wait to the ceiling: 350ms doubling reaches 30s by the 8th.
+    // Drive the wait to the ceiling: 350ms doubling clamps from the 6th on.
     await harness.controller.hydrateRoomState();
     for (let i = 0; i < 11; i += 1) {
       const armed = win.scheduled[win.scheduled.length - 1];
@@ -1675,7 +1675,7 @@ test("a video binding after a long wait hydrates promptly, not at the ceiling", 
     const saturated = win.scheduled[win.scheduled.length - 1];
     assert.equal(
       saturated.ms,
-      30_000,
+      10_000,
       "precondition: the wait streak must be saturated",
     );
 
@@ -1696,6 +1696,56 @@ test("a video binding after a long wait hydrates promptly, not at the ceiling", 
       win.scheduled[win.scheduled.length - 1].ms,
       350,
       "the wait that follows a binding restarts its backoff",
+    );
+  } finally {
+    win.restore();
+  }
+});
+
+test("resetting hydration retry frees the timer slot for the new room", async () => {
+  const win = installWindowTimerStub();
+  try {
+    // Clearing the streaks is only half of it. The single-timer guard in
+    // `scheduleHydrationRetry` refuses to arm while one is pending, so a room
+    // switch that left the old room's timer armed would silently drop the new
+    // room's 150ms bootstrap retry entirely (#229).
+    const roomState = createRoomStateWithPlayback({
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      currentTime: 42,
+      playState: "paused",
+      actorId: "remote-member",
+      seq: 5,
+    });
+    const harness = createController({
+      video: createStubVideo(false),
+      now: 30_000,
+      currentVideo: null,
+      requestRoomStateHydration: async () => ({
+        ok: true,
+        roomState,
+        memberId: "local-member",
+        roomCode: "ROOM01",
+      }),
+    });
+    harness.runtimeState.pendingRoomStateHydration = true;
+    harness.runtimeState.lastUserGestureAt = 29_500;
+
+    await harness.controller.hydrateRoomState();
+    assert.equal(win.scheduled.length, 1, "the old room armed a retry");
+
+    harness.controller.resetHydrationRetry();
+    assert.deepEqual(
+      win.cleared,
+      [win.scheduled[0].id],
+      "the pending timer must be cancelled, not just the streak",
+    );
+
+    harness.controller.scheduleHydrationRetry(150);
+    assert.equal(win.scheduled.length, 2, "the new room's retry must arm");
+    assert.equal(
+      win.scheduled[1].ms,
+      150,
+      "and at its own delay, not the old room's backed-off one",
     );
   } finally {
     win.restore();

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -29,6 +29,8 @@ function createController(overrides: {
   runtimeState?: ReturnType<typeof createContentRuntimeState>;
   video?: HTMLVideoElement | null;
   now?: number;
+  /** Virtual clock for tests that need time to advance during the test. */
+  getNow?: () => number;
   userGestureGraceMs?: number;
   remotePauseDebounceMs?: number;
   normalizeUrl?: (url: string | undefined | null) => string | null;
@@ -64,7 +66,7 @@ function createController(overrides: {
     initialRoomStatePauseHoldMs: 3_000,
     userGestureGraceMs: overrides.userGestureGraceMs ?? 1_200,
     remotePauseDebounceMs: overrides.remotePauseDebounceMs ?? 0,
-    getNow: () => overrides.now ?? 10_000,
+    getNow: () => overrides.getNow?.() ?? overrides.now ?? 10_000,
     debugLog: (msg) => logs.push(msg),
     shouldLogHeartbeat: () => true,
     requestRoomStateHydration:
@@ -1575,12 +1577,14 @@ test("video element binding is a no-op when no hydration is waiting", async () =
   }
 });
 
-test("repeated video rebinds decay instead of hydrating once per rebind", async () => {
+test("a rebind storm cannot starve hydration by resetting the timer", async () => {
   const win = installWindowTimerStub();
   try {
-    // A player that rebuilds its element in a loop reports a bind every time.
-    // Routing those through the backoff is what stops them from becoming one
-    // `sync:request` per rebuild at the 250ms bind interval (#229).
+    // Real timing, not hand-fired callbacks: a player rebuilding its element
+    // reports a bind about every 250ms (the bind poll interval). A binding that
+    // cancelled the pending timer and armed a longer one would be re-cancelled
+    // before it ever fired, so hydration would never run at all and the pending
+    // state would be held for as long as the rebuilding lasted (#229).
     const roomState = createRoomStateWithPlayback({
       url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
       currentTime: 42,
@@ -1588,45 +1592,79 @@ test("repeated video rebinds decay instead of hydrating once per rebind", async 
       actorId: "remote-member",
       seq: 5,
     });
+    const startClock = 30_000;
+    let clock = startClock;
+    const hydrationClocks: number[] = [];
     const harness = createController({
       video: createStubVideo(false),
-      now: 30_000,
+      getNow: () => clock,
       currentVideo: null,
-      requestRoomStateHydration: async () => ({
-        ok: true,
-        roomState,
-        memberId: "local-member",
-        roomCode: "ROOM01",
-      }),
+      requestRoomStateHydration: async () => {
+        hydrationClocks.push(clock);
+        return {
+          ok: true,
+          roomState,
+          memberId: "local-member",
+          roomCode: "ROOM01",
+        };
+      },
     });
     harness.runtimeState.pendingRoomStateHydration = true;
-    harness.runtimeState.lastUserGestureAt = 29_500;
+    harness.runtimeState.lastUserGestureAt = 0;
+
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+    // The stub records delays, not deadlines; pair each armed timer with the
+    // clock reading it was armed at so the simulation can fire it on time.
+    let armedCount = 0;
+    let dueAt: number | null = null;
+    let dueCb: (() => void) | null = null;
+    const trackArming = () => {
+      while (armedCount < win.scheduled.length) {
+        const timer = win.scheduled[armedCount];
+        armedCount += 1;
+        dueAt = clock + timer.ms;
+        dueCb = timer.cb;
+      }
+    };
 
     await harness.controller.hydrateRoomState();
+    trackArming();
+    assert.equal(hydrationClocks.length, 1);
 
-    // `hydrateRoomState` is async, so let it finish arming the next retry
-    // before the following rebind is reported.
-    const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
-
-    const bindArmedDelays: number[] = [];
-    for (let i = 0; i < 4; i += 1) {
-      const before = win.scheduled.length;
-      harness.controller.notifyVideoElementBound();
-      assert.equal(
-        win.scheduled.length,
-        before + 1,
-        `rebind ${i} must re-arm exactly one hydration`,
-      );
-      const armed = win.scheduled[win.scheduled.length - 1];
-      bindArmedDelays.push(armed.ms);
-      armed.cb();
-      await settle();
+    // 10 seconds of virtual time, stepping 50ms, rebinding every 250ms.
+    for (let step = 0; step < 200; step += 1) {
+      clock += 50;
+      if (dueAt !== null && clock >= dueAt && dueCb) {
+        const fire = dueCb;
+        dueAt = null;
+        dueCb = null;
+        fire();
+        await settle();
+        trackArming();
+      }
+      if (step % 5 === 0) {
+        harness.controller.notifyVideoElementBound();
+        trackArming();
+      }
     }
 
-    assert.deepEqual(
-      bindArmedDelays,
-      [50, 100, 200, 400],
-      "successive rebinds must back off on their own streak",
+    // Counting alone cannot tell "few because it decayed" from "few because it
+    // starved" — both are small. What distinguishes them is *when*: a starved
+    // timer stops firing once the bind backoff passes the rebind interval, so
+    // the tail of the window is empty.
+    // The bind backoff passes the 250ms rebind interval within the first
+    // second, which is when a cancel-and-re-arm implementation stops firing for
+    // good (measured: its last hydration lands at +750ms). A decaying one keeps
+    // going with growing gaps (measured: +6450ms and still counting), so any
+    // hydration well past that first second separates the two.
+    assert.ok(
+      hydrationClocks.some((at) => at >= startClock + 3_000),
+      `hydration must keep running in a rebind storm (ran at ${hydrationClocks.join(", ")})`,
+    );
+    // …but nowhere near one per rebind: 40 rebinds happened in this window.
+    assert.ok(
+      hydrationClocks.length < 15,
+      `and must still back off rather than run per rebind (ran ${hydrationClocks.length}x)`,
     );
   } finally {
     win.restore();

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -31,6 +31,8 @@ function createController(overrides: {
   now?: number;
   /** Virtual clock for tests that need time to advance during the test. */
   getNow?: () => number;
+  /** Virtual monotonic clock, as `performance.now()` would give. */
+  getMonotonicNow?: () => number;
   userGestureGraceMs?: number;
   remotePauseDebounceMs?: number;
   normalizeUrl?: (url: string | undefined | null) => string | null;
@@ -67,6 +69,11 @@ function createController(overrides: {
     userGestureGraceMs: overrides.userGestureGraceMs ?? 1_200,
     remotePauseDebounceMs: overrides.remotePauseDebounceMs ?? 0,
     getNow: () => overrides.getNow?.() ?? overrides.now ?? 10_000,
+    getMonotonicNow: () =>
+      overrides.getMonotonicNow?.() ??
+      overrides.getNow?.() ??
+      overrides.now ??
+      10_000,
     debugLog: (msg) => logs.push(msg),
     shouldLogHeartbeat: () => true,
     requestRoomStateHydration:
@@ -1425,9 +1432,14 @@ test("backs off consecutive hydration retries instead of re-arming a flat delay"
     harness.runtimeState.lastUserGestureAt = 29_500;
 
     // Six consecutive cycles that each re-arm the retry (the page bridge never
-    // becomes ready), driven directly rather than through the timer stub.
-    for (let i = 0; i < 6; i += 1) {
-      await harness.controller.hydrateRoomState();
+    // becomes ready). Driven through the timer, because only timer-driven
+    // retries accumulate the streak — an externally initiated
+    // `hydrateRoomState` is a fresh start and resets it.
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+    await harness.controller.hydrateRoomState();
+    for (let i = 0; i < 5; i += 1) {
+      win.scheduled[win.scheduled.length - 1].cb();
+      await settle();
     }
 
     assert.deepEqual(
@@ -1470,21 +1482,25 @@ test("resets hydration retry backoff once a cycle completes without retrying", a
     harness.runtimeState.pendingRoomStateHydration = true;
     harness.runtimeState.lastUserGestureAt = 29_500;
 
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
     await harness.controller.hydrateRoomState();
-    await harness.controller.hydrateRoomState();
+    win.scheduled[win.scheduled.length - 1].cb();
+    await settle();
     assert.deepEqual(
       win.scheduled.map((timer) => timer.ms),
       [350, 700],
     );
 
-    // A cycle that arms no retry clears the streak...
+    // A timer-driven cycle that arms no retry clears the streak...
     bridgeReady = true;
-    await harness.controller.hydrateRoomState();
+    win.scheduled[win.scheduled.length - 1].cb();
+    await settle();
     assert.equal(win.scheduled.length, 2, "clean cycle must not arm a retry");
 
-    // ...so the next isolated retry starts from its caller's delay again.
+    // ...so the next retry starts from its caller's delay again.
     bridgeReady = false;
-    await harness.controller.hydrateRoomState();
+    harness.controller.scheduleHydrationRetry();
     assert.deepEqual(
       win.scheduled.map((timer) => timer.ms),
       [350, 700, 350],
@@ -1784,6 +1800,115 @@ test("resetting hydration retry frees the timer slot for the new room", async ()
       win.scheduled[1].ms,
       150,
       "and at its own delay, not the old room's backed-off one",
+    );
+  } finally {
+    win.restore();
+  }
+});
+
+test("an externally driven hydration drops the previous page's backoff", async () => {
+  const win = installWindowTimerStub();
+  try {
+    // An SPA navigation within the same room calls `hydrateRoomState` directly
+    // (`navigation-controller`). The streaks belong to the page that just went
+    // away, and nothing would wake the new page early — Bilibili reuses the same
+    // `<video>` element across such a navigation, so no bind is reported (#229).
+    const roomState = createRoomStateWithPlayback({
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      currentTime: 42,
+      playState: "paused",
+      actorId: "remote-member",
+      seq: 5,
+    });
+    const harness = createController({
+      video: createStubVideo(false),
+      now: 30_000,
+      currentVideo: null,
+      requestRoomStateHydration: async () => ({
+        ok: true,
+        roomState,
+        memberId: "local-member",
+        roomCode: "ROOM01",
+      }),
+    });
+    harness.runtimeState.pendingRoomStateHydration = true;
+    harness.runtimeState.lastUserGestureAt = 29_500;
+
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+    await harness.controller.hydrateRoomState();
+    for (let i = 0; i < 5; i += 1) {
+      win.scheduled[win.scheduled.length - 1].cb();
+      await settle();
+    }
+    assert.equal(
+      win.scheduled[win.scheduled.length - 1].ms,
+      10_000,
+      "precondition: the old page saturated the backoff",
+    );
+
+    await harness.controller.hydrateRoomState();
+
+    assert.equal(
+      win.scheduled[win.scheduled.length - 1].ms,
+      350,
+      "a navigation must start the new page's backoff over",
+    );
+  } finally {
+    win.restore();
+  }
+});
+
+test("the retry deadline is compared on a monotonic clock", async () => {
+  const win = installWindowTimerStub();
+  try {
+    // The deadline is captured when the timer is armed. Read from `Date.now()`,
+    // a backward step shrinks `now + delay` and makes a candidate look earlier
+    // than a deadline it is not — so the comparison would preempt, cancel a
+    // timer that was about to fire, and restart the full delay.
+    const roomState = createRoomStateWithPlayback({
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      currentTime: 42,
+      playState: "paused",
+      actorId: "remote-member",
+      seq: 5,
+    });
+    let monotonic = 100_000;
+    let wallClock = 1_700_000_000_000;
+    const harness = createController({
+      video: createStubVideo(false),
+      getNow: () => wallClock,
+      getMonotonicNow: () => monotonic,
+      currentVideo: null,
+      requestRoomStateHydration: async () => ({
+        ok: true,
+        roomState,
+        memberId: "local-member",
+        roomCode: "ROOM01",
+      }),
+    });
+    harness.runtimeState.pendingRoomStateHydration = true;
+    harness.runtimeState.lastUserGestureAt = 0;
+
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+    await harness.controller.hydrateRoomState();
+    // Grow the bind streak so a preemption would cost a long re-wait.
+    for (let i = 0; i < 6; i += 1) {
+      harness.controller.notifyVideoElementBound();
+      monotonic += 1;
+      if (win.scheduled[win.scheduled.length - 1].ms <= 1) break;
+    }
+    const armedBefore = win.scheduled.length;
+
+    // Real time barely moved; the wall clock jumped an hour backwards.
+    monotonic += 5;
+    wallClock -= 3_600_000;
+    harness.controller.notifyVideoElementBound();
+    await settle();
+
+    assert.equal(
+      win.scheduled.length,
+      armedBefore,
+      "a backward wall-clock step must not preempt the pending retry",
     );
   } finally {
     win.restore();

--- a/extension/test/room-state-controller.test.ts
+++ b/extension/test/room-state-controller.test.ts
@@ -10,6 +10,8 @@ import { setLocaleForTests } from "../src/shared/i18n";
 function createController(shownToasts: string[]) {
   const runtimeState = createContentRuntimeState();
   runtimeState.localMemberId = "self";
+  const hydrationRetries: Array<number | undefined> = [];
+  let hydrationResets = 0;
   const controller = createRoomStateController({
     runtimeState,
     toastState: createToastCoordinatorState(),
@@ -21,9 +23,19 @@ function createController(shownToasts: string[]) {
     normalizeUrl: (url) => url ?? null,
     debugLog: () => {},
     resetPlaybackSyncState: () => {},
-    scheduleHydrationRetry: () => {},
+    scheduleHydrationRetry: (delayMs) => {
+      hydrationRetries.push(delayMs);
+    },
+    resetHydrationRetry: () => {
+      hydrationResets += 1;
+    },
   });
-  return { controller, runtimeState };
+  return {
+    controller,
+    runtimeState,
+    hydrationRetries,
+    hydrationResetCount: () => hydrationResets,
+  };
 }
 
 const sharedUrl = "https://www.bilibili.com/video/BV1?p=2";
@@ -70,4 +82,45 @@ test("room state controller stays silent for the local sharer's manual share", (
 
   assert.deepEqual(shownToasts, []);
   setLocaleForTests(null);
+});
+
+test("switching rooms clears the previous room's hydration backoff", () => {
+  // Both hydration backoff streaks measure how long *this* room's wait has been
+  // failing, and the retry timer belongs to it too. Carried into a new room they
+  // either stretch the 150ms bootstrap retry below to the ceiling, or make the
+  // single-timer guard refuse it outright — leaving the new room behind the
+  // hydration gate with broadcasts suppressed and a pause held (#229).
+  const harness = createController([]);
+
+  harness.controller.handleSyncStatus({
+    roomCode: "ROOM01",
+    connected: true,
+    memberId: "self",
+    rttMs: 10,
+  });
+  assert.equal(
+    harness.hydrationResetCount(),
+    0,
+    "the first room is not a switch",
+  );
+  assert.deepEqual(harness.hydrationRetries, [150]);
+
+  harness.runtimeState.hasReceivedInitialRoomState = true;
+  harness.controller.handleSyncStatus({
+    roomCode: "ROOM02",
+    connected: true,
+    memberId: "self",
+    rttMs: 10,
+  });
+
+  assert.equal(
+    harness.hydrationResetCount(),
+    1,
+    "a room switch must clear the previous room's retry state",
+  );
+  assert.deepEqual(
+    harness.hydrationRetries,
+    [150, 150],
+    "and the new room still gets its bootstrap retry",
+  );
 });

--- a/extension/test/room-state-controller.test.ts
+++ b/extension/test/room-state-controller.test.ts
@@ -124,3 +124,48 @@ test("switching rooms clears the previous room's hydration backoff", () => {
     "and the new room still gets its bootstrap retry",
   );
 });
+
+test("leaving a room clears the hydration backoff for the next one", () => {
+  // `roomChanged` needs both codes non-null, but leaving then joining reports
+  // `ROOM01 -> null -> ROOM02`: neither call satisfies it, so without a reset on
+  // the clearing path the old room's timer and streaks survive into the new
+  // room and its 150ms bootstrap retry is stretched or refused outright (#229).
+  const harness = createController([]);
+
+  harness.controller.handleSyncStatus({
+    roomCode: "ROOM01",
+    connected: true,
+    memberId: "self",
+    rttMs: 10,
+  });
+  assert.equal(harness.hydrationResetCount(), 0);
+
+  harness.controller.handleSyncStatus({
+    roomCode: null,
+    connected: true,
+    memberId: null,
+    rttMs: null,
+  });
+  assert.equal(
+    harness.hydrationResetCount(),
+    1,
+    "leaving must clear the retry state, since the later join will not",
+  );
+
+  harness.controller.handleSyncStatus({
+    roomCode: "ROOM02",
+    connected: true,
+    memberId: "self",
+    rttMs: 10,
+  });
+  assert.equal(
+    harness.hydrationResetCount(),
+    1,
+    "the join itself is not a switch, so it adds no further reset",
+  );
+  assert.deepEqual(
+    harness.hydrationRetries,
+    [150, 150],
+    "and the new room still gets its bootstrap retry",
+  );
+});


### PR DESCRIPTION
## Summary

- **后台只在答不上来时才发 `sync:request`** —— `content:get-room-state` 混淆了「把你有的状态给我」和「去刷新一下」，内容脚本的 hydration 重试为前者在循环里调用它，后台却对每次调用都无条件转发。一个播放器迟迟不产出 `<video>` 的标签页每 350ms 打一次服务端，单独就能打满每会话 6 次/10 秒的限流器。
- **hydration 重试改指数退避** —— 调用方传的延迟作为首个间隔，连续重试翻倍至 5s 封顶，一个未再武装重试的干净周期后计数器归零。

## 为什么缓存不需要轮询保鲜

连接期间服务端 push `room:state`；重连时 `socket-controller` 的 open handler 重发 `room:join`，握手带回新快照；中间窗口正是 `awaitingFreshRoomState` 标记的区间。本地 Codex review 独立枚举了 6 条缓存刷新路径，与人工审计一致。

## 关于退避上限取 5s 而非 issue 里的 30s

这是一处有依据的偏离。核实发现 video 元素绑定后**只记录 `lastVideoElementBoundAt`，不会重新应用房间状态**，所以 hydrate 重试是慢加载播放器最终出 `<video>` 后追上房间的唯一路径，上限即最坏追赶延迟——30s 会造成可感知的不同步。主修复落地后这条路径已不产生任何服务端流量，退避只需约束本地开销，5s 已把卡住标签页的唤醒从 ~171/min 降到 ~12/min。理由写在 `HYDRATION_RETRY_MAX_DELAY_MS` 的注释里。

## 未采纳的 issue 建议

- **在途请求合并**：主条件修好后，`!video` 路径已完全不发请求；剩余的无缓存场景下多标签页初次 hydrate 是有限次突发（K 个标签页 K 条请求，随后被退避摊开），不足以触发限流。加在途注册表需要引入抑制标志，AGENTS.md 明确要求避免这类叠加。
- **限流响应携带房间状态**：issue 正文里已划掉，对主路径零收益。

## 同类路径审计

| 路径 | 结论 |
| --- | --- |
| `:563` 页面桥未就绪（350ms） | 退避生效 |
| `:609` `!video`（350ms） | 主修复 + 退避 |
| `:869` 无房间态（1500ms） | 退避 1500→3000→5000；仍会转发（无缓存，合法用途） |
| `room-state-controller:144`（150ms，#148 那条循环） | 退避生效，状态到达后干净周期重置 |
| socket 半开（无 close 事件） | 非回归：半开时 `sync:request` 本就发不出去，恢复靠服务端心跳 (#157) |
| MV3 worker 重启 | 行为与修复前完全一致（`connected=false` → `connect()` → rejoin） |

Fixes #229

## Test plan

- [x] 4 条回归测试，**每条都验过判别力**（`cp` 备份 → 回退修复 → 确认失败 → 从备份还原）：
  - 有缓存时不轮询服务端 —— 回退后失败
  - 无缓存时仍发 `sync:request`（对照组）—— 回退后不受影响
  - 连续重试退避到 5s 封顶 —— 回退后失败
  - 干净周期后退避重置 —— 回退后失败
- [x] 预提交序列六项全绿，逐项独立取退出码（未用管道截断）：`format:check` / `lint` / `typecheck` / `build` / `test` / `audit` 均 `exit=0`
- [x] 本地 Codex review：三类风险（缓存永久陈旧 / 退避计数器重置 / 调用方语义被破坏）均报 NONE
- [ ] 线上验证：`sync:request` 拒绝占比从 72% 降至接近 0，且 Grafana 上 **130/min 的量子台阶消失**（见 issue 中的验收信号）