### PR TITLE
fix: 内容脚本经过时长一律改用单调钟

### DIFF
--- a/extension/src/content/festival-bridge.ts
+++ b/extension/src/content/festival-bridge.ts
@@ -208,7 +208,7 @@ export function createFestivalBridgeController(): FestivalBridgeController {
       // video, so the auto-share self-check cannot confirm a stale target.
       if (
         maxAgeMs !== undefined &&
-        Date.now() - festivalSnapshot.updatedAt >= maxAgeMs
+        performance.now() - festivalSnapshot.updatedAt >= maxAgeMs
       ) {
         return null;
       }
@@ -225,7 +225,7 @@ export function createFestivalBridgeController(): FestivalBridgeController {
         !isBangumiPage &&
         festivalSnapshot &&
         canUseCachedFestivalSnapshot(pathname) &&
-        Date.now() - festivalSnapshot.updatedAt < maxAgeMs
+        performance.now() - festivalSnapshot.updatedAt < maxAgeMs
       ) {
         return {
           videoId: festivalSnapshot.videoId,
@@ -247,7 +247,7 @@ export function createFestivalBridgeController(): FestivalBridgeController {
         return !isBangumiPage &&
           festivalSnapshot &&
           canUseCachedFestivalSnapshot(pathname) &&
-          Date.now() - festivalSnapshot.updatedAt < maxAgeMs
+          performance.now() - festivalSnapshot.updatedAt < maxAgeMs
           ? {
               videoId: festivalSnapshot.videoId,
               url: festivalSnapshot.url,
@@ -258,7 +258,11 @@ export function createFestivalBridgeController(): FestivalBridgeController {
 
       festivalSnapshot = {
         ...nextSnapshot,
-        updatedAt: Date.now(),
+        // Monotonic: this stamp exists only to age the snapshot out against
+        // `maxAgeMs` above, and an interval measured on this machine must not
+        // move when the wall clock is stepped. Unrelated to the wire field of
+        // the same name on `PlaybackState`.
+        updatedAt: performance.now(),
         pathname,
         pageUrl,
       };

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -215,10 +215,23 @@ function debugLog(message: string): void {
   }).catch(() => undefined);
 }
 
+/**
+ * Every timestamp below is monotonic (`performance.now()`), and so is every
+ * timestamp the controllers this file wires up store. They are all intervals
+ * measured on this machine — a throttle window, a pause hold, the age of a user
+ * gesture — and none of them may move when the wall clock is stepped. Some of
+ * these fields (`lastUserGestureAt`) are written here and compared in three
+ * other controllers, so the domain is only consistent if every writer and every
+ * reader uses the same clock.
+ *
+ * The single exception in the content script is `PlaybackState.updatedAt`, a
+ * wire field that stays on the wall clock; it is produced in
+ * `playback-broadcast` / `page-video`, never here.
+ */
 function shouldLogHeartbeat(
   state: { key: string | null; at: number },
   key: string,
-  now = Date.now(),
+  now = performance.now(),
 ): boolean {
   if (state.key === key && now - state.at < HEARTBEAT_LOG_INTERVAL_MS) {
     return false;
@@ -229,12 +242,12 @@ function shouldLogHeartbeat(
 }
 
 function activatePauseHold(durationMs = PAUSE_HOLD_MS): void {
-  runtimeState.pauseHoldUntil = Date.now() + durationMs;
+  runtimeState.pauseHoldUntil = performance.now() + durationMs;
 }
 
 async function init(): Promise<void> {
   startUserGestureTracking((insidePlayer) => {
-    const now = Date.now();
+    const now = performance.now();
     runtimeState.lastUserGestureAt = now;
     if (insidePlayer) {
       runtimeState.lastUserGestureInPlayerAt = now;

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -59,9 +59,15 @@ export function createNavigationController(args: {
   }) => void;
   cancelAutoShareNextVideo?: () => void;
   debugLog: (message: string) => void;
-  getNow?: () => number;
+  /**
+   * Monotonic time source. Every timestamp this controller stores and every
+   * window it compares is an interval measured on this machine, so none of them
+   * may move when the wall clock is stepped. The wall clock is only correct for
+   * the wire field `PlaybackState.updatedAt`, which is produced elsewhere.
+   */
+  getMonotonicNow?: () => number;
 }): NavigationController {
-  const nowOf = () => args.getNow?.() ?? Date.now();
+  const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
   // Compares the path portion of two page URLs (ignoring query/hash), used to
   // tell a same-page festival autoplay from a navigation to a different page.
   const samePathname = (a: string, b: string): boolean => {
@@ -269,7 +275,7 @@ export function createNavigationController(args: {
       activeSharedUrl !== null && isUnstableSharedVideoUrl(activeSharedUrl)
         ? (previousResolvedSharedVideoUrl ?? activeSharedUrl)
         : activeSharedUrl;
-    const now = nowOf();
+    const now = monotonicNow();
     // Captured before `resetUserGestureState` below zeroes it, so the
     // natural-end check can tell whether a gesture postdates the natural end.
     const lastUserGestureAt = args.runtimeState.lastUserGestureAt;

--- a/extension/src/content/page-video.ts
+++ b/extension/src/content/page-video.ts
@@ -73,12 +73,17 @@ export function resolveSharedVideoTitle(
   );
 }
 
+/**
+ * `updatedAt` goes on the wire as the protocol's "sender timestamp (ms)", so it
+ * is a WALL-CLOCK reading — unlike every elapsed-duration reading in the content
+ * script. See {@link createPlaybackBroadcastPayload} for the full reasoning.
+ */
 export function createSharePayload(args: {
   sharedVideo: SharedVideo;
   playback: VideoPlaybackSnapshot | null;
   actorId: string;
   seq: number;
-  now: number;
+  updatedAt: number;
 }): { video: SharedVideo; playback: PlaybackState | null } {
   if (!args.playback) {
     return {
@@ -94,7 +99,7 @@ export function createSharePayload(args: {
       currentTime: args.playback.currentTime,
       playState: args.playback.playState,
       playbackRate: args.playback.playbackRate,
-      updatedAt: args.now,
+      updatedAt: args.updatedAt,
       serverTime: 0,
       actorId: args.actorId,
       seq: args.seq,

--- a/extension/src/content/pending-local-override.ts
+++ b/extension/src/content/pending-local-override.ts
@@ -26,10 +26,16 @@ export function createPendingLocalOverrideController(args: {
   runtimeState: ContentRuntimeState;
   userGestureGraceMs: number;
   normalizeUrl: (url: string | undefined | null) => string | null;
-  getNow?: () => number;
+  /**
+   * Monotonic time source. Every timestamp this controller stores and every
+   * window it compares is an interval measured on this machine, so none of them
+   * may move when the wall clock is stepped. The wall clock is only correct for
+   * the wire field `PlaybackState.updatedAt`, which is produced elsewhere.
+   */
+  getMonotonicNow?: () => number;
   debugLog: (message: string) => void;
 }): PendingLocalOverrideController {
-  const nowOf = () => args.getNow?.() ?? Date.now();
+  const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
 
   function clearPendingLocalPlaybackOverride(reason = "unknown"): void {
     if (args.runtimeState.pendingLocalPlaybackOverride) {
@@ -108,7 +114,7 @@ export function createPendingLocalOverrideController(args: {
       return { shouldIgnore: false };
     }
 
-    if (nowOf() >= pending.expiresAt) {
+    if (monotonicNow() >= pending.expiresAt) {
       clearPendingLocalPlaybackOverride("expired");
       return { shouldIgnore: false };
     }

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -68,12 +68,18 @@ export function createPlaybackBindingController(args: {
   applyPendingPlaybackApplication: (video: HTMLVideoElement) => void;
   activatePauseHold: (durationMs?: number) => void;
   debugLog: (message: string) => void;
-  getNow?: () => number;
+  /**
+   * Monotonic time source. Every timestamp this controller stores and every
+   * window it compares is an interval measured on this machine, so none of them
+   * may move when the wall clock is stepped. The wall clock is only correct for
+   * the wire field `PlaybackState.updatedAt`, which is produced elsewhere.
+   */
+  getMonotonicNow?: () => number;
 }): PlaybackBindingController {
   let videoBindingTimer: number | null = null;
   let pauseBufferUpgradeTimerId: number | null = null;
   let sharerEndedFlushTimerId: number | null = null;
-  const nowOf = () => args.getNow?.() ?? Date.now();
+  const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
   const scheduleUpgradeTimer = (cb: () => void, ms: number): number | null => {
     if (
       typeof globalThis.window !== "undefined" &&
@@ -135,14 +141,15 @@ export function createPlaybackBindingController(args: {
     }, args.bufferPauseUpgradeMs);
   };
   const hasRecentUserGesture = () =>
-    nowOf() - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs;
+    monotonicNow() - args.runtimeState.lastUserGestureAt <
+    args.userGestureGraceMs;
   // A genuine intent to control the player (pointer inside the player container
   // or a play-toggle key), as opposed to any document-level gesture. Authorizing
   // playback on a "load paused" non-shared page requires this stronger signal so
   // a stray click on blank space / a popup cannot wave the page-load autoplay
   // through.
   const hasRecentUserGestureInPlayer = () =>
-    nowOf() - args.runtimeState.lastUserGestureInPlayerAt <
+    monotonicNow() - args.runtimeState.lastUserGestureInPlayerAt <
     args.userGestureGraceMs;
   // A FRESH in-player play intent: an in-player gesture that also postdates the
   // last forced pause. While the page bridge resolves, the unconfirmed-context
@@ -158,7 +165,7 @@ export function createPlaybackBindingController(args: {
     const explicitAction = args.runtimeState.lastExplicitUserAction;
     if (
       explicitAction?.kind !== "seek" ||
-      nowOf() - explicitAction.at >= args.userGestureGraceMs
+      monotonicNow() - explicitAction.at >= args.userGestureGraceMs
     ) {
       return null;
     }
@@ -217,9 +224,9 @@ export function createPlaybackBindingController(args: {
    * same predicate authorizes playback on "load paused" pages, where arrow keys
    * must NOT count.
    *
-   * Both timestamps come from `Date.now()`, whose resolution browsers coarsen,
-   * so a gesture landing in the same tick as the window opening is genuinely
-   * ambiguous. Ties go to the user (`<`, not `<=`): mistaking an echo for a user
+   * Both timestamps come from `performance.now()`, whose resolution browsers
+   * coarsen, so a gesture landing in the same tick as the window opening is
+   * genuinely ambiguous. Ties go to the user (`<`, not `<=`): mistaking an echo for a user
    * action is merely the behaviour that existed before this guard, whereas
    * discarding a real interaction would be a new harm introduced by it.
    */
@@ -236,7 +243,7 @@ export function createPlaybackBindingController(args: {
       return false;
     }
     return (
-      nowOf() < args.runtimeState.programmaticApplyUntil &&
+      monotonicNow() < args.runtimeState.programmaticApplyUntil &&
       args.runtimeState.lastUserGestureInPlayerAt <
         args.runtimeState.programmaticApplyAt
     );
@@ -247,12 +254,13 @@ export function createPlaybackBindingController(args: {
       return;
     }
     if (
-      nowOf() - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs &&
+      monotonicNow() - args.runtimeState.lastUserGestureAt <
+        args.userGestureGraceMs &&
       args.runtimeState.lastUserGestureAt > args.runtimeState.lastForcedPauseAt
     ) {
       args.runtimeState.lastExplicitPlaybackAction = {
         playState,
-        at: nowOf(),
+        at: monotonicNow(),
       };
     }
   }
@@ -262,13 +270,14 @@ export function createPlaybackBindingController(args: {
       return;
     }
     if (
-      nowOf() - args.runtimeState.lastUserGestureAt < args.userGestureGraceMs &&
+      monotonicNow() - args.runtimeState.lastUserGestureAt <
+        args.userGestureGraceMs &&
       args.runtimeState.lastUserGestureAt > args.runtimeState.lastForcedPauseAt
     ) {
       if (
         kind === "play" &&
         args.runtimeState.lastExplicitUserAction?.kind === "seek" &&
-        nowOf() - args.runtimeState.lastExplicitUserAction.at <
+        monotonicNow() - args.runtimeState.lastExplicitUserAction.at <
           args.userGestureGraceMs &&
         args.runtimeState.lastUserGestureAt <=
           args.runtimeState.lastExplicitUserAction.at
@@ -278,7 +287,7 @@ export function createPlaybackBindingController(args: {
       const previousAction = args.runtimeState.lastExplicitUserAction;
       args.runtimeState.lastExplicitUserAction = {
         kind,
-        at: nowOf(),
+        at: monotonicNow(),
       };
       if (kind === "seek") {
         // One gesture produces `seeking` AND `seeked`, and the `seeking`
@@ -293,7 +302,7 @@ export function createPlaybackBindingController(args: {
         const continuesInFlightSeek =
           previousAction?.kind === "seek" &&
           previousAction.at > args.runtimeState.lastForcedPauseAt &&
-          nowOf() - previousAction.at < args.userGestureGraceMs;
+          monotonicNow() - previousAction.at < args.userGestureGraceMs;
         if (!continuesInFlightSeek) {
           args.runtimeState.explicitSeekOriginPlayState =
             args.runtimeState.intendedPlayState;
@@ -355,7 +364,7 @@ export function createPlaybackBindingController(args: {
    * it on the shared path is both safe and complete.
    */
   function classifyUnobservedPauseAsBuffer(video: HTMLVideoElement): void {
-    const now = nowOf();
+    const now = monotonicNow();
     if (
       !video.paused ||
       args.runtimeState.pauseStartedAt > 0 ||
@@ -381,7 +390,10 @@ export function createPlaybackBindingController(args: {
     video: HTMLVideoElement,
   ): boolean {
     const signature = args.runtimeState.programmaticApplySignature;
-    if (!signature || nowOf() >= args.runtimeState.programmaticApplyUntil) {
+    if (
+      !signature ||
+      monotonicNow() >= args.runtimeState.programmaticApplyUntil
+    ) {
       return false;
     }
 
@@ -420,7 +432,7 @@ export function createPlaybackBindingController(args: {
     }
     args.runtimeState.sharedVideoNaturalEndUrl =
       args.runtimeState.activeSharedUrl;
-    args.runtimeState.sharedVideoNaturalEndAt = nowOf();
+    args.runtimeState.sharedVideoNaturalEndAt = monotonicNow();
     // Whether this end was reached right after an in-video seek (seek-to-end),
     // captured now while the old page's action state is still intact (the next
     // page's `play` has not yet overwritten it). The navigation controller only
@@ -474,11 +486,11 @@ export function createPlaybackBindingController(args: {
     }
 
     args.runtimeState.intendedPlayState = "paused";
-    args.runtimeState.lastForcedPauseAt = nowOf();
+    args.runtimeState.lastForcedPauseAt = monotonicNow();
     args.runtimeState.suppressedLocalEndPauseUrl =
       args.runtimeState.activeSharedUrl;
     args.runtimeState.suppressedLocalEndPauseUntil =
-      nowOf() + args.initialRoomStatePauseHoldMs;
+      monotonicNow() + args.initialRoomStatePauseHoldMs;
     args.activatePauseHold(args.initialRoomStatePauseHoldMs);
     args.debugLog(
       `Held non-sharer at shared video natural end to block local autoplay-next`,
@@ -537,8 +549,8 @@ export function createPlaybackBindingController(args: {
     const armedUrl = args.runtimeState.activeSharedUrl;
     args.runtimeState.sharerEndedSuppressionUrl = armedUrl;
     args.runtimeState.sharerEndedSuppressionUntil =
-      nowOf() + args.initialRoomStatePauseHoldMs;
-    args.runtimeState.sharerEndedSuppressionArmedAt = nowOf();
+      monotonicNow() + args.initialRoomStatePauseHoldMs;
+    args.runtimeState.sharerEndedSuppressionArmedAt = monotonicNow();
     clearSharerEndedFlushTimer();
     sharerEndedFlushTimerId = scheduleUpgradeTimer(() => {
       sharerEndedFlushTimerId = null;
@@ -601,10 +613,10 @@ export function createPlaybackBindingController(args: {
       isCurrentVideoShared(currentVideo) &&
       args.runtimeState.intendedPlayState !== "playing" &&
       args.runtimeState.suppressedLocalEndPauseUrl !== null &&
-      nowOf() < args.runtimeState.suppressedLocalEndPauseUntil &&
+      monotonicNow() < args.runtimeState.suppressedLocalEndPauseUntil &&
       args.normalizeUrl(currentVideo.url) ===
         args.runtimeState.suppressedLocalEndPauseUrl &&
-      nowOf() - args.runtimeState.lastUserGestureAt >=
+      monotonicNow() - args.runtimeState.lastUserGestureAt >=
         args.userGestureGraceMs &&
       !video.paused,
     );
@@ -649,7 +661,7 @@ export function createPlaybackBindingController(args: {
     const lastAction = args.runtimeState.lastExplicitUserAction;
     if (
       lastAction?.kind === "seek" &&
-      nowOf() - lastAction.at < args.userGestureGraceMs &&
+      monotonicNow() - lastAction.at < args.userGestureGraceMs &&
       args.runtimeState.lastUserGestureAt <= lastAction.at
     ) {
       return false;
@@ -735,7 +747,7 @@ export function createPlaybackBindingController(args: {
     args.runtimeState.intendedPlayState = "paused";
     args.runtimeState.nonSharerAutoplayHoldUrl = normalizedCurrentUrl;
     args.activatePauseHold(args.initialRoomStatePauseHoldMs);
-    args.runtimeState.lastForcedPauseAt = nowOf();
+    args.runtimeState.lastForcedPauseAt = monotonicNow();
     args.debugLog(
       "Forced pause for non-shared video autoplay (in room, load paused)",
     );
@@ -767,7 +779,7 @@ export function createPlaybackBindingController(args: {
       `Suppressed page autoplay while waiting for initial room state of ${args.runtimeState.activeRoomCode}`,
     );
     args.runtimeState.intendedPlayState = "paused";
-    args.runtimeState.lastForcedPauseAt = nowOf();
+    args.runtimeState.lastForcedPauseAt = monotonicNow();
     window.setTimeout(() => {
       if (!video.paused) {
         pauseVideo(video);
@@ -782,7 +794,7 @@ export function createPlaybackBindingController(args: {
     if (
       !args.runtimeState.activeRoomCode ||
       !args.runtimeState.activeSharedUrl ||
-      nowOf() >= args.runtimeState.pauseHoldUntil
+      monotonicNow() >= args.runtimeState.pauseHoldUntil
     ) {
       return false;
     }
@@ -860,7 +872,7 @@ export function createPlaybackBindingController(args: {
       explicitNonSharedPlaybackUrl:
         args.runtimeState.explicitNonSharedPlaybackUrl,
       lastExplicitPlaybackAction: args.runtimeState.lastExplicitPlaybackAction,
-      now: nowOf(),
+      now: monotonicNow(),
       userGestureGraceMs: args.userGestureGraceMs,
     });
 
@@ -905,7 +917,7 @@ export function createPlaybackBindingController(args: {
         args.runtimeState.lastExplicitUserAction = null;
         args.runtimeState.explicitSeekOriginPlayState = null;
         args.runtimeState.lastExplicitPlaybackAction = null;
-        args.runtimeState.lastForcedPauseAt = nowOf();
+        args.runtimeState.lastForcedPauseAt = monotonicNow();
         window.setTimeout(() => {
           pauseVideo(video);
         }, 0);
@@ -921,7 +933,7 @@ export function createPlaybackBindingController(args: {
         args.debugLog(
           `Re-paused non-sharer multi-part autoplay after shared video natural end`,
         );
-        args.runtimeState.lastForcedPauseAt = nowOf();
+        args.runtimeState.lastForcedPauseAt = monotonicNow();
         window.setTimeout(() => {
           pauseVideo(video);
         }, 0);
@@ -933,12 +945,13 @@ export function createPlaybackBindingController(args: {
         isCurrentVideoShared(currentVideo) &&
         args.hasRecentRemoteStopIntent(currentVideo.url) &&
         args.runtimeState.intendedPlayState !== "playing" &&
-        nowOf() - args.runtimeState.lastUserGestureAt >= args.userGestureGraceMs
+        monotonicNow() - args.runtimeState.lastUserGestureAt >=
+          args.userGestureGraceMs
       ) {
         args.debugLog(
           `Forced pause hold reapplied after unexpected resume intended=${args.runtimeState.intendedPlayState}`,
         );
-        args.runtimeState.lastForcedPauseAt = nowOf();
+        args.runtimeState.lastForcedPauseAt = monotonicNow();
         window.setTimeout(() => {
           pauseVideo(video);
         }, 0);
@@ -951,7 +964,7 @@ export function createPlaybackBindingController(args: {
         );
         args.runtimeState.explicitNonSharedPlaybackUrl = null;
         args.runtimeState.lastNonSharedGuardUrl = null;
-        args.runtimeState.lastForcedPauseAt = nowOf();
+        args.runtimeState.lastForcedPauseAt = monotonicNow();
         window.setTimeout(() => {
           pauseVideo(video);
         }, 0);
@@ -1026,7 +1039,7 @@ export function createPlaybackBindingController(args: {
         if (hasRecentUserGesture()) {
           args.cancelActiveSoftApply(video, "pause");
         }
-        const now = nowOf();
+        const now = monotonicNow();
         const recentBufferSignal =
           args.runtimeState.lastBufferSignalAt > 0 &&
           now - args.runtimeState.lastBufferSignalAt <
@@ -1086,11 +1099,11 @@ export function createPlaybackBindingController(args: {
         scheduleBroadcast(video, "pause", 120);
       },
       onWaiting: () => {
-        args.runtimeState.lastBufferSignalAt = nowOf();
+        args.runtimeState.lastBufferSignalAt = monotonicNow();
         scheduleBroadcast(video, "waiting");
       },
       onStalled: () => {
-        args.runtimeState.lastBufferSignalAt = nowOf();
+        args.runtimeState.lastBufferSignalAt = monotonicNow();
         scheduleBroadcast(video, "stalled");
       },
       onLoadedMetadata: () => {
@@ -1162,7 +1175,10 @@ export function createPlaybackBindingController(args: {
       },
       onTimeUpdate: () => {
         args.maintainActiveSoftApply(video);
-        if (nowOf() - args.getLastBroadcastAt() > 2000 && !video.paused) {
+        if (
+          monotonicNow() - args.getLastBroadcastAt() > 2000 &&
+          !video.paused
+        ) {
           void args.broadcastPlayback(video, "timeupdate");
         }
       },
@@ -1173,7 +1189,7 @@ export function createPlaybackBindingController(args: {
       // here from the first bind on a freshly loaded page; both leave an element
       // whose paused state we never observed transitioning. The pause
       // classifiers use this timestamp to avoid reporting either as a user pause.
-      args.runtimeState.lastVideoElementBoundAt = nowOf();
+      args.runtimeState.lastVideoElementBoundAt = monotonicNow();
       // This poll is the one place that learns a `<video>` exists. Hydration
       // used to discover it by polling `document.querySelector("video")` on its
       // own 350ms timer — the same query this loop already runs at 250ms — and

--- a/extension/src/content/playback-broadcast.ts
+++ b/extension/src/content/playback-broadcast.ts
@@ -51,6 +51,15 @@ export function shouldPauseForNonSharedBroadcast(args: {
   );
 }
 
+/**
+ * `updatedAt` is the one timestamp in this module that leaves the machine: it is
+ * the protocol's "sender timestamp (ms)", so it must be a WALL-CLOCK reading
+ * (`Date.now()`) even though every other `now` here is a monotonic one. Nothing
+ * currently reads it back — the server deliberately measures elapsed time from
+ * its own `serverTime` instead (`room-service.ts`) — but it is a documented wire
+ * field, and putting a `performance.now()` reading there would silently redefine
+ * it for anyone who does.
+ */
 export function createPlaybackBroadcastPayload(args: {
   currentVideo: SharedVideo;
   currentTime: number;
@@ -61,7 +70,7 @@ export function createPlaybackBroadcastPayload(args: {
   playbackRate: number;
   actorId: string;
   seq: number;
-  now: number;
+  updatedAt: number;
 }): PlaybackState {
   const payload: PlaybackState = {
     url: args.currentVideo.url,
@@ -69,7 +78,7 @@ export function createPlaybackBroadcastPayload(args: {
     playState: args.playState,
     syncIntent: args.syncIntent,
     playbackRate: args.playbackRate,
-    updatedAt: args.now,
+    updatedAt: args.updatedAt,
     serverTime: 0,
     actorId: args.actorId,
     seq: args.seq,

--- a/extension/src/content/room-state-apply-controller.ts
+++ b/extension/src/content/room-state-apply-controller.ts
@@ -74,7 +74,6 @@ export function createRoomStateApplyController(args: {
    * synchronously.
    */
   remotePauseDebounceMs?: number;
-  getNow?: () => number;
   /**
    * Monotonic time source for the hydration retry deadline. Must not be the
    * wall clock — see {@link preemptHydrationRetry}.
@@ -152,7 +151,6 @@ export function createRoomStateApplyController(args: {
   }) => string;
 }): RoomStateApplyController {
   const ignoredRoomStateLogState = { key: null as string | null, at: 0 };
-  const nowOf = () => args.getNow?.() ?? Date.now();
   const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
   let hydrateRetryTimer: number | null = null;
   /**
@@ -294,7 +292,7 @@ export function createRoomStateApplyController(args: {
     args.activatePauseHold(args.initialRoomStatePauseHoldMs);
     const video = args.getVideoElement();
     if (video && !video.paused) {
-      args.runtimeState.lastForcedPauseAt = nowOf();
+      args.runtimeState.lastForcedPauseAt = monotonicNow();
       args.debugLog(`${input.logReason} for ${input.roomCode}`);
       pauseVideo(video);
     }
@@ -329,7 +327,8 @@ export function createRoomStateApplyController(args: {
     if (
       video &&
       !video.paused &&
-      nowOf() - args.runtimeState.lastUserGestureAt >= args.userGestureGraceMs
+      monotonicNow() - args.runtimeState.lastUserGestureAt >=
+        args.userGestureGraceMs
     ) {
       args.debugLog(`Suppressed autoplay for empty room ${roomCode}`);
       pauseVideo(video);
@@ -392,7 +391,7 @@ export function createRoomStateApplyController(args: {
    * by whatever armed it first no matter how often the event repeats.
    *
    * Both readings come from a monotonic clock, never the wall clock. The
-   * deadline is a `nowOf()`-style reading captured when the timer was armed, so
+   * deadline is a `monotonicNow()`-style reading captured when the timer was armed, so
    * a *backward* wall-clock step would shrink `now + delay` and make the
    * candidate look earlier than a deadline it is not — the comparison would
    * preempt, cancel a timer that was about to fire, and restart the full delay,
@@ -445,7 +444,7 @@ export function createRoomStateApplyController(args: {
       pendingRoomStateHydration: args.runtimeState.pendingRoomStateHydration,
       explicitNonSharedPlaybackUrl:
         args.runtimeState.explicitNonSharedPlaybackUrl,
-      now: nowOf(),
+      now: monotonicNow(),
       lastLocalIntentAt: args.runtimeState.lastLocalIntentAt,
       lastLocalIntentPlayState: args.runtimeState.lastLocalIntentPlayState,
       localIntentGuardMs: args.localIntentGuardMs,
@@ -709,7 +708,7 @@ export function createRoomStateApplyController(args: {
           args.debugLog(
             `Suppressed autoplay during unstable shared url hydration for ${state.roomCode}`,
           );
-          args.runtimeState.lastForcedPauseAt = nowOf();
+          args.runtimeState.lastForcedPauseAt = monotonicNow();
           pauseVideo(video);
         }
       }
@@ -1004,10 +1003,11 @@ export function createRoomStateApplyController(args: {
         !video.paused &&
         playback &&
         shouldPreserveInitialPause &&
-        nowOf() - args.runtimeState.lastUserGestureAt >= args.userGestureGraceMs
+        monotonicNow() - args.runtimeState.lastUserGestureAt >=
+          args.userGestureGraceMs
       ) {
         args.runtimeState.intendedPlayState = playback.playState;
-        args.runtimeState.lastForcedPauseAt = nowOf();
+        args.runtimeState.lastForcedPauseAt = monotonicNow();
         args.debugLog(
           `Suppressed autoplay during hydrate for ${response.roomState.roomCode}`,
         );

--- a/extension/src/content/share-controller.ts
+++ b/extension/src/content/share-controller.ts
@@ -169,7 +169,9 @@ export function createShareController(args: {
         : null,
       actorId: args.runtimeState.localMemberId ?? "local",
       seq: args.nextSeq(),
-      now: Date.now(),
+      // Wall clock on purpose: this one goes on the wire. Everything the content
+      // script measures a duration with reads the monotonic clock instead.
+      updatedAt: Date.now(),
     });
   }
 

--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -68,7 +68,13 @@ export function createSoftApplyController(args: {
   debugLog: (message: string) => void;
   userGestureGraceMs: number;
   programmaticApplyWindowMs: number;
-  getNow?: () => number;
+  /**
+   * Monotonic time source. Every timestamp this controller stores and every
+   * window it compares is an interval measured on this machine, so none of them
+   * may move when the wall clock is stepped. The wall clock is only correct for
+   * the wire field `PlaybackState.updatedAt`, which is produced elsewhere.
+   */
+  getMonotonicNow?: () => number;
   armProgrammaticApplyWindow: (
     signature: ReturnType<typeof createProgrammaticPlaybackSignature>,
     reason: "pending" | "apply",
@@ -76,7 +82,7 @@ export function createSoftApplyController(args: {
     scope?: ProgrammaticApplyScope,
   ) => void;
 }): SoftApplyController {
-  const nowOf = () => args.getNow?.() ?? Date.now();
+  const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
   let activeSoftApply: {
     normalizedUrl: string;
     targetTime: number;
@@ -109,7 +115,8 @@ export function createSoftApplyController(args: {
 
   function armSoftApplyCooldown(normalizedUrl: string, reason: string): void {
     args.runtimeState.softApplyCooldownUrl = normalizedUrl;
-    args.runtimeState.softApplyCooldownUntil = nowOf() + SOFT_APPLY_COOLDOWN_MS;
+    args.runtimeState.softApplyCooldownUntil =
+      monotonicNow() + SOFT_APPLY_COOLDOWN_MS;
     args.debugLog(
       `Soft apply cooldown armed url=${normalizedUrl} result=${reason} until=${args.runtimeState.softApplyCooldownUntil}`,
     );
@@ -219,7 +226,7 @@ export function createSoftApplyController(args: {
     if (activeSoftApplyTimer !== null) {
       window.clearTimeout(activeSoftApplyTimer);
     }
-    const delayMs = Math.max(0, activeSoftApply.deadlineAt - nowOf());
+    const delayMs = Math.max(0, activeSoftApply.deadlineAt - monotonicNow());
     activeSoftApplyTimer = window.setTimeout(() => {
       activeSoftApplyTimer = null;
       if (!activeSoftApply) {
@@ -286,10 +293,10 @@ export function createSoftApplyController(args: {
       normalizedUrl,
       targetTime: playback.currentTime,
       restorePlaybackRate,
-      deadlineAt: nowOf() + timeoutMs,
+      deadlineAt: monotonicNow() + timeoutMs,
       armCooldownOnConverge: nextArmCooldownOnConverge,
       convergeByRelativeDrift,
-      startedAt: nowOf(),
+      startedAt: monotonicNow(),
     };
     scheduleActiveSoftApplyTimeout();
     args.debugLog(
@@ -358,7 +365,7 @@ export function createSoftApplyController(args: {
     }
     const elapsedSeconds = Math.max(
       0,
-      (nowOf() - activeSoftApply.startedAt) / 1_000,
+      (monotonicNow() - activeSoftApply.startedAt) / 1_000,
     );
     const expectedTargetTime =
       activeSoftApply.targetTime +
@@ -376,7 +383,7 @@ export function createSoftApplyController(args: {
     if (!activeSoftApply) {
       return;
     }
-    if (nowOf() >= activeSoftApply.deadlineAt) {
+    if (monotonicNow() >= activeSoftApply.deadlineAt) {
       cancelActiveSoftApply(
         video,
         activeSoftApply.convergeByRelativeDrift ? "drift-closed" : "timeout",
@@ -453,7 +460,7 @@ export function createSoftApplyController(args: {
     playback: PlaybackState,
   ): boolean {
     if (
-      args.runtimeState.softApplyCooldownUntil <= nowOf() ||
+      args.runtimeState.softApplyCooldownUntil <= monotonicNow() ||
       !args.runtimeState.softApplyCooldownUrl
     ) {
       return false;

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -101,7 +101,13 @@ export function createSyncController(args: {
   duplicateBroadcastWindowMs: number;
   nextSeq: () => number;
   markBroadcastAt: (at: number) => void;
-  getNow?: () => number;
+  /**
+   * Monotonic time source. Every timestamp this controller stores and every
+   * window it compares is an interval measured on this machine, so none of them
+   * may move when the wall clock is stepped. The wall clock is only correct for
+   * the wire field `PlaybackState.updatedAt`, which is produced elsewhere.
+   */
+  getMonotonicNow?: () => number;
   debugLog: (message: string) => void;
   shouldLogHeartbeat: (
     state: { key: string | null; at: number },
@@ -127,7 +133,7 @@ export function createSyncController(args: {
     state: RoomState,
   ) => void;
 }): SyncController {
-  const nowOf = () => args.getNow?.() ?? Date.now();
+  const monotonicNow = () => args.getMonotonicNow?.() ?? performance.now();
   const ignoredRemotePlaybackLogState = { key: null as string | null, at: 0 };
   const duplicateBroadcastLogState = { key: null as string | null, at: 0 };
   /**
@@ -222,7 +228,7 @@ export function createSyncController(args: {
     state: { key: string | null; at: number },
     key: string,
     message: string,
-    now = nowOf(),
+    now = monotonicNow(),
   ): void {
     if (args.shouldLogHeartbeat(state, key, now)) {
       args.debugLog(message);
@@ -234,7 +240,7 @@ export function createSyncController(args: {
     eventSource: LocalPlaybackEventSource,
     trace: string,
     _normalizedUrl: string | null,
-    _now = nowOf(),
+    _now = monotonicNow(),
   ): void {
     if (
       eventSource === "timeupdate" ||
@@ -248,7 +254,7 @@ export function createSyncController(args: {
   }
 
   function activatePauseHold(durationMs = args.pauseHoldMs): void {
-    args.runtimeState.pauseHoldUntil = nowOf() + durationMs;
+    args.runtimeState.pauseHoldUntil = monotonicNow() + durationMs;
   }
 
   function armProgrammaticApplyWindow(
@@ -269,10 +275,10 @@ export function createSyncController(args: {
       ...signature,
       url: normalizedSignatureUrl,
     };
-    args.runtimeState.programmaticApplyAt = nowOf();
+    args.runtimeState.programmaticApplyAt = monotonicNow();
     args.runtimeState.programmaticApplyScope = scope;
     args.runtimeState.programmaticApplyUntil =
-      nowOf() + args.programmaticApplyWindowMs;
+      monotonicNow() + args.programmaticApplyWindowMs;
     args.debugLog(
       `Programmatic apply window armed actor=${actorId} playState=${signature.playState} url=${signature.url} delta=n/a result=${reason} scope=${scope} until=${args.runtimeState.programmaticApplyUntil}`,
     );
@@ -285,7 +291,7 @@ export function createSyncController(args: {
     debugLog: args.debugLog,
     userGestureGraceMs: args.userGestureGraceMs,
     programmaticApplyWindowMs: args.programmaticApplyWindowMs,
-    getNow: args.getNow,
+    getMonotonicNow: args.getMonotonicNow,
     armProgrammaticApplyWindow,
   });
 
@@ -293,7 +299,7 @@ export function createSyncController(args: {
     runtimeState: args.runtimeState,
     userGestureGraceMs: args.userGestureGraceMs,
     normalizeUrl: args.normalizeUrl,
-    getNow: args.getNow,
+    getMonotonicNow: args.getMonotonicNow,
     debugLog: args.debugLog,
   });
 
@@ -503,13 +509,13 @@ export function createSyncController(args: {
     }
 
     args.runtimeState.remoteFollowPlayingUntil =
-      nowOf() + args.remoteFollowPlayingWindowMs;
+      monotonicNow() + args.remoteFollowPlayingWindowMs;
     args.runtimeState.remoteFollowPlayingUrl = args.normalizeUrl(playback.url);
   }
 
   function hasRecentRemoteStopIntent(currentVideoUrl: string): boolean {
     return hasRecentRemoteStopIntentGuard({
-      now: nowOf(),
+      now: monotonicNow(),
       pauseHoldUntil: args.runtimeState.pauseHoldUntil,
       normalizedCurrentUrl: args.normalizeUrl(currentVideoUrl),
       activeSharedUrl: args.runtimeState.activeSharedUrl,
@@ -523,7 +529,7 @@ export function createSyncController(args: {
     const remembered = rememberRemotePlaybackForSuppressionGuard({
       playback,
       normalizedUrl: url,
-      now: nowOf(),
+      now: monotonicNow(),
       remoteEchoSuppressionMs: args.remoteEchoSuppressionMs,
       remotePlayTransitionGuardMs: args.remotePlayTransitionGuardMs,
     });
@@ -550,7 +556,7 @@ export function createSyncController(args: {
       playState,
       currentTime: video.currentTime,
       playbackRate: video.playbackRate,
-      now: nowOf(),
+      now: monotonicNow(),
     });
 
     if (
@@ -620,7 +626,7 @@ export function createSyncController(args: {
       playState,
       currentTime,
       lastExplicitPlaybackAction: args.runtimeState.lastExplicitPlaybackAction,
-      now: nowOf(),
+      now: monotonicNow(),
       userGestureGraceMs: args.userGestureGraceMs,
     });
 
@@ -628,7 +634,7 @@ export function createSyncController(args: {
       args.runtimeState.recentRemotePlayingIntent &&
       decision.nextRecentRemotePlayingIntent &&
       args.runtimeState.lastExplicitPlaybackAction &&
-      nowOf() - args.runtimeState.lastExplicitPlaybackAction.at <
+      monotonicNow() - args.runtimeState.lastExplicitPlaybackAction.at <
         args.userGestureGraceMs &&
       args.runtimeState.lastExplicitPlaybackAction.playState === "paused" &&
       playState === "paused"
@@ -847,7 +853,7 @@ export function createSyncController(args: {
     eventSource: LocalPlaybackEventSource = "manual",
     naturalEnd?: boolean,
   ): Promise<void> {
-    const now = nowOf();
+    const now = monotonicNow();
     if (!args.runtimeState.hydrationReady) {
       args.debugLog("Skip broadcast before hydration ready");
       logBroadcastTrace(
@@ -1527,7 +1533,11 @@ export function createSyncController(args: {
       playbackRate: video.playbackRate,
       actorId: args.runtimeState.localMemberId ?? "local",
       seq: args.nextSeq(),
-      now,
+      // NOT `now`. `now` is this machine's monotonic reading, which every local
+      // window in this function is measured against; `updatedAt` is a wire field
+      // documented as a wall-clock sender timestamp. They are different clocks
+      // and this is the only place in the function where the wire one is right.
+      updatedAt: Date.now(),
     });
     pendingLocalOverride.rememberPendingLocalPlaybackOverride(payload, now);
 
@@ -1586,7 +1596,7 @@ export function createSyncController(args: {
     initialRoomStatePauseHoldMs: args.initialRoomStatePauseHoldMs,
     userGestureGraceMs: args.userGestureGraceMs,
     remotePauseDebounceMs: args.remotePauseDebounceMs,
-    getNow: args.getNow,
+    getMonotonicNow: args.getMonotonicNow,
     debugLog: args.debugLog,
     shouldLogHeartbeat: args.shouldLogHeartbeat,
     requestRoomStateHydration: args.requestRoomStateHydration,
@@ -1641,7 +1651,7 @@ export function createSyncController(args: {
         naturalEnd: playback.naturalEnd === true,
         currentTime: playback.currentTime,
         playbackRate: playback.playbackRate,
-        at: nowOf(),
+        at: monotonicNow(),
       };
     }
     await roomStateApplyController.applyRoomState(state, shareToast);

--- a/extension/test/festival-bridge.test.ts
+++ b/extension/test/festival-bridge.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createFestivalBridgeController } from "../src/content/festival-bridge";
+import { installClockStubs } from "./clock-stubs";
 
 interface PageBridgeDetail {
   epId?: string | number;
@@ -325,6 +326,45 @@ test("festival bridge does not fall back to another festival page snapshot", asy
 
     assert.equal(nextSnapshot, null);
   } finally {
+    dom.restore();
+  }
+});
+
+test("ages the cached snapshot on the monotonic clock", async () => {
+  const dom = installBridgeDomStub([
+    {
+      bvid: "BVfestival",
+      cid: 123,
+      title: "Festival Episode",
+    },
+  ]);
+  // This controller takes no clock, so the globals are the only way to drive it.
+  const clock = installClockStubs({
+    wall: 1_700_000_000_000,
+    monotonic: 5_000,
+  });
+  const controller = createFestivalBridgeController();
+
+  try {
+    await controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl: "https://www.bilibili.com/festival/demo",
+      maxAgeMs: 0,
+    });
+
+    // An NTP correction jumps the wall clock an hour forward while barely any
+    // time has actually passed. The snapshot is 100ms old, not an hour old, and
+    // discarding it would send the auto-share self-check back to the page bridge
+    // for a video that has not changed.
+    clock.clocks.wall += 3_600_000;
+    clock.clocks.monotonic += 100;
+
+    assert.equal(
+      controller.resolveVideoUrlForPage("/festival/demo", 60_000),
+      "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123",
+    );
+  } finally {
+    clock.restore();
     dom.restore();
   }
 });

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -183,7 +183,7 @@ test("navigation controller suppresses autoplay (load paused) when switching to 
       runtimeState.pauseHoldUntil = 10_000 + durationMs;
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -244,7 +244,7 @@ test("navigation controller suppresses a non-shared SPA navigation immediately v
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -309,7 +309,7 @@ test("navigation controller schedules auto-share when a shared source autoplays 
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -347,7 +347,7 @@ test("navigation controller schedules auto-share when a bangumi season page auto
   runtimeState.activeSharedByMemberId = "member-1";
   runtimeState.localMemberId = "member-1";
   // The shared episode just naturally ended on this page (durable timestamp,
-  // within the hold window of getNow 10_000 / initialRoomStatePauseHoldMs 1_500).
+  // within the hold window of getMonotonicNow 10_000 / initialRoomStatePauseHoldMs 1_500).
   runtimeState.sharedVideoNaturalEndUrl =
     "https://www.bilibili.com/bangumi/play/ep249469";
   runtimeState.sharedVideoNaturalEndAt = 9_000;
@@ -378,7 +378,7 @@ test("navigation controller schedules auto-share when a bangumi season page auto
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -442,7 +442,7 @@ test("navigation controller holds a non-sharer when a bangumi season page autopl
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -474,7 +474,7 @@ test("navigation controller does not treat an expired end marker as a season-pag
   runtimeState.activeSharedByMemberId = "member-2";
   runtimeState.localMemberId = "member-1";
   // A natural-end timestamp that is now EXPIRED (older than the hold window:
-  // getNow 10_000 − 8_000 = 2_000 > 1_500). A later unrelated navigation must
+  // getMonotonicNow 10_000 − 8_000 = 2_000 > 1_500). A later unrelated navigation must
   // not be misread as the shared episode's autoplay-next.
   runtimeState.sharedVideoNaturalEndUrl =
     "https://www.bilibili.com/bangumi/play/ep249469";
@@ -501,7 +501,7 @@ test("navigation controller does not treat an expired end marker as a season-pag
     activatePauseHold: () => {},
     scheduleAutoShareNextVideo: () => {},
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -530,7 +530,7 @@ test("navigation controller schedules auto-share on a natural-end autoplay despi
   runtimeState.localMemberId = "member-1";
   // The sharer dragged to the last seconds of the shared episode: the seek
   // gesture is still inside the grace window when it auto-advances.
-  runtimeState.lastUserGestureAt = 9_800; // getNow 10_000, grace 300 → recent
+  runtimeState.lastUserGestureAt = 9_800; // getMonotonicNow 10_000, grace 300 → recent
   // The shared episode then naturally ended, recorded as preceded by a seek.
   runtimeState.sharedVideoNaturalEndUrl =
     "https://www.bilibili.com/bangumi/play/ep249469";
@@ -562,7 +562,7 @@ test("navigation controller schedules auto-share on a natural-end autoplay despi
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -625,7 +625,7 @@ test("navigation controller does not auto-share a manual click even when its ges
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -682,7 +682,7 @@ test("navigation controller does not reuse a stale seek-to-end flag for a later 
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -731,7 +731,7 @@ test("navigation controller chains the next auto-share before the room confirms 
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -817,7 +817,7 @@ test("navigation controller does not auto-share a recent user-initiated navigati
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -867,7 +867,7 @@ test("navigation controller cancels a pending auto-share on a manual non-autopla
       cancelCalls += 1;
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -927,7 +927,7 @@ test("navigation controller suppresses autoplay and does not auto-share a manual
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -990,7 +990,7 @@ test("navigation controller does not auto-share an autoplay that started from a 
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -1059,7 +1059,7 @@ test("navigation controller pauses non-sharer autoplay to a different video", ()
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -1127,7 +1127,7 @@ test("navigation controller arms autoplay suppression for a non-shared video tha
       pauseHoldCalls += 1;
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -1250,7 +1250,7 @@ test("navigation controller keeps autoplay suppression armed when switching to a
       pauseHoldCalls += 1;
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -1422,7 +1422,7 @@ test("navigation controller anchors active shared url for post-navigation settle
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -1641,7 +1641,7 @@ test("navigation controller schedules auto-share when a festival page autoplays 
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -1680,7 +1680,7 @@ test("navigation controller schedules auto-share when the first festival resolut
   runtimeState.activeSharedByMemberId = "member-1";
   runtimeState.localMemberId = "member-1";
   // The shared video A ended on this festival page (durable natural-end marker
-  // within the hold window of getNow 10_000 / initialRoomStatePauseHoldMs 1_500).
+  // within the hold window of getMonotonicNow 10_000 / initialRoomStatePauseHoldMs 1_500).
   runtimeState.sharedVideoNaturalEndUrl =
     "https://www.bilibili.com/video/BVa?cid=1";
   runtimeState.sharedVideoNaturalEndAt = 9_000;
@@ -1715,7 +1715,7 @@ test("navigation controller schedules auto-share when the first festival resolut
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -1776,7 +1776,7 @@ test("navigation controller pauses when the first festival resolution is a diffe
     activatePauseHold: () => {},
     scheduleAutoShareNextVideo: () => {},
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -1826,7 +1826,7 @@ test("navigation controller suppresses a first festival resolution while a joine
     },
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -1881,7 +1881,7 @@ test("navigation controller adopts a first festival resolution without pausing t
     },
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -1943,7 +1943,7 @@ test("navigation controller does not flip-flop when a festival snapshot is brief
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -2004,7 +2004,7 @@ test("navigation controller adopts a first festival resolution when the room sha
     },
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -2067,7 +2067,7 @@ test("navigation controller defers, not cancels, when a festival address bar kee
       cancelCalls += 1;
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -2141,7 +2141,7 @@ test("navigation controller auto-shares a same-page autoplay off a bare-route fe
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -2220,7 +2220,7 @@ test("navigation controller anchors a bare-route festival share even when the ad
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -2295,7 +2295,7 @@ test("navigation controller anchors a bare-route festival share when the resolve
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -2372,7 +2372,7 @@ test("navigation controller does not auto-share a first festival resolution to a
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -2423,7 +2423,7 @@ test("navigation controller does not pause a non-sharer on a first festival reso
     activatePauseHold: () => {},
     scheduleAutoShareNextVideo: () => {},
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -2478,7 +2478,7 @@ test("navigation controller does not auto-share a gesture-driven first festival 
       autoShareRequests.push(input);
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {

--- a/extension/test/page-video.test.ts
+++ b/extension/test/page-video.test.ts
@@ -101,7 +101,7 @@ test("builds share payload from video playback snapshot", () => {
     },
     actorId: "member-1",
     seq: 7,
-    now: 99,
+    updatedAt: 99,
   });
 
   assert.equal(payload.playback?.seq, 7);

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { SharedVideo } from "@bili-syncplay/protocol";
 import { createContentRuntimeState } from "../src/content/runtime-state";
+import { installClockStubs } from "./clock-stubs";
 import { createPlaybackBindingController } from "../src/content/playback-binding-controller";
 import { createRoomStateController } from "../src/content/room-state-controller";
 import { createToastCoordinatorState } from "../src/content/toast";
@@ -89,7 +90,7 @@ test("playback binding controller forwards ratechange event source", async () =>
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   try {
@@ -137,7 +138,7 @@ test("playback binding controller cancels active soft apply on pause and seek", 
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   try {
@@ -178,7 +179,7 @@ test("playback binding controller does not cancel active soft apply for programm
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 2_500,
+    getMonotonicNow: () => 2_500,
   });
 
   try {
@@ -217,7 +218,7 @@ test("playback binding controller preserves explicit seek intent across immediat
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -273,7 +274,7 @@ test("playback binding controller does not mark programmatic ratechange as expli
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   try {
@@ -322,7 +323,7 @@ test("playback binding controller re-pauses seek-triggered autoplay when intende
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   const originalPause = dom.video.pause;
@@ -386,7 +387,7 @@ test("playback binding controller keeps hydration pause guard when shared url is
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   dom.video.pause = () => {
@@ -474,7 +475,7 @@ test("playback binding controller keeps hydration guard after direct room switch
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   dom.video.pause = () => {
@@ -552,7 +553,7 @@ test("playback binding controller keeps hydration pause guard for unstable festi
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   dom.video.pause = () => {
@@ -620,7 +621,7 @@ test("playback binding controller reapplies pause hold for unstable identity aft
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   dom.video.pause = () => {
@@ -690,7 +691,7 @@ test("playback binding controller reapplies pause hold for unstable room shared 
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   dom.video.pause = () => {
@@ -754,7 +755,7 @@ test("playback binding controller clears explicit seek intent after seek-trigger
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   globalThis.window.setTimeout = ((callback: TimerHandler) => {
@@ -818,7 +819,7 @@ test("playback binding controller allows manual play after a newer gesture follo
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -885,7 +886,7 @@ test("playback binding controller holds a page-load autoplay authorized only by 
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   dom.video.pause = () => {
@@ -979,7 +980,7 @@ test("playback binding controller still holds the delayed autoplay when the only
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 20_000,
+    getMonotonicNow: () => 20_000,
   });
 
   dom.video.pause = () => {
@@ -1059,7 +1060,7 @@ test("playback binding controller holds a seek-triggered non-shared autoplay, th
       runtimeState.pauseHoldUntil = now + durationMs;
     },
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   dom.video.pause = () => {
@@ -1144,7 +1145,7 @@ test("playback binding controller allows explicit play on a non-shared page", as
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   try {
@@ -1204,7 +1205,7 @@ test("playback binding controller suppresses auto-resumed non-shared broadcast a
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   dom.video.pause = () => {
@@ -1285,7 +1286,7 @@ test("playback binding controller pauses delayed non-sharer autoplay into a non-
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_200,
+    getMonotonicNow: () => 1_200,
   });
 
   dom.video.pause = () => {
@@ -1360,7 +1361,7 @@ test("playback binding controller pauses delayed non-sharer autoplay even after 
     activatePauseHold: () => {},
     debugLog: () => {},
     // Well past the expired pauseHoldUntil of 5_000.
-    getNow: () => 20_000,
+    getMonotonicNow: () => 20_000,
   });
 
   dom.video.pause = () => {
@@ -1430,7 +1431,7 @@ test("playback binding controller lets the user watch an explicitly opened local
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 20_000,
+    getMonotonicNow: () => 20_000,
   });
 
   dom.video.pause = () => {
@@ -1502,7 +1503,7 @@ test("playback binding controller pauses an unmarked non-shared page reached by 
       runtimeState.pauseHoldUntil = 20_000 + durationMs;
     },
     debugLog: () => {},
-    getNow: () => 20_000,
+    getMonotonicNow: () => 20_000,
   });
 
   dom.video.pause = () => {
@@ -1577,7 +1578,7 @@ test("playback binding controller pauses a non-shared video even when room inten
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 20_000,
+    getMonotonicNow: () => 20_000,
   });
 
   dom.video.pause = () => {
@@ -1642,7 +1643,7 @@ test("playback binding controller periodic tick pauses a non-shared video alread
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 20_000,
+    getMonotonicNow: () => 20_000,
   });
 
   dom.video.pause = () => {
@@ -1732,7 +1733,7 @@ test("playback binding controller holds a play while the page bridge is resolvin
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   dom.video.pause = () => {
@@ -1828,7 +1829,7 @@ test("playback binding controller stops force-pausing an unresolved non-shared p
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 20_000,
+    getMonotonicNow: () => 20_000,
   });
 
   dom.video.pause = () => {
@@ -1905,7 +1906,7 @@ test("playback binding controller does not re-pause an authorized non-shared pla
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   dom.video.pause = () => {
@@ -1994,7 +1995,7 @@ test("playback binding controller preserves the explicit non-shared authorizatio
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 20_000,
+    getMonotonicNow: () => 20_000,
   });
 
   globalThis.window.setTimeout = ((callback: TimerHandler) => {
@@ -2065,7 +2066,7 @@ test("playback binding controller re-pauses a pre-pause stale gesture while the 
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 20_000,
+    getMonotonicNow: () => 20_000,
   });
 
   dom.video.pause = () => {
@@ -2132,7 +2133,7 @@ test("playback binding controller still holds an unsolicited autoplay while the 
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 20_000,
+    getMonotonicNow: () => 20_000,
   });
 
   dom.video.pause = () => {
@@ -2200,7 +2201,7 @@ test("playback binding controller allows manual play on non-shared page after au
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   dom.video.pause = () => {
@@ -2290,7 +2291,7 @@ test("playback binding controller suppresses non-shared autoplay replayed after 
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   dom.video.pause = () => {
@@ -2368,7 +2369,7 @@ test("playback binding controller holds a non-sharer at the shared video natural
       runtimeState.pauseHoldUntil = 10_000 + durationMs;
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   dom.video.pause = () => {
@@ -2441,7 +2442,7 @@ test("playback binding controller does not pause the sharer at the shared video 
       pauseHoldCalls += 1;
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   dom.video.pause = () => {
@@ -2506,7 +2507,7 @@ test("playback binding controller does not pause a non-sharer before the shared 
       pauseHoldCalls += 1;
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   dom.video.pause = () => {
@@ -2571,7 +2572,7 @@ test("playback binding controller re-pauses non-sharer multi-part autoplay after
       runtimeState.pauseHoldUntil = 10_000 + durationMs;
     },
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   dom.video.pause = () => {
@@ -2633,7 +2634,7 @@ test("playback binding controller classifies pause as buffer when waiting fired 
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -2677,7 +2678,7 @@ test("playback binding controller treats pause as user-initiated when fresh gest
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -2720,7 +2721,7 @@ test("playback binding controller clears buffer-pause classification on resume",
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -2790,7 +2791,7 @@ test("playback binding controller does not classify pause as buffer-induced insi
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -2850,7 +2851,7 @@ test("playback binding controller still classifies pause as buffer-induced when 
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -2901,7 +2902,7 @@ test("playback binding controller re-broadcasts paused after buffer-pause upgrad
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -2972,7 +2973,7 @@ test("playback binding controller suppresses the natural-end pause for a non-sha
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 5_000,
+    getMonotonicNow: () => 5_000,
   });
 
   dom.video.pause = () => {
@@ -3048,7 +3049,7 @@ test("playback binding controller suppresses the natural-end pause broadcast for
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 5_000,
+    getMonotonicNow: () => 5_000,
   });
 
   dom.video.pause = () => {
@@ -3133,7 +3134,7 @@ test("playback binding controller records the seek-to-end flag when a seek prece
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 5_000,
+    getMonotonicNow: () => 5_000,
   });
 
   dom.video.pause = () => {
@@ -3202,7 +3203,7 @@ test("playback binding controller flushes the sharer's terminal paused state whe
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 5_000,
+    getMonotonicNow: () => 5_000,
   });
 
   try {
@@ -3279,7 +3280,7 @@ test("playback binding controller does not flush a sharer end state once autopla
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 5_000,
+    getMonotonicNow: () => 5_000,
   });
 
   try {
@@ -3340,7 +3341,7 @@ test("playback binding controller does not arm sharer end suppression for a non-
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 5_000,
+    getMonotonicNow: () => 5_000,
   });
 
   dom.video.pause = () => {
@@ -3390,7 +3391,7 @@ test("playback binding controller classifies a stall on a rebuilt element as buf
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -3435,7 +3436,7 @@ test("playback binding controller does not reclassify a user pause when transpor
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -3483,7 +3484,7 @@ test("playback binding controller leaves an unobserved pause alone when the room
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -3524,7 +3525,7 @@ test("playback binding controller classifies a pause right after a video rebind 
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -3586,7 +3587,7 @@ test("playback binding controller upgrades an unobserved stall to paused after t
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -3616,7 +3617,7 @@ test("playback binding controller upgrades an unobserved stall to paused after t
 
 function createEchoHarness(
   runtimeState: ReturnType<typeof createContentRuntimeState>,
-  getNow: () => number,
+  getMonotonicNow: () => number,
 ) {
   return createPlaybackBindingController({
     runtimeState,
@@ -3636,7 +3637,7 @@ function createEchoHarness(
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow,
+    getMonotonicNow,
   });
 }
 
@@ -3811,7 +3812,7 @@ test("a user seek that cancels an active rate catch-up is still recorded", async
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   try {
@@ -3867,7 +3868,7 @@ test("a user pause that cancels an active rate catch-up is still recorded", () =
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   try {
@@ -3917,7 +3918,7 @@ test("a ratechange is enough to classify an unobserved pause as buffering", () =
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -3958,7 +3959,7 @@ test("a real user pause is not reclassified by the shared broadcast path", () =>
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
   });
 
   try {
@@ -4001,7 +4002,7 @@ test("playback binding controller keeps the seek origin across seeking and seeke
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -4047,7 +4048,7 @@ test("playback binding controller re-snapshots the origin for a new seek gesture
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -4095,7 +4096,7 @@ test("playback binding controller re-samples the seek origin after a forced paus
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
   });
 
   try {
@@ -4153,7 +4154,7 @@ test("playback binding controller reports a newly bound video element once", () 
     applyPendingPlaybackApplication: () => {},
     activatePauseHold: () => {},
     debugLog: () => {},
-    getNow: () => 1_100,
+    getMonotonicNow: () => 1_100,
   });
 
   try {
@@ -4165,6 +4166,63 @@ test("playback binding controller reports a newly bound video element once", () 
     controller.attachPlaybackListeners();
     assert.equal(bindings, 1, "same element must not re-report");
   } finally {
+    dom.restore();
+  }
+});
+
+test("records explicit user actions on the monotonic clock by default", async () => {
+  const dom = installDomStub();
+  // Stub the GLOBALS and inject NO clock: which source the default reads is the
+  // whole question, and an injected clock answers it for free. The two domains
+  // must also hold different values — equal ones pass either way.
+  const clock = installClockStubs({
+    wall: 1_700_000_000_000,
+    monotonic: 1_100,
+  });
+  const runtimeState = createContentRuntimeState();
+  // A gesture recorded moments ago, in the monotonic domain.
+  runtimeState.lastUserGestureAt = 1_000;
+  const events: string[] = [];
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async (_video, eventSource) => {
+      events.push(eventSource ?? "manual");
+    },
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("ratechange")!(new Event("ratechange"));
+    await Promise.resolve();
+
+    // Two claims at once. The stamp is a monotonic reading, not a wall-clock
+    // one; and the 100ms-old gesture that authorizes this event was only
+    // recognised as recent because both sides of `now - lastUserGestureAt` are
+    // in the same domain — on the wall clock the gap reads as ~54 years, the
+    // gesture looks ancient, and the event is no longer an explicit user action.
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "ratechange",
+      at: 1_100,
+    });
+    assert.deepEqual(events, ["ratechange"]);
+  } finally {
+    clock.restore();
     dom.restore();
   }
 });

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import type { RoomState, SharedVideo } from "@bili-syncplay/protocol";
 import type { RoomStateHydrationResponse } from "../src/shared/messages";
 import { createContentRuntimeState } from "../src/content/runtime-state";
+import { installClockStubs } from "./clock-stubs";
 import { createRoomStateApplyController } from "../src/content/room-state-apply-controller";
 
 function createEmptyRoomState(roomCode = "ROOM01"): RoomState {
@@ -29,10 +30,14 @@ function createController(overrides: {
   runtimeState?: ReturnType<typeof createContentRuntimeState>;
   video?: HTMLVideoElement | null;
   now?: number;
-  /** Virtual clock for tests that need time to advance during the test. */
-  getNow?: () => number;
-  /** Virtual monotonic clock, as `performance.now()` would give. */
+  /** Virtual monotonic clock for tests that need time to advance. */
   getMonotonicNow?: () => number;
+  /**
+   * Inject no clock at all, so the controller falls back to its default source.
+   * Required by any test asking WHICH clock the default is: an injected one
+   * answers that for free.
+   */
+  omitMonotonicClock?: boolean;
   userGestureGraceMs?: number;
   remotePauseDebounceMs?: number;
   normalizeUrl?: (url: string | undefined | null) => string | null;
@@ -68,12 +73,9 @@ function createController(overrides: {
     initialRoomStatePauseHoldMs: 3_000,
     userGestureGraceMs: overrides.userGestureGraceMs ?? 1_200,
     remotePauseDebounceMs: overrides.remotePauseDebounceMs ?? 0,
-    getNow: () => overrides.getNow?.() ?? overrides.now ?? 10_000,
-    getMonotonicNow: () =>
-      overrides.getMonotonicNow?.() ??
-      overrides.getNow?.() ??
-      overrides.now ??
-      10_000,
+    getMonotonicNow: overrides.omitMonotonicClock
+      ? undefined
+      : () => overrides.getMonotonicNow?.() ?? overrides.now ?? 10_000,
     debugLog: (msg) => logs.push(msg),
     shouldLogHeartbeat: () => true,
     requestRoomStateHydration:
@@ -1613,7 +1615,7 @@ test("a rebind storm cannot starve hydration by resetting the timer", async () =
     const hydrationClocks: number[] = [];
     const harness = createController({
       video: createStubVideo(false),
-      getNow: () => clock,
+      getMonotonicNow: () => clock,
       currentVideo: null,
       requestRoomStateHydration: async () => {
         hydrationClocks.push(clock);
@@ -1860,6 +1862,12 @@ test("an externally driven hydration drops the previous page's backoff", async (
 
 test("the retry deadline is compared on a monotonic clock", async () => {
   const win = installWindowTimerStub();
+  // Stub the GLOBALS and inject nothing: the question is which source the
+  // controller's default reads, and an injected clock answers it for free.
+  const clock = installClockStubs({
+    wall: 1_700_000_000_000,
+    monotonic: 100_000,
+  });
   try {
     // The deadline is captured when the timer is armed. Read from `Date.now()`,
     // a backward step shrinks `now + delay` and makes a candidate look earlier
@@ -1872,12 +1880,9 @@ test("the retry deadline is compared on a monotonic clock", async () => {
       actorId: "remote-member",
       seq: 5,
     });
-    let monotonic = 100_000;
-    let wallClock = 1_700_000_000_000;
     const harness = createController({
       video: createStubVideo(false),
-      getNow: () => wallClock,
-      getMonotonicNow: () => monotonic,
+      omitMonotonicClock: true,
       currentVideo: null,
       requestRoomStateHydration: async () => ({
         ok: true,
@@ -1894,14 +1899,14 @@ test("the retry deadline is compared on a monotonic clock", async () => {
     // Grow the bind streak so a preemption would cost a long re-wait.
     for (let i = 0; i < 6; i += 1) {
       harness.controller.notifyVideoElementBound();
-      monotonic += 1;
+      clock.clocks.monotonic += 1;
       if (win.scheduled[win.scheduled.length - 1].ms <= 1) break;
     }
     const armedBefore = win.scheduled.length;
 
     // Real time barely moved; the wall clock jumped an hour backwards.
-    monotonic += 5;
-    wallClock -= 3_600_000;
+    clock.clocks.monotonic += 5;
+    clock.clocks.wall -= 3_600_000;
     harness.controller.notifyVideoElementBound();
     await settle();
 
@@ -1911,6 +1916,7 @@ test("the retry deadline is compared on a monotonic clock", async () => {
       "a backward wall-clock step must not preempt the pending retry",
     );
   } finally {
+    clock.restore();
     win.restore();
   }
 });

--- a/extension/test/soft-apply-controller.test.ts
+++ b/extension/test/soft-apply-controller.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import type { PlaybackState } from "@bili-syncplay/protocol";
 import { createContentRuntimeState } from "../src/content/runtime-state";
 import { createSoftApplyController } from "../src/content/soft-apply-controller";
+import { installClockStubs } from "./clock-stubs";
 
 function installWindowStub() {
   const originalWindow = globalThis.window;
@@ -80,7 +81,7 @@ test("chained upsertActiveSoftApply preserves the first session's restore rate",
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
-      getNow: () => now,
+      getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
 
@@ -123,7 +124,7 @@ test("upsertActiveSoftApply for a different url starts a fresh restore rate", ()
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
-      getNow: () => 10_000,
+      getMonotonicNow: () => 10_000,
       armProgrammaticApplyWindow: () => {},
     });
 
@@ -169,7 +170,7 @@ test("explicit user ratechange cancels a rate-only session without reverting the
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
-      getNow: () => now,
+      getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
 
@@ -214,7 +215,7 @@ test("drift-closed honors the sticky cooldown of a soft-apply taken over by a ra
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
-      getNow: () => now,
+      getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
 
@@ -259,7 +260,7 @@ test("isActiveRateOnlyCatchUp flags pure rate-only sessions but not real soft-ap
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
-      getNow: () => 10_000,
+      getMonotonicNow: () => 10_000,
       armProgrammaticApplyWindow: () => {},
     });
 
@@ -311,7 +312,7 @@ test("relative-drift session settling via the timer still honors a sticky cooldo
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
-      getNow: () => now,
+      getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
 
@@ -356,7 +357,7 @@ test("a steadily advancing peer no longer cancels a catch-up as target-shifted",
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
-      getNow: () => now,
+      getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
 
@@ -405,7 +406,7 @@ test("a peer's buffering does not abort an active catch-up, a real pause still d
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
-      getNow: () => now,
+      getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
 
@@ -459,7 +460,7 @@ test("hasActiveCorrectionSession covers real soft-apply, not just rate-only catc
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
-      getNow: () => 20_000,
+      getMonotonicNow: () => 20_000,
       armProgrammaticApplyWindow: () => {},
     });
     const url = "https://www.bilibili.com/video/BV1xx411c7mD?p=1";
@@ -494,7 +495,7 @@ test("the rate restore on cancel arms a ratechange-scoped window", () => {
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
-      getNow: () => 10_000,
+      getMonotonicNow: () => 10_000,
       armProgrammaticApplyWindow: (_signature, _reason, actorId, scope) => {
         armed.push({ actorId, scope });
       },
@@ -534,7 +535,7 @@ test("cancel restores an elevated defaultPlaybackRate the player already reset",
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
-      getNow: () => 10_000,
+      getMonotonicNow: () => 10_000,
       armProgrammaticApplyWindow: () => {},
     });
 
@@ -579,7 +580,7 @@ test("cancel still leaves an explicit user rate alone", () => {
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
-      getNow: () => 10_000,
+      getMonotonicNow: () => 10_000,
       armProgrammaticApplyWindow: () => {},
     });
 
@@ -596,6 +597,44 @@ test("cancel still leaves an explicit user rate alone", () => {
     assert.equal(video.playbackRate, 2);
     assert.equal(video.defaultPlaybackRate, 2);
   } finally {
+    windowStub.restore();
+  }
+});
+
+test("arms the soft-apply cooldown on the monotonic clock by default", () => {
+  const windowStub = installWindowStub();
+  // Globals stubbed, no clock injected: an injected clock cannot tell us which
+  // source the default reads. The two domains hold very different values so
+  // only one of them can satisfy the assertion.
+  const clock = installClockStubs({
+    wall: 1_700_000_000_000,
+    monotonic: 10_000,
+  });
+  try {
+    const runtimeState = createContentRuntimeState();
+    const video = createVideo({ currentTime: 24, playbackRate: 1 });
+    const controller = createSoftApplyController({
+      runtimeState,
+      normalizeUrl: (url) => url?.trim() ?? null,
+      getVideoElement: () => video,
+      debugLog: () => {},
+      userGestureGraceMs: 300,
+      programmaticApplyWindowMs: 700,
+      armProgrammaticApplyWindow: () => {},
+    });
+
+    controller.upsertActiveSoftApply(
+      createPlayback({ currentTime: 24.5, playbackRate: 1 }),
+      0.5,
+    );
+    controller.cancelActiveSoftApply(video, "converged");
+
+    // 10_000 + SOFT_APPLY_COOLDOWN_MS. A wall-clock reading here would put the
+    // deadline ~54 years out and the cooldown would never lift for the rest of
+    // the page's life.
+    assert.equal(runtimeState.softApplyCooldownUntil, 12_500);
+  } finally {
+    clock.restore();
     windowStub.restore();
   }
 });

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -6,6 +6,10 @@ import type {
   SharedVideo,
 } from "@bili-syncplay/protocol";
 import { createContentRuntimeState } from "../src/content/runtime-state";
+import { installClockStubs } from "./clock-stubs";
+
+/** A wall-clock reading, deliberately nowhere near the tests' monotonic values. */
+const WIRE_UPDATED_AT = 1_700_000_000_000;
 import { createSyncController } from "../src/content/sync-controller";
 
 function installWindowStub() {
@@ -62,7 +66,7 @@ function createControllerHarness() {
     duplicateBroadcastWindowMs: 1_000,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
-    getNow: () => now,
+    getMonotonicNow: () => now,
     debugLog: (message) => {
       debugLogs.push(message);
     },
@@ -215,7 +219,7 @@ test("sync controller schedules hydration retry when room exists but initial roo
     duplicateBroadcastWindowMs: 1_000,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
-    getNow: () => 10_000,
+    getMonotonicNow: () => 10_000,
     debugLog: (message) => {
       harness.debugLogs.push(message);
     },
@@ -627,8 +631,14 @@ test("sync controller does not force-pause local playback after remote buffering
   );
 });
 
-test("sync controller allows explicit user seek inside the silence window", async () => {
+test("sync controller allows explicit user seek inside the silence window", async (t) => {
   const harness = createControllerHarness();
+  // `updatedAt` is a WIRE field and stays on the wall clock; every window this
+  // test exercises is on the injected monotonic clock (`setNow`). Pinning the
+  // wall clock to a value far from the monotonic one is what makes the payload
+  // assertion below prove the two are separate domains rather than one clock.
+  const clock = installClockStubs({ wall: WIRE_UPDATED_AT, monotonic: 0 });
+  t.after(() => clock.restore());
   const sharedVideo = {
     videoId: "BV1xx411c7mD",
     url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
@@ -673,7 +683,7 @@ test("sync controller allows explicit user seek inside the silence window", asyn
       playState: "playing",
       syncIntent: "explicit-seek",
       playbackRate: 1,
-      updatedAt: 22_000,
+      updatedAt: WIRE_UPDATED_AT,
       serverTime: 0,
       actorId: "local-member",
       seq: 1,
@@ -790,8 +800,14 @@ test("sync controller lets the seek grace window expire back to the real state",
   assert.equal(lastBroadcastPlayState(harness), "buffering");
 });
 
-test("sync controller does not treat a seek as explicit after a forced pause invalidates it", async () => {
+test("sync controller does not treat a seek as explicit after a forced pause invalidates it", async (t) => {
   const harness = createControllerHarness();
+  // `updatedAt` is a WIRE field and stays on the wall clock; every window this
+  // test exercises is on the injected monotonic clock (`setNow`). Pinning the
+  // wall clock to a value far from the monotonic one is what makes the payload
+  // assertion below prove the two are separate domains rather than one clock.
+  const clock = installClockStubs({ wall: WIRE_UPDATED_AT, monotonic: 0 });
+  t.after(() => clock.restore());
   const sharedVideo = {
     videoId: "BV1xx411c7mD",
     url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
@@ -826,7 +842,7 @@ test("sync controller does not treat a seek as explicit after a forced pause inv
       playState: "paused",
       syncIntent: undefined,
       playbackRate: 1,
-      updatedAt: 22_000,
+      updatedAt: WIRE_UPDATED_AT,
       serverTime: 0,
       actorId: "local-member",
       seq: 1,
@@ -840,8 +856,14 @@ test("sync controller does not treat a seek as explicit after a forced pause inv
   );
 });
 
-test("sync controller marks explicit user ratechange with explicit-ratechange intent", async () => {
+test("sync controller marks explicit user ratechange with explicit-ratechange intent", async (t) => {
   const harness = createControllerHarness();
+  // `updatedAt` is a WIRE field and stays on the wall clock; every window this
+  // test exercises is on the injected monotonic clock (`setNow`). Pinning the
+  // wall clock to a value far from the monotonic one is what makes the payload
+  // assertion below prove the two are separate domains rather than one clock.
+  const clock = installClockStubs({ wall: WIRE_UPDATED_AT, monotonic: 0 });
+  t.after(() => clock.restore());
   const sharedVideo = {
     videoId: "BV1xx411c7mD",
     url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
@@ -876,7 +898,7 @@ test("sync controller marks explicit user ratechange with explicit-ratechange in
       playState: "playing",
       syncIntent: "explicit-ratechange",
       playbackRate: 1.5,
-      updatedAt: 22_000,
+      updatedAt: WIRE_UPDATED_AT,
       serverTime: 0,
       actorId: "local-member",
       seq: 1,
@@ -1702,7 +1724,7 @@ test("sync controller broadcasts buffering when active pause is classified as bu
     duplicateBroadcastWindowMs: 1_000,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
-    getNow: () => 20_400,
+    getMonotonicNow: () => 20_400,
     debugLog: (message) => harness.debugLogs.push(message),
     shouldLogHeartbeat: () => true,
     sendPlaybackUpdate: async (payload) => {
@@ -1771,7 +1793,7 @@ test("sync controller broadcasts paused once buffer-pause upgrade window elapses
     duplicateBroadcastWindowMs: 1_000,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
-    getNow: () => 21_700, // 1700ms after pauseStartedAt, past upgrade threshold
+    getMonotonicNow: () => 21_700, // 1700ms after pauseStartedAt, past upgrade threshold
     debugLog: (message) => harness.debugLogs.push(message),
     shouldLogHeartbeat: () => true,
     sendPlaybackUpdate: async (payload) => {
@@ -1887,7 +1909,7 @@ test("sync controller tags broadcast with userInitiated:true on a fresh user pau
     duplicateBroadcastWindowMs: 1_000,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
-    getNow: () => 20_400,
+    getMonotonicNow: () => 20_400,
     debugLog: (message) => harness.debugLogs.push(message),
     shouldLogHeartbeat: () => true,
     sendPlaybackUpdate: async (payload) => {
@@ -1961,7 +1983,7 @@ test("sync controller omits userInitiated when a pause is buffer-induced", async
     duplicateBroadcastWindowMs: 1_000,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
-    getNow: () => 20_400,
+    getMonotonicNow: () => 20_400,
     debugLog: (message) => harness.debugLogs.push(message),
     shouldLogHeartbeat: () => true,
     sendPlaybackUpdate: async (payload) => {
@@ -2040,7 +2062,7 @@ test("sync controller omits userInitiated on buffer-pause upgrade re-broadcast",
     duplicateBroadcastWindowMs: 1_000,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
-    getNow: () => 21_700,
+    getMonotonicNow: () => 21_700,
     debugLog: (message) => harness.debugLogs.push(message),
     shouldLogHeartbeat: () => true,
     sendPlaybackUpdate: async (payload) => {
@@ -2229,7 +2251,7 @@ test("programmatic apply signature stores the normalized url for mismatched (fes
     duplicateBroadcastWindowMs: 1_000,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
-    getNow: () => 20_000,
+    getMonotonicNow: () => 20_000,
     debugLog: (message) => harness.debugLogs.push(message),
     shouldLogHeartbeat: () => true,
     sendPlaybackUpdate: async (payload) => {
@@ -2645,7 +2667,7 @@ test("sync controller keeps userInitiated on a pause that cancelled a rate catch
     duplicateBroadcastWindowMs: 1_000,
     nextSeq: () => 1,
     markBroadcastAt: () => {},
-    getNow: () => 20_400,
+    getMonotonicNow: () => 20_400,
     debugLog: (message) => harness.debugLogs.push(message),
     shouldLogHeartbeat: () => true,
     sendPlaybackUpdate: async (payload) => {


### PR DESCRIPTION
## 背景

#231 的第二块，接 #232（后台层）。内容脚本的 6 个控制器各自持有

```ts
const nowOf = () => args.getNow?.() ?? Date.now();
```

而它们存的每一个时间戳都是本机的一段间隔。挂钟不测量间隔：

- **回拨** → 间隔算成负数或偏小 → 宽限窗口被误判为"仍然新鲜"，本该广播的用户操作被当成程序化回声抑制
- **前跳** → 间隔偏大 → 宽限窗口被误判为"已过期"，程序化暂停可能被误报成用户暂停广播给整个房间

后者正是 #184 / #142 那一类"误报暂停"缺陷的成因形态。

## 关键结论：这一层不能按控制器拆分

`lastUserGestureAt` 在 `content/index.ts` 写入，在 `playback-binding-controller`、`room-state-apply-controller`、`playback-broadcast` 三处读取。只迁移一半会拿单调读数去减挂钟写入值，差值约 `1.7e12`，永远读作"很久以前"——**比不改更糟**。写方与读方必须同时改，所以只能整体迁移。这一点 #231 原先的计划里没写到。

## 变更点

- `getNow` → `getMonotonicNow`，默认源 `Date.now()` → `performance.now()`：`navigation-controller`、`pending-local-override`、`playback-binding-controller`、`soft-apply-controller`、`sync-controller`
- `room-state-apply-controller` 原本同时持有两个时钟（#210 加的单调钟只用于 hydration 截止），现在合并为一个
- `content/index.ts` 的手势时间戳、`pauseHoldUntil`、心跳节流；`festival-bridge` 的快照 TTL
- **生产装配从不注入时钟**（`content/index.ts` 不传 `getNow`），所以本 PR 改变的正是默认源

## 唯一留在挂钟上的：`PlaybackState.updatedAt`

协议文档写明是"发送方时间戳（毫秒）"，是本目录下唯一会离开本机的时间值。全库审计确认目前没有消费方——服务端刻意改用自己的 `serverTime` 计算经过时长（`room-service.ts:1402` 的注释说明是防伪造）——但它是文档化的线格式字段，塞一个 `performance.now()` 读数进去会静默改变它的含义。

为此把两个载荷构造函数的形参由 `now` 改名为 `updatedAt`，把域别写进签名。`sync-controller` 的 `broadcastPlayback` 是唯一两种域同时出现的函数（同一个 `now` 原本既喂窗口又喂线格式），已就地注明。

`festival-bridge` 的 requestId 仍用 `Date.now()`：那是标识，不是时长。

## 审计

| 位置 | 结论 |
| --- | --- |
| `content/*` 全部 `Date.now()` | 仅剩 requestId + 两处 `updatedAt` |
| 内容↔后台消息中的时间字段 | 无（`shared/messages.ts` 只有 `connectedAt`，属后台→popup 且无消费方） |
| `lastLocalPlaybackVersion.serverTime` / `playback-apply` 的版本比较 | 服务端域，比较双方都是服务端时刻，不动 |
| `toast.ts` 的 `serverTime` 差值 | 同上 |

## Test plan

新增测试一律 **stub 全局双钟且不注入时钟**——注入了就测不出默认源是哪个，而生产从不注入。既有的 `the retry deadline is compared on a monotonic clock` 也改成这种形式（它原本靠注入两个不同时钟，合并后已无从区分）。

逐处回退验证判别力，均失败：

- [x] 回退 playback-binding 默认 → `records explicit user actions on the monotonic clock by default`
- [x] 回退 soft-apply 默认 → `arms the soft-apply cooldown on the monotonic clock by default`
- [x] 回退 festival TTL → `ages the cached snapshot on the monotonic clock`
- [x] 把 `updatedAt` 换回单调读数 → sync-controller 三条载荷断言
- [x] `format:check` / `lint` / `typecheck` / `build` / `test` / `audit` 全绿（616 条扩展测试）
- [ ] 手动验证（改系统时间复现属破坏性操作，未在本机执行）

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
