### PR TITLE
fix: 后台经过时长一律改用单调钟

### DIFF
--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -132,6 +132,8 @@ const roomSessionController = createRoomSessionController({
     shareController.clearPendingLocalShare(reason),
   expirePendingLocalShareIfNeeded: () =>
     shareController.expirePendingLocalShareIfNeeded(),
+  getActivePendingLocalShareUrl: () =>
+    shareController.getActivePendingLocalShareUrl(),
   normalizeUrl,
   logServerError,
   shareToastTtlMs: SHARE_TOAST_TTL_MS,

--- a/extension/src/background/room-manager.ts
+++ b/extension/src/background/room-manager.ts
@@ -7,6 +7,14 @@ import type {
 import type { SharedVideoToastPayload } from "../shared/messages";
 import { isSocketWritable } from "./socket-manager";
 
+/**
+ * `now` must come from a monotonic clock: it becomes a TTL deadline that
+ * {@link getPendingShareToastFor} compares against another reading of the same
+ * clock, which makes the pair an elapsed duration. The key also embeds it, but
+ * only needs to be unique per share event — and a monotonic reading is the
+ * better source for that too, since a stepped-back wall clock can hand out a
+ * value it already used.
+ */
 export function createPendingShareToast(args: {
   state: RoomState;
   normalizedSharedUrl: string | null;
@@ -27,6 +35,10 @@ export function createPendingShareToast(args: {
   };
 }
 
+/**
+ * `now` must be read from the same monotonic clock that produced `expiresAt`
+ * (see {@link createPendingShareToast}).
+ */
 export function getPendingShareToastFor(args: {
   pendingShareToast:
     (SharedVideoToastPayload & { expiresAt: number; roomCode: string }) | null;

--- a/extension/src/background/room-session-controller.ts
+++ b/extension/src/background/room-session-controller.ts
@@ -8,7 +8,6 @@ import { PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import type { BackgroundToContentMessage } from "../shared/messages";
 import {
   decideIncomingRoomState,
-  getActivePendingLocalShareUrl,
   isSharedVideoChange,
   type RoomLifecycleAction,
 } from "./room-state";
@@ -71,6 +70,13 @@ export function createRoomSessionController(args: {
   markPlaybackArrival: (playback: RoomState["playback"], atMs: number) => void;
   clearPendingLocalShare: (reason: string) => void;
   expirePendingLocalShareIfNeeded: () => void;
+  /**
+   * Asked of the share controller rather than re-derived here: the marker's
+   * deadline lives on a monotonic clock owned by that controller, and a second
+   * copy of the comparison would be a second clock read that nothing keeps in
+   * the same domain.
+   */
+  getActivePendingLocalShareUrl: () => string | null;
   normalizeUrl: (url: string | undefined | null) => string | null;
   logServerError: (code: string, message: string) => void;
   shareToastTtlMs: number;
@@ -540,12 +546,7 @@ export function createRoomSessionController(args: {
     const decision = decideIncomingRoomState({
       currentRoomState: args.roomSessionState.roomState,
       normalizedPendingLocalShareUrl: args.normalizeUrl(
-        getActivePendingLocalShareUrl({
-          pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
-          pendingLocalShareExpiresAt:
-            args.shareState.pendingLocalShareExpiresAt,
-          now: Date.now(),
-        }),
+        args.getActivePendingLocalShareUrl(),
       ),
       normalizedIncomingSharedUrl: args.normalizeUrl(
         nextState.sharedVideo?.url,
@@ -636,7 +637,7 @@ export function createRoomSessionController(args: {
     return createRoomPendingShareToast({
       state,
       normalizedSharedUrl: args.normalizeUrl(state.sharedVideo?.url),
-      now: Date.now(),
+      now: monotonicNow(),
       ttlMs: args.shareToastTtlMs,
     });
   }
@@ -649,7 +650,7 @@ export function createRoomSessionController(args: {
         args.shareState.pendingShareToast?.videoUrl,
       ),
       normalizedSharedUrl: args.normalizeUrl(state.sharedVideo?.url),
-      now: Date.now(),
+      now: monotonicNow(),
     });
     args.shareState.pendingShareToast = result.pendingShareToast;
     return result.shareToast;

--- a/extension/src/background/room-state.ts
+++ b/extension/src/background/room-state.ts
@@ -26,6 +26,13 @@ export type IncomingRoomStateDecision =
       confirmedPendingLocalShare: boolean;
     };
 
+/**
+ * `now` must come from a MONOTONIC clock (`performance.now()`), not `Date.now()`.
+ * The deadline it produces is only ever compared against another reading of the
+ * same clock by {@link getActivePendingLocalShareUrl}, so the two together
+ * measure an elapsed duration — and a wall clock does not measure durations. See
+ * that function for what a clock step does to this marker.
+ */
 export function createPendingLocalShareExpiry(
   now: number,
   timeoutMs = PENDING_LOCAL_SHARE_TIMEOUT_MS,
@@ -33,6 +40,17 @@ export function createPendingLocalShareExpiry(
   return now + timeoutMs;
 }
 
+/**
+ * `now` must be read from the same monotonic clock that produced
+ * `pendingLocalShareExpiresAt` (see {@link createPendingLocalShareExpiry}).
+ *
+ * On a wall clock a backward step inside the timeout window makes this keep
+ * answering "still pending" past the deadline, and the backstop does not save
+ * it: the expiry timer's callback re-runs this same check and, finding the
+ * marker still live, declines to clear it. That timer is one-shot and does not
+ * re-arm, so the marker leaks for the rest of the session and blocks every
+ * subsequent auto-share.
+ */
 export function getActivePendingLocalShareUrl(args: {
   pendingLocalShareUrl: string | null;
   pendingLocalShareExpiresAt: number | null;

--- a/extension/src/background/share-controller.ts
+++ b/extension/src/background/share-controller.ts
@@ -86,7 +86,14 @@ export function createShareController(args: {
   persistState: () => Promise<void>;
   notifyAll: () => void;
   rememberSharedSourceTab: (tabId?: number, videoUrl?: string | null) => void;
+  getMonotonicNow?: () => number;
 }): ShareController {
+  // The pending-share deadline is an elapsed duration measured entirely on this
+  // machine, so it must not move when the wall clock is stepped. It is never
+  // persisted (see `persistBackgroundState`) and never leaves this worker, so a
+  // clock whose origin resets with the service worker is safe here.
+  const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
+
   function clearPendingLocalShareTimer(): void {
     if (args.shareState.pendingLocalShareTimer !== null) {
       clearTimeout(args.shareState.pendingLocalShareTimer);
@@ -318,7 +325,7 @@ export function createShareController(args: {
     return getActivePendingLocalShareUrl({
       pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
       pendingLocalShareExpiresAt: args.shareState.pendingLocalShareExpiresAt,
-      now: Date.now(),
+      now: monotonicNow(),
     });
   }
 
@@ -334,11 +341,10 @@ export function createShareController(args: {
   }
 
   function expirePendingLocalShareIfNeeded(): void {
-    const activePendingShare = getActivePendingLocalShareUrl({
-      pendingLocalShareUrl: args.shareState.pendingLocalShareUrl,
-      pendingLocalShareExpiresAt: args.shareState.pendingLocalShareExpiresAt,
-      now: Date.now(),
-    });
+    // Deliberately routed through the same reader every other caller uses:
+    // duplicating the liveness test means duplicating the clock read, and the
+    // duplicate is what has to be found by hand when the clock domain moves.
+    const activePendingShare = readActivePendingLocalShareUrl();
     if (args.shareState.pendingLocalShareUrl && activePendingShare === null) {
       clearPendingLocalShare(
         `share confirmation timed out after ${PENDING_LOCAL_SHARE_TIMEOUT_MS}ms`,
@@ -357,9 +363,8 @@ export function createShareController(args: {
     // manual share's marker should block the next auto-share).
     args.shareState.pendingLocalShareIsAutoShare = isAutoShare;
     args.shareState.pendingLocalShareUrl = url;
-    args.shareState.pendingLocalShareExpiresAt = createPendingLocalShareExpiry(
-      Date.now(),
-    );
+    args.shareState.pendingLocalShareExpiresAt =
+      createPendingLocalShareExpiry(monotonicNow());
     args.log(
       "background",
       `Waiting up to ${PENDING_LOCAL_SHARE_TIMEOUT_MS}ms for share confirmation ${url}`,

--- a/extension/src/background/socket-controller.ts
+++ b/extension/src/background/socket-controller.ts
@@ -47,7 +47,14 @@ export function createSocketController(args: {
   onOpen: () => void;
   onAdminSessionReset: (reason: string) => void;
   formatAdminSessionResetReason: (reason: string) => string;
+  getMonotonicNow?: () => number;
 }): SocketController {
+  // `reconnectDeadlineMs` exists only so the popup can count down to the retry
+  // that `setTimeout` is already going to perform. A wall clock would make the
+  // two disagree after a clock step — the countdown would read minutes while the
+  // timer fires on schedule — because only one of them is measuring a duration.
+  const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
+
   async function connect(): Promise<void> {
     if (
       args.connectionState.socket &&
@@ -445,7 +452,7 @@ export function createSocketController(args: {
     const retryDelayMs = getReconnectDelayMs(
       args.connectionState.reconnectAttempt,
     );
-    args.connectionState.reconnectDeadlineMs = Date.now() + retryDelayMs;
+    args.connectionState.reconnectDeadlineMs = monotonicNow() + retryDelayMs;
     args.log("background", `Reconnect scheduled in ${retryDelayMs}ms`);
     args.connectionState.reconnectTimer = self.setTimeout(() => {
       args.connectionState.reconnectDeadlineMs = null;
@@ -466,7 +473,10 @@ export function createSocketController(args: {
     if (args.connectionState.reconnectDeadlineMs === null) {
       return null;
     }
-    return Math.max(0, args.connectionState.reconnectDeadlineMs - Date.now());
+    return Math.max(
+      0,
+      args.connectionState.reconnectDeadlineMs - monotonicNow(),
+    );
   }
 
   function resetReconnectState(): void {

--- a/extension/test/background-share-controller.test.ts
+++ b/extension/test/background-share-controller.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { PROTOCOL_VERSION } from "@bili-syncplay/protocol";
 import { createBackgroundRuntimeState } from "../src/background/runtime-state";
 import { createShareController } from "../src/background/share-controller";
+import { installClockStubs, installFakeSelfTimers } from "./clock-stubs";
 
 // Node < 22 has no global WebSocket; production `isSocketWritable` reads
 // `WebSocket.OPEN`. Provide the readyState statics so these unit tests run on
@@ -424,4 +425,85 @@ test("background share controller reports missing member token without queuing a
   assert.deepEqual(harness.sendToServerCalls, []);
   assert.equal(harness.runtimeState.share.pendingLocalShareUrl, null);
   assert.equal(harness.notifyAllCalls, 0);
+});
+
+const PENDING_SHARE_VIDEO = {
+  video: {
+    videoId: "BV199W9zEEcH",
+    url: "https://www.bilibili.com/video/BV199W9zEEcH",
+    title: "New Video",
+  },
+  playback: null,
+};
+
+test("background share controller expires a pending local share across a backward wall-clock step", async () => {
+  // No clock is injected into the controller: this asserts which source its
+  // DEFAULT reads, which an injected one would hide.
+  const clock = installClockStubs({
+    wall: 1_700_000_000_000,
+    monotonic: 1_000,
+  });
+  const timers = installFakeSelfTimers();
+  const harness = createControllerHarness();
+  harness.runtimeState.connection.connected = true;
+  harness.runtimeState.room.roomCode = "ROOM01";
+  harness.runtimeState.room.memberToken = "member-token-1";
+  harness.runtimeState.room.memberId = "member-1";
+
+  try {
+    await harness.controller.queueOrSendSharedVideo(PENDING_SHARE_VIDEO, 123);
+    assert.equal(harness.controller.hasActivePendingLocalShare(), true);
+    assert.equal(timers.pending().length, 1);
+
+    // The full 10s confirmation window elapses...
+    clock.clocks.monotonic += 10_001;
+    // ...and an NTP correction steps the wall clock back a minute inside it.
+    clock.clocks.wall -= 60_000;
+
+    // The one-shot backstop fires on schedule (setTimeout is unaffected by the
+    // step) and re-tests the deadline.
+    timers.runAll();
+
+    assert.equal(harness.runtimeState.share.pendingLocalShareUrl, null);
+    assert.equal(harness.controller.hasActivePendingLocalShare(), false);
+    // Nothing is left to have another go: the backstop does not re-arm, so a
+    // marker this pass declines to clear is a marker that leaks for the rest of
+    // the session, blocking every later auto-share.
+    assert.deepEqual(timers.pending(), []);
+  } finally {
+    timers.restore();
+    clock.restore();
+  }
+});
+
+test("background share controller keeps a pending local share across a forward wall-clock step", async () => {
+  const clock = installClockStubs({
+    wall: 1_700_000_000_000,
+    monotonic: 1_000,
+  });
+  const timers = installFakeSelfTimers();
+  const harness = createControllerHarness();
+  harness.runtimeState.connection.connected = true;
+  harness.runtimeState.room.roomCode = "ROOM01";
+  harness.runtimeState.room.memberToken = "member-token-1";
+  harness.runtimeState.room.memberId = "member-1";
+
+  try {
+    await harness.controller.queueOrSendSharedVideo(PENDING_SHARE_VIDEO, 123);
+
+    // The clock jumps a minute forward while barely any time has actually
+    // passed. Expiring here would let the very next `room:state` — still the
+    // pre-share snapshot — roll the room back off the video just shared.
+    clock.clocks.wall += 60_000;
+    clock.clocks.monotonic += 100;
+
+    assert.equal(harness.controller.hasActivePendingLocalShare(), true);
+    assert.equal(
+      harness.controller.getActivePendingLocalShareUrl(),
+      "https://www.bilibili.com/video/BV199W9zEEcH",
+    );
+  } finally {
+    timers.restore();
+    clock.restore();
+  }
 });

--- a/extension/test/clock-stubs.ts
+++ b/extension/test/clock-stubs.ts
@@ -1,0 +1,88 @@
+/**
+ * Test doubles for the two clocks the background reads.
+ *
+ * These stub the GLOBALS rather than injecting a time source, because that is
+ * the only way to test *which* clock a default reads: a controller that takes
+ * `getMonotonicNow` and is handed one in the test passes whether its fallback is
+ * `performance.now()` or `Date.now()`. Move the two clocks in opposite
+ * directions and only the correct source survives.
+ */
+
+export interface StubbedClocks {
+  /** What `Date.now()` returns. Step it to simulate an NTP correction. */
+  wall: number;
+  /** What `performance.now()` returns. Only ever advance it. */
+  monotonic: number;
+}
+
+export function installClockStubs(initial: StubbedClocks): {
+  clocks: StubbedClocks;
+  restore: () => void;
+} {
+  const clocks = { ...initial };
+  const originalDateNow = Date.now;
+  const originalPerformanceNow = performance.now;
+  Date.now = () => clocks.wall;
+  performance.now = () => clocks.monotonic;
+
+  return {
+    clocks,
+    restore() {
+      Date.now = originalDateNow;
+      performance.now = originalPerformanceNow;
+    },
+  };
+}
+
+export interface FakeTimer {
+  id: number;
+  delayMs: number;
+  fn: () => void;
+}
+
+/**
+ * Replaces `self.setTimeout` with a queue the test drains by hand, so a 10s
+ * backstop can be observed firing without waiting 10s — and so a test can assert
+ * that nothing was left armed afterwards.
+ *
+ * The global `clearTimeout` is deliberately left alone: production clears these
+ * ids through it, but a test that arms one timer and drains it never reaches
+ * that path, and stubbing a global the test runner also uses buys nothing here.
+ */
+export function installFakeSelfTimers(): {
+  pending: () => FakeTimer[];
+  runAll: () => void;
+  restore: () => void;
+} {
+  const originalSelf = (globalThis as { self?: unknown }).self;
+  let timers: FakeTimer[] = [];
+  let nextId = 1;
+
+  Object.assign(globalThis, {
+    self: {
+      setTimeout(fn: () => void, delayMs: number): number {
+        const id = nextId;
+        nextId += 1;
+        timers.push({ id, delayMs, fn });
+        return id;
+      },
+      clearTimeout(id: number): void {
+        timers = timers.filter((timer) => timer.id !== id);
+      },
+    },
+  });
+
+  return {
+    pending: () => [...timers],
+    runAll() {
+      const due = timers;
+      timers = [];
+      for (const timer of due) {
+        timer.fn();
+      }
+    },
+    restore() {
+      Object.assign(globalThis, { self: originalSelf });
+    },
+  };
+}

--- a/extension/test/room-session-controller.test.ts
+++ b/extension/test/room-session-controller.test.ts
@@ -7,12 +7,14 @@ import {
 } from "@bili-syncplay/protocol";
 import { createBackgroundRuntimeState } from "../src/background/runtime-state";
 import { createRoomSessionController } from "../src/background/room-session-controller";
+import { getActivePendingLocalShareUrl } from "../src/background/room-state";
 import { setLocaleForTests } from "../src/shared/i18n";
 
 function createControllerHarness(options?: {
   bootstrapRoomStateTimeoutMs?: number;
   persistState?: (callCount: number) => Promise<void> | void;
   getMonotonicNow?: () => number;
+  getActivePendingLocalShareUrl?: () => string | null;
   onEnsureSharedVideoOpen?: () => void;
 }) {
   const runtimeState = createBackgroundRuntimeState();
@@ -94,6 +96,18 @@ function createControllerHarness(options?: {
       runtimeState.share.pendingLocalShareExpiresAt = null;
     },
     expirePendingLocalShareIfNeeded: () => {},
+    // Stands in for the share controller, which owns the marker's clock. The
+    // default reproduces the wall-clock expiry the older tests below set up; a
+    // test that cares which clock answers overrides it.
+    getActivePendingLocalShareUrl:
+      options?.getActivePendingLocalShareUrl ??
+      (() =>
+        getActivePendingLocalShareUrl({
+          pendingLocalShareUrl: runtimeState.share.pendingLocalShareUrl,
+          pendingLocalShareExpiresAt:
+            runtimeState.share.pendingLocalShareExpiresAt,
+          now: Date.now(),
+        })),
     normalizeUrl: (url) => url?.trim() ?? null,
     logServerError: (code, message) => {
       logs.push(`server-error:${code}:${message}`);
@@ -1067,4 +1081,110 @@ test("drops a member delta that a later room state superseded", async () => {
       line.includes("Dropped superseded member state"),
     ),
   );
+});
+
+test("takes the pending-share verdict from the share controller, not a wall-clock re-derivation", async () => {
+  const pendingUrl = "https://www.bilibili.com/video/BVpending";
+  const harness = createControllerHarness({
+    // The share controller owns the marker and measures its deadline on a
+    // monotonic clock, so it still reports the share as in flight.
+    getActivePendingLocalShareUrl: () => pendingUrl,
+  });
+  harness.runtimeState.share.pendingLocalShareUrl = pendingUrl;
+  // The wall-clock stamp says the opposite. It is the same field a second copy
+  // of the liveness test would read, so re-deriving the verdict here instead of
+  // asking the owner flips the answer.
+  harness.runtimeState.share.pendingLocalShareExpiresAt = Date.now() - 60_000;
+
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: {
+      roomCode: "ROOM11",
+      sharedVideo: {
+        videoId: "BVother",
+        url: "https://www.bilibili.com/video/BVother",
+        title: "Someone else's video",
+        sharedByMemberId: "member-9",
+      },
+      playback: null,
+      members: [{ id: "member-9", name: "Bob" }],
+    },
+  } satisfies ServerMessage);
+
+  // Our own share is still in flight, so a room state showing a different video
+  // is the pre-share snapshot and must not roll the room back onto it.
+  assert.equal(harness.runtimeState.room.roomState, null);
+  assert.deepEqual(harness.ensureSharedVideoOpenCalls, []);
+  assert.deepEqual(harness.notifyContentMessages, []);
+  assert.ok(
+    harness.logs.some((line) => line.startsWith("Ignored stale room state")),
+  );
+});
+
+test("expires the pending share toast on the monotonic clock", async () => {
+  let monotonic = 5_000;
+  const harness = createControllerHarness({
+    getMonotonicNow: () => monotonic,
+  });
+  const sharedVideo = {
+    videoId: "BVtoast",
+    url: "https://www.bilibili.com/video/BVtoast",
+    title: "Toast Video",
+    sharedByMemberId: "member-1",
+  };
+
+  // Creates the pending toast with an 8s TTL (`shareToastTtlMs` in the harness).
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: {
+      roomCode: "ROOM12",
+      sharedVideo,
+      playback: null,
+      members: [{ id: "member-1", name: "Alice" }],
+    },
+  } satisfies ServerMessage);
+
+  // A later state for the SAME shared video mints no new toast, so the pending
+  // one is re-tested against its deadline. Still inside the TTL on the monotonic
+  // clock, so it rides along again.
+  monotonic = 9_000;
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: {
+      roomCode: "ROOM12",
+      sharedVideo,
+      playback: null,
+      members: [
+        { id: "member-1", name: "Alice" },
+        { id: "member-2", name: "Bob" },
+      ],
+    },
+  } satisfies ServerMessage);
+
+  assert.ok(
+    (harness.notifyContentMessages[1] as { shareToast: unknown }).shareToast,
+  );
+
+  // Past it: the toast must be dropped. The wall clock is never touched in this
+  // test, so an implementation reading it would still call this fresh.
+  monotonic = 20_000;
+  await harness.controller.handleServerMessage({
+    type: "room:state",
+    payload: {
+      roomCode: "ROOM12",
+      sharedVideo,
+      playback: null,
+      members: [
+        { id: "member-1", name: "Alice" },
+        { id: "member-2", name: "Bob" },
+        { id: "member-3", name: "Carol" },
+      ],
+    },
+  } satisfies ServerMessage);
+
+  assert.equal(
+    (harness.notifyContentMessages[2] as { shareToast: unknown }).shareToast,
+    null,
+  );
+  assert.equal(harness.runtimeState.share.pendingShareToast, null);
 });

--- a/extension/test/socket-controller.test.ts
+++ b/extension/test/socket-controller.test.ts
@@ -4,6 +4,7 @@ import type { SharedVideo } from "@bili-syncplay/protocol";
 import { createBackgroundRuntimeState } from "../src/background/runtime-state";
 import { createSocketController } from "../src/background/socket-controller";
 import { setLocaleForTests, t } from "../src/shared/i18n";
+import { installClockStubs } from "./clock-stubs";
 
 class FakeWebSocket {
   static readonly CONNECTING = 0;
@@ -521,6 +522,42 @@ test("an admin reset aborts an in-flight reconnect probe instead of opening a gh
     assert.equal(harness.runtimeState.connection.connected, false);
   } finally {
     harness?.controller.clearReconnectTimer();
+    globals.restore();
+  }
+});
+
+test("counts down the reconnect retry on the monotonic clock", () => {
+  const globals = installGlobals();
+  // No clock injected: this asserts which source the default reads.
+  const clock = installClockStubs({
+    wall: 1_700_000_000_000,
+    monotonic: 1_000,
+  });
+  let harness: ReturnType<typeof createHarness> | undefined;
+
+  try {
+    harness = createHarness();
+    harness.controller.scheduleReconnect();
+
+    const armedDelayMs = harness.controller.getRetryInMs();
+    assert.equal(armedDelayMs, 1_000);
+
+    // A forward wall-clock correction must not shorten the countdown: the
+    // `setTimeout` it is narrating has not moved, so the popup would claim a
+    // retry that has not happened.
+    clock.clocks.wall += 60_000;
+    assert.equal(harness.controller.getRetryInMs(), 1_000);
+
+    // Time actually passing does shorten it.
+    clock.clocks.monotonic += 400;
+    assert.equal(harness.controller.getRetryInMs(), 600);
+
+    // ...and a backward correction must not stretch it back out.
+    clock.clocks.wall -= 120_000;
+    assert.equal(harness.controller.getRetryInMs(), 600);
+  } finally {
+    harness?.controller.clearReconnectTimer();
+    clock.restore();
     globals.restore();
   }
 });


### PR DESCRIPTION
## 背景

#231 的第一块。挂钟（`Date.now()`）在 NTP 校正或用户改系统时间时不单调，而经过时长要求单调。`setTimeout` 本身不受钟差影响，所以"定时器 + 挂钟时间戳"混用的地方，两者会在钟跳后失配。

## 主症状：`pendingLocalShare` 标记会无限期滞留

- 起点：`share-controller.ts` `setPendingLocalShare` 用 `Date.now()` 算 10 秒截止
- 判定：`room-state.ts` `getActivePendingLocalShareUrl` 比 `expiresAt > now`
- 兜底：`share-controller.ts` 一次性 `self.setTimeout(..., 10s)`

**兜底救不了它**：定时器回调调用的 `expirePendingLocalShareIfNeeded()` 走的是同一个判定。窗口内挂钟一旦向后跳，判定继续答"仍在等待"，回调就不清除标记；而该定时器是一次性的、回调里也不重排。于是标记滞留到本次 service worker 生命周期结束，期间一直阻塞 auto-share-next。

（这一条更正了我在 #230 第 6 轮里说的"另有 `pendingLocalShareTimer` 兜底"——那个判断是错的。）

## 变更点

- `share-controller`：注入单调时钟（默认 `performance.now()`），起点与判定各一处
- `room-session-controller`：share toast 的 TTL 起点与比较改用已有的 `monotonicNow()`
- `socket-controller`：`reconnectDeadlineMs` 改用单调钟。它只喂 popup 的"N 秒后重试"显示，钟一跳就和实际 `setTimeout` 对不上
- `room-session-controller` 里**就地重算**的过期判定改为向 share-controller 查询。判定的时钟归它所有，第二份拷贝就是第二次时钟读取，没有任何东西保证两者同域——这正是 #230 复盘里"决策要放在拥有所需信息的那一层"的同一形态
- `share-controller.expirePendingLocalShareIfNeeded` 内部同样收敛到单一 reader，去掉重复的判定与时钟读取

三处状态都不入持久化（`persistBackgroundState` 只写 `room.*`），因此 `performance.now()` 随 worker 重启重置时间原点是安全的。

## 审计：后台其余 `Date.now()` 逐项确认

| 位置 | 结论 |
| --- | --- |
| `clock-controller.ts:87/115` | 与服务端交换的挂钟值，**本就该用挂钟** |
| `diagnostics-controller.ts:40`、`logger.ts:9` | 日志时间戳，不适用 |
| `popup-state-controller.ts:60` `connectedAt` | 全库无消费方，不构成时长比较 |

内容脚本侧的 22 处留给 #231 的第二个 PR（同一个 `nowOf()` 在那些文件里还兼作日志时间戳和服务端交换值，须逐处判定用途）。

## Test plan

新增测试用 stub **全局双钟反向移动**验证"默认时钟源"——注入时钟测不出默认走的是哪个（#230 教训）。

逐处回退验证判别力，均失败：

- [x] 回退 `share-controller` 三处 → `expires a pending local share across a backward wall-clock step`、`keeps a pending local share across a forward wall-clock step` 失败
- [x] 回退 `room-session-controller` 的委托 → `takes the pending-share verdict from the share controller, not a wall-clock re-derivation` 失败
- [x] 回退 toast 时钟 → `expires the pending share toast on the monotonic clock` 失败
- [x] 回退重连倒计时 → `counts down the reconnect retry on the monotonic clock` 失败
- [x] `format:check` / `lint` / `typecheck` / `build` / `test` / `audit` 全绿
- [ ] 手动验证（改系统时间复现属破坏性操作，未在本机执行）

Refs #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
