### PR TITLE
fix: 断线不再吊销成员身份

### DIFF
--- a/.claude/skills/review-round/scripts/reply-resolve.sh
+++ b/.claude/skills/review-round/scripts/reply-resolve.sh
@@ -11,6 +11,15 @@ THREAD_ID=${1:?用法: reply-resolve.sh <线程id> <回复正文> <已见评论�
 BODY=${2:?缺少回复正文}
 SEEN=${3:?缺少「第 1 步看到的评论数」——用于检测扫描后是否有新评论}
 
+# 非整数会让下面的 `[ "$TOTAL" -ne "$SEEN" ]` 以「integer expression expected」失败，
+# 而失败的 test 只是让 if 不成立——新评论保护就此被静默跳过，线程照样被 resolve。
+# 实测触发方式：回复正文里含 ASCII 双引号，参数被提前截断、发生词拆分，$3 变成正文
+# 里的某个片段。多余的参数同样是这种截断的信号。
+[ "$#" -le 3 ] || die "参数多于 3 个（第 4 个是 '$4'）——回复正文很可能没有被完整引起来"
+case $SEEN in
+  '' | *[!0-9]*) die "「已见评论数」必须是整数，实际收到：'$SEEN'（回复正文里的引号可能截断了参数）" ;;
+esac
+
 ME=$(gh api user --jq .login) || die "无法确定当前登录用户"
 
 read_thread() {
@@ -39,6 +48,10 @@ read -r TOTAL RESOLVED MINE <<<"$(printf '%s' "$RESP" | BODY="$BODY" ME="$ME" no
     process.stdout.write(`${n.comments.totalCount} ${n.isResolved} ${mine}`);
   });
 ')"
+
+case $TOTAL in
+  '' | *[!0-9]*) die "无法读出线程评论数（收到：'$TOTAL'）" ;;
+esac
 
 if [ "$RESOLVED" = "true" ]; then
   echo "线程 ${THREAD_ID:0:20} 已是 resolved，跳过"

--- a/.claude/skills/review-round/scripts/selftest.sh
+++ b/.claude/skills/review-round/scripts/selftest.sh
@@ -92,6 +92,24 @@ grep -q 'TOTAL" -ne "\$SEEN' "$HERE/reply-resolve.sh" &&
   ok "reply-resolve.sh 比对扫描后是否有新评论" || no "缺少评论数比对"
 grep -q '不执行 resolve' "$HERE/reply-resolve.sh" &&
   ok "回复失败时不 resolve" || no "缺少回复失败保护"
+# 非整数的「已见评论数」会让上面那个 test 以 integer expression expected 失败，而失败的
+# test 只是让 if 不成立——保护被静默跳过，线程照样被 resolve。实测触发方式：回复正文
+# 里含 ASCII 双引号，参数被截断并发生词拆分。
+# 断言的是错误信息而不只是退出码：假 thread id 本来就会让查询失败并 exit 1，
+# 只看退出码的话，去掉校验后这条用例照样是绿的。
+# 断言错误信息而不只是退出码：假 thread id 本来就会让查询失败并 exit 1，只看退出码
+# 的话，去掉校验后这两条照样是绿的。输出先落到变量——pipefail 下把被测脚本放在管道
+# 左侧，它的非零退出会让整条管道判失败，`grep` 命中与否就无从体现。
+BAD_SEEN_OUT=$("$HERE/reply-resolve.sh" PRRT_fake "body" "+" 2>&1 || true)
+case $BAD_SEEN_OUT in
+  *必须是整数*) ok "非整数的已见评论数被拒（否则新评论保护会被静默跳过）" ;;
+  *) no "非整数评论数未被拒" ;;
+esac
+EXTRA_ARG_OUT=$("$HERE/reply-resolve.sh" PRRT_fake "a" "b" 1 2>&1 || true)
+case $EXTRA_ARG_OUT in
+  *"参数多于 3 个"*) ok "参数多于 3 个被拒（回复正文未被完整引起来的信号）" ;;
+  *) no "多余参数未被拒" ;;
+esac
 
 echo "== 6. 分支校验必须比 SHA 而非只比分支名 =="
 grep -q 'headRefOid' "$HERE/verify-branch.sh" && ok "verify-branch.sh 读取 headRefOid" || no "未校验 SHA"

--- a/server/src/active-room-registry.ts
+++ b/server/src/active-room-registry.ts
@@ -17,6 +17,7 @@ export type ActiveRoomRegistry = {
   releaseRoomLock: RuntimeStore["releaseRoomLock"];
   removeMember: RuntimeStore["removeMember"];
   revokeMemberToken: RuntimeStore["revokeMemberToken"];
+  evictMemberToken: RuntimeStore["evictMemberToken"];
   deleteRoom: RuntimeStore["deleteRoom"];
 };
 
@@ -40,6 +41,7 @@ export function createActiveRoomRegistry(
     releaseRoomLock: store.releaseRoomLock,
     removeMember: store.removeMember,
     revokeMemberToken: store.revokeMemberToken,
+    evictMemberToken: store.evictMemberToken,
     deleteRoom: store.deleteRoom,
   };
 }

--- a/server/src/active-room-registry.ts
+++ b/server/src/active-room-registry.ts
@@ -18,6 +18,7 @@ export type ActiveRoomRegistry = {
   removeMember: RuntimeStore["removeMember"];
   revokeMemberToken: RuntimeStore["revokeMemberToken"];
   evictMemberToken: RuntimeStore["evictMemberToken"];
+  hasRoomResidue: RuntimeStore["hasRoomResidue"];
   getRoomGeneration: RuntimeStore["getRoomGeneration"];
   markRoomGeneration: RuntimeStore["markRoomGeneration"];
   deleteRoom: RuntimeStore["deleteRoom"];
@@ -44,6 +45,7 @@ export function createActiveRoomRegistry(
     removeMember: store.removeMember,
     revokeMemberToken: store.revokeMemberToken,
     evictMemberToken: store.evictMemberToken,
+    hasRoomResidue: store.hasRoomResidue,
     getRoomGeneration: store.getRoomGeneration,
     markRoomGeneration: store.markRoomGeneration,
     deleteRoom: store.deleteRoom,

--- a/server/src/active-room-registry.ts
+++ b/server/src/active-room-registry.ts
@@ -16,6 +16,7 @@ export type ActiveRoomRegistry = {
   acquireRoomLock: RuntimeStore["acquireRoomLock"];
   releaseRoomLock: RuntimeStore["releaseRoomLock"];
   removeMember: RuntimeStore["removeMember"];
+  revokeMemberToken: RuntimeStore["revokeMemberToken"];
   deleteRoom: RuntimeStore["deleteRoom"];
 };
 
@@ -38,6 +39,7 @@ export function createActiveRoomRegistry(
     acquireRoomLock: store.acquireRoomLock,
     releaseRoomLock: store.releaseRoomLock,
     removeMember: store.removeMember,
+    revokeMemberToken: store.revokeMemberToken,
     deleteRoom: store.deleteRoom,
   };
 }

--- a/server/src/active-room-registry.ts
+++ b/server/src/active-room-registry.ts
@@ -18,6 +18,8 @@ export type ActiveRoomRegistry = {
   removeMember: RuntimeStore["removeMember"];
   revokeMemberToken: RuntimeStore["revokeMemberToken"];
   evictMemberToken: RuntimeStore["evictMemberToken"];
+  getRoomGeneration: RuntimeStore["getRoomGeneration"];
+  markRoomGeneration: RuntimeStore["markRoomGeneration"];
   deleteRoom: RuntimeStore["deleteRoom"];
 };
 
@@ -42,6 +44,8 @@ export function createActiveRoomRegistry(
     removeMember: store.removeMember,
     revokeMemberToken: store.revokeMemberToken,
     evictMemberToken: store.evictMemberToken,
+    getRoomGeneration: store.getRoomGeneration,
+    markRoomGeneration: store.markRoomGeneration,
     deleteRoom: store.deleteRoom,
   };
 }

--- a/server/src/admin-command-consumer.ts
+++ b/server/src/admin-command-consumer.ts
@@ -15,6 +15,16 @@ export async function createAdminCommandConsumer(options: {
     memberToken: string,
     expiresAt: number,
   ) => void | Promise<void>;
+  /**
+   * Ends the kicked member's identity so their `memberToken` can no longer
+   * reclaim their `memberId`. Required explicitly since #234: the disconnect
+   * below no longer revokes it, and without this the block would only hold them
+   * out for its TTL before they returned as the same member.
+   */
+  revokeMemberToken: (
+    roomCode: string,
+    memberId: string,
+  ) => void | Promise<void>;
   disconnectSessionSocket: (
     session: Session,
     reason: string,
@@ -119,6 +129,7 @@ export async function createAdminCommandConsumer(options: {
               now() + 60_000,
             );
           }
+          await options.revokeMemberToken(command.roomCode, command.memberId);
         } catch (error) {
           options.logEvent?.("admin_command_executed", {
             commandType: command.kind,

--- a/server/src/admin-command-consumer.ts
+++ b/server/src/admin-command-consumer.ts
@@ -10,20 +10,21 @@ export async function createAdminCommandConsumer(options: {
   adminCommandBus: AdminCommandBus;
   getLocalSession: (sessionId: string) => Session | null;
   listLocalSessionsByRoom: (roomCode: string) => Session[];
-  blockMemberToken: (
-    roomCode: string,
-    memberToken: string,
-    expiresAt: number,
-  ) => void | Promise<void>;
   /**
-   * Ends the kicked member's identity so their `memberToken` can no longer
-   * reclaim their `memberId`. Required explicitly since #234: the disconnect
-   * below no longer revokes it, and without this the block would only hold them
-   * out for its TTL before they returned as the same member.
+   * Blocks the token AND ends the identity as one commit.
+   *
+   * Both halves are needed — the block only holds them out for its TTL, and
+   * without the revoke they would come back as the same member once it lapsed —
+   * but they must not be two writes. When the block landed and the revoke then
+   * failed there was nothing to roll the block back with: the admin was told the
+   * kick failed while the member kept working until their next reconnect, which
+   * was then refused with `member_kicked` (#237 review).
    */
-  revokeMemberToken: (
+  evictMemberToken: (
     roomCode: string,
     memberId: string,
+    memberToken: string,
+    blockedUntil: number,
   ) => void | Promise<void>;
   disconnectSessionSocket: (
     session: Session,
@@ -123,13 +124,13 @@ export async function createAdminCommandConsumer(options: {
 
         try {
           if (session.memberToken) {
-            await options.blockMemberToken(
+            await options.evictMemberToken(
               command.roomCode,
+              command.memberId,
               session.memberToken,
               now() + 60_000,
             );
           }
-          await options.revokeMemberToken(command.roomCode, command.memberId);
         } catch (error) {
           options.logEvent?.("admin_command_executed", {
             commandType: command.kind,

--- a/server/src/admin/action-service.ts
+++ b/server/src/admin/action-service.ts
@@ -29,10 +29,16 @@ export class AdminActionError extends Error {
 export function createAdminActionService(options: {
   instanceId: string;
   roomStore: RoomStore;
-  runtimeStore: Pick<
-    RuntimeStore,
-    "listSessionsByRoom" | "getSession" | "deleteRoom"
-  >;
+  runtimeStore: Pick<RuntimeStore, "listSessionsByRoom" | "getSession">;
+  /**
+   * Tears down a deleted room's runtime state, guarded and retried.
+   *
+   * Not `runtimeStore.deleteRoom`: both paths below delete the persisted room
+   * first and irrecoverably, so a teardown that fails has no way back — the code
+   * would never reach the reaper again. The room service owns the retry ledger
+   * and the generation check, so it has to be the one entry point (#237 review).
+   */
+  teardownRoomRuntime: (roomCode: string) => Promise<void>;
   listClusterSessions: () => Promise<
     Awaited<ReturnType<RuntimeStore["listClusterSessions"]>>
   >;
@@ -227,7 +233,7 @@ export function createAdminActionService(options: {
       }
 
       await options.roomStore.deleteRoom(roomCode);
-      await options.runtimeStore.deleteRoom(roomCode);
+      await options.teardownRoomRuntime(roomCode);
       await options.publishRoomDeleted(roomCode);
       const disconnectedSessionCount = disconnectResults.filter(
         ({ result }) => result.status === "ok",
@@ -260,7 +266,7 @@ export function createAdminActionService(options: {
       // left its runtime keys behind — including the tokens of members who had
       // disconnected but whose identity is deliberately retained (#234) — and a
       // recycled room code would inherit them (#237 review).
-      await options.runtimeStore.deleteRoom(roomCode);
+      await options.teardownRoomRuntime(roomCode);
 
       options.logEvent("admin_room_expired", {
         roomCode,

--- a/server/src/admin/action-service.ts
+++ b/server/src/admin/action-service.ts
@@ -227,7 +227,7 @@ export function createAdminActionService(options: {
       }
 
       await options.roomStore.deleteRoom(roomCode);
-      options.runtimeStore.deleteRoom(roomCode);
+      await options.runtimeStore.deleteRoom(roomCode);
       await options.publishRoomDeleted(roomCode);
       const disconnectedSessionCount = disconnectResults.filter(
         ({ result }) => result.status === "ok",
@@ -256,6 +256,11 @@ export function createAdminActionService(options: {
 
       await getRoomOrThrow(roomCode);
       await options.roomStore.deleteRoom(roomCode);
+      // Same teardown `closeRoom` above performs. Without it an expired room
+      // left its runtime keys behind — including the tokens of members who had
+      // disconnected but whose identity is deliberately retained (#234) — and a
+      // recycled room code would inherit them (#237 review).
+      await options.runtimeStore.deleteRoom(roomCode);
 
       options.logEvent("admin_room_expired", {
         roomCode,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -218,6 +218,8 @@ export async function createSyncServer(
       localRuntimeStore.listSessionsByRoom(roomCode),
     blockMemberToken: (roomCode, memberToken, expiresAt) =>
       runtimeStore.blockMemberToken(roomCode, memberToken, expiresAt),
+    revokeMemberToken: (roomCode, memberId) =>
+      runtimeStore.revokeMemberToken(roomCode, memberId),
     disconnectSessionSocket: (session, reason) => {
       if (!hasAttachedSocket(session)) {
         return;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -216,10 +216,13 @@ export async function createSyncServer(
     getLocalSession: (sessionId) => localRuntimeStore.getSession(sessionId),
     listLocalSessionsByRoom: (roomCode) =>
       localRuntimeStore.listSessionsByRoom(roomCode),
-    blockMemberToken: (roomCode, memberToken, expiresAt) =>
-      runtimeStore.blockMemberToken(roomCode, memberToken, expiresAt),
-    revokeMemberToken: (roomCode, memberId) =>
-      runtimeStore.revokeMemberToken(roomCode, memberId),
+    evictMemberToken: (roomCode, memberId, memberToken, blockedUntil) =>
+      runtimeStore.evictMemberToken(
+        roomCode,
+        memberId,
+        memberToken,
+        blockedUntil,
+      ),
     disconnectSessionSocket: (session, reason) => {
       if (!hasAttachedSocket(session)) {
         return;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -161,6 +161,8 @@ export async function createSyncServer(
       Promise.resolve(
         sharedRuntimeStore.findMemberIdByToken(roomCode, memberToken),
       ),
+    resolveRoomResidue: (roomCode) =>
+      Promise.resolve(sharedRuntimeStore.hasRoomResidue(roomCode)),
     resolveBlockedMemberToken: (roomCode, memberToken, currentTime) =>
       Promise.resolve(
         sharedRuntimeStore.isMemberTokenBlocked(

--- a/server/src/bootstrap/admin-services.ts
+++ b/server/src/bootstrap/admin-services.ts
@@ -151,6 +151,8 @@ export function createAdminServices(args: {
       instanceId: args.persistenceConfig.instanceId,
       roomStore: args.roomStore,
       runtimeStore: args.runtimeStore,
+      teardownRoomRuntime: (roomCode) =>
+        args.roomService.teardownRoomRuntime(roomCode),
       listClusterSessions: () => args.runtimeStore.listClusterSessions(),
       listClusterSessionsByRoom: (roomCode) =>
         args.runtimeStore.listClusterSessionsByRoom(roomCode),

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -304,6 +304,9 @@ export async function createServerBootstrapContext(
       ? await createRedisRuntimeStore(persistenceConfig.redisUrl, {
           now,
           keyPrefix: getRedisRuntimeKeyPrefix(persistenceConfig.redisNamespace),
+          // Twice the room's own empty-room lifetime, so a member token always
+          // outlives the room it identifies a member of, never the reverse.
+          memberTokenRetentionMs: persistenceConfig.emptyRoomTtlMs * 2,
           metricsCollector,
           ...(runtimeStorePendingOperationLogger
             ? {

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -304,8 +304,9 @@ export async function createServerBootstrapContext(
       ? await createRedisRuntimeStore(persistenceConfig.redisUrl, {
           now,
           keyPrefix: getRedisRuntimeKeyPrefix(persistenceConfig.redisNamespace),
-          // Twice the room's own empty-room lifetime, so a member token always
-          // outlives the room it identifies a member of, never the reverse.
+          // How long a disconnected member can still reclaim their identity.
+          // Twice the empty-room lifetime, so it comfortably covers a restart
+          // or a node failover without outliving the room by much.
           memberTokenRetentionMs: persistenceConfig.emptyRoomTtlMs * 2,
           metricsCollector,
           ...(runtimeStorePendingOperationLogger

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -18,7 +18,7 @@ import {
   MIN_PROTOCOL_VERSION,
   CURRENT_PROTOCOL_VERSION,
 } from "./messages.js";
-import { RoomServiceError } from "./room-service.js";
+import { RoomServiceError, type LeaveRoomReason } from "./room-service.js";
 import { withPlaybackAge } from "./room-state-age.js";
 import type { RoomEventBusMessage } from "./room-event-bus.js";
 import { hasAttachedSocket } from "./types.js";
@@ -57,7 +57,10 @@ export function createMessageHandler(options: {
       displayName?: string,
       previousMemberToken?: string,
     ) => Promise<{ room: { code: string }; memberToken: string }>;
-    leaveRoomForSession: (session: Session) => Promise<{
+    leaveRoomForSession: (
+      session: Session,
+      reason?: LeaveRoomReason,
+    ) => Promise<{
       room: { code: string } | null;
       notifyRoom?: boolean;
       memberRemoved?: boolean;
@@ -121,7 +124,12 @@ export function createMessageHandler(options: {
     session: Session,
     message: ClientMessage,
   ) => Promise<void>;
-  leaveRoom: (session: Session) => Promise<void>;
+  /**
+   * `reason` decides whether the member keeps their identity. A socket close
+   * must pass `"disconnect"`: the client still holds its `memberToken` and
+   * will present it on the next join to reclaim the same `memberId` (#234).
+   */
+  leaveRoom: (session: Session, reason?: LeaveRoomReason) => Promise<void>;
   flushPendingPublishes: () => Promise<void>;
 } {
   const { config, roomService, logEvent, send, sendError } = options;
@@ -356,12 +364,15 @@ export function createMessageHandler(options: {
     }
   }
 
-  async function leaveRoom(session: Session): Promise<void> {
+  async function leaveRoom(
+    session: Session,
+    reason: LeaveRoomReason = "client-request",
+  ): Promise<void> {
     const roomCode = session.roomCode;
     const memberId = session.memberId ?? session.id;
     const displayName = session.displayName;
     const { room, notifyRoom, memberRemoved } =
-      await roomService.leaveRoomForSession(session);
+      await roomService.leaveRoomForSession(session, reason);
     if (!roomCode || (!room && !notifyRoom)) {
       return;
     }

--- a/server/src/mirrored-runtime-store.ts
+++ b/server/src/mirrored-runtime-store.ts
@@ -32,6 +32,24 @@ function mirrorAwaitedWrite<TArgs extends unknown[]>(
   };
 }
 
+/**
+ * Mirrors a teardown and hands back the SHARED store's promise.
+ *
+ * Local first, unlike {@link mirrorAwaitedWrite}: a teardown that half-fails
+ * should still drop the local copy, because keeping runtime state for a room
+ * that no longer exists is worse than losing it. The promise is still returned
+ * so the caller can see the shared side fail.
+ */
+function mirrorAwaitedTeardown<TArgs extends unknown[]>(
+  localMethod: (...args: TArgs) => unknown,
+  sharedMethod: (...args: TArgs) => void | Promise<void>,
+): (...args: TArgs) => Promise<void> {
+  return async (...args: TArgs) => {
+    localMethod(...args);
+    await sharedMethod(...args);
+  };
+}
+
 function mirrorLocalResult<TArgs extends unknown[], TResult>(
   localMethod: (...args: TArgs) => TResult,
   sharedMethod: (...args: TArgs) => unknown,
@@ -119,7 +137,7 @@ export function createMirroredRuntimeStore(
       localRuntimeStore.revokeMemberToken,
       sharedRuntimeStore.revokeMemberToken,
     ),
-    deleteRoom: mirrorVoidWrite(
+    deleteRoom: mirrorAwaitedTeardown(
       localRuntimeStore.deleteRoom,
       sharedRuntimeStore.deleteRoom,
     ),

--- a/server/src/mirrored-runtime-store.ts
+++ b/server/src/mirrored-runtime-store.ts
@@ -143,11 +143,15 @@ export function createMirroredRuntimeStore(
     ),
     // Read from the shared view: the generation has to be the one every node
     // agrees on, or a teardown decided here would compare against a local copy.
+    hasRoomResidue: readShared(sharedRuntimeStore.hasRoomResidue),
     getRoomGeneration: readShared(sharedRuntimeStore.getRoomGeneration),
-    markRoomGeneration: mirrorAwaitedTeardown(
-      localRuntimeStore.markRoomGeneration,
-      sharedRuntimeStore.markRoomGeneration,
-    ),
+    // Shared only, in both directions. A local copy would be written by whichever
+    // node created the room and cleared by whichever node tore it down — rarely
+    // the same one — so every node accumulated generations for rooms it merely
+    // happened to create, with nothing to expire them (#237 review). Nothing
+    // reads the local copy here anyway: the reads above go to the shared store,
+    // and the shared store's own teardown clears its local mirror unconditionally.
+    markRoomGeneration: readShared(sharedRuntimeStore.markRoomGeneration),
     deleteRoom: mirrorAwaitedTeardown(
       localRuntimeStore.deleteRoom,
       sharedRuntimeStore.deleteRoom,

--- a/server/src/mirrored-runtime-store.ts
+++ b/server/src/mirrored-runtime-store.ts
@@ -11,18 +11,24 @@ function mirrorVoidWrite<TArgs extends unknown[]>(
 }
 
 /**
- * Mirrors the write and hands back the SHARED store's promise, so the caller can
- * wait for durability. `mirrorVoidWrite` drops it, which would leave the kick
- * awaiting nothing in a mirrored deployment — exactly the gap the awaitable
- * revoke exists to close (#237 review).
+ * Durable-first write: the SHARED store goes first and the local mirror is only
+ * updated once it succeeded, so the caller can both wait for durability and
+ * trust that a rejection changed nothing.
+ *
+ * Order matters. Writing locally first left a partial apply behind on failure —
+ * the kick's revoke rejected after the local token was already gone, so the
+ * admin was told the kick failed while the member stayed connected with a
+ * member token nothing would accept, failing every later request (#237 review).
+ * `mirrorVoidWrite` additionally drops the promise, which would leave the kick
+ * awaiting nothing at all.
  */
 function mirrorAwaitedWrite<TArgs extends unknown[]>(
   localMethod: (...args: TArgs) => unknown,
   sharedMethod: (...args: TArgs) => void | Promise<void>,
-): (...args: TArgs) => void | Promise<void> {
-  return (...args: TArgs) => {
+): (...args: TArgs) => Promise<void> {
+  return async (...args: TArgs) => {
+    await sharedMethod(...args);
     localMethod(...args);
-    return sharedMethod(...args);
   };
 }
 

--- a/server/src/mirrored-runtime-store.ts
+++ b/server/src/mirrored-runtime-store.ts
@@ -10,6 +10,22 @@ function mirrorVoidWrite<TArgs extends unknown[]>(
   };
 }
 
+/**
+ * Mirrors the write and hands back the SHARED store's promise, so the caller can
+ * wait for durability. `mirrorVoidWrite` drops it, which would leave the kick
+ * awaiting nothing in a mirrored deployment — exactly the gap the awaitable
+ * revoke exists to close (#237 review).
+ */
+function mirrorAwaitedWrite<TArgs extends unknown[]>(
+  localMethod: (...args: TArgs) => unknown,
+  sharedMethod: (...args: TArgs) => void | Promise<void>,
+): (...args: TArgs) => void | Promise<void> {
+  return (...args: TArgs) => {
+    localMethod(...args);
+    return sharedMethod(...args);
+  };
+}
+
 function mirrorLocalResult<TArgs extends unknown[], TResult>(
   localMethod: (...args: TArgs) => TResult,
   sharedMethod: (...args: TArgs) => unknown,
@@ -80,7 +96,7 @@ export function createMirroredRuntimeStore(
       sharedRuntimeStore.addMember,
     ),
     findMemberIdByToken: readLocal(localRuntimeStore.findMemberIdByToken),
-    blockMemberToken: mirrorVoidWrite(
+    blockMemberToken: mirrorAwaitedWrite(
       localRuntimeStore.blockMemberToken,
       sharedRuntimeStore.blockMemberToken,
     ),
@@ -93,7 +109,7 @@ export function createMirroredRuntimeStore(
       localRuntimeStore.removeMember,
       sharedRuntimeStore.removeMember,
     ),
-    revokeMemberToken: mirrorVoidWrite(
+    revokeMemberToken: mirrorAwaitedWrite(
       localRuntimeStore.revokeMemberToken,
       sharedRuntimeStore.revokeMemberToken,
     ),

--- a/server/src/mirrored-runtime-store.ts
+++ b/server/src/mirrored-runtime-store.ts
@@ -93,6 +93,10 @@ export function createMirroredRuntimeStore(
       localRuntimeStore.removeMember,
       sharedRuntimeStore.removeMember,
     ),
+    revokeMemberToken: mirrorVoidWrite(
+      localRuntimeStore.revokeMemberToken,
+      sharedRuntimeStore.revokeMemberToken,
+    ),
     deleteRoom: mirrorVoidWrite(
       localRuntimeStore.deleteRoom,
       sharedRuntimeStore.deleteRoom,

--- a/server/src/mirrored-runtime-store.ts
+++ b/server/src/mirrored-runtime-store.ts
@@ -141,6 +141,13 @@ export function createMirroredRuntimeStore(
       localRuntimeStore.revokeMemberToken,
       sharedRuntimeStore.revokeMemberToken,
     ),
+    // Read from the shared view: the generation has to be the one every node
+    // agrees on, or a teardown decided here would compare against a local copy.
+    getRoomGeneration: readShared(sharedRuntimeStore.getRoomGeneration),
+    markRoomGeneration: mirrorAwaitedTeardown(
+      localRuntimeStore.markRoomGeneration,
+      sharedRuntimeStore.markRoomGeneration,
+    ),
     deleteRoom: mirrorAwaitedTeardown(
       localRuntimeStore.deleteRoom,
       sharedRuntimeStore.deleteRoom,

--- a/server/src/mirrored-runtime-store.ts
+++ b/server/src/mirrored-runtime-store.ts
@@ -133,6 +133,10 @@ export function createMirroredRuntimeStore(
       localRuntimeStore.removeMember,
       sharedRuntimeStore.removeMember,
     ),
+    evictMemberToken: mirrorAwaitedWrite(
+      localRuntimeStore.evictMemberToken,
+      sharedRuntimeStore.evictMemberToken,
+    ),
     revokeMemberToken: mirrorAwaitedWrite(
       localRuntimeStore.revokeMemberToken,
       sharedRuntimeStore.revokeMemberToken,

--- a/server/src/mirrored-runtime-store.ts
+++ b/server/src/mirrored-runtime-store.ts
@@ -33,20 +33,26 @@ function mirrorAwaitedWrite<TArgs extends unknown[]>(
 }
 
 /**
- * Mirrors a teardown and hands back the SHARED store's promise.
+ * Runs a conditional teardown against the SHARED store and mirrors it locally
+ * only once that reported it applied.
  *
- * Local first, unlike {@link mirrorAwaitedWrite}: a teardown that half-fails
- * should still drop the local copy, because keeping runtime state for a room
- * that no longer exists is worse than losing it. The promise is still returned
- * so the caller can see the shared side fail.
+ * The condition can only be judged where the generation lives, which is the
+ * shared store — this store no longer keeps a local copy. Handing the expected
+ * generation to the local delete as well compared it against a value that is
+ * always `null`: a legacy room (expected `null`) wiped the local state even when
+ * the shared side went on to decline, and an ordinary room (expected non-null)
+ * could never clear the local mirror at all (#237 review).
  */
-function mirrorAwaitedTeardown<TArgs extends unknown[]>(
-  localMethod: (...args: TArgs) => unknown,
-  sharedMethod: (...args: TArgs) => void | Promise<void>,
-): (...args: TArgs) => Promise<void> {
-  return async (...args: TArgs) => {
-    localMethod(...args);
-    await sharedMethod(...args);
+function mirrorConditionalTeardown(
+  localDelete: RuntimeStore["deleteRoom"],
+  sharedDelete: RuntimeStore["deleteRoom"],
+): RuntimeStore["deleteRoom"] {
+  return async (code, expectedGeneration) => {
+    const applied = await sharedDelete(code, expectedGeneration);
+    if (applied) {
+      localDelete(code);
+    }
+    return applied;
   };
 }
 
@@ -152,7 +158,7 @@ export function createMirroredRuntimeStore(
     // reads the local copy here anyway: the reads above go to the shared store,
     // and the shared store's own teardown clears its local mirror unconditionally.
     markRoomGeneration: readShared(sharedRuntimeStore.markRoomGeneration),
-    deleteRoom: mirrorAwaitedTeardown(
+    deleteRoom: mirrorConditionalTeardown(
       localRuntimeStore.deleteRoom,
       sharedRuntimeStore.deleteRoom,
     ),

--- a/server/src/redis-room-store.ts
+++ b/server/src/redis-room-store.ts
@@ -194,7 +194,7 @@ local roomsKey = KEYS[1]
 local roomKeyPrefix = ARGV[1]
 local now = tonumber(ARGV[2])
 local candidates = redis.call("ZRANGEBYSCORE", roomsKey, "-inf", now)
-local deletedCount = 0
+local deletedCodes = {}
 
 for _, code in ipairs(candidates) do
   local key = roomKeyPrefix .. code
@@ -221,13 +221,13 @@ for _, code in ipairs(candidates) do
       elseif tonumber(expiresAt) ~= nil and tonumber(expiresAt) <= now then
         redis.call("DEL", key)
         redis.call("ZREM", roomsKey, code)
-        deletedCount = deletedCount + 1
+        deletedCodes[#deletedCodes + 1] = code
       end
     end
   end
 end
 
-return deletedCount
+return deletedCodes
 `;
 
 // Chunk the repair passes: a first run against a database that has never been
@@ -723,14 +723,14 @@ export async function createRedisRoomStore(
       // keyspace walk inside one reaper tick per interval, which is what made
       // this operation's histogram bimodal.
       await ensureBootstrapReconciled();
-      const deletedCount = await redis.eval(
+      const deletedCodes = await redis.eval(
         DELETE_EXPIRED_ROOMS_LUA,
         1,
         roomsByExpiryKey,
         roomKeyPrefix,
         String(currentTime),
       );
-      return Number(deletedCount);
+      return Array.isArray(deletedCodes) ? (deletedCodes as string[]) : [];
     },
     async listRooms(
       query: Pick<

--- a/server/src/redis-room-store.ts
+++ b/server/src/redis-room-store.ts
@@ -208,7 +208,12 @@ for _, code in ipairs(candidates) do
   if not readable then
     redis.call("ZREM", roomsKey, code)
   elseif not rawRoom then
+    -- Index entry without a body: the room is gone, so report it like any other
+    -- deletion. Staying silent left its runtime state uncollected, and since a
+    -- code is only handed out once nothing remains under it, that code stopped
+    -- being allocatable (#237 review).
     redis.call("ZREM", roomsKey, code)
+    deletedCodes[#deletedCodes + 1] = code
   else
     local ok, room = pcall(cjson.decode, rawRoom)
     -- cjson.decode("1") yields a truthy scalar; indexing it raises a Lua

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -262,6 +262,24 @@ function deserializeSession(fields: Record<string, string>): Session | null {
   };
 }
 
+/**
+ * Revoke a member token, optionally only while the memberId is still bound to
+ * the caller's session (or bound to nobody).
+ *
+ * The guard has to read the SHARED binding, not a node-local one: after a member
+ * reconnects onto another node, the old node's local map still lists the old
+ * session as the member, so a node-local check would let that node's explicit
+ * leave revoke the identity the new node is actively using (#237 review).
+ */
+const REVOKE_MEMBER_TOKEN_LUA = `
+local bound = redis.call("HGET", KEYS[1], ARGV[1])
+if ARGV[2] ~= "" and bound and bound ~= ARGV[2] then
+  return 0
+end
+redis.call("HDEL", KEYS[2], ARGV[1])
+return 1
+`;
+
 async function loadSession(
   redis: RedisClient,
   prefix: string,
@@ -289,9 +307,18 @@ async function loadSession(
  * `markSessionJoinedRoom` + `addMember` (including its `PERSIST`) ran, and then
  * this pass removed a now-active room from the index and re-armed a TTL on the
  * tokens of members who were back — which would expire them mid-session.
+ *
+ * Emptiness needs BOTH indexes. A join writes the member binding
+ * (`addMember`) before the session index (`onRoomJoined` →
+ * `markSessionJoinedRoom`), so between those two the session set is still empty
+ * while the room is already in use; checking only the sessions would re-arm the
+ * TTL on a hash a live member had just written (#237 review).
  */
 const CLEANUP_EMPTY_ROOM_LUA = `
 if redis.call("SCARD", KEYS[1]) ~= 0 then
+  return 0
+end
+if redis.call("HLEN", KEYS[4]) ~= 0 then
   return 0
 end
 redis.call("SREM", KEYS[2], ARGV[1])
@@ -308,10 +335,11 @@ async function cleanupEmptyRoomIndex(
 ): Promise<void> {
   const cleaned = await redis.eval(
     CLEANUP_EMPTY_ROOM_LUA,
-    3,
+    4,
     roomSessionsKey(prefix, roomCode),
     `${prefix}rooms`,
     roomMemberTokensKey(prefix, roomCode),
+    roomMembersKey(prefix, roomCode),
     roomCode,
     String(memberTokenRetentionMs),
   );
@@ -398,6 +426,7 @@ export async function createRedisRuntimeStore(
   function trackOperation<T>(
     operationName: string,
     operation: Promise<T>,
+    awaitFailures = false,
   ): Promise<T | undefined> {
     const startedAt = performance.now();
     let failureRecorded = false;
@@ -454,7 +483,20 @@ export async function createRedisRuntimeStore(
         performance.now() - startedAt,
       );
     });
-    return handledOperation;
+    return awaitFailures ? trackedOperation : handledOperation;
+  }
+
+  /**
+   * `trackOperation`, but the returned promise rejects when the write fails
+   * instead of resolving to `undefined`. For writes whose caller must not
+   * proceed on an unconfirmed result — revoking an identity, where the kick
+   * disconnects the socket and reports success right afterwards.
+   */
+  function trackAwaitedOperation<T>(
+    operationName: string,
+    operation: Promise<T>,
+  ): Promise<T> {
+    return trackOperation(operationName, operation, true) as Promise<T>;
   }
 
   function queueSessionOperation(
@@ -735,29 +777,38 @@ export async function createRedisRuntimeStore(
       return room;
     },
     async findMemberIdByToken(code: string, memberToken: string) {
+      // Redis is the ONLY authority here. Falling back to the local mirror on a
+      // miss let a node that had once hosted this member keep answering from its
+      // own cache: a revoke performed on another node updates Redis and that
+      // node, never this one, so a later join landing here would re-accept a
+      // token an explicit leave or a kick had already ended (#237 review).
+      //
+      // Draining first is what the fallback used to cover — this store's writes
+      // are asynchronous, so a join reading immediately after `addMember` could
+      // otherwise miss its own write.
+      await store.flush();
       const memberTokens = await redis.hgetall(
         roomMemberTokensKey(keyPrefix, code),
       );
-      const matchedMemberId = findMemberIdByTokenEntries(
+      return findMemberIdByTokenEntries(
         Object.entries(memberTokens),
         memberToken,
       );
-      if (matchedMemberId) {
-        return matchedMemberId;
-      }
-      return localRuntimeStore.findMemberIdByToken(code, memberToken);
     },
     blockMemberToken(code: string, memberToken: string, expiresAt: number) {
       ensurePendingCapacity("block_member_token");
       localRuntimeStore.blockMemberToken(code, memberToken, expiresAt);
-      void trackOperation(
+      // Same reason as `revokeMemberToken`: the kick already awaits this and
+      // then reports the member evicted, so an unconfirmed write would report
+      // an eviction that had not happened on any other node yet.
+      return trackAwaitedOperation(
         "block_member_token",
         redis.zadd(
           blockedTokensKey(keyPrefix, code),
           String(expiresAt),
           memberToken,
         ),
-      );
+      ).then(() => undefined);
     },
     async isMemberTokenBlocked(
       code: string,
@@ -879,16 +930,23 @@ export async function createRedisRuntimeStore(
       );
       return removal;
     },
-    revokeMemberToken(code: string, memberId: string) {
+    revokeMemberToken(code: string, memberId: string, session?: Session) {
       ensurePendingCapacity("revoke_member_token");
-      localRuntimeStore.revokeMemberToken(code, memberId);
-      void trackOperation(
+      localRuntimeStore.revokeMemberToken(code, memberId, session);
+      // Awaited, and rejecting: the kick disconnects the socket and reports
+      // success as soon as this resolves, so resolving before the write landed
+      // would report an eviction while the old token still resolved.
+      return trackAwaitedOperation(
         "revoke_member_token",
-        redis
-          .multi()
-          .hdel(roomMemberTokensKey(keyPrefix, code), memberId)
-          .exec(),
-      );
+        redis.eval(
+          REVOKE_MEMBER_TOKEN_LUA,
+          2,
+          roomMembersKey(keyPrefix, code),
+          roomMemberTokensKey(keyPrefix, code),
+          memberId,
+          session?.id ?? "",
+        ),
+      ).then(() => undefined);
     },
     deleteRoom(code: string) {
       ensurePendingCapacity("delete_room");

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -346,8 +346,19 @@ end
 return 1
 `;
 
-/** Any key still present means the code is not free to hand out. */
+/**
+ * Any key still present means the code is not free to hand out.
+ *
+ * The two score-indexed sets are trimmed by the current time first. Redis does
+ * not drop zset members when their score passes, and the lazy sweeps that
+ * normally do it (`isMemberTokenBlocked`, `tryClaimMessageSlot`) are only
+ * reached through a room that no longer exists — so a long-lapsed block or a
+ * dedup slot whose TTL ran out years ago would keep the code reserved forever
+ * (#237 review).
+ */
 const ROOM_RESIDUE_LUA = `
+redis.call("ZREMRANGEBYSCORE", KEYS[4], "-inf", ARGV[1])
+redis.call("ZREMRANGEBYSCORE", KEYS[6], "-inf", ARGV[1])
 for index = 1, #KEYS do
   if redis.call("EXISTS", KEYS[index]) == 1 then
     return 1
@@ -1134,6 +1145,7 @@ export async function createRedisRuntimeStore(
         blockedTokensKey(keyPrefix, code),
         roomSessionsKey(keyPrefix, code),
         dedupTrackingZsetKey(keyPrefix, code),
+        String(now()),
       );
       return Number(found) === 1;
     },
@@ -1183,9 +1195,11 @@ export async function createRedisRuntimeStore(
           );
         })(),
       ).then((applied) => {
-        if (Number(applied) === 1) {
-          localRuntimeStore.deleteRoom(code);
+        if (Number(applied) !== 1) {
+          return false;
         }
+        localRuntimeStore.deleteRoom(code);
+        return true;
       });
     },
     async close() {

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -324,15 +324,34 @@ return 1
  * A zset scored by expiry, pruned lazily on read/write — the same shape this
  * store already uses for blocked tokens. Redis hash fields cannot carry their
  * own TTL, and a per-member key would make token lookup a scan.
+ *
+ * Deleted in batches. Handing an unbounded result set to `unpack` overflows
+ * Lua's stack once enough identities expire between two token accesses, and the
+ * error aborts the script BEFORE the zset is trimmed — so every later access
+ * re-ran the same doomed script and the room could never be joined again (#237
+ * review). `ZREM` on exactly the batch just deleted (not `ZREMRANGEBYSCORE`
+ * over the whole range) is what makes stopping early safe.
+ *
+ * Stopping early only softens the boundary: an identity may stay resolvable a
+ * little past its retention until a later access finishes the sweep. Retention
+ * is "at least this long", never "at most".
  */
+const PRUNE_MEMBER_TOKENS_BATCH = 500;
+const PRUNE_MEMBER_TOKENS_MAX_BATCHES = 20;
 const PRUNE_MEMBER_TOKENS_LUA = `
-local expired = redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", ARGV[1])
-if #expired == 0 then
-  return 0
+local removed = 0
+for _ = 1, tonumber(ARGV[3]) do
+  local expired = redis.call(
+    "ZRANGEBYSCORE", KEYS[1], "-inf", ARGV[1], "LIMIT", 0, tonumber(ARGV[2])
+  )
+  if #expired == 0 then
+    return removed
+  end
+  redis.call("HDEL", KEYS[2], unpack(expired))
+  redis.call("ZREM", KEYS[1], unpack(expired))
+  removed = removed + #expired
 end
-redis.call("HDEL", KEYS[2], unpack(expired))
-redis.call("ZREMRANGEBYSCORE", KEYS[1], "-inf", ARGV[1])
-return #expired
+return removed
 `;
 
 async function cleanupEmptyRoomIndex(
@@ -497,6 +516,8 @@ export async function createRedisRuntimeStore(
       roomMemberTokenExpiryKey(keyPrefix, code),
       roomMemberTokensKey(keyPrefix, code),
       String(now()),
+      String(PRUNE_MEMBER_TOKENS_BATCH),
+      String(PRUNE_MEMBER_TOKENS_MAX_BATCHES),
     );
   }
 
@@ -957,8 +978,13 @@ export async function createRedisRuntimeStore(
     },
     deleteRoom(code: string) {
       ensurePendingCapacity("delete_room");
+      // Local first: this is a teardown, so leaving a copy of a room that no
+      // longer exists behind is worse than a partial apply. The shared promise
+      // is returned so the caller can tell whether the runtime keys actually
+      // went — the persisted room and its expiry index are already gone by
+      // then, so nothing will ever hand out this room code again (#237 review).
       localRuntimeStore.deleteRoom(code);
-      void trackOperation(
+      return trackAwaitedOperation(
         "delete_room",
         (async () => {
           const trackingKey = dedupTrackingZsetKey(keyPrefix, code);

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -20,6 +20,7 @@ type RedisMulti = {
   del: (...keys: string[]) => RedisMulti;
   hset: (key: string, ...args: unknown[]) => RedisMulti;
   hdel: (key: string, ...fields: string[]) => RedisMulti;
+  persist: (key: string) => RedisMulti;
   exec: () => Promise<unknown>;
 };
 
@@ -51,6 +52,8 @@ type RedisClient = {
     ...args: Array<string | number>
   ) => Promise<unknown>;
   del: (...keys: string[]) => Promise<unknown>;
+  pexpire: (key: string, milliseconds: number) => Promise<unknown>;
+  persist: (key: string) => Promise<unknown>;
 };
 
 type PendingOperationLogContext = {
@@ -74,6 +77,14 @@ type RedisRuntimeSession = {
 
 type RuntimeStoreOptions = {
   keyPrefix?: string;
+  /**
+   * How long a room with no sessions left keeps its member tokens. Identity has
+   * to outlive a disconnect (#234) but not the room itself, so the moment a room
+   * empties its tokens are put on a clock; a reconnect before it fires clears
+   * the clock again. Default comfortably exceeds `persistence.emptyRoomTtlMs`,
+   * so tokens outlive the room rather than the other way round.
+   */
+  memberTokenRetentionMs?: number;
   now?: () => number;
   maxPendingOperations?: number;
   pendingOperationTimeoutMs?: number;
@@ -115,6 +126,7 @@ const RUNTIME_STORE_METHOD_NAMES = [
   "acquireRoomLock",
   "releaseRoomLock",
   "removeMember",
+  "revokeMemberToken",
   "deleteRoom",
   "heartbeatNode",
   "listNodeStatuses",
@@ -193,6 +205,9 @@ function nodeStatusKey(prefix: string, instanceId: string): string {
   return `${prefix}node:${instanceId}`;
 }
 
+// Twice the default `emptyRoomTtlMs` (15 min), so an emptied room's tokens
+// outlive the room they identify members of rather than the other way round.
+const DEFAULT_MEMBER_TOKEN_RETENTION_MS = 30 * 60_000;
 const DEFAULT_MAX_PENDING_OPERATIONS = 256;
 const DEFAULT_PENDING_OPERATION_TIMEOUT_MS = 5_000;
 // Floor TTL applied only when the caller's expiresAt is already non-positive
@@ -259,13 +274,61 @@ async function loadSession(
   return deserializeSession(fields);
 }
 
+/**
+ * Drop an emptied room from the index and put its member tokens on a clock.
+ *
+ * Member tokens outlive a disconnect on purpose (#234), which means nothing
+ * else deletes them once the last session goes and the room is left to expire —
+ * `resolveRoom`'s lazy cleanup only fires if somebody touches the code again.
+ * Arming the clock exactly here bounds that: while anyone is still connected the
+ * key carries no TTL at all, so a long-lived room never loses the identities of
+ * the people in it, and `addMember` lifts the clock again on reconnect.
+ *
+ * The emptiness check and the two writes run as ONE script. Read-then-write from
+ * the client let a reconnect land in between: `SCARD` saw zero, the client's
+ * `markSessionJoinedRoom` + `addMember` (including its `PERSIST`) ran, and then
+ * this pass removed a now-active room from the index and re-armed a TTL on the
+ * tokens of members who were back — which would expire them mid-session.
+ */
+const CLEANUP_EMPTY_ROOM_LUA = `
+if redis.call("SCARD", KEYS[1]) ~= 0 then
+  return 0
+end
+redis.call("SREM", KEYS[2], ARGV[1])
+redis.call("PEXPIRE", KEYS[3], ARGV[2])
+return 1
+`;
+
 async function cleanupEmptyRoomIndex(
   redis: RedisClient,
   prefix: string,
   roomCode: string,
+  memberTokenRetentionMs: number,
+  localRuntimeStore: RuntimeStore,
 ): Promise<void> {
-  if ((await redis.scard(roomSessionsKey(prefix, roomCode))) === 0) {
-    await redis.srem(`${prefix}rooms`, roomCode);
+  const cleaned = await redis.eval(
+    CLEANUP_EMPTY_ROOM_LUA,
+    3,
+    roomSessionsKey(prefix, roomCode),
+    `${prefix}rooms`,
+    roomMemberTokensKey(prefix, roomCode),
+    roomCode,
+    String(memberTokenRetentionMs),
+  );
+  if (Number(cleaned) !== 1) {
+    return;
+  }
+  // Only once the script reports it acted. The local map is a cache with no
+  // clock of its own, so keeping a copy would both leak in memory and answer
+  // `findMemberIdByToken` from it long after Redis let the tokens go. A
+  // reconnect that beats this line still recovers: its `addMember` wrote to
+  // Redis, which `findMemberIdByToken` consults first.
+  const localRoom = localRuntimeStore.getRoom(roomCode);
+  if (!localRoom) {
+    return;
+  }
+  for (const memberId of Array.from(localRoom.memberTokens.keys())) {
+    localRuntimeStore.revokeMemberToken(roomCode, memberId);
   }
 }
 
@@ -280,6 +343,8 @@ export async function createRedisRuntimeStore(
     })) as RedisClient;
   const keyPrefix = options.keyPrefix ?? "bsp:runtime:";
   const now = options.now ?? Date.now;
+  const memberTokenRetentionMs =
+    options.memberTokenRetentionMs ?? DEFAULT_MEMBER_TOKEN_RETENTION_MS;
   const maxPendingOperations =
     options.maxPendingOperations ?? DEFAULT_MAX_PENDING_OPERATIONS;
   const pendingOperationTimeoutMs =
@@ -468,12 +533,14 @@ export async function createRedisRuntimeStore(
             session.memberId,
           );
           if (currentSessionId === session.id) {
+            // Clears the stale session→member binding left by the previous run
+            // of this instance. It must NOT touch the member-token hash: this
+            // runs at startup, right before those very clients reconnect, and
+            // dropping their tokens is what handed everybody a new `memberId`
+            // after each restart (#234). The tokens are cleaned up by an
+            // explicit leave, an admin kick, or `deleteRoom`.
             transaction.hdel(
               roomMembersKey(keyPrefix, session.roomCode),
-              session.memberId,
-            );
-            transaction.hdel(
-              roomMemberTokensKey(keyPrefix, session.roomCode),
               session.memberId,
             );
           }
@@ -481,7 +548,13 @@ export async function createRedisRuntimeStore(
 
         await transaction.exec();
         if (session.roomCode) {
-          await cleanupEmptyRoomIndex(redis, keyPrefix, session.roomCode);
+          await cleanupEmptyRoomIndex(
+            redis,
+            keyPrefix,
+            session.roomCode,
+            memberTokenRetentionMs,
+            localRuntimeStore,
+          );
         }
         purgedCount += 1;
       }
@@ -503,7 +576,13 @@ export async function createRedisRuntimeStore(
         }
         await transaction.exec();
         if (roomCode) {
-          await cleanupEmptyRoomIndex(redis, keyPrefix, roomCode);
+          await cleanupEmptyRoomIndex(
+            redis,
+            keyPrefix,
+            roomCode,
+            memberTokenRetentionMs,
+            localRuntimeStore,
+          );
         }
       });
     },
@@ -533,7 +612,13 @@ export async function createRedisRuntimeStore(
         transaction.sadd(`${keyPrefix}rooms`, roomCode);
         await transaction.exec();
         if (roomCodeToLeave) {
-          await cleanupEmptyRoomIndex(redis, keyPrefix, roomCodeToLeave);
+          await cleanupEmptyRoomIndex(
+            redis,
+            keyPrefix,
+            roomCodeToLeave,
+            memberTokenRetentionMs,
+            localRuntimeStore,
+          );
         }
       });
     },
@@ -553,7 +638,13 @@ export async function createRedisRuntimeStore(
           .hset(sessionKey(keyPrefix, sessionId), "roomCode", "")
           .srem(roomSessionsKey(keyPrefix, targetRoomCode), sessionId)
           .exec();
-        await cleanupEmptyRoomIndex(redis, keyPrefix, targetRoomCode);
+        await cleanupEmptyRoomIndex(
+          redis,
+          keyPrefix,
+          targetRoomCode,
+          memberTokenRetentionMs,
+          localRuntimeStore,
+        );
       });
     },
     recordEvent(event: string, timestamp?: number) {
@@ -638,6 +729,7 @@ export async function createRedisRuntimeStore(
           .multi()
           .hset(roomMembersKey(keyPrefix, code), memberId, session.id)
           .hset(roomMemberTokensKey(keyPrefix, code), memberId, memberToken)
+          .persist(roomMemberTokensKey(keyPrefix, code))
           .exec(),
       );
       return room;
@@ -775,15 +867,28 @@ export async function createRedisRuntimeStore(
             memberId,
           );
           if (shouldRemoveMemberBinding(currentSessionId, session?.id)) {
+            // Presence only. The member-token hash is deliberately untouched so
+            // a reconnect can reclaim this `memberId`; `revokeMemberToken` is
+            // the one that ends it. See `removeMemberFromRoom` (#234).
             await redis
               .multi()
               .hdel(roomMembersKey(keyPrefix, code), memberId)
-              .hdel(roomMemberTokensKey(keyPrefix, code), memberId)
               .exec();
           }
         })(),
       );
       return removal;
+    },
+    revokeMemberToken(code: string, memberId: string) {
+      ensurePendingCapacity("revoke_member_token");
+      localRuntimeStore.revokeMemberToken(code, memberId);
+      void trackOperation(
+        "revoke_member_token",
+        redis
+          .multi()
+          .hdel(roomMemberTokensKey(keyPrefix, code), memberId)
+          .exec(),
+      );
     },
     deleteRoom(code: string) {
       ensurePendingCapacity("delete_room");

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -12,7 +12,6 @@ import {
   findMemberIdByTokenEntries,
   getPreviousRoomToLeave,
   resolveRoomCodeToLeave,
-  shouldRemoveMemberBinding,
 } from "./runtime-store-state.js";
 
 type RedisMulti = {
@@ -323,6 +322,29 @@ redis.call("SREM", KEYS[2], ARGV[2])
 return 1
 `;
 
+/**
+ * Drop a member's presence and start their identity's retention clock — but
+ * only if they still HAVE an identity.
+ *
+ * A kick deletes the token and its expiry entry, and the socket close that
+ * follows still runs this path. Registering an expiry unconditionally then left
+ * a `member-token-expiry` entry with no token behind it, which nothing collects
+ * once the room goes quiet (the prune is lazy). The binding check has to be in
+ * the same script as both writes, or the same interleaving reappears between
+ * them (#237 review).
+ */
+const REMOVE_MEMBER_LUA = `
+local bound = redis.call("HGET", KEYS[1], ARGV[1])
+if ARGV[2] ~= "" and bound and bound ~= ARGV[2] then
+  return 0
+end
+redis.call("HDEL", KEYS[1], ARGV[1])
+if redis.call("HEXISTS", KEYS[2], ARGV[1]) == 1 then
+  redis.call("ZADD", KEYS[3], ARGV[3], ARGV[1])
+end
+return 1
+`;
+
 const MARK_ROOM_GENERATION_LUA = `
 redis.call("SET", KEYS[1], ARGV[1])
 return 1
@@ -483,7 +505,6 @@ export async function createRedisRuntimeStore(
   function trackOperation<T>(
     operationName: string,
     operation: Promise<T>,
-    awaitFailures = false,
   ): Promise<T | undefined> {
     const startedAt = performance.now();
     let failureRecorded = false;
@@ -540,20 +561,48 @@ export async function createRedisRuntimeStore(
         performance.now() - startedAt,
       );
     });
-    return awaitFailures ? trackedOperation : handledOperation;
+    return handledOperation;
   }
 
   /**
-   * `trackOperation`, but the returned promise rejects when the write fails
-   * instead of resolving to `undefined`. For writes whose caller must not
-   * proceed on an unconfirmed result — revoking an identity, where the kick
-   * disconnects the socket and reports success right afterwards.
+   * `trackOperation`, but the returned promise reports the write's REAL outcome:
+   * it rejects when the write fails, and it never resolves early.
+   *
+   * Deliberately outside the pending-operation timeout. That timeout rejects
+   * without cancelling the underlying command, so an operation that merely ran
+   * slow still landed in Redis afterwards — and the caller had already been told
+   * it failed. For a kick that meant the admin saw `block_failed` and the
+   * session stayed connected while the shared store went on to block and revoke
+   * it anyway (#237 review). Callers of this helper act on the answer, so an
+   * answer that can be wrong is worse than a slow one; the operation is still
+   * registered below for backpressure accounting.
    */
   function trackAwaitedOperation<T>(
     operationName: string,
     operation: Promise<T>,
   ): Promise<T> {
-    return trackOperation(operationName, operation, true) as Promise<T>;
+    const startedAt = performance.now();
+    const settled = operation.catch(() => undefined);
+    pendingOperations.add(settled);
+    void settled.finally(() => {
+      pendingOperations.delete(settled);
+      metricsCollector?.observeRedisRuntimeStoreDuration(
+        operationName,
+        performance.now() - startedAt,
+      );
+    });
+    return operation.catch((error: unknown) => {
+      metricsCollector?.observeRedisRuntimeStoreFailure(operationName);
+      logPendingOperationError(
+        {
+          operationName,
+          pendingCount: pendingOperations.size,
+          reason: "failed",
+        },
+        error,
+      );
+      throw error;
+    });
   }
 
   /** Collect identities past their retention. Lazy — called on token reads/writes. */
@@ -973,29 +1022,22 @@ export async function createRedisRuntimeStore(
     removeMember(code: string, memberId: string, session?: Session) {
       ensurePendingCapacity("remove_member");
       const removal = localRuntimeStore.removeMember(code, memberId, session);
+      // Presence only. The member token itself is deliberately kept so a
+      // reconnect can reclaim this `memberId` (#234) — but it goes on its own
+      // clock, so a room that never empties still releases the people who left
+      // it. The script starts that clock only while a token is actually there.
       void trackOperation(
         "remove_member",
-        (async () => {
-          const currentSessionId = await redis.hget(
-            roomMembersKey(keyPrefix, code),
-            memberId,
-          );
-          if (shouldRemoveMemberBinding(currentSessionId, session?.id)) {
-            // Presence only. The member token itself is deliberately kept so a
-            // reconnect can reclaim this `memberId` (#234) — but it now goes on
-            // its own clock, so a room that never empties still releases the
-            // people who left it.
-            await redis
-              .multi()
-              .hdel(roomMembersKey(keyPrefix, code), memberId)
-              .zadd(
-                roomMemberTokenExpiryKey(keyPrefix, code),
-                String(now() + memberTokenRetentionMs),
-                memberId,
-              )
-              .exec();
-          }
-        })(),
+        redis.eval(
+          REMOVE_MEMBER_LUA,
+          3,
+          roomMembersKey(keyPrefix, code),
+          roomMemberTokensKey(keyPrefix, code),
+          roomMemberTokenExpiryKey(keyPrefix, code),
+          memberId,
+          session?.id ?? "",
+          String(now() + memberTokenRetentionMs),
+        ),
       );
       return removal;
     },

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -126,6 +126,7 @@ const RUNTIME_STORE_METHOD_NAMES = [
   "removeMember",
   "revokeMemberToken",
   "evictMemberToken",
+  "hasRoomResidue",
   "getRoomGeneration",
   "markRoomGeneration",
   "deleteRoom",
@@ -343,6 +344,16 @@ if redis.call("HEXISTS", KEYS[2], ARGV[1]) == 1 then
   redis.call("ZADD", KEYS[3], ARGV[3], ARGV[1])
 end
 return 1
+`;
+
+/** Any key still present means the code is not free to hand out. */
+const ROOM_RESIDUE_LUA = `
+for index = 1, #KEYS do
+  if redis.call("EXISTS", KEYS[index]) == 1 then
+    return 1
+  end
+end
+return 0
 `;
 
 const MARK_ROOM_GENERATION_LUA = `
@@ -709,11 +720,23 @@ export async function createRedisRuntimeStore(
               roomMembersKey(keyPrefix, session.roomCode),
               session.memberId,
             );
-            transaction.zadd(
-              roomMemberTokenExpiryKey(keyPrefix, session.roomCode),
-              String(now() + memberTokenRetentionMs),
-              session.memberId,
-            );
+            // Only while the identity still exists. A kick deletes the token and
+            // its expiry entry; if the process died before the socket close ran,
+            // this path picks the binding up at startup and would otherwise
+            // register an expiry for a token that is not there — the same defect
+            // `REMOVE_MEMBER_LUA` fixed on the ordinary path (#237 review).
+            if (
+              (await redis.hget(
+                roomMemberTokensKey(keyPrefix, session.roomCode),
+                session.memberId,
+              )) !== null
+            ) {
+              transaction.zadd(
+                roomMemberTokenExpiryKey(keyPrefix, session.roomCode),
+                String(now() + memberTokenRetentionMs),
+                session.memberId,
+              );
+            }
           }
         }
 
@@ -1094,6 +1117,26 @@ export async function createRedisRuntimeStore(
         localRuntimeStore.revokeMemberToken(code, memberId, session);
       });
     },
+    async hasRoomResidue(code: string) {
+      // Pruned first, so identities that have merely aged out do not keep the
+      // code reserved.
+      await pruneExpiredMemberTokens(code);
+      // Deliberately without the generation key: it is not state a new room can
+      // inherit (its own stamp overwrites it), and counting it would mean a code
+      // is only ever freed by a successful teardown — losing the path where the
+      // residue simply ages out.
+      const found = await redis.eval(
+        ROOM_RESIDUE_LUA,
+        6,
+        roomMembersKey(keyPrefix, code),
+        roomMemberTokensKey(keyPrefix, code),
+        roomMemberTokenExpiryKey(keyPrefix, code),
+        blockedTokensKey(keyPrefix, code),
+        roomSessionsKey(keyPrefix, code),
+        dedupTrackingZsetKey(keyPrefix, code),
+      );
+      return Number(found) === 1;
+    },
     async getRoomGeneration(code: string) {
       return await redis.get(roomGenerationKey(keyPrefix, code));
     },
@@ -1107,9 +1150,7 @@ export async function createRedisRuntimeStore(
           roomGenerationKey(keyPrefix, code),
           generation,
         ),
-      ).then(() => {
-        localRuntimeStore.markRoomGeneration(code, generation);
-      });
+      ).then(() => undefined);
     },
     deleteRoom(code: string, expectedGeneration?: string | null) {
       ensurePendingCapacity("delete_room");

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -54,6 +54,7 @@ type RedisClient = {
     ...args: Array<string | number>
   ) => Promise<unknown>;
   del: (...keys: string[]) => Promise<unknown>;
+  get: (key: string) => Promise<string | null>;
 };
 
 type PendingOperationLogContext = {
@@ -126,6 +127,8 @@ const RUNTIME_STORE_METHOD_NAMES = [
   "removeMember",
   "revokeMemberToken",
   "evictMemberToken",
+  "getRoomGeneration",
+  "markRoomGeneration",
   "deleteRoom",
   "heartbeatNode",
   "listNodeStatuses",
@@ -175,6 +178,10 @@ function roomMemberTokensKey(prefix: string, roomCode: string): string {
 
 function roomMemberTokenExpiryKey(prefix: string, roomCode: string): string {
   return `${prefix}room:${roomCode}:member-token-expiry`;
+}
+
+function roomGenerationKey(prefix: string, roomCode: string): string {
+  return `${prefix}room:${roomCode}:generation`;
 }
 
 function blockedTokensKey(prefix: string, roomCode: string): string {
@@ -292,6 +299,32 @@ const EVICT_MEMBER_LUA = `
 redis.call("ZADD", KEYS[1], ARGV[3], ARGV[2])
 redis.call("HDEL", KEYS[2], ARGV[1])
 redis.call("ZREM", KEYS[3], ARGV[1])
+return 1
+`;
+
+/**
+ * Delete a room's runtime keys only while its generation is the one the caller
+ * decided against. `ARGV[1]` is `""` for "no generation", which matches only an
+ * absent key — a room that predates generations is still collected, one that has
+ * since been stamped by a new occupant is left alone.
+ */
+const DELETE_ROOM_LUA = `
+if ARGV[1] ~= "*" then
+  local stored = redis.call("GET", KEYS[1])
+  if (stored or "") ~= ARGV[1] then
+    return 0
+  end
+end
+for index = 3, #KEYS do
+  redis.call("DEL", KEYS[index])
+end
+redis.call("DEL", KEYS[1])
+redis.call("SREM", KEYS[2], ARGV[2])
+return 1
+`;
+
+const MARK_ROOM_GENERATION_LUA = `
+redis.call("SET", KEYS[1], ARGV[1])
 return 1
 `;
 
@@ -1019,34 +1052,58 @@ export async function createRedisRuntimeStore(
         localRuntimeStore.revokeMemberToken(code, memberId, session);
       });
     },
-    deleteRoom(code: string) {
+    async getRoomGeneration(code: string) {
+      return await redis.get(roomGenerationKey(keyPrefix, code));
+    },
+    markRoomGeneration(code: string, generation: string) {
+      ensurePendingCapacity("mark_room_generation");
+      return trackAwaitedOperation(
+        "mark_room_generation",
+        redis.eval(
+          MARK_ROOM_GENERATION_LUA,
+          1,
+          roomGenerationKey(keyPrefix, code),
+          generation,
+        ),
+      ).then(() => {
+        localRuntimeStore.markRoomGeneration(code, generation);
+      });
+    },
+    deleteRoom(code: string, expectedGeneration?: string | null) {
       ensurePendingCapacity("delete_room");
-      // Local first: this is a teardown, so leaving a copy of a room that no
-      // longer exists behind is worse than a partial apply. The shared promise
-      // is returned so the caller can tell whether the runtime keys actually
-      // went — the persisted room and its expiry index are already gone by
-      // then, so nothing will ever hand out this room code again (#237 review).
-      localRuntimeStore.deleteRoom(code);
+      // Shared first here, unlike the other teardowns: whether this delete may
+      // proceed at all is decided by the script, against the generation every
+      // node agrees on. Dropping the local copy before knowing the answer would
+      // be exactly the wipe the generation exists to prevent (#237 review).
       return trackAwaitedOperation(
         "delete_room",
         (async () => {
           const trackingKey = dedupTrackingZsetKey(keyPrefix, code);
           const dedupKeys = await redis.zrange(trackingKey, 0, -1);
-          const multi = redis
-            .multi()
-            .del(roomMembersKey(keyPrefix, code))
-            .del(roomMemberTokensKey(keyPrefix, code))
-            .del(roomMemberTokenExpiryKey(keyPrefix, code))
-            .del(blockedTokensKey(keyPrefix, code))
-            .del(roomSessionsKey(keyPrefix, code))
-            .del(trackingKey)
-            .srem(`${keyPrefix}rooms`, code);
-          if (dedupKeys.length > 0) {
-            multi.del(...dedupKeys);
-          }
-          return multi.exec();
+          const keys = [
+            roomGenerationKey(keyPrefix, code),
+            `${keyPrefix}rooms`,
+            roomMembersKey(keyPrefix, code),
+            roomMemberTokensKey(keyPrefix, code),
+            roomMemberTokenExpiryKey(keyPrefix, code),
+            blockedTokensKey(keyPrefix, code),
+            roomSessionsKey(keyPrefix, code),
+            trackingKey,
+            ...dedupKeys,
+          ];
+          return await redis.eval(
+            DELETE_ROOM_LUA,
+            keys.length,
+            ...keys,
+            expectedGeneration === undefined ? "*" : (expectedGeneration ?? ""),
+            code,
+          );
         })(),
-      );
+      ).then((applied) => {
+        if (Number(applied) === 1) {
+          localRuntimeStore.deleteRoom(code);
+        }
+      });
     },
     async close() {
       await Promise.allSettled(Array.from(pendingOperations));

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -577,13 +577,23 @@ export async function createRedisRuntimeStore(
           );
           if (currentSessionId === session.id) {
             // Clears the stale session→member binding left by the previous run
-            // of this instance. It must NOT touch the member-token hash: this
-            // runs at startup, right before those very clients reconnect, and
+            // of this instance. It must NOT delete the member token: this runs
+            // at startup, right before those very clients reconnect, and
             // dropping their tokens is what handed everybody a new `memberId`
-            // after each restart (#234). The tokens are cleaned up by an
-            // explicit leave, an admin kick, or `deleteRoom`.
+            // after each restart (#234).
+            //
+            // It does start the identity's retention clock, in the same
+            // transaction. This is a disconnect like any other — it just took a
+            // process crash to notice — and without it a member who never comes
+            // back would keep their token forever, since `removeMember` is the
+            // only other place that arms it (#237 review).
             transaction.hdel(
               roomMembersKey(keyPrefix, session.roomCode),
+              session.memberId,
+            );
+            transaction.zadd(
+              roomMemberTokenExpiryKey(keyPrefix, session.roomCode),
+              String(now() + memberTokenRetentionMs),
               session.memberId,
             );
           }
@@ -779,10 +789,10 @@ export async function createRedisRuntimeStore(
     },
     blockMemberToken(code: string, memberToken: string, expiresAt: number) {
       ensurePendingCapacity("block_member_token");
-      localRuntimeStore.blockMemberToken(code, memberToken, expiresAt);
-      // Same reason as `revokeMemberToken`: the kick already awaits this and
-      // then reports the member evicted, so an unconfirmed write would report
-      // an eviction that had not happened on any other node yet.
+      // Durable-first, same as `revokeMemberToken`: the kick awaits this and
+      // then reports the member evicted, so an unconfirmed write would report an
+      // eviction that had not happened on any other node yet, and mirroring
+      // before it landed would leave this node blocking a token nobody else does.
       return trackAwaitedOperation(
         "block_member_token",
         redis.zadd(
@@ -790,7 +800,9 @@ export async function createRedisRuntimeStore(
           String(expiresAt),
           memberToken,
         ),
-      ).then(() => undefined);
+      ).then(() => {
+        localRuntimeStore.blockMemberToken(code, memberToken, expiresAt);
+      });
     },
     async isMemberTokenBlocked(
       code: string,
@@ -920,7 +932,11 @@ export async function createRedisRuntimeStore(
     },
     revokeMemberToken(code: string, memberId: string, session?: Session) {
       ensurePendingCapacity("revoke_member_token");
-      localRuntimeStore.revokeMemberToken(code, memberId, session);
+      // Durable-first: the local mirror is only updated once Redis accepted the
+      // revocation. Mirroring first left a partial apply behind when the write
+      // failed — the caller saw a rejection while this node had already dropped
+      // the token (#237 review).
+      //
       // Awaited, and rejecting: the kick disconnects the socket and reports
       // success as soon as this resolves, so resolving before the write landed
       // would report an eviction while the old token still resolved.
@@ -935,7 +951,9 @@ export async function createRedisRuntimeStore(
           memberId,
           session?.id ?? "",
         ),
-      ).then(() => undefined);
+      ).then(() => {
+        localRuntimeStore.revokeMemberToken(code, memberId, session);
+      });
     },
     deleteRoom(code: string) {
       ensurePendingCapacity("delete_room");

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -125,6 +125,7 @@ const RUNTIME_STORE_METHOD_NAMES = [
   "releaseRoomLock",
   "removeMember",
   "revokeMemberToken",
+  "evictMemberToken",
   "deleteRoom",
   "heartbeatNode",
   "listNodeStatuses",
@@ -275,6 +276,20 @@ local bound = redis.call("HGET", KEYS[1], ARGV[1])
 if ARGV[2] ~= "" and bound and bound ~= ARGV[2] then
   return 0
 end
+redis.call("HDEL", KEYS[2], ARGV[1])
+redis.call("ZREM", KEYS[3], ARGV[1])
+return 1
+`;
+
+/**
+ * Evict a member in one commit: block the token and end the identity together.
+ *
+ * Two independent writes could not be made consistent by ordering alone — once
+ * the block landed there was nothing to roll it back with if the revoke then
+ * failed (#237 review). One script either does both or neither.
+ */
+const EVICT_MEMBER_LUA = `
+redis.call("ZADD", KEYS[1], ARGV[3], ARGV[2])
 redis.call("HDEL", KEYS[2], ARGV[1])
 redis.call("ZREM", KEYS[3], ARGV[1])
 return 1
@@ -950,6 +965,34 @@ export async function createRedisRuntimeStore(
         })(),
       );
       return removal;
+    },
+    evictMemberToken(
+      code: string,
+      memberId: string,
+      memberToken: string,
+      blockedUntil: number,
+    ) {
+      ensurePendingCapacity("evict_member_token");
+      return trackAwaitedOperation(
+        "evict_member_token",
+        redis.eval(
+          EVICT_MEMBER_LUA,
+          3,
+          blockedTokensKey(keyPrefix, code),
+          roomMemberTokensKey(keyPrefix, code),
+          roomMemberTokenExpiryKey(keyPrefix, code),
+          memberId,
+          memberToken,
+          String(blockedUntil),
+        ),
+      ).then(() => {
+        localRuntimeStore.evictMemberToken(
+          code,
+          memberId,
+          memberToken,
+          blockedUntil,
+        );
+      });
     },
     revokeMemberToken(code: string, memberId: string, session?: Session) {
       ensurePendingCapacity("revoke_member_token");

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -5,6 +5,7 @@ import type { MetricsCollector } from "./admin/metrics.js";
 import type { ActiveRoom, ClusterNodeStatus, Session } from "./types.js";
 import {
   createInMemoryRuntimeStore,
+  DEFAULT_MEMBER_TOKEN_RETENTION_MS,
   type RuntimeStore,
 } from "./runtime-store.js";
 import {
@@ -20,7 +21,8 @@ type RedisMulti = {
   del: (...keys: string[]) => RedisMulti;
   hset: (key: string, ...args: unknown[]) => RedisMulti;
   hdel: (key: string, ...fields: string[]) => RedisMulti;
-  persist: (key: string) => RedisMulti;
+  zadd: (key: string, score: string, member: string) => RedisMulti;
+  zrem: (key: string, ...members: string[]) => RedisMulti;
   exec: () => Promise<unknown>;
 };
 
@@ -52,8 +54,6 @@ type RedisClient = {
     ...args: Array<string | number>
   ) => Promise<unknown>;
   del: (...keys: string[]) => Promise<unknown>;
-  pexpire: (key: string, milliseconds: number) => Promise<unknown>;
-  persist: (key: string) => Promise<unknown>;
 };
 
 type PendingOperationLogContext = {
@@ -78,11 +78,9 @@ type RedisRuntimeSession = {
 type RuntimeStoreOptions = {
   keyPrefix?: string;
   /**
-   * How long a room with no sessions left keeps its member tokens. Identity has
-   * to outlive a disconnect (#234) but not the room itself, so the moment a room
-   * empties its tokens are put on a clock; a reconnect before it fires clears
-   * the clock again. Default comfortably exceeds `persistence.emptyRoomTtlMs`,
-   * so tokens outlive the room rather than the other way round.
+   * How long a DISCONNECTED member's identity survives before their token stops
+   * reclaiming it. Per identity, not per room — see
+   * `DEFAULT_MEMBER_TOKEN_RETENTION_MS`.
    */
   memberTokenRetentionMs?: number;
   now?: () => number;
@@ -174,6 +172,10 @@ function roomMemberTokensKey(prefix: string, roomCode: string): string {
   return `${prefix}room:${roomCode}:member-tokens`;
 }
 
+function roomMemberTokenExpiryKey(prefix: string, roomCode: string): string {
+  return `${prefix}room:${roomCode}:member-token-expiry`;
+}
+
 function blockedTokensKey(prefix: string, roomCode: string): string {
   return `${prefix}room:${roomCode}:blocked-member-tokens`;
 }
@@ -205,9 +207,6 @@ function nodeStatusKey(prefix: string, instanceId: string): string {
   return `${prefix}node:${instanceId}`;
 }
 
-// Twice the default `emptyRoomTtlMs` (15 min), so an emptied room's tokens
-// outlive the room they identify members of rather than the other way round.
-const DEFAULT_MEMBER_TOKEN_RETENTION_MS = 30 * 60_000;
 const DEFAULT_MAX_PENDING_OPERATIONS = 256;
 const DEFAULT_PENDING_OPERATION_TIMEOUT_MS = 5_000;
 // Floor TTL applied only when the caller's expiresAt is already non-positive
@@ -277,6 +276,7 @@ if ARGV[2] ~= "" and bound and bound ~= ARGV[2] then
   return 0
 end
 redis.call("HDEL", KEYS[2], ARGV[1])
+redis.call("ZREM", KEYS[3], ARGV[1])
 return 1
 `;
 
@@ -293,71 +293,61 @@ async function loadSession(
 }
 
 /**
- * Drop an emptied room from the index and put its member tokens on a clock.
+ * Drop an emptied room from the index.
  *
- * Member tokens outlive a disconnect on purpose (#234), which means nothing
- * else deletes them once the last session goes and the room is left to expire —
- * `resolveRoom`'s lazy cleanup only fires if somebody touches the code again.
- * Arming the clock exactly here bounds that: while anyone is still connected the
- * key carries no TTL at all, so a long-lived room never loses the identities of
- * the people in it, and `addMember` lifts the clock again on reconnect.
+ * Emptiness needs BOTH indexes, and the check plus the write are one script. A
+ * join writes the member binding (`addMember`) before the session index
+ * (`onRoomJoined` → `markSessionJoinedRoom`), so between those two the session
+ * set is still empty while the room is already in use; a read-then-write from
+ * the client could also let a whole reconnect land between the check and the
+ * write (#237 review).
  *
- * The emptiness check and the two writes run as ONE script. Read-then-write from
- * the client let a reconnect land in between: `SCARD` saw zero, the client's
- * `markSessionJoinedRoom` + `addMember` (including its `PERSIST`) ran, and then
- * this pass removed a now-active room from the index and re-armed a TTL on the
- * tokens of members who were back — which would expire them mid-session.
- *
- * Emptiness needs BOTH indexes. A join writes the member binding
- * (`addMember`) before the session index (`onRoomJoined` →
- * `markSessionJoinedRoom`), so between those two the session set is still empty
- * while the room is already in use; checking only the sessions would re-arm the
- * TTL on a hash a live member had just written (#237 review).
+ * Member tokens are NOT touched here. Their retention is per identity — see
+ * `PRUNE_MEMBER_TOKENS_LUA` — because hanging it off "the room emptied" never
+ * released anything while the room stayed busy, and in a cluster only the node
+ * that happened to observe the emptying ever acted on it.
  */
 const CLEANUP_EMPTY_ROOM_LUA = `
 if redis.call("SCARD", KEYS[1]) ~= 0 then
   return 0
 end
-if redis.call("HLEN", KEYS[4]) ~= 0 then
+if redis.call("HLEN", KEYS[3]) ~= 0 then
   return 0
 end
 redis.call("SREM", KEYS[2], ARGV[1])
-redis.call("PEXPIRE", KEYS[3], ARGV[2])
 return 1
+`;
+
+/**
+ * Collect identities whose retention has run out.
+ *
+ * A zset scored by expiry, pruned lazily on read/write — the same shape this
+ * store already uses for blocked tokens. Redis hash fields cannot carry their
+ * own TTL, and a per-member key would make token lookup a scan.
+ */
+const PRUNE_MEMBER_TOKENS_LUA = `
+local expired = redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", ARGV[1])
+if #expired == 0 then
+  return 0
+end
+redis.call("HDEL", KEYS[2], unpack(expired))
+redis.call("ZREMRANGEBYSCORE", KEYS[1], "-inf", ARGV[1])
+return #expired
 `;
 
 async function cleanupEmptyRoomIndex(
   redis: RedisClient,
   prefix: string,
   roomCode: string,
-  memberTokenRetentionMs: number,
-  localRuntimeStore: RuntimeStore,
 ): Promise<void> {
-  const cleaned = await redis.eval(
+  await redis.eval(
     CLEANUP_EMPTY_ROOM_LUA,
-    4,
+    3,
     roomSessionsKey(prefix, roomCode),
     `${prefix}rooms`,
-    roomMemberTokensKey(prefix, roomCode),
     roomMembersKey(prefix, roomCode),
     roomCode,
-    String(memberTokenRetentionMs),
   );
-  if (Number(cleaned) !== 1) {
-    return;
-  }
-  // Only once the script reports it acted. The local map is a cache with no
-  // clock of its own, so keeping a copy would both leak in memory and answer
-  // `findMemberIdByToken` from it long after Redis let the tokens go. A
-  // reconnect that beats this line still recovers: its `addMember` wrote to
-  // Redis, which `findMemberIdByToken` consults first.
-  const localRoom = localRuntimeStore.getRoom(roomCode);
-  if (!localRoom) {
-    return;
-  }
-  for (const memberId of Array.from(localRoom.memberTokens.keys())) {
-    localRuntimeStore.revokeMemberToken(roomCode, memberId);
-  }
 }
 
 export async function createRedisRuntimeStore(
@@ -499,6 +489,17 @@ export async function createRedisRuntimeStore(
     return trackOperation(operationName, operation, true) as Promise<T>;
   }
 
+  /** Collect identities past their retention. Lazy — called on token reads/writes. */
+  async function pruneExpiredMemberTokens(code: string): Promise<void> {
+    await redis.eval(
+      PRUNE_MEMBER_TOKENS_LUA,
+      2,
+      roomMemberTokenExpiryKey(keyPrefix, code),
+      roomMemberTokensKey(keyPrefix, code),
+      String(now()),
+    );
+  }
+
   function queueSessionOperation(
     sessionId: string,
     operationName: string,
@@ -590,13 +591,7 @@ export async function createRedisRuntimeStore(
 
         await transaction.exec();
         if (session.roomCode) {
-          await cleanupEmptyRoomIndex(
-            redis,
-            keyPrefix,
-            session.roomCode,
-            memberTokenRetentionMs,
-            localRuntimeStore,
-          );
+          await cleanupEmptyRoomIndex(redis, keyPrefix, session.roomCode);
         }
         purgedCount += 1;
       }
@@ -618,13 +613,7 @@ export async function createRedisRuntimeStore(
         }
         await transaction.exec();
         if (roomCode) {
-          await cleanupEmptyRoomIndex(
-            redis,
-            keyPrefix,
-            roomCode,
-            memberTokenRetentionMs,
-            localRuntimeStore,
-          );
+          await cleanupEmptyRoomIndex(redis, keyPrefix, roomCode);
         }
       });
     },
@@ -654,13 +643,7 @@ export async function createRedisRuntimeStore(
         transaction.sadd(`${keyPrefix}rooms`, roomCode);
         await transaction.exec();
         if (roomCodeToLeave) {
-          await cleanupEmptyRoomIndex(
-            redis,
-            keyPrefix,
-            roomCodeToLeave,
-            memberTokenRetentionMs,
-            localRuntimeStore,
-          );
+          await cleanupEmptyRoomIndex(redis, keyPrefix, roomCodeToLeave);
         }
       });
     },
@@ -680,13 +663,7 @@ export async function createRedisRuntimeStore(
           .hset(sessionKey(keyPrefix, sessionId), "roomCode", "")
           .srem(roomSessionsKey(keyPrefix, targetRoomCode), sessionId)
           .exec();
-        await cleanupEmptyRoomIndex(
-          redis,
-          keyPrefix,
-          targetRoomCode,
-          memberTokenRetentionMs,
-          localRuntimeStore,
-        );
+        await cleanupEmptyRoomIndex(redis, keyPrefix, targetRoomCode);
       });
     },
     recordEvent(event: string, timestamp?: number) {
@@ -720,6 +697,7 @@ export async function createRedisRuntimeStore(
       return localRuntimeStore.getActiveRoomCodes();
     },
     async getRoom(code: string) {
+      await pruneExpiredMemberTokens(code);
       const memberTokens = await redis.hgetall(
         roomMemberTokensKey(keyPrefix, code),
       );
@@ -771,7 +749,10 @@ export async function createRedisRuntimeStore(
           .multi()
           .hset(roomMembersKey(keyPrefix, code), memberId, session.id)
           .hset(roomMemberTokensKey(keyPrefix, code), memberId, memberToken)
-          .persist(roomMemberTokensKey(keyPrefix, code))
+          // Back in use: take this identity off the clock. Per member, not the
+          // whole hash — `PERSIST`ing the hash kept every departed visitor of a
+          // busy room alive forever (#237 review).
+          .zrem(roomMemberTokenExpiryKey(keyPrefix, code), memberId)
           .exec(),
       );
       return room;
@@ -787,6 +768,7 @@ export async function createRedisRuntimeStore(
       // are asynchronous, so a join reading immediately after `addMember` could
       // otherwise miss its own write.
       await store.flush();
+      await pruneExpiredMemberTokens(code);
       const memberTokens = await redis.hgetall(
         roomMemberTokensKey(keyPrefix, code),
       );
@@ -918,12 +900,18 @@ export async function createRedisRuntimeStore(
             memberId,
           );
           if (shouldRemoveMemberBinding(currentSessionId, session?.id)) {
-            // Presence only. The member-token hash is deliberately untouched so
-            // a reconnect can reclaim this `memberId`; `revokeMemberToken` is
-            // the one that ends it. See `removeMemberFromRoom` (#234).
+            // Presence only. The member token itself is deliberately kept so a
+            // reconnect can reclaim this `memberId` (#234) — but it now goes on
+            // its own clock, so a room that never empties still releases the
+            // people who left it.
             await redis
               .multi()
               .hdel(roomMembersKey(keyPrefix, code), memberId)
+              .zadd(
+                roomMemberTokenExpiryKey(keyPrefix, code),
+                String(now() + memberTokenRetentionMs),
+                memberId,
+              )
               .exec();
           }
         })(),
@@ -940,9 +928,10 @@ export async function createRedisRuntimeStore(
         "revoke_member_token",
         redis.eval(
           REVOKE_MEMBER_TOKEN_LUA,
-          2,
+          3,
           roomMembersKey(keyPrefix, code),
           roomMemberTokensKey(keyPrefix, code),
+          roomMemberTokenExpiryKey(keyPrefix, code),
           memberId,
           session?.id ?? "",
         ),
@@ -960,6 +949,7 @@ export async function createRedisRuntimeStore(
             .multi()
             .del(roomMembersKey(keyPrefix, code))
             .del(roomMemberTokensKey(keyPrefix, code))
+            .del(roomMemberTokenExpiryKey(keyPrefix, code))
             .del(blockedTokensKey(keyPrefix, code))
             .del(roomSessionsKey(keyPrefix, code))
             .del(trackingKey)

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -196,6 +196,7 @@ export function createRoomService(options: {
     roomCode: string,
   ) => Promise<ReturnType<typeof roomStateOf> | null>;
   deleteExpiredRooms: (currentTime?: number) => Promise<number>;
+  teardownRoomRuntime: (code: string) => Promise<void>;
 } {
   const { config, persistence, roomStore, generateToken, logEvent } = options;
   const runtimeStoreOption = options.runtimeStore ?? options.activeRooms;
@@ -448,7 +449,15 @@ export function createRoomService(options: {
         continue;
       }
       try {
-        await runtimeStore.deleteRoom(code);
+        // The generation is read HERE, where the teardown is decided, and the
+        // delete only applies while it still holds. That is what finally closes
+        // the recycled-code race: the two guards around this are both
+        // check-then-act, and no arrangement of them makes the delete itself
+        // conditional (#237 review).
+        await runtimeStore.deleteRoom(
+          code,
+          await runtimeStore.getRoomGeneration(code),
+        );
         pendingRuntimeTeardowns.delete(code);
       } catch (error) {
         pendingRuntimeTeardowns.add(code);
@@ -1094,6 +1103,16 @@ export function createRoomService(options: {
   }
 
   return {
+    /**
+     * Tear down a deleted room's runtime state, guarded and retried.
+     *
+     * Exposed so the admin paths use the same one entry point: they delete the
+     * persisted room irrecoverably first, so a teardown that fails there has no
+     * way back — the room code would never reach the reaper again (#237 review).
+     */
+    async teardownRoomRuntime(code: string) {
+      await collectRuntimeStateForDeletedRooms([code]);
+    },
     async createRoomForSession(session, displayName) {
       setSessionDisplayName(session, displayName);
       await leaveCurrentRoom(session);
@@ -1142,6 +1161,11 @@ export function createRoomService(options: {
           "internal_error",
         );
       }
+
+      // A fresh generation marks the start of this room instance. Any teardown
+      // still owed for the code's previous occupant was decided against the old
+      // one and will now decline.
+      await runtimeStore.markRoomGeneration(room.code, randomUUID());
 
       const memberToken = generateToken();
       session.memberId = session.id;

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -941,6 +941,9 @@ export function createRoomService(options: {
     // considered its stale session the current member and would revoke the token
     // the new node was using (#237 review).
 
+    // Recomputed from the shared view inside the try; the catch reads it too.
+    let roomEmpty = removal.roomEmpty;
+
     try {
       // Inside the try: revoking is a durable write that now rejects when it
       // fails, and outside the recovery path a failure left the member removed
@@ -963,7 +966,18 @@ export function createRoomService(options: {
         return { room: null };
       }
 
-      if (!removal.roomEmpty) {
+      // Emptiness has to come from the SHARED member state. `removal.roomEmpty`
+      // is this node's local view: when an old node's socket cleanup interleaves
+      // with the same member reconnecting elsewhere, the old node removes its
+      // only local member and calls the room empty — then writes an `expiresAt`
+      // over the one the new node's join had just cleared, and the reaper
+      // eventually deletes a room that still has members (#237 review).
+      const sharedRoom = await resolveActiveRoom(roomCode).catch(() => null);
+      roomEmpty = sharedRoom
+        ? sharedRoom.members.size === 0
+        : removal.roomEmpty;
+
+      if (!roomEmpty) {
         logEvent("room_left", {
           sessionId: session.id,
           roomCode,
@@ -1036,7 +1050,7 @@ export function createRoomService(options: {
             origin: session.origin,
             reason: "socket_detached",
           });
-          if (removal.roomEmpty) {
+          if (roomEmpty) {
             // Emptying-leave plus failed expiry write may leave the persisted
             // room without `expiresAt`, so the reaper won't collect it. We
             // can NOT force-delete here: the expiry write could have failed
@@ -1198,7 +1212,18 @@ export function createRoomService(options: {
       try {
         await runtimeStore.markRoomGeneration(room.code, randomUUID());
       } catch (error) {
-        await roomStore.deleteRoom(room.code).catch(() => undefined);
+        // CAS on the version we just created, not a delete by code. Between the
+        // failure and this line an admin can expire the (still memberless) room
+        // and another request can take the code — deleting by code would then
+        // remove the replacement out from under its owner, who had already been
+        // told the creation succeeded (#237 review).
+        //
+        // Expiring rather than deleting: `updateRoom` is the only conditional
+        // primitive the store has, and a room marked expired is collected by the
+        // reaper and can never be mistaken for a live one.
+        await roomStore
+          .updateRoom(room.code, room.version, { expiresAt: now() })
+          .catch(() => undefined);
         logEvent("room_persist_failed", {
           sessionId: session.id,
           roomCode: room.code,

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -74,6 +74,12 @@ export class RoomServiceError extends Error {
 export type RoomServiceRuntimeStore = ActiveRoomRegistry &
   Partial<Pick<RuntimeStore, "registerSession" | "flush">>;
 
+/**
+ * Why a session is leaving a room. Identity (`memberToken`) survives a
+ * `"disconnect"` and is revoked on a `"client-request"`; see `leaveCurrentRoom`.
+ */
+export type LeaveRoomReason = "client-request" | "disconnect";
+
 type JoinedRoomAccess = {
   session: Session;
   persistedRoom: PersistedRoom;
@@ -144,7 +150,10 @@ export function createRoomService(options: {
     displayName?: string,
     previousMemberToken?: string,
   ) => Promise<{ room: PersistedRoom; memberToken: string }>;
-  leaveRoomForSession: (session: Session) => Promise<{
+  leaveRoomForSession: (
+    session: Session,
+    reason?: LeaveRoomReason,
+  ) => Promise<{
     room: PersistedRoom | null;
     notifyRoom?: boolean;
     memberRemoved?: boolean;
@@ -801,7 +810,22 @@ export function createRoomService(options: {
     return readyState === OPEN;
   }
 
-  async function leaveCurrentRoom(session: Session): Promise<{
+  /**
+   * `reason` decides whether the member's identity survives.
+   *
+   * - `"client-request"` — an explicit `room:leave`. The member is done with the
+   *   room, so their `memberToken` is revoked and a later join is issued a fresh
+   *   `memberId`.
+   * - `"disconnect"` — the socket closed. The client still holds its token and
+   *   is expected to come back with it, so identity is KEPT. Revoking here is
+   *   what broke #234: every server restart closes every socket at once, so
+   *   every member returned with a new `memberId` and
+   *   `sharedVideo.sharedByMemberId` matched nobody.
+   */
+  async function leaveCurrentRoom(
+    session: Session,
+    reason: LeaveRoomReason = "client-request",
+  ): Promise<{
     room: PersistedRoom | null;
     notifyRoom?: boolean;
     memberRemoved?: boolean;
@@ -821,6 +845,14 @@ export function createRoomService(options: {
           roomEmpty: false,
           removed: false,
         };
+    // Gated on `removal.removed`, exactly like the removal itself: a superseded
+    // session leaving must not revoke the identity a NEWER session already
+    // reclaimed. `removeMemberFromRoom` returns `removed: false` in that case
+    // (the memberId now maps to a different session), and revoking anyway would
+    // invalidate the live member's token.
+    if (reason === "client-request" && session.memberId && removal.removed) {
+      runtimeStore.revokeMemberToken(roomCode, session.memberId);
+    }
     await runtimeStore.flush?.();
     clearSessionRoom(session);
 
@@ -1104,6 +1136,12 @@ export function createRoomService(options: {
             joinIdentity.memberId,
             session,
           );
+          // Deliberately no `revokeMemberToken` here. `removeMember` already
+          // declines when a newer session owns this memberId, but a bare revoke
+          // has no such guard and would delete that live session's binding. The
+          // leftover binding is harmless either way: the client whose join failed
+          // reclaims the same memberId when it retries with the same token, which
+          // is what we want.
           await runtimeStore.flush?.();
 
           const currentRuntimeSession =

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -427,12 +427,22 @@ export function createRoomService(options: {
     codes: Iterable<string>,
   ): Promise<void> {
     for (const code of new Set(codes)) {
-      // Room codes are recycled. Between the persisted delete and this line a
-      // brand-new room can already have claimed the code and written member
-      // state, and tearing down "the old room" would wipe it — leaving the new
-      // owner with a session that says joined and a runtime that disagrees. A
-      // live room under this code means the old one is already gone.
-      const currentRoom = await roomStore.getRoom(code).catch(() => null);
+      // Defence in depth behind the allocation-time check: a teardown queued
+      // for retry could otherwise fire after its code came back into use — the
+      // residue it was queued for may have expired on its own in the meantime,
+      // which frees the code for allocation.
+      //
+      // A read failure is "unknown", NOT "absent". Treating it as absent made
+      // this guard fail in exactly the conditions that queue teardowns in the
+      // first place, and it would then wipe the new room's members and tokens
+      // (#237 review). Keep the debt and try again later.
+      let currentRoom: PersistedRoom | null;
+      try {
+        currentRoom = await roomStore.getRoom(code);
+      } catch {
+        pendingRuntimeTeardowns.add(code);
+        continue;
+      }
       if (currentRoom) {
         pendingRuntimeTeardowns.delete(code);
         continue;
@@ -1092,6 +1102,21 @@ export function createRoomService(options: {
       let room: PersistedRoom | null = null;
       for (let attempt = 0; attempt < 5; attempt += 1) {
         const roomCode = nextRoomCode();
+        // Room codes are recycled, so a code is only safe to hand out once no
+        // runtime state remains under it. Enforcing that HERE — at the one point
+        // where a code becomes live — is what makes the rest of the lifecycle
+        // simple: a teardown can never collide with a new room, and a new room
+        // can never inherit the previous occupant's identities, so neither needs
+        // its own guard (#237 review).
+        //
+        // An unreadable runtime store means "unknown", never "empty": try
+        // another code rather than risk handing out a dirty one.
+        const runtimeResidue = await resolveActiveRoom(roomCode).catch(
+          () => "unknown" as const,
+        );
+        if (runtimeResidue !== null) {
+          continue;
+        }
         try {
           room = await roomStore.createRoom({
             code: roomCode,
@@ -1116,23 +1141,6 @@ export function createRoomService(options: {
           INTERNAL_SERVER_ERROR_MESSAGE,
           "internal_error",
         );
-      }
-
-      // Room codes are recycled, and a teardown that failed earlier may have
-      // left the previous occupant's runtime state under this one. A brand-new
-      // room must start clean, or a returning member of the OLD room would have
-      // their token resolve to their old `memberId` inside the new one (#237
-      // review). Best-effort: hygiene, not a reason to fail the creation.
-      try {
-        await runtimeStore.deleteRoom(room.code);
-      } catch (error) {
-        logEvent("room_runtime_cleanup_failed", {
-          roomCode: room.code,
-          provider: persistence.provider,
-          result: "error",
-          reason: "room_create_clean_slate",
-          error: error instanceof Error ? error.message : String(error),
-        });
       }
 
       const memberToken = generateToken();

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -866,13 +866,24 @@ export function createRoomService(options: {
     // removal, so after a member reconnected onto another node the old node still
     // considered its stale session the current member and would revoke the token
     // the new node was using (#237 review).
-    if (reason === "client-request" && session.memberId) {
-      await runtimeStore.revokeMemberToken(roomCode, session.memberId, session);
-    }
-    await runtimeStore.flush?.();
-    clearSessionRoom(session);
 
     try {
+      // Inside the try: revoking is a durable write that now rejects when it
+      // fails, and outside the recovery path a failure left the member removed
+      // from the runtime while `clearSessionRoom` had not run — the client got
+      // an internal error still believing it was joined, with no runtime
+      // membership behind it (#237 review). `restoreLeaveState` in the catch
+      // re-adds the member with the snapshot token, undoing both.
+      if (reason === "client-request" && session.memberId) {
+        await runtimeStore.revokeMemberToken(
+          roomCode,
+          session.memberId,
+          session,
+        );
+      }
+      await runtimeStore.flush?.();
+      clearSessionRoom(session);
+
       const persistedRoom = await resolveRoom(roomCode);
       if (!persistedRoom) {
         return { room: null };

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -415,6 +415,44 @@ export function createRoomService(options: {
     });
   }
 
+  /**
+   * Room codes whose runtime teardown failed, retried on every later reaper
+   * pass. Kept because a failed teardown is otherwise unrecoverable: the
+   * persisted room and its expiry index are already gone, so nothing else will
+   * ever produce this code again (#237 review).
+   */
+  const pendingRuntimeTeardowns = new Set<string>();
+
+  async function collectRuntimeStateForDeletedRooms(
+    codes: Iterable<string>,
+  ): Promise<void> {
+    for (const code of new Set(codes)) {
+      // Room codes are recycled. Between the persisted delete and this line a
+      // brand-new room can already have claimed the code and written member
+      // state, and tearing down "the old room" would wipe it — leaving the new
+      // owner with a session that says joined and a runtime that disagrees. A
+      // live room under this code means the old one is already gone.
+      const currentRoom = await roomStore.getRoom(code).catch(() => null);
+      if (currentRoom) {
+        pendingRuntimeTeardowns.delete(code);
+        continue;
+      }
+      try {
+        await runtimeStore.deleteRoom(code);
+        pendingRuntimeTeardowns.delete(code);
+      } catch (error) {
+        pendingRuntimeTeardowns.add(code);
+        logEvent("room_runtime_cleanup_failed", {
+          roomCode: code,
+          provider: persistence.provider,
+          result: "error",
+          pendingRetryCount: pendingRuntimeTeardowns.size,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
   async function resolveRoom(code: string): Promise<PersistedRoom | null> {
     const room = await roomStore.getRoom(code);
     if (!room) {
@@ -422,10 +460,9 @@ export function createRoomService(options: {
     }
     if (room.expiresAt !== null && room.expiresAt <= now()) {
       await roomStore.deleteRoom(code);
-      // Awaited for the same reason as the reaper's teardown below: the
-      // persisted room is already gone, so a silent failure here strands the
-      // runtime keys with nothing left to name them.
-      await runtimeStore.deleteRoom(code);
+      // Same helper as the reaper: it refuses to tear down a code that has
+      // already been recycled, and queues a failed teardown for retry.
+      await collectRuntimeStateForDeletedRooms([code]);
       return null;
     }
     return room;
@@ -1081,6 +1118,23 @@ export function createRoomService(options: {
         );
       }
 
+      // Room codes are recycled, and a teardown that failed earlier may have
+      // left the previous occupant's runtime state under this one. A brand-new
+      // room must start clean, or a returning member of the OLD room would have
+      // their token resolve to their old `memberId` inside the new one (#237
+      // review). Best-effort: hygiene, not a reason to fail the creation.
+      try {
+        await runtimeStore.deleteRoom(room.code);
+      } catch (error) {
+        logEvent("room_runtime_cleanup_failed", {
+          roomCode: room.code,
+          provider: persistence.provider,
+          result: "error",
+          reason: "room_create_clean_slate",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
       const memberToken = generateToken();
       session.memberId = session.id;
       runtimeStore.addMember(room.code, session.memberId, session, memberToken);
@@ -1625,28 +1679,15 @@ export function createRoomService(options: {
 
     async deleteExpiredRooms(currentTime = now()) {
       const deletedCodes = await roomStore.deleteExpiredRooms(currentTime);
-      // The reaper is the only path that deletes a room nobody touches again,
-      // so it is also the only chance to collect the runtime state that outlives
-      // it. Member tokens survive a disconnect on purpose (#234); without this
-      // they would accumulate for every abandoned room, and a recycled room code
-      // would inherit the previous room's identities (#237 review).
-      //
-      // Awaited, and failures are surfaced rather than swallowed: the persisted
-      // room and its expiry index are already gone, so this code will never come
-      // back from the reaper and a silent failure strands those keys for good.
-      // One failure must not skip the remaining rooms.
-      for (const code of deletedCodes) {
-        try {
-          await runtimeStore.deleteRoom(code);
-        } catch (error) {
-          logEvent("room_runtime_cleanup_failed", {
-            roomCode: code,
-            provider: persistence.provider,
-            result: "error",
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
+      // Retries first, then this pass's own codes. The reaper is the only path
+      // that deletes a room nobody touches again, so it is also the only chance
+      // to collect the runtime state that outlives it — member tokens survive a
+      // disconnect on purpose (#234) — and once the persisted room is gone
+      // nothing will ever name that code again (#237 review).
+      await collectRuntimeStateForDeletedRooms([
+        ...pendingRuntimeTeardowns,
+        ...deletedCodes,
+      ]);
       return deletedCodes.length;
     },
   };

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -437,10 +437,25 @@ export function createRoomService(options: {
       // this guard fail in exactly the conditions that queue teardowns in the
       // first place, and it would then wipe the new room's members and tokens
       // (#237 review). Keep the debt and try again later.
+      // Pinned BEFORE anything is checked, so it names the room instance this
+      // teardown is about. Reading it after the absence check below left a
+      // second window: a code recycled between the two reads handed us the NEW
+      // room's generation, which then matched and wiped it (#237 review).
+      let expectedGeneration: string | null;
+      try {
+        expectedGeneration = await runtimeStore.getRoomGeneration(code);
+      } catch {
+        pendingRuntimeTeardowns.add(code);
+        continue;
+      }
+
       let currentRoom: PersistedRoom | null;
       try {
         currentRoom = await roomStore.getRoom(code);
       } catch {
+        // A read failure is "unknown", NOT "absent". Treating it as absent made
+        // this guard fail in exactly the conditions that queue teardowns in the
+        // first place. Keep the debt and try again later.
         pendingRuntimeTeardowns.add(code);
         continue;
       }
@@ -449,15 +464,10 @@ export function createRoomService(options: {
         continue;
       }
       try {
-        // The generation is read HERE, where the teardown is decided, and the
-        // delete only applies while it still holds. That is what finally closes
-        // the recycled-code race: the two guards around this are both
-        // check-then-act, and no arrangement of them makes the delete itself
-        // conditional (#237 review).
-        await runtimeStore.deleteRoom(
-          code,
-          await runtimeStore.getRoomGeneration(code),
-        );
+        // The delete only applies while that generation still holds. Both
+        // guards around it are check-then-act; no arrangement of them makes the
+        // delete itself conditional, which is what actually closes the race.
+        await runtimeStore.deleteRoom(code, expectedGeneration);
         pendingRuntimeTeardowns.delete(code);
       } catch (error) {
         pendingRuntimeTeardowns.add(code);
@@ -1111,7 +1121,14 @@ export function createRoomService(options: {
      * way back — the room code would never reach the reaper again (#237 review).
      */
     async teardownRoomRuntime(code: string) {
-      await collectRuntimeStateForDeletedRooms([code]);
+      // The backlog rides along. `deleteExpiredRooms` is the only other thing
+      // that drains it, and the standalone global-admin process never runs the
+      // reaper — an admin close/expire whose teardown failed there would have
+      // queued a retry nothing ever performed (#237 review).
+      await collectRuntimeStateForDeletedRooms([
+        ...pendingRuntimeTeardowns,
+        code,
+      ]);
     },
     async createRoomForSession(session, displayName) {
       setSessionDisplayName(session, displayName);
@@ -1165,7 +1182,29 @@ export function createRoomService(options: {
       // A fresh generation marks the start of this room instance. Any teardown
       // still owed for the code's previous occupant was decided against the old
       // one and will now decline.
-      await runtimeStore.markRoomGeneration(room.code, randomUUID());
+      //
+      // On failure the persisted room has to go with it: it would otherwise sit
+      // there with no members and no `expiresAt`, which the reaper never
+      // collects, holding its code and counting towards room totals forever
+      // (#237 review).
+      try {
+        await runtimeStore.markRoomGeneration(room.code, randomUUID());
+      } catch (error) {
+        await roomStore.deleteRoom(room.code).catch(() => undefined);
+        logEvent("room_persist_failed", {
+          sessionId: session.id,
+          roomCode: room.code,
+          provider: persistence.provider,
+          result: "error",
+          reason: "room_generation_mark_failed",
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw new RoomServiceError(
+          "internal_error",
+          INTERNAL_SERVER_ERROR_MESSAGE,
+          "internal_error",
+        );
+      }
 
       const memberToken = generateToken();
       session.memberId = session.id;

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -422,7 +422,10 @@ export function createRoomService(options: {
     }
     if (room.expiresAt !== null && room.expiresAt <= now()) {
       await roomStore.deleteRoom(code);
-      runtimeStore.deleteRoom(code);
+      // Awaited for the same reason as the reaper's teardown below: the
+      // persisted room is already gone, so a silent failure here strands the
+      // runtime keys with nothing left to name them.
+      await runtimeStore.deleteRoom(code);
       return null;
     }
     return room;
@@ -1627,8 +1630,22 @@ export function createRoomService(options: {
       // it. Member tokens survive a disconnect on purpose (#234); without this
       // they would accumulate for every abandoned room, and a recycled room code
       // would inherit the previous room's identities (#237 review).
+      //
+      // Awaited, and failures are surfaced rather than swallowed: the persisted
+      // room and its expiry index are already gone, so this code will never come
+      // back from the reaper and a silent failure strands those keys for good.
+      // One failure must not skip the remaining rooms.
       for (const code of deletedCodes) {
-        runtimeStore.deleteRoom(code);
+        try {
+          await runtimeStore.deleteRoom(code);
+        } catch (error) {
+          logEvent("room_runtime_cleanup_failed", {
+            roomCode: code,
+            provider: persistence.provider,
+            result: "error",
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
       return deletedCodes.length;
     },

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -149,6 +149,7 @@ export function createRoomService(options: {
     memberToken: string,
     currentTime: number,
   ) => Promise<boolean>;
+  resolveRoomResidue?: (roomCode: string) => Promise<boolean>;
 }): {
   createRoomForSession: (
     session: Session,
@@ -215,6 +216,10 @@ export function createRoomService(options: {
     options.resolveMemberIdByToken ??
     ((roomCode: string, memberToken: string) =>
       Promise.resolve(runtimeStore.findMemberIdByToken(roomCode, memberToken)));
+  const resolveRoomResidue =
+    options.resolveRoomResidue ??
+    ((roomCode: string) =>
+      Promise.resolve(runtimeStore.hasRoomResidue(roomCode)));
   const resolveBlockedMemberToken =
     options.resolveBlockedMemberToken ??
     ((roomCode: string, memberToken: string, currentTime: number) =>
@@ -1145,12 +1150,15 @@ export function createRoomService(options: {
         // can never inherit the previous occupant's identities, so neither needs
         // its own guard (#237 review).
         //
+        // Every runtime key, not just the members/tokens view `getRoom` gives:
+        // a code carrying only leftover session index entries, blocked tokens,
+        // dedup slots or a generation would otherwise read as free and take the
+        // old room's ghosts into the new one (#237 review).
+        //
         // An unreadable runtime store means "unknown", never "empty": try
         // another code rather than risk handing out a dirty one.
-        const runtimeResidue = await resolveActiveRoom(roomCode).catch(
-          () => "unknown" as const,
-        );
-        if (runtimeResidue !== null) {
+        const dirty = await resolveRoomResidue(roomCode).catch(() => true);
+        if (dirty) {
           continue;
         }
         try {

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -89,6 +89,17 @@ type JoinedRoomAccess = {
 type JoinTargetState = {
   activeRoom: ActiveRoom | null;
   reconnectMemberId: string | null;
+  /**
+   * Whether `reconnectMemberId` is still occupying a seat, i.e. this join
+   * replaces a live session rather than adding a member.
+   *
+   * Not the same thing as `reconnectMemberId !== null` any more. Member tokens
+   * now outlive a disconnect (#234), so a member who dropped hours ago still
+   * resolves one — and treating that as a seat-holder let them rejoin past
+   * `maxMembersPerRoom` once someone else had taken the last seat, once per
+   * disconnected member (#237 review).
+   */
+  reconnectHoldsSeat: boolean;
   activeMemberCount: number;
 };
 
@@ -641,6 +652,9 @@ export function createRoomService(options: {
     return {
       activeRoom,
       reconnectMemberId,
+      reconnectHoldsSeat:
+        reconnectMemberId !== null &&
+        (activeRoom?.members.has(reconnectMemberId) ?? false),
       activeMemberCount: activeRoom?.members.size ?? 0,
     };
   }
@@ -705,7 +719,7 @@ export function createRoomService(options: {
     );
     if (
       joinTargetState.activeMemberCount >= config.maxMembersPerRoom &&
-      joinTargetState.reconnectMemberId === null
+      !joinTargetState.reconnectHoldsSeat
     ) {
       throw new RoomServiceError("room_full", ROOM_FULL_MESSAGE, "room_full");
     }
@@ -728,8 +742,9 @@ export function createRoomService(options: {
         joinToken: args.joinToken,
         previousMemberToken: args.previousMemberToken,
       });
-      const needsCapacitySerialization =
-        joinTargetState.reconnectMemberId === null;
+      // A reconnect that no longer holds a seat consumes one like any other
+      // join, so it has to serialize on the admission lock too.
+      const needsCapacitySerialization = !joinTargetState.reconnectHoldsSeat;
 
       if (
         room.expiresAt === null &&
@@ -845,13 +860,14 @@ export function createRoomService(options: {
           roomEmpty: false,
           removed: false,
         };
-    // Gated on `removal.removed`, exactly like the removal itself: a superseded
-    // session leaving must not revoke the identity a NEWER session already
-    // reclaimed. `removeMemberFromRoom` returns `removed: false` in that case
-    // (the memberId now maps to a different session), and revoking anyway would
-    // invalidate the live member's token.
-    if (reason === "client-request" && session.memberId && removal.removed) {
-      runtimeStore.revokeMemberToken(roomCode, session.memberId);
+    // The session is passed so the STORE decides whether this leave still owns
+    // the identity, against the shared member binding. Gating on `removal.removed`
+    // instead only worked within one node: the mirrored store returns the local
+    // removal, so after a member reconnected onto another node the old node still
+    // considered its stale session the current member and would revoke the token
+    // the new node was using (#237 review).
+    if (reason === "client-request" && session.memberId) {
+      await runtimeStore.revokeMemberToken(roomCode, session.memberId, session);
     }
     await runtimeStore.flush?.();
     clearSessionRoom(session);
@@ -1594,7 +1610,16 @@ export function createRoomService(options: {
     },
 
     async deleteExpiredRooms(currentTime = now()) {
-      return await roomStore.deleteExpiredRooms(currentTime);
+      const deletedCodes = await roomStore.deleteExpiredRooms(currentTime);
+      // The reaper is the only path that deletes a room nobody touches again,
+      // so it is also the only chance to collect the runtime state that outlives
+      // it. Member tokens survive a disconnect on purpose (#234); without this
+      // they would accumulate for every abandoned room, and a recycled room code
+      // would inherit the previous room's identities (#237 review).
+      for (const code of deletedCodes) {
+        runtimeStore.deleteRoom(code);
+      }
+      return deletedCodes.length;
     },
   };
 }

--- a/server/src/room-store.ts
+++ b/server/src/room-store.ts
@@ -34,7 +34,14 @@ export type RoomStore = {
     patch: PersistedRoomPatch,
   ) => Promise<RoomUpdateResult>;
   deleteRoom: (code: string) => Promise<void>;
-  deleteExpiredRooms: (now: number) => Promise<number>;
+  /**
+   * Deletes every expired room and returns their codes.
+   *
+   * Codes, not a count: the runtime store keeps per-room state that outlives a
+   * disconnect (member tokens, since #234) and nothing else collects it once the
+   * room is gone, so the caller has to be told WHICH rooms died (#237 review).
+   */
+  deleteExpiredRooms: (now: number) => Promise<string[]>;
   listRooms: (
     query: Pick<
       RoomListQuery,
@@ -164,15 +171,15 @@ export function createInMemoryRoomStore(
     async deleteRoom(code): Promise<void> {
       rooms.delete(code);
     },
-    async deleteExpiredRooms(currentTime): Promise<number> {
-      let deletedCount = 0;
+    async deleteExpiredRooms(currentTime): Promise<string[]> {
+      const deletedCodes: string[] = [];
       for (const [code, room] of rooms.entries()) {
         if (room.expiresAt !== null && room.expiresAt <= currentTime) {
           rooms.delete(code);
-          deletedCount += 1;
+          deletedCodes.push(code);
         }
       }
-      return deletedCount;
+      return deletedCodes;
     },
     async listRooms(query) {
       const items = Array.from(rooms.values())

--- a/server/src/runtime-store-state.ts
+++ b/server/src/runtime-store-state.ts
@@ -158,15 +158,29 @@ export function removeMemberFromRoom(
  * Revoke a member's identity: after this, their `memberToken` no longer reclaims
  * their `memberId` and a rejoin is issued a new one. The counterpart to
  * {@link removeMemberFromRoom}, which only drops presence.
+ *
+ * `session` makes it conditional, under the same rule as
+ * {@link shouldRemoveMemberBinding}: revoke only while the memberId is unbound
+ * or still bound to that session. A session that has already been replaced —
+ * the member reconnected, possibly onto another node — must not be able to
+ * revoke the identity its successor is now using, which is what an
+ * unconditional revoke on an explicit leave would do.
  */
 export function revokeMemberTokenInRoom(
   rooms: Map<string, ActiveRoom>,
   code: string,
   memberId: string,
+  session?: Session,
 ): boolean {
   const room = rooms.get(code) ?? null;
   if (!room) {
     return false;
+  }
+  if (session) {
+    const currentSession = room.members.get(memberId);
+    if (currentSession && currentSession !== session) {
+      return false;
+    }
   }
   const revoked = room.memberTokens.delete(memberId);
   if (room.members.size === 0 && room.memberTokens.size === 0) {

--- a/server/src/runtime-store-state.ts
+++ b/server/src/runtime-store-state.ts
@@ -107,6 +107,22 @@ export function shouldRemoveMemberBinding(
   );
 }
 
+/**
+ * Drop a member's *presence*. Their `memberToken` is deliberately left behind.
+ *
+ * A disconnect is not a departure: the client still holds the token and will
+ * present it on the next `room:join` to reclaim the same `memberId`
+ * (`buildJoinIdentity`). Deleting it here revoked identity on every socket
+ * close, so even a brief network blip — and every server restart, which closes
+ * every socket at once — handed everybody a fresh `memberId`. Anything keyed on
+ * the old one then pointed at nobody, most visibly
+ * `sharedVideo.sharedByMemberId`: after a restart no member matched it, every
+ * client evaluated `isLocalSharedSource()` as false, and the room could no
+ * longer advance to the next video (#234).
+ *
+ * Revocation is a separate, deliberate act — see {@link revokeMemberTokenInRoom},
+ * called on an explicit `room:leave`, on an admin kick, and when the room dies.
+ */
 export function removeMemberFromRoom(
   rooms: Map<string, ActiveRoom>,
   code: string,
@@ -126,10 +142,35 @@ export function removeMemberFromRoom(
   }
 
   const existed = room.members.delete(memberId);
-  room.memberTokens.delete(memberId);
   const roomEmpty = room.members.size === 0;
-  if (roomEmpty) {
+  // `roomEmpty` stays a statement about *members*, which is what every caller
+  // means by it. The entry itself only goes once no identity is left to
+  // reclaim, otherwise the last member to disconnect would take everyone's
+  // tokens down with the room. Room counters read `roomSessionIds`, not this
+  // map, so a token-only entry inflates nothing.
+  if (roomEmpty && room.memberTokens.size === 0) {
     rooms.delete(code);
   }
   return { room: roomEmpty ? null : room, roomEmpty, removed: existed };
+}
+
+/**
+ * Revoke a member's identity: after this, their `memberToken` no longer reclaims
+ * their `memberId` and a rejoin is issued a new one. The counterpart to
+ * {@link removeMemberFromRoom}, which only drops presence.
+ */
+export function revokeMemberTokenInRoom(
+  rooms: Map<string, ActiveRoom>,
+  code: string,
+  memberId: string,
+): boolean {
+  const room = rooms.get(code) ?? null;
+  if (!room) {
+    return false;
+  }
+  const revoked = room.memberTokens.delete(memberId);
+  if (room.members.size === 0 && room.memberTokens.size === 0) {
+    rooms.delete(code);
+  }
+  return revoked;
 }

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -115,8 +115,20 @@ export type RuntimeStore = {
   ) => Promise<boolean>;
 };
 
+/**
+ * How long a member's identity survives their disconnect.
+ *
+ * Retention is per IDENTITY, not per room. Hanging it off "the room emptied"
+ * never released anything while the room stayed busy — a public room with a
+ * steady trickle of visitors kept every departed visitor's token forever — and
+ * in a cluster only the one node that observed the emptying ever acted on it
+ * (#237 review).
+ */
+export const DEFAULT_MEMBER_TOKEN_RETENTION_MS = 30 * 60_000;
+
 export function createInMemoryRuntimeStore(
   now: () => number = Date.now,
+  memberTokenRetentionMs: number = DEFAULT_MEMBER_TOKEN_RETENTION_MS,
 ): RuntimeStore {
   const startedAt = now();
   const sessionsById = new Map<string, Session>();
@@ -132,6 +144,26 @@ export function createInMemoryRuntimeStore(
     Map<string, { token: string; expiresAt: number }>
   >();
   const nodeStatuses = new Map<string, ClusterNodeStatus>();
+  // memberId → when its token stops reclaiming the identity. Only disconnected
+  // members appear here; `addMember` removes the entry again.
+  const memberTokenExpiryByRoom = new Map<string, Map<string, number>>();
+
+  /** Drop identities whose retention has run out. Lazy: no timers. */
+  function pruneExpiredMemberTokens(code: string, currentTime = now()): void {
+    const expiryByMember = memberTokenExpiryByRoom.get(code);
+    if (!expiryByMember) {
+      return;
+    }
+    for (const [memberId, expiresAt] of Array.from(expiryByMember.entries())) {
+      if (expiresAt <= currentTime) {
+        expiryByMember.delete(memberId);
+        revokeMemberTokenInRoom(rooms, code, memberId);
+      }
+    }
+    if (expiryByMember.size === 0) {
+      memberTokenExpiryByRoom.delete(code);
+    }
+  }
 
   function pruneEvents(currentTime: number): void {
     while (
@@ -270,13 +302,18 @@ export function createInMemoryRuntimeStore(
       return new Set(roomSessionIds.keys());
     },
     getRoom(code) {
+      pruneExpiredMemberTokens(code);
       return rooms.get(code) ?? null;
     },
     getOrCreateRoom,
     addMember(code, memberId, session, memberToken) {
+      pruneExpiredMemberTokens(code);
+      // Back in use: the identity is no longer on the clock.
+      memberTokenExpiryByRoom.get(code)?.delete(memberId);
       return addMemberToRoom(rooms, code, memberId, session, memberToken);
     },
     findMemberIdByToken(code, memberToken) {
+      pruneExpiredMemberTokens(code);
       const room = rooms.get(code) ?? null;
       if (!room) {
         return null;
@@ -344,13 +381,30 @@ export function createInMemoryRuntimeStore(
       return Promise.resolve(true);
     },
     removeMember(code, memberId, session) {
-      return removeMemberFromRoom(rooms, code, memberId, session);
+      pruneExpiredMemberTokens(code);
+      const removal = removeMemberFromRoom(rooms, code, memberId, session);
+      // Presence is gone but the identity survives (#234) — start its clock, so
+      // a room that never empties still releases the people who left it.
+      if (removal.removed && rooms.get(code)?.memberTokens.has(memberId)) {
+        const expiryByMember =
+          memberTokenExpiryByRoom.get(code) ?? new Map<string, number>();
+        expiryByMember.set(memberId, now() + memberTokenRetentionMs);
+        memberTokenExpiryByRoom.set(code, expiryByMember);
+      }
+      return removal;
     },
     revokeMemberToken(code, memberId, session) {
-      revokeMemberTokenInRoom(rooms, code, memberId, session);
+      if (revokeMemberTokenInRoom(rooms, code, memberId, session)) {
+        const expiryByMember = memberTokenExpiryByRoom.get(code);
+        expiryByMember?.delete(memberId);
+        if (expiryByMember?.size === 0) {
+          memberTokenExpiryByRoom.delete(code);
+        }
+      }
     },
     deleteRoom(code) {
       rooms.delete(code);
+      memberTokenExpiryByRoom.delete(code);
       roomSessionIds.delete(code);
       blockedMemberTokensByRoom.delete(code);
       claimedSlotsByRoom.delete(code);

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -109,8 +109,34 @@ export type RuntimeStore = {
    * the teardown is durable and rejects if it failed — the caller is usually
    * deleting the persisted room in the same breath, after which nothing will
    * ever name this room code again, so a silent failure strands the keys.
+   *
+   * `expectedGeneration` makes the teardown target ONE room instance. Room codes
+   * are recycled, and a teardown is decided (the room is gone) and performed
+   * (delete its keys) at two different moments; between them the code can come
+   * back into use, and an unconditional delete would then wipe the new room's
+   * members and tokens. Two check-then-act guards cannot compose their way out
+   * of that — only the delete itself can be conditional (#237 review).
+   *
+   * Read the generation with {@link RuntimeStore.getRoomGeneration} when the
+   * teardown is decided and pass it here; a mismatch means the code changed
+   * hands and the teardown is skipped. `null` matches only `null`, so a room
+   * that predates generations is still collected, and one that has since been
+   * stamped is left alone.
    */
-  deleteRoom: (code: string) => void | Promise<void>;
+  deleteRoom: (
+    code: string,
+    expectedGeneration?: string | null,
+  ) => void | Promise<void>;
+  /** The generation stamped on this code's runtime state, or null. */
+  getRoomGeneration: (code: string) => string | null | Promise<string | null>;
+  /**
+   * Stamp a fresh generation on a code, marking the start of a new room
+   * instance. Called once when a room is created.
+   */
+  markRoomGeneration: (
+    code: string,
+    generation: string,
+  ) => void | Promise<void>;
   heartbeatNode: (status: ClusterNodeStatus) => Promise<void>;
   listNodeStatuses: (currentTime?: number) => Promise<ClusterNodeStatus[]>;
   purgeNodeStatus: (instanceId: string) => Promise<void>;
@@ -169,6 +195,8 @@ export function createInMemoryRuntimeStore(
   // memberId → when its token stops reclaiming the identity. Only disconnected
   // members appear here; `addMember` removes the entry again.
   const memberTokenExpiryByRoom = new Map<string, Map<string, number>>();
+  // code → the generation of the room instance currently using it.
+  const roomGenerations = new Map<string, string>();
 
   /** Drop identities whose retention has run out. Lazy: no timers. */
   function pruneExpiredMemberTokens(code: string, currentTime = now()): void {
@@ -439,7 +467,20 @@ export function createInMemoryRuntimeStore(
       revokeMemberIdentity(code, memberId);
     },
     revokeMemberToken: revokeMemberIdentity,
-    deleteRoom(code) {
+    getRoomGeneration(code) {
+      return roomGenerations.get(code) ?? null;
+    },
+    markRoomGeneration(code, generation) {
+      roomGenerations.set(code, generation);
+    },
+    deleteRoom(code, expectedGeneration) {
+      if (
+        expectedGeneration !== undefined &&
+        (roomGenerations.get(code) ?? null) !== expectedGeneration
+      ) {
+        return;
+      }
+      roomGenerations.delete(code);
       rooms.delete(code);
       memberTokenExpiryByRoom.delete(code);
       roomSessionIds.delete(code);

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -88,7 +88,13 @@ export type RuntimeStore = {
     memberId: string,
     session?: Session,
   ) => void | Promise<void>;
-  deleteRoom: (code: string) => void;
+  /**
+   * Tear down every runtime key for a room. Returns a promise that settles once
+   * the teardown is durable and rejects if it failed — the caller is usually
+   * deleting the persisted room in the same breath, after which nothing will
+   * ever name this room code again, so a silent failure strands the keys.
+   */
+  deleteRoom: (code: string) => void | Promise<void>;
   heartbeatNode: (status: ClusterNodeStatus) => Promise<void>;
   listNodeStatuses: (currentTime?: number) => Promise<ClusterNodeStatus[]>;
   purgeNodeStatus: (instanceId: string) => Promise<void>;

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -127,6 +127,15 @@ export type RuntimeStore = {
     code: string,
     expectedGeneration?: string | null,
   ) => void | Promise<void>;
+  /**
+   * Whether ANY runtime state remains under this code.
+   *
+   * Not `getRoom() !== null`: that answers "are there members or member tokens",
+   * which is a strict subset. A code carrying only leftover session index
+   * entries, blocked tokens, dedup slots or a generation would read as free, be
+   * handed to a new room, and take the old room's ghosts with it (#237 review).
+   */
+  hasRoomResidue: (code: string) => boolean | Promise<boolean>;
   /** The generation stamped on this code's runtime state, or null. */
   getRoomGeneration: (code: string) => string | null | Promise<string | null>;
   /**
@@ -467,6 +476,21 @@ export function createInMemoryRuntimeStore(
       revokeMemberIdentity(code, memberId);
     },
     revokeMemberToken: revokeMemberIdentity,
+    hasRoomResidue(code) {
+      pruneExpiredMemberTokens(code);
+      // Deliberately NOT the generation or a held room lock. Neither is state a
+      // new room could inherit — the generation is overwritten by the new room's
+      // own stamp, and a lock is transient — and counting them would mean a code
+      // is freed only by a successful teardown, losing the self-healing path
+      // where the residue simply ages out.
+      return (
+        rooms.has(code) ||
+        roomSessionIds.has(code) ||
+        blockedMemberTokensByRoom.has(code) ||
+        memberTokenExpiryByRoom.has(code) ||
+        claimedSlotsByRoom.has(code)
+      );
+    },
     getRoomGeneration(code) {
       return roomGenerations.get(code) ?? null;
     },

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -126,7 +126,7 @@ export type RuntimeStore = {
   deleteRoom: (
     code: string,
     expectedGeneration?: string | null,
-  ) => void | Promise<void>;
+  ) => boolean | Promise<boolean>;
   /**
    * Whether ANY runtime state remains under this code.
    *
@@ -502,7 +502,7 @@ export function createInMemoryRuntimeStore(
         expectedGeneration !== undefined &&
         (roomGenerations.get(code) ?? null) !== expectedGeneration
       ) {
-        return;
+        return false;
       }
       roomGenerations.delete(code);
       rooms.delete(code);
@@ -511,6 +511,7 @@ export function createInMemoryRuntimeStore(
       blockedMemberTokensByRoom.delete(code);
       claimedSlotsByRoom.delete(code);
       ownedRoomLocks.delete(code);
+      return true;
     },
     async heartbeatNode(status) {
       nodeStatuses.set(status.instanceId, { ...status });

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -54,6 +54,22 @@ export type RuntimeStore = {
     memberToken: string,
     expiresAt: number,
   ) => void | Promise<void>;
+  /**
+   * Evict a member: block their token AND end their identity, as ONE commit.
+   *
+   * A kick is a single act, but it used to be two independent durable writes.
+   * When the block landed and the revoke then failed, nothing could roll the
+   * block back: the admin was told the kick failed while the member kept working
+   * until their next reconnect, which was refused with `member_kicked` (#237
+   * review). Durable-first only protects each write's own local mirror; it
+   * cannot undo a write that already succeeded.
+   */
+  evictMemberToken: (
+    code: string,
+    memberId: string,
+    memberToken: string,
+    blockedUntil: number,
+  ) => void | Promise<void>;
   isMemberTokenBlocked: (
     code: string,
     memberToken: string,
@@ -199,6 +215,20 @@ export function createInMemoryRuntimeStore(
 
   const getOrCreateRoom = (code: string): ActiveRoom =>
     getOrCreateActiveRoom(rooms, code);
+
+  function revokeMemberIdentity(
+    code: string,
+    memberId: string,
+    session?: Session,
+  ): void {
+    if (revokeMemberTokenInRoom(rooms, code, memberId, session)) {
+      const expiryByMember = memberTokenExpiryByRoom.get(code);
+      expiryByMember?.delete(memberId);
+      if (expiryByMember?.size === 0) {
+        memberTokenExpiryByRoom.delete(code);
+      }
+    }
+  }
 
   return {
     registerSession(session) {
@@ -399,15 +429,16 @@ export function createInMemoryRuntimeStore(
       }
       return removal;
     },
-    revokeMemberToken(code, memberId, session) {
-      if (revokeMemberTokenInRoom(rooms, code, memberId, session)) {
-        const expiryByMember = memberTokenExpiryByRoom.get(code);
-        expiryByMember?.delete(memberId);
-        if (expiryByMember?.size === 0) {
-          memberTokenExpiryByRoom.delete(code);
-        }
-      }
+    evictMemberToken(code, memberId, memberToken, blockedUntil) {
+      const activeEntries = pruneBlockedMemberTokens(code, now());
+      activeEntries.push({ memberToken, expiresAt: blockedUntil });
+      blockedMemberTokensByRoom.set(code, activeEntries);
+      // Not `this.revokeMemberToken`: every consumer takes these off the object
+      // as bare references (`active-room-registry`, the mirrored store), so
+      // `this` is gone by the time they call it.
+      revokeMemberIdentity(code, memberId);
     },
+    revokeMemberToken: revokeMemberIdentity,
     deleteRoom(code) {
       rooms.delete(code);
       memberTokenExpiryByRoom.delete(code);

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -7,6 +7,7 @@ import {
   getOrCreateActiveRoom,
   type KickedMemberBlock,
   removeMemberFromRoom,
+  revokeMemberTokenInRoom,
   resolveRoomCodeToLeave,
 } from "./runtime-store-state.js";
 
@@ -53,11 +54,22 @@ export type RuntimeStore = {
     memberToken: string,
     currentTime?: number,
   ) => boolean;
+  /**
+   * Drop a member's presence. Their `memberToken` survives so a reconnect can
+   * reclaim the same `memberId`; use {@link RuntimeStore.revokeMemberToken} to
+   * end that. See `removeMemberFromRoom` for why the two are separate.
+   */
   removeMember: (
     code: string,
     memberId: string,
     session?: Session,
   ) => { room: ActiveRoom | null; roomEmpty: boolean; removed: boolean };
+  /**
+   * Revoke a member's identity so their `memberToken` can no longer reclaim
+   * their `memberId`. Only for deliberate departures: an explicit `room:leave`,
+   * an admin kick, or unwinding a join that failed partway.
+   */
+  revokeMemberToken: (code: string, memberId: string) => void;
   deleteRoom: (code: string) => void;
   heartbeatNode: (status: ClusterNodeStatus) => Promise<void>;
   listNodeStatuses: (currentTime?: number) => Promise<ClusterNodeStatus[]>;
@@ -315,6 +327,9 @@ export function createInMemoryRuntimeStore(
     },
     removeMember(code, memberId, session) {
       return removeMemberFromRoom(rooms, code, memberId, session);
+    },
+    revokeMemberToken(code, memberId) {
+      revokeMemberTokenInRoom(rooms, code, memberId);
     },
     deleteRoom(code) {
       rooms.delete(code);

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -44,11 +44,16 @@ export type RuntimeStore = {
     memberToken: string,
   ) => ActiveRoom;
   findMemberIdByToken: (code: string, memberToken: string) => string | null;
+  /**
+   * Block a token until `expiresAt`. Like {@link RuntimeStore.revokeMemberToken},
+   * the returned promise settles once the block is durable and rejects if the
+   * write failed — the kick acts on it immediately.
+   */
   blockMemberToken: (
     code: string,
     memberToken: string,
     expiresAt: number,
-  ) => void;
+  ) => void | Promise<void>;
   isMemberTokenBlocked: (
     code: string,
     memberToken: string,
@@ -66,10 +71,23 @@ export type RuntimeStore = {
   ) => { room: ActiveRoom | null; roomEmpty: boolean; removed: boolean };
   /**
    * Revoke a member's identity so their `memberToken` can no longer reclaim
-   * their `memberId`. Only for deliberate departures: an explicit `room:leave`,
-   * an admin kick, or unwinding a join that failed partway.
+   * their `memberId`. Only for deliberate departures: an explicit `room:leave`
+   * or an admin kick.
+   *
+   * Pass `session` to make it conditional on that session still owning the
+   * memberId (see `revokeMemberTokenInRoom`); omit it only where the caller
+   * means "this identity is over regardless of who holds it now" — the kick.
+   *
+   * The returned promise settles once the revocation is durable and REJECTS if
+   * the write failed. A caller that acts on the revocation (the kick disconnects
+   * the socket right after) must await it: resolving early would report success
+   * while the old token still resolved (#237 review).
    */
-  revokeMemberToken: (code: string, memberId: string) => void;
+  revokeMemberToken: (
+    code: string,
+    memberId: string,
+    session?: Session,
+  ) => void | Promise<void>;
   deleteRoom: (code: string) => void;
   heartbeatNode: (status: ClusterNodeStatus) => Promise<void>;
   listNodeStatuses: (currentTime?: number) => Promise<ClusterNodeStatus[]>;
@@ -328,8 +346,8 @@ export function createInMemoryRuntimeStore(
     removeMember(code, memberId, session) {
       return removeMemberFromRoom(rooms, code, memberId, session);
     },
-    revokeMemberToken(code, memberId) {
-      revokeMemberTokenInRoom(rooms, code, memberId);
+    revokeMemberToken(code, memberId, session) {
+      revokeMemberTokenInRoom(rooms, code, memberId, session);
     },
     deleteRoom(code) {
       rooms.delete(code);

--- a/server/src/ws-session-handler.ts
+++ b/server/src/ws-session-handler.ts
@@ -9,6 +9,7 @@ import {
   type ServerMessage,
 } from "@bili-syncplay/protocol";
 import { createSessionRateLimitState } from "./rate-limit.js";
+import type { LeaveRoomReason } from "./room-service.js";
 import { hasAttachedSocket } from "./types.js";
 import type { LogEvent, SecurityConfig, Session } from "./types.js";
 import {
@@ -64,7 +65,9 @@ export async function cleanupSessionAfterClose(options: {
   session: Session;
   code: number;
   reason: Buffer;
-  messageHandler: { leaveRoom: (session: Session) => Promise<void> };
+  messageHandler: {
+    leaveRoom: (session: Session, reason?: LeaveRoomReason) => Promise<void>;
+  };
   runtimeStore: Pick<RuntimeStore, "unregisterSession">;
   securityPolicy: {
     decrementConnectionCount: (remoteAddress: string | null) => void;
@@ -76,7 +79,11 @@ export async function cleanupSessionAfterClose(options: {
   const roomCodeAtClose = options.session.roomCode;
 
   try {
-    await options.messageHandler.leaveRoom(options.session);
+    // `"disconnect"`, never the default: the socket closed, the member did
+    // not ask to leave. Their `memberToken` must outlive this so the rejoin
+    // reclaims the same `memberId` — a server restart closes every socket at
+    // once, and revoking here reissued the whole room new ids (#234).
+    await options.messageHandler.leaveRoom(options.session, "disconnect");
   } catch (error) {
     options.logEvent("ws_connection_cleanup_failed", {
       sessionId: options.session.id,
@@ -209,7 +216,7 @@ export function createWsConnectionHandler(args: {
       session: Session,
       message: ClientMessage,
     ) => Promise<void>;
-    leaveRoom: (session: Session) => Promise<void>;
+    leaveRoom: (session: Session, reason?: LeaveRoomReason) => Promise<void>;
   };
   logEvent: LogEvent;
   pendingSessionCleanup: Set<Promise<void>>;

--- a/server/test/admin-action-service.test.ts
+++ b/server/test/admin-action-service.test.ts
@@ -89,7 +89,7 @@ function createService(options: {
       saveRoom: async () => {
         throw new Error("saveRoom should not be called in this test");
       },
-      deleteExpiredRooms: async () => 0,
+      deleteExpiredRooms: async () => [],
       createRoom: async () => {
         throw new Error("createRoom should not be called in this test");
       },

--- a/server/test/admin-action-service.test.ts
+++ b/server/test/admin-action-service.test.ts
@@ -245,3 +245,26 @@ test("admin action service keeps room state when closeRoom cannot disconnect eve
   assert.equal(auditLogs.items[0]?.result, "rejected");
   assert.equal(auditLogs.items[0]?.reason, "command_failed");
 });
+
+test("admin expireRoom tears down the room's runtime state", async () => {
+  const runtimeDeletes: string[] = [];
+  const service = createService({
+    requestAdminCommand: async () => {
+      throw new Error("no command expected");
+    },
+    deleteRuntimeRoom: (roomCode) => {
+      runtimeDeletes.push(roomCode);
+    },
+  });
+
+  await service.expireRoom(
+    { username: "admin" } as Parameters<typeof service.expireRoom>[0],
+    "ROOMXP",
+  );
+
+  // `closeRoom` has always done this; `expireRoom` did not, so an expired room
+  // left its runtime keys behind — including the tokens of members who had
+  // disconnected but whose identity is deliberately retained (#234) — and a
+  // recycled room code would inherit them.
+  assert.deepEqual(runtimeDeletes, ["ROOMXP"]);
+});

--- a/server/test/admin-action-service.test.ts
+++ b/server/test/admin-action-service.test.ts
@@ -97,7 +97,9 @@ function createService(options: {
     runtimeStore: {
       listSessionsByRoom: () => options.sessionsByRoom ?? [],
       getSession: () => options.session ?? null,
-      deleteRoom: options.deleteRuntimeRoom ?? (() => {}),
+    },
+    teardownRoomRuntime: async (roomCode) => {
+      options.deleteRuntimeRoom?.(roomCode);
     },
     listClusterSessions: async () => (options.session ? [options.session] : []),
     listClusterSessionsByRoom: async () => options.sessionsByRoom ?? [],

--- a/server/test/admin-command-consumer.test.ts
+++ b/server/test/admin-command-consumer.test.ts
@@ -213,3 +213,46 @@ test("admin command consumer keeps a kick block when disconnect fails", async ()
     await consumer.close();
   }
 });
+
+test("admin command consumer fails the kick when revoking the token does not land", async () => {
+  const bus = createInMemoryAdminCommandBus(() => 6_000);
+  const session = createSession("session-e", "ROOM05", "member-e");
+  let disconnected = false;
+
+  const consumer = await createAdminCommandConsumer({
+    instanceId: "node-a",
+    adminCommandBus: bus,
+    getLocalSession() {
+      return null;
+    },
+    listLocalSessionsByRoom(roomCode) {
+      return roomCode === "ROOM05" ? [session] : [];
+    },
+    blockMemberToken() {},
+    // The store reports the revocation failed. Reporting the kick as done here
+    // would claim an eviction while the old token still resolved everywhere.
+    async revokeMemberToken() {
+      throw new Error("revoke failed");
+    },
+    disconnectSessionSocket() {
+      disconnected = true;
+    },
+    now: () => 6_000,
+  });
+
+  try {
+    const result = await bus.request({
+      kind: "kick_member",
+      requestId: "req-5",
+      targetInstanceId: "node-a",
+      roomCode: "ROOM05",
+      memberId: "member-e",
+      requestedAt: 5_000,
+    });
+
+    assert.notEqual(result.status, "ok");
+    assert.equal(disconnected, false);
+  } finally {
+    await consumer.close();
+  }
+});

--- a/server/test/admin-command-consumer.test.ts
+++ b/server/test/admin-command-consumer.test.ts
@@ -54,6 +54,7 @@ test("admin command consumer disconnects a local session", async () => {
       return [];
     },
     blockMemberToken() {},
+    revokeMemberToken() {},
     disconnectSessionSocket(_session, reason) {
       disconnectedReason = reason;
     },
@@ -79,6 +80,7 @@ test("admin command consumer disconnects a local session", async () => {
 test("admin command consumer blocks token and disconnects a kicked member", async () => {
   const bus = createInMemoryAdminCommandBus(() => 3_000);
   const session = createSession("session-b", "ROOM02", "member-b");
+  const revoked: Array<{ roomCode: string; memberId: string }> = [];
   const blocked: Array<{ roomCode: string; token: string; expiresAt: number }> =
     [];
 
@@ -93,6 +95,9 @@ test("admin command consumer blocks token and disconnects a kicked member", asyn
     },
     blockMemberToken(roomCode, token, expiresAt) {
       blocked.push({ roomCode, token, expiresAt });
+    },
+    revokeMemberToken(roomCode, memberId) {
+      revoked.push({ roomCode, memberId });
     },
     disconnectSessionSocket() {},
     now: () => 3_000,
@@ -116,6 +121,10 @@ test("admin command consumer blocks token and disconnects a kicked member", asyn
         expiresAt: 63_000,
       },
     ]);
+    // The block only holds them out for its TTL. Since #234 the disconnect below
+    // no longer revokes identity, so the kick has to do it explicitly — without
+    // this the member would come back as themselves once the block lapsed.
+    assert.deepEqual(revoked, [{ roomCode: "ROOM02", memberId: "member-b" }]);
   } finally {
     await consumer.close();
   }
@@ -138,6 +147,7 @@ test("admin command consumer does not disconnect a member when token blocking fa
     blockMemberToken() {
       throw new Error("block failed");
     },
+    revokeMemberToken() {},
     disconnectSessionSocket() {
       disconnected = true;
     },
@@ -179,6 +189,7 @@ test("admin command consumer keeps a kick block when disconnect fails", async ()
     blockMemberToken(_roomCode, token) {
       blocked.push(token);
     },
+    revokeMemberToken() {},
     disconnectSessionSocket() {
       throw new Error("disconnect failed");
     },

--- a/server/test/admin-command-consumer.test.ts
+++ b/server/test/admin-command-consumer.test.ts
@@ -53,8 +53,7 @@ test("admin command consumer disconnects a local session", async () => {
     listLocalSessionsByRoom() {
       return [];
     },
-    blockMemberToken() {},
-    revokeMemberToken() {},
+    evictMemberToken() {},
     disconnectSessionSocket(_session, reason) {
       disconnectedReason = reason;
     },
@@ -93,10 +92,8 @@ test("admin command consumer blocks token and disconnects a kicked member", asyn
     listLocalSessionsByRoom(roomCode) {
       return roomCode === "ROOM02" ? [session] : [];
     },
-    blockMemberToken(roomCode, token, expiresAt) {
-      blocked.push({ roomCode, token, expiresAt });
-    },
-    revokeMemberToken(roomCode, memberId) {
+    evictMemberToken(roomCode, memberId, token, blockedUntil) {
+      blocked.push({ roomCode, token, expiresAt: blockedUntil });
       revoked.push({ roomCode, memberId });
     },
     disconnectSessionSocket() {},
@@ -144,10 +141,9 @@ test("admin command consumer does not disconnect a member when token blocking fa
     listLocalSessionsByRoom(roomCode) {
       return roomCode === "ROOM03" ? [session] : [];
     },
-    blockMemberToken() {
+    evictMemberToken() {
       throw new Error("block failed");
     },
-    revokeMemberToken() {},
     disconnectSessionSocket() {
       disconnected = true;
     },
@@ -186,10 +182,9 @@ test("admin command consumer keeps a kick block when disconnect fails", async ()
     listLocalSessionsByRoom(roomCode) {
       return roomCode === "ROOM04" ? [session] : [];
     },
-    blockMemberToken(_roomCode, token) {
+    evictMemberToken(_roomCode, _memberId, token) {
       blocked.push(token);
     },
-    revokeMemberToken() {},
     disconnectSessionSocket() {
       throw new Error("disconnect failed");
     },
@@ -228,11 +223,10 @@ test("admin command consumer fails the kick when revoking the token does not lan
     listLocalSessionsByRoom(roomCode) {
       return roomCode === "ROOM05" ? [session] : [];
     },
-    blockMemberToken() {},
-    // The store reports the revocation failed. Reporting the kick as done here
+    // The store reports the eviction failed. Reporting the kick as done here
     // would claim an eviction while the old token still resolved everywhere.
-    async revokeMemberToken() {
-      throw new Error("revoke failed");
+    async evictMemberToken() {
+      throw new Error("evict failed");
     },
     disconnectSessionSocket() {
       disconnected = true;

--- a/server/test/mirrored-runtime-store.test.ts
+++ b/server/test/mirrored-runtime-store.test.ts
@@ -97,3 +97,38 @@ test("mirrored runtime store keeps room generations out of the local mirror", as
   // Reads go to the shared view, so nothing is lost by not keeping a copy.
   assert.equal(await store.getRoomGeneration("ROOMMG"), "generation-1");
 });
+
+test("mirrored teardown clears the local mirror whenever the shared one applied", async () => {
+  const local = createInMemoryRuntimeStore();
+  const shared = createInMemoryRuntimeStore();
+  const store = createMirroredRuntimeStore(local, shared);
+
+  store.addMember("ROOMTD", "member-td", createSession("session-td"), "tok-td");
+  await store.markRoomGeneration("ROOMTD", "generation-td");
+
+  assert.equal(await store.deleteRoom("ROOMTD", "generation-td"), true);
+
+  // The generation only exists in the shared store, so handing the expected
+  // value to the local delete too compared it against a local `null` that never
+  // matches: an ordinary room could never clear its local mirror at all.
+  assert.equal(local.getRoom("ROOMTD"), null);
+  assert.equal(shared.getRoom("ROOMTD"), null);
+});
+
+test("mirrored teardown leaves the local mirror alone when the shared one declines", async () => {
+  const local = createInMemoryRuntimeStore();
+  const shared = createInMemoryRuntimeStore();
+  const store = createMirroredRuntimeStore(local, shared);
+
+  store.addMember("ROOMTS", "member-ts", createSession("session-ts"), "tok-ts");
+  await store.markRoomGeneration("ROOMTS", "generation-live");
+
+  // A teardown scheduled before the room was stamped still expects `null`.
+  assert.equal(await store.deleteRoom("ROOMTS", null), false);
+
+  // Local generations are always `null`, so `null` matched there unconditionally
+  // and the stale teardown wiped this node's view of a room the shared store had
+  // just declined to delete.
+  assert.notEqual(local.getRoom("ROOMTS"), null);
+  assert.notEqual(shared.getRoom("ROOMTS"), null);
+});

--- a/server/test/mirrored-runtime-store.test.ts
+++ b/server/test/mirrored-runtime-store.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMirroredRuntimeStore } from "../src/mirrored-runtime-store.js";
+import {
+  createInMemoryRuntimeStore,
+  type RuntimeStore,
+} from "../src/runtime-store.js";
+import type { AttachedSession, Session } from "../src/types.js";
+
+function createSession(id: string): Session {
+  return {
+    id,
+    connectionState: "attached",
+    socket: {
+      readyState: 1,
+      OPEN: 1,
+      send() {},
+      close() {},
+      terminate() {},
+    } as unknown as AttachedSession["socket"],
+    instanceId: "test-node",
+    remoteAddress: null,
+    origin: null,
+    roomCode: null,
+    memberId: null,
+    memberToken: null,
+    displayName: id,
+    joinedAt: null,
+    invalidMessageCount: 0,
+    rateLimitState: {
+      roomCreate: { windowStart: 0, count: 0 },
+      roomJoin: { windowStart: 0, count: 0 },
+      videoShare: { windowStart: 0, count: 0 },
+      playbackUpdate: { tokens: 0, lastRefillAt: 0 },
+      syncRequest: { windowStart: 0, count: 0 },
+      syncPing: { tokens: 0, lastRefillAt: 0 },
+    },
+  };
+}
+
+test("mirrored runtime store leaves the local mirror untouched when the shared revoke fails", async () => {
+  const local = createInMemoryRuntimeStore();
+  const shared = createInMemoryRuntimeStore();
+  const failing: RuntimeStore = {
+    ...shared,
+    revokeMemberToken: async () => {
+      throw new Error("shared store unavailable");
+    },
+  };
+  const store = createMirroredRuntimeStore(local, failing);
+  const session = createSession("session-mirror");
+
+  store.addMember("ROOMMR", "member-mirror", session, "token-mirror");
+
+  await assert.rejects(
+    Promise.resolve(store.revokeMemberToken("ROOMMR", "member-mirror")),
+    /shared store unavailable/,
+  );
+
+  // Durable-first: a rejection must change nothing. Mirroring first left the
+  // kick's caller with a failure while this node had already dropped the token,
+  // so the member stayed connected holding one nothing would accept.
+  assert.equal(
+    local.findMemberIdByToken("ROOMMR", "token-mirror"),
+    "member-mirror",
+  );
+});
+
+test("mirrored runtime store applies the local revoke once the shared one lands", async () => {
+  const local = createInMemoryRuntimeStore();
+  const shared = createInMemoryRuntimeStore();
+  const store = createMirroredRuntimeStore(local, shared);
+  const session = createSession("session-mirror-ok");
+
+  store.addMember("ROOMMK", "member-mirror-ok", session, "token-mirror-ok");
+  await store.revokeMemberToken("ROOMMK", "member-mirror-ok");
+
+  // Control for the test above: the reordering must not stop the mirror from
+  // being updated on the success path.
+  assert.equal(local.findMemberIdByToken("ROOMMK", "token-mirror-ok"), null);
+  assert.equal(shared.findMemberIdByToken("ROOMMK", "token-mirror-ok"), null);
+});

--- a/server/test/mirrored-runtime-store.test.ts
+++ b/server/test/mirrored-runtime-store.test.ts
@@ -80,3 +80,20 @@ test("mirrored runtime store applies the local revoke once the shared one lands"
   assert.equal(local.findMemberIdByToken("ROOMMK", "token-mirror-ok"), null);
   assert.equal(shared.findMemberIdByToken("ROOMMK", "token-mirror-ok"), null);
 });
+
+test("mirrored runtime store keeps room generations out of the local mirror", async () => {
+  const local = createInMemoryRuntimeStore();
+  const shared = createInMemoryRuntimeStore();
+  const store = createMirroredRuntimeStore(local, shared);
+
+  await store.markRoomGeneration("ROOMMG", "generation-1");
+
+  // Mirroring it locally leaked: the node that CREATES a room writes the
+  // generation, but the node that tears it down clears it — rarely the same one,
+  // and nothing expires generations. Every node accumulated entries for rooms it
+  // merely happened to create.
+  assert.equal(local.getRoomGeneration("ROOMMG"), null);
+  assert.equal(shared.getRoomGeneration("ROOMMG"), "generation-1");
+  // Reads go to the shared view, so nothing is lost by not keeping a copy.
+  assert.equal(await store.getRoomGeneration("ROOMMG"), "generation-1");
+});

--- a/server/test/redis-room-store.test.ts
+++ b/server/test/redis-room-store.test.ts
@@ -1183,3 +1183,41 @@ test("redis room reaper survives a candidate whose key turns the wrong type", as
     await store.close();
   }
 });
+
+test("redis room store reports codes whose index entry outlived the room body", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = uniqueNamespace("nobody");
+  const roomsKey = `${namespace}:rooms-by-expiry`;
+  const store = await createRedisRoomStore(REDIS_URL, { namespace });
+  const redis = await connect();
+
+  try {
+    const room = await store.createRoom({
+      code: "NOBODY",
+      joinToken: "join-token-123456",
+      createdAt: 1,
+    });
+    const expiring = await store.updateRoom(room.code, room.version, {
+      expiresAt: 10,
+      lastActiveAt: 2,
+    });
+    assert.equal(expiring.ok, true);
+
+    // The body disappears while the expiry index still lists the code.
+    await redis.del(`${namespace}:room:NOBODY`);
+
+    // Reporting it is what gets its runtime state collected. Staying silent
+    // stranded that state, and since a code is only handed out once nothing
+    // remains under it, the code stopped being allocatable altogether.
+    assert.deepEqual(await store.deleteExpiredRooms(10), ["NOBODY"]);
+    assert.equal(await redis.zscore(roomsKey, "NOBODY"), null);
+  } finally {
+    await redis.del(roomsKey);
+    await redis.quit();
+    await store.close();
+  }
+});

--- a/server/test/redis-room-store.test.ts
+++ b/server/test/redis-room-store.test.ts
@@ -121,7 +121,7 @@ test("redis room reaper deletes expired rooms and drops their membership", async
     });
     assert.equal(expiring.ok, true);
 
-    assert.equal(await store.deleteExpiredRooms(10), 1);
+    assert.equal((await store.deleteExpiredRooms(10)).length, 1);
     assert.equal(await store.getRoom(room.code), null);
     assert.equal(await redis.zscore(roomsKey, room.code), null);
     assert.equal(await store.countRooms({ includeExpired: true }), 0);
@@ -153,7 +153,7 @@ test("redis room reaper rescores rather than deletes a room whose expiry was cle
     // it up as a candidate and must repair it instead of deleting the room.
     await redis.zadd(roomsKey, "10", room.code);
 
-    assert.equal(await store.deleteExpiredRooms(10), 0);
+    assert.equal((await store.deleteExpiredRooms(10)).length, 0);
     assert.ok(await store.getRoom(room.code));
     assert.equal(await redis.zscore(roomsKey, room.code), "inf");
   } finally {
@@ -197,7 +197,7 @@ test("redis room store migrates a database that predates the sorted set", async 
     assert.equal(await redis.zscore(roomsKey, "OLDTWO"), "70");
     assert.equal(await store.countRooms({ includeExpired: true }), 2);
     assert.equal(await store.countRooms({ includeExpired: false }), 1);
-    assert.equal(await store.deleteExpiredRooms(100), 1);
+    assert.equal((await store.deleteExpiredRooms(100)).length, 1);
   } finally {
     await redis.del(
       `${namespace}:room:OLDONE`,
@@ -719,7 +719,7 @@ test("redis room reaper waits for the migration pass before its first sweep", as
     );
 
     store = await createRedisRoomStore(REDIS_URL, { namespace });
-    assert.equal(await store.deleteExpiredRooms(100), 1);
+    assert.equal((await store.deleteExpiredRooms(100)).length, 1);
     assert.equal(await redis.exists(`${namespace}:room:NOREAD`), 0);
     assert.equal(await redis.zscore(roomsKey, "NOREAD"), null);
   } finally {
@@ -747,7 +747,7 @@ test("redis room reaper does not reconcile again after the migration pass", asyn
       now: () => clock,
     });
     // Settle the migration pass first, so what follows can only be a later one.
-    assert.equal(await store.deleteExpiredRooms(100), 0);
+    assert.equal((await store.deleteExpiredRooms(100)).length, 0);
 
     // Written straight to Redis afterwards, exactly as a node on an older
     // build would: expired, but with no membership for the reaper's range
@@ -762,12 +762,12 @@ test("redis room reaper does not reconcile again after the migration pass", asyn
     // Well past the interval the pass used to be re-triggered on, so a tick
     // that still reconciled would be free to do so here.
     clock += 900_000 * 4;
-    assert.equal(await store.deleteExpiredRooms(100), 0);
+    assert.equal((await store.deleteExpiredRooms(100)).length, 0);
     assert.equal(await redis.exists(`${namespace}:room:LATEBD`), 1);
 
     // The reconciler's timer is what collects it, one tick later.
     await store.reconcileRoomIndex();
-    assert.equal(await store.deleteExpiredRooms(100), 1);
+    assert.equal((await store.deleteExpiredRooms(100)).length, 1);
     assert.equal(await redis.exists(`${namespace}:room:LATEBD`), 0);
   } finally {
     await redis.del(`${namespace}:room:LATEBD`, roomsKey);
@@ -849,7 +849,7 @@ test("redis room store keeps working when one room body is corrupt", async (t) =
       rooms.map((listed) => listed.code),
       ["GOODEX"],
     );
-    assert.equal(await store.deleteExpiredRooms(100), 1);
+    assert.equal((await store.deleteExpiredRooms(100)).length, 1);
     assert.equal(await redis.exists(`${namespace}:room:GOODEX`), 0);
 
     // The corrupt body is left alone rather than silently dropped.
@@ -934,7 +934,7 @@ test("redis room store skips bodies whose fields are the wrong shape", async (t)
       rooms.map((listed) => listed.code),
       ["GOODEX"],
     );
-    assert.equal(await store.deleteExpiredRooms(100), 1);
+    assert.equal((await store.deleteExpiredRooms(100)).length, 1);
     assert.equal(await redis.exists(`${namespace}:room:GOODEX`), 0);
 
     // The unusable bodies are left alone, not silently destroyed.
@@ -987,7 +987,7 @@ test("redis room reaper survives a body corrupted into a JSON scalar", async (t)
     );
     await redis.zadd(roomsKey, "20", "VICTIM");
 
-    assert.equal(await store.deleteExpiredRooms(100), 1);
+    assert.equal((await store.deleteExpiredRooms(100)).length, 1);
     assert.equal(await redis.exists(`${namespace}:room:VICTIM`), 0);
     // The scalar body is left alone rather than deleted on a guess.
     assert.equal(await redis.exists(`${namespace}:room:SCALAR`), 1);
@@ -1110,7 +1110,7 @@ test("redis room store isolates a room key of the wrong type", async (t) => {
     assert.equal(await redis.zscore(roomsKey, doomed.code), null);
 
     // The genuinely expired room is still collected.
-    assert.equal(await store.deleteExpiredRooms(100), 1);
+    assert.equal((await store.deleteExpiredRooms(100)).length, 1);
     assert.equal(await redis.exists(`${namespace}:room:EXPIRE`), 0);
     // The wrong-type key itself is left alone rather than destroyed.
     assert.equal(await redis.exists(`${namespace}:room:WRONGT`), 1);
@@ -1169,7 +1169,7 @@ test("redis room reaper survives a candidate whose key turns the wrong type", as
 
     // Without the guard the script raises on the first candidate and the room
     // ordered after it is never collected.
-    assert.equal(await store.deleteExpiredRooms(100), 1);
+    assert.equal((await store.deleteExpiredRooms(100)).length, 1);
     assert.equal(await redis.exists(`${namespace}:room:REAPME`), 0);
     assert.equal(await redis.zscore(roomsKey, doomed.code), null);
     assert.equal(await redis.exists(`${namespace}:room:BADKEY`), 1);

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -1065,3 +1065,90 @@ test("redis runtime store starts the retention clock for bindings cleared at sta
     await observer.close();
   }
 });
+
+test("redis runtime store prunes a large expired identity set without wedging the room", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  let currentTime = 1_000;
+  const store = await createRedisRuntimeStore(REDIS_URL, {
+    keyPrefix,
+    now: () => currentTime,
+    memberTokenRetentionMs: 1,
+  });
+
+  try {
+    // Past what `unpack` tolerates in one go — measured against this Redis, the
+    // unbounded form starts failing with "too many results to unpack" somewhere
+    // between 7500 and 8000. The error aborted the script before the zset was
+    // trimmed, so every later access re-ran the same doomed script and the room
+    // could never be joined again.
+    const memberCount = 8_500;
+    for (let index = 0; index < memberCount; index += 1) {
+      const session = createSession(`session-bulk-${index}`);
+      session.memberId = `member-bulk-${index}`;
+      session.memberToken = `token-bulk-${index}`;
+      store.addMember("ROOMBK", session.memberId, session, session.memberToken);
+      store.removeMember("ROOMBK", session.memberId, session);
+      // Drain periodically: this store caps how many writes may be in flight.
+      if (index % 100 === 99) {
+        await store.flush?.();
+      }
+    }
+    await store.flush?.();
+
+    currentTime += 1_000;
+    // Must not throw, and must actually resolve — a wedged script fails here.
+    assert.equal(
+      await store.findMemberIdByToken("ROOMBK", "token-bulk-0"),
+      null,
+    );
+    assert.equal(
+      await store.findMemberIdByToken(
+        "ROOMBK",
+        `token-bulk-${memberCount - 1}`,
+      ),
+      null,
+    );
+
+    // A fresh member can still join the room afterwards.
+    const rejoin = createSession("session-bulk-after");
+    rejoin.memberId = "member-bulk-after";
+    rejoin.memberToken = "token-bulk-after";
+    store.addMember("ROOMBK", rejoin.memberId, rejoin, rejoin.memberToken);
+    await store.flush?.();
+    assert.equal(
+      await store.findMemberIdByToken("ROOMBK", "token-bulk-after"),
+      "member-bulk-after",
+    );
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store surfaces a failed room teardown to the caller", async () => {
+  // The persisted room is deleted in the same breath, after which nothing will
+  // ever name this room code again — a silent failure strands the runtime keys.
+  const fakeRedis = {
+    ...createFakeRedisClient([Promise.reject(new Error("redis unavailable"))]),
+    async zrange() {
+      return [];
+    },
+  };
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:teardown:",
+    redisClient: fakeRedis,
+  });
+
+  try {
+    await assert.rejects(
+      Promise.resolve(store.deleteRoom("ROOMTD")),
+      /redis unavailable/,
+    );
+  } finally {
+    await store.close();
+  }
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -77,7 +77,10 @@ function createFakeRedisClient(execPromises: Promise<unknown>[]) {
         hdel() {
           return this;
         },
-        persist() {
+        zadd() {
+          return this;
+        },
+        zrem() {
           return this;
         },
         exec() {
@@ -96,12 +99,6 @@ function createFakeRedisClient(execPromises: Promise<unknown>[]) {
     },
     async scard() {
       return 0;
-    },
-    async pexpire() {
-      return 1;
-    },
-    async persist() {
-      return 1;
     },
     async sadd() {
       return null;
@@ -609,7 +606,7 @@ test("redis runtime store counts a timed-out operation failure only once", async
   }
 });
 
-test("redis runtime store bounds member token retention to the emptied room", async (t) => {
+test("redis runtime store bounds how long a disconnected identity survives", async (t) => {
   if (!REDIS_URL) {
     t.skip("REDIS_URL is not configured.");
     return;
@@ -632,8 +629,8 @@ test("redis runtime store bounds member token retention to the emptied room", as
     store.addMember("ROOMRT", session.memberId, session, session.memberToken);
     await store.flush?.();
 
-    // Still connected: no clock at all, so a room that stays busy for days
-    // never loses the identities of the people in it.
+    // Still connected: no clock at all, so someone who never leaves keeps their
+    // identity however long the session lasts.
     await new Promise((resolve) => setTimeout(resolve, 200));
     assert.equal(
       await store.findMemberIdByToken("ROOMRT", "token-retention"),
@@ -650,8 +647,8 @@ test("redis runtime store bounds member token retention to the emptied room", as
       "member-retention",
     );
 
-    // ...but not indefinitely: nothing else would ever collect it once the room
-    // is left to expire untouched.
+    // ...but not indefinitely, and this no longer waits on the room emptying:
+    // retention is per identity, so it runs out even in a room that stays busy.
     await new Promise((resolve) => setTimeout(resolve, 200));
     assert.equal(
       await store.findMemberIdByToken("ROOMRT", "token-retention"),
@@ -662,7 +659,7 @@ test("redis runtime store bounds member token retention to the emptied room", as
   }
 });
 
-test("redis runtime store lifts member token retention when someone reconnects", async (t) => {
+test("redis runtime store lifts the retention clock when someone reconnects", async (t) => {
   if (!REDIS_URL) {
     t.skip("REDIS_URL is not configured.");
     return;
@@ -716,11 +713,10 @@ test("redis runtime store lifts member token retention when someone reconnects",
 });
 
 test("redis runtime store empties a room in a single atomic step", async () => {
-  // The emptiness check and the two writes it authorises must be ONE command.
-  // Read-then-write from the client let a reconnect land in between: `SCARD`
-  // saw zero, the returning client's join + `addMember` (including its
-  // `PERSIST`) ran, and only then did the cleanup drop a now-active room from
-  // the index and re-arm a TTL on the tokens of members who were back.
+  // The emptiness check and the write it authorises must be ONE command. Read-
+  // then-write from the client let a whole reconnect land in between: `SCARD`
+  // saw zero, the returning client's join + `addMember` ran, and only then did
+  // the cleanup drop a now-active room from the index.
   const evalCalls: Array<{ script: string; args: Array<string | number> }> = [];
   const forbidden: string[] = [];
   const fakeRedis = {
@@ -761,10 +757,11 @@ test("redis runtime store empties a room in a single atomic step", async () => {
 
     const cleanup = evalCalls.find((call) => call.script.includes("SCARD"));
     assert.ok(cleanup, "the empty-room cleanup must run as a script");
-    // Same script also does the two writes, so nothing can interleave with the
-    // decision it just made.
+    // Same script also does the write, so nothing can interleave with the
+    // decision it just made, and it consults BOTH indexes: a join writes the
+    // member binding before the session index.
+    assert.ok(cleanup.script.includes("HLEN"));
     assert.ok(cleanup.script.includes("SREM"));
-    assert.ok(cleanup.script.includes("PEXPIRE"));
     assert.deepEqual(forbidden, []);
   } finally {
     await store.close();
@@ -913,6 +910,56 @@ test("redis runtime store surfaces a failed member token revocation to the calle
     await assert.rejects(
       Promise.resolve(store.revokeMemberToken("ROOMRV", "member-rv")),
       /redis unavailable/,
+    );
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store releases a departed visitor from a room that never empties", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  const store = await createRedisRuntimeStore(REDIS_URL, {
+    keyPrefix,
+    memberTokenRetentionMs: 120,
+  });
+  const host = createSession("session-host");
+  host.memberId = "member-host";
+  host.memberToken = "token-host";
+  const visitor = createSession("session-visitor");
+  visitor.memberId = "member-visitor";
+  visitor.memberToken = "token-visitor";
+
+  try {
+    // The host never leaves, so the room is never empty and a room-scoped clock
+    // would never start. A public room with a steady trickle of visitors then
+    // accumulates one token per visitor, forever.
+    store.registerSession(host);
+    store.markSessionJoinedRoom(host.id, "ROOMBZ");
+    store.addMember("ROOMBZ", host.memberId, host, host.memberToken);
+    store.registerSession(visitor);
+    store.markSessionJoinedRoom(visitor.id, "ROOMBZ");
+    store.addMember("ROOMBZ", visitor.memberId, visitor, visitor.memberToken);
+    await store.flush?.();
+
+    store.removeMember("ROOMBZ", visitor.memberId, visitor);
+    store.markSessionLeftRoom(visitor.id, "ROOMBZ");
+    await store.flush?.();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    assert.equal(
+      await store.findMemberIdByToken("ROOMBZ", "token-visitor"),
+      null,
+      "the visitor's identity must be released even though the room stayed busy",
+    );
+    // The host is still connected, so their identity is untouched.
+    assert.equal(
+      await store.findMemberIdByToken("ROOMBZ", "token-host"),
+      "member-host",
     );
   } finally {
     await store.close();

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Redis } from "ioredis";
 import { createRedisRuntimeStore } from "../src/redis-runtime-store.js";
 import type { AttachedSession, Session } from "../src/types.js";
 
@@ -1305,6 +1306,112 @@ test("redis runtime store declines a teardown decided against an older room gene
       await store.findMemberIdByToken("ROOMGN", "token-gen-new"),
       null,
     );
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store does not register a retention entry for a member with no token", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  const store = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const observer = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const redis = new Redis(REDIS_URL);
+  const session = createSession("session-kicked");
+  session.memberId = "member-kicked";
+  session.memberToken = "token-kicked";
+
+  try {
+    store.addMember("ROOMKX", session.memberId, session, session.memberToken);
+    await store.flush?.();
+
+    // The kick takes the token and its retention entry away...
+    await store.evictMemberToken(
+      "ROOMKX",
+      "member-kicked",
+      "token-kicked",
+      Date.now() + 60_000,
+    );
+    await store.flush?.();
+
+    // ...and the socket close arrives afterwards, as it always does.
+    store.removeMember("ROOMKX", session.memberId, session);
+    await store.flush?.();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    // Registering a retention entry here would leave one with no token behind
+    // it, and the prune is lazy — nothing collects it once the room goes quiet.
+    assert.equal(
+      await redis.zscore(
+        `${keyPrefix}room:ROOMKX:member-token-expiry`,
+        "member-kicked",
+      ),
+      null,
+    );
+    assert.equal(
+      await observer.findMemberIdByToken("ROOMKX", "token-kicked"),
+      null,
+    );
+  } finally {
+    await redis.quit();
+    await store.close();
+    await observer.close();
+  }
+});
+
+test("redis runtime store waits for the real result of an awaited write", async () => {
+  // The pending-operation timeout rejects without cancelling the command, so a
+  // write that merely ran slow still landed — after its caller had been told it
+  // failed. A kick reported `block_failed` while the shared store went on to
+  // block and revoke the member anyway.
+  let settleEval!: () => void;
+  const evalGate = new Promise<void>((resolve) => {
+    settleEval = resolve;
+  });
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async eval() {
+      await evalGate;
+      return 1;
+    },
+  };
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:slow-evict:",
+    redisClient: fakeRedis,
+    pendingOperationTimeoutMs: 20,
+  });
+
+  try {
+    const eviction = store.evictMemberToken(
+      "ROOMSL",
+      "member-slow",
+      "token-slow",
+      Date.now() + 60_000,
+    );
+    let settledEarly = false;
+    void Promise.resolve(eviction).then(
+      () => {
+        settledEarly = true;
+      },
+      () => {
+        settledEarly = true;
+      },
+    );
+
+    // Well past the timeout the wrapper used to reject on.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    assert.equal(
+      settledEarly,
+      false,
+      "an awaited write must not report an outcome the store does not have yet",
+    );
+
+    settleEval();
+    await eviction;
   } finally {
     await store.close();
   }

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -77,6 +77,9 @@ function createFakeRedisClient(execPromises: Promise<unknown>[]) {
         hdel() {
           return this;
         },
+        persist() {
+          return this;
+        },
         exec() {
           return execPromise;
         },
@@ -93,6 +96,12 @@ function createFakeRedisClient(execPromises: Promise<unknown>[]) {
     },
     async scard() {
       return 0;
+    },
+    async pexpire() {
+      return 1;
+    },
+    async persist() {
+      return 1;
     },
     async sadd() {
       return null;
@@ -309,6 +318,61 @@ test("redis runtime store can purge stale sessions for a restarted instance", as
     assert.deepEqual(await observer.listClusterSessionsByRoom("ROOMRS"), []);
     const room = await observer.getRoom("ROOMRS");
     assert.equal(room?.members.size ?? 0, 0);
+    // The purge clears the stale session→member binding, but must NOT revoke
+    // identity: it runs at startup, immediately before those same clients
+    // reconnect, and dropping their tokens is what reissued every member a new
+    // memberId after each restart (#234).
+    assert.equal(room?.memberTokens.get("member-restart"), "token-restart");
+    assert.equal(
+      await observer.findMemberIdByToken("ROOMRS", "token-restart"),
+      "member-restart",
+    );
+  } finally {
+    await store.close();
+    await observer.close();
+  }
+});
+
+test("redis runtime store keeps the member token when only presence is dropped", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  const store = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const observer = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const session = createSession("session-presence");
+  session.memberId = "member-presence";
+  session.memberToken = "token-presence";
+
+  try {
+    store.registerSession(session);
+    store.markSessionJoinedRoom(session.id, "ROOMPR");
+    store.addMember("ROOMPR", session.memberId, session, session.memberToken);
+    await store.flush?.();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    // A disconnect: presence goes, identity stays, so the reconnect can reclaim
+    // the same memberId.
+    store.removeMember("ROOMPR", session.memberId, session);
+    await store.flush?.();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    assert.equal(
+      await observer.findMemberIdByToken("ROOMPR", "token-presence"),
+      "member-presence",
+    );
+
+    // An explicit leave / kick: identity goes too.
+    store.revokeMemberToken("ROOMPR", session.memberId);
+    await store.flush?.();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    assert.equal(
+      await observer.findMemberIdByToken("ROOMPR", "token-presence"),
+      null,
+    );
   } finally {
     await store.close();
     await observer.close();
@@ -540,6 +604,168 @@ test("redis runtime store counts a timed-out operation failure only once", async
     await store.flush?.();
 
     assert.deepEqual(failureOperations, ["register_session"]);
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store bounds member token retention to the emptied room", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  // A retention short enough to observe. Production derives it from
+  // `emptyRoomTtlMs` so tokens outlive the room, never the reverse.
+  const store = await createRedisRuntimeStore(REDIS_URL, {
+    keyPrefix,
+    memberTokenRetentionMs: 120,
+  });
+  const session = createSession("session-retention");
+  session.memberId = "member-retention";
+  session.memberToken = "token-retention";
+
+  try {
+    store.registerSession(session);
+    store.markSessionJoinedRoom(session.id, "ROOMRT");
+    store.addMember("ROOMRT", session.memberId, session, session.memberToken);
+    await store.flush?.();
+
+    // Still connected: no clock at all, so a room that stays busy for days
+    // never loses the identities of the people in it.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    assert.equal(
+      await store.findMemberIdByToken("ROOMRT", "token-retention"),
+      "member-retention",
+    );
+
+    // The last session goes. Identity outlives the disconnect...
+    store.removeMember("ROOMRT", session.memberId, session);
+    store.unregisterSession(session.id);
+    await store.flush?.();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.equal(
+      await store.findMemberIdByToken("ROOMRT", "token-retention"),
+      "member-retention",
+    );
+
+    // ...but not indefinitely: nothing else would ever collect it once the room
+    // is left to expire untouched.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    assert.equal(
+      await store.findMemberIdByToken("ROOMRT", "token-retention"),
+      null,
+    );
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store lifts member token retention when someone reconnects", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  const store = await createRedisRuntimeStore(REDIS_URL, {
+    keyPrefix,
+    memberTokenRetentionMs: 150,
+  });
+  // A second instance stands in for another node: its local mirror is empty, so
+  // it can only answer from Redis. Asking `store` itself would be answered from
+  // the copy `addMember` just put back in its own map, which is exactly the
+  // reading that cannot tell whether Redis still holds the token.
+  const observer = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const session = createSession("session-relift");
+  session.memberId = "member-relift";
+  session.memberToken = "token-relift";
+
+  try {
+    store.registerSession(session);
+    store.markSessionJoinedRoom(session.id, "ROOMRL");
+    store.addMember("ROOMRL", session.memberId, session, session.memberToken);
+    await store.flush?.();
+
+    store.removeMember("ROOMRL", session.memberId, session);
+    store.unregisterSession(session.id);
+    await store.flush?.();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    // Reconnect inside the window: the clock must be lifted, not merely
+    // restarted, or a room that keeps churning members would eventually drop
+    // identities while people are still in it.
+    const reconnected = createSession("session-relift-2");
+    reconnected.memberId = "member-relift";
+    reconnected.memberToken = "token-relift";
+    store.registerSession(reconnected);
+    store.markSessionJoinedRoom(reconnected.id, "ROOMRL");
+    store.addMember("ROOMRL", "member-relift", reconnected, "token-relift");
+    await store.flush?.();
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    assert.equal(
+      await observer.findMemberIdByToken("ROOMRL", "token-relift"),
+      "member-relift",
+    );
+  } finally {
+    await store.close();
+    await observer.close();
+  }
+});
+
+test("redis runtime store empties a room in a single atomic step", async () => {
+  // The emptiness check and the two writes it authorises must be ONE command.
+  // Read-then-write from the client let a reconnect land in between: `SCARD`
+  // saw zero, the returning client's join + `addMember` (including its
+  // `PERSIST`) ran, and only then did the cleanup drop a now-active room from
+  // the index and re-arm a TTL on the tokens of members who were back.
+  const evalCalls: Array<{ script: string; args: Array<string | number> }> = [];
+  const forbidden: string[] = [];
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async scard() {
+      forbidden.push("scard");
+      return 0;
+    },
+    async srem() {
+      forbidden.push("srem");
+      return null;
+    },
+    async pexpire() {
+      forbidden.push("pexpire");
+      return 1;
+    },
+    async hgetall() {
+      return { id: "session-atomic", roomCode: "ROOMAT" };
+    },
+    async eval(
+      script: string,
+      _numKeys: number,
+      ...args: Array<string | number>
+    ) {
+      evalCalls.push({ script, args });
+      return 1;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:atomic:",
+    redisClient: fakeRedis,
+  });
+
+  try {
+    store.markSessionLeftRoom("session-atomic", "ROOMAT");
+    await store.flush?.();
+
+    const cleanup = evalCalls.find((call) => call.script.includes("SCARD"));
+    assert.ok(cleanup, "the empty-room cleanup must run as a script");
+    // Same script also does the two writes, so nothing can interleave with the
+    // decision it just made.
+    assert.ok(cleanup.script.includes("SREM"));
+    assert.ok(cleanup.script.includes("PEXPIRE"));
+    assert.deepEqual(forbidden, []);
   } finally {
     await store.close();
   }

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -1152,3 +1152,98 @@ test("redis runtime store surfaces a failed room teardown to the caller", async 
     await store.close();
   }
 });
+
+test("redis runtime store commits the block and the revoke of a kick together", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  const currentTime = 1_000;
+  const store = await createRedisRuntimeStore(REDIS_URL, {
+    keyPrefix,
+    now: () => currentTime,
+  });
+  const observer = await createRedisRuntimeStore(REDIS_URL, {
+    keyPrefix,
+    now: () => currentTime,
+  });
+  const session = createSession("session-evict");
+  session.memberId = "member-evict";
+  session.memberToken = "token-evict";
+
+  try {
+    store.addMember("ROOMEV", session.memberId, session, session.memberToken);
+    await store.flush?.();
+
+    // One commit. As two independent writes, a block that landed could not be
+    // rolled back when the revoke then failed: the admin saw the kick fail while
+    // the member kept working until their next reconnect, which was refused.
+    await store.evictMemberToken(
+      "ROOMEV",
+      "member-evict",
+      "token-evict",
+      currentTime + 60_000,
+    );
+    await store.flush?.();
+
+    assert.equal(
+      await observer.isMemberTokenBlocked("ROOMEV", "token-evict", currentTime),
+      true,
+    );
+    assert.equal(
+      await observer.findMemberIdByToken("ROOMEV", "token-evict"),
+      null,
+    );
+  } finally {
+    await store.close();
+    await observer.close();
+  }
+});
+
+test("redis runtime store leaves a kick entirely unapplied when it fails", async () => {
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async eval() {
+      throw new Error("redis unavailable");
+    },
+  };
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:evict-fail:",
+    redisClient: fakeRedis,
+  });
+  const session = createSession("session-evict-fail");
+  session.memberId = "member-evict-fail";
+  session.memberToken = "token-evict-fail";
+
+  try {
+    store.addMember("ROOMEF", session.memberId, session, session.memberToken);
+    await store.flush?.();
+
+    await assert.rejects(
+      Promise.resolve(
+        store.evictMemberToken(
+          "ROOMEF",
+          "member-evict-fail",
+          "token-evict-fail",
+          // A real future instant: the local block store prunes by wall clock,
+          // so a small absolute number would read as already expired and the
+          // assertion below could not tell a stray block from none.
+          Date.now() + 60_000,
+        ),
+      ),
+      /redis unavailable/,
+    );
+
+    // Neither half applied locally either — no block left behind for a kick the
+    // admin was told had failed.
+    assert.equal(
+      await store.isMemberTokenBlocked("ROOMEF", "token-evict-fail"),
+      false,
+    );
+  } finally {
+    await store.flush?.();
+    await store.close();
+  }
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -127,6 +127,9 @@ function createFakeRedisClient(execPromises: Promise<unknown>[]) {
     async del() {
       return null;
     },
+    async get() {
+      return null;
+    },
     // 仅用于 releaseRoomLock 的 CAS 脚本;这些用例不走锁路径,返回 null 表示未释放。
     async eval() {
       return null;
@@ -1133,9 +1136,13 @@ test("redis runtime store surfaces a failed room teardown to the caller", async 
   // The persisted room is deleted in the same breath, after which nothing will
   // ever name this room code again — a silent failure strands the runtime keys.
   const fakeRedis = {
-    ...createFakeRedisClient([Promise.reject(new Error("redis unavailable"))]),
+    ...createFakeRedisClient([]),
     async zrange() {
       return [];
+    },
+    // The teardown is one conditional script now, so that is what has to fail.
+    async eval() {
+      throw new Error("redis unavailable");
     },
   };
   const store = await createRedisRuntimeStore("redis://unused", {
@@ -1244,6 +1251,61 @@ test("redis runtime store leaves a kick entirely unapplied when it fails", async
     );
   } finally {
     await store.flush?.();
+    await store.close();
+  }
+});
+
+test("redis runtime store declines a teardown decided against an older room generation", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  const store = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const previous = createSession("session-gen-old");
+  previous.memberId = "member-gen-old";
+  previous.memberToken = "token-gen-old";
+  const current = createSession("session-gen-new");
+  current.memberId = "member-gen-new";
+  current.memberToken = "token-gen-new";
+
+  try {
+    await store.markRoomGeneration("ROOMGN", "generation-1");
+    store.addMember(
+      "ROOMGN",
+      previous.memberId,
+      previous,
+      previous.memberToken,
+    );
+    await store.flush?.();
+
+    // A teardown is decided against the room as it stands now.
+    const decidedAgainst = await store.getRoomGeneration("ROOMGN");
+    assert.equal(decidedAgainst, "generation-1");
+
+    // Before it runs, the code comes back into use as a different room.
+    await store.markRoomGeneration("ROOMGN", "generation-2");
+    store.addMember("ROOMGN", current.memberId, current, current.memberToken);
+    await store.flush?.();
+
+    await store.deleteRoom("ROOMGN", decidedAgainst);
+    await store.flush?.();
+
+    // The stale teardown must not take the new room's state with it.
+    assert.equal(
+      await store.findMemberIdByToken("ROOMGN", "token-gen-new"),
+      "member-gen-new",
+    );
+
+    // A teardown decided against the CURRENT generation still works.
+    await store.deleteRoom("ROOMGN", "generation-2");
+    await store.flush?.();
+    assert.equal(
+      await store.findMemberIdByToken("ROOMGN", "token-gen-new"),
+      null,
+    );
+  } finally {
     await store.close();
   }
 });

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -1416,3 +1416,92 @@ test("redis runtime store waits for the real result of an awaited write", async 
     await store.close();
   }
 });
+
+test("redis runtime store does not register a retention entry during startup purge without a token", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  const store = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const redis = new Redis(REDIS_URL);
+  const session = createSession("session-crash-kicked");
+  session.instanceId = "crashed-node";
+  session.memberId = "member-crash-kicked";
+  session.memberToken = "token-crash-kicked";
+
+  try {
+    store.registerSession(session);
+    store.markSessionJoinedRoom(session.id, "ROOMCK");
+    store.addMember("ROOMCK", session.memberId, session, session.memberToken);
+    await store.flush?.();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    // Kicked, then the process died before the socket close ran — so the member
+    // binding is still there for the startup purge to find.
+    await store.evictMemberToken(
+      "ROOMCK",
+      "member-crash-kicked",
+      "token-crash-kicked",
+      Date.now() + 60_000,
+    );
+    await store.flush?.();
+
+    assert.equal(await store.purgeSessionsByInstance?.("crashed-node"), 1);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    // The identity is gone, so there is nothing to put on a clock. Registering
+    // one anyway leaves an entry the lazy prune never reaches once the room goes
+    // quiet — the same defect the ordinary remove path had.
+    assert.equal(
+      await redis.zscore(
+        `${keyPrefix}room:ROOMCK:member-token-expiry`,
+        "member-crash-kicked",
+      ),
+      null,
+    );
+  } finally {
+    await redis.quit();
+    await store.close();
+  }
+});
+
+test("redis runtime store treats leftover session keys as residue on a room code", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  const store = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const session = createSession("session-residue");
+
+  try {
+    assert.equal(await store.hasRoomResidue("ROOMRS"), false);
+
+    store.registerSession(session);
+    store.markSessionJoinedRoom(session.id, "ROOMRS");
+    await store.flush?.();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    // No members and no member tokens: the members/tokens view `getRoom` offers
+    // reads as empty, which is what used to gate room code allocation.
+    assert.equal((await store.getRoom("ROOMRS"))?.members.size ?? 0, 0);
+    assert.equal(await store.hasRoomResidue("ROOMRS"), true);
+
+    // A generation on its own is not residue: a new room overwrites it, and
+    // counting it would mean only a successful teardown ever frees a code.
+    const clean = await createRedisRuntimeStore(REDIS_URL, {
+      keyPrefix: `${keyPrefix}gen:`,
+    });
+    try {
+      await clean.markRoomGeneration("ROOMGO", "generation-1");
+      assert.equal(await clean.hasRoomResidue("ROOMGO"), false);
+    } finally {
+      await clean.close();
+    }
+  } finally {
+    await store.close();
+  }
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -1505,3 +1505,42 @@ test("redis runtime store treats leftover session keys as residue on a room code
     await store.close();
   }
 });
+
+test("redis runtime store stops reserving a code whose blocked and dedup entries have lapsed", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  let currentTime = 1_000;
+  const store = await createRedisRuntimeStore(REDIS_URL, {
+    keyPrefix,
+    now: () => currentTime,
+  });
+
+  try {
+    store.evictMemberToken(
+      "ROOMLP",
+      "member-lapsed",
+      "token-lapsed",
+      currentTime + 60_000,
+    );
+    await store.tryClaimMessageSlot(
+      "ROOMLP",
+      "dedup-lapsed",
+      currentTime + 30_000,
+    );
+    await store.flush?.();
+    assert.equal(await store.hasRoomResidue("ROOMLP"), true);
+
+    currentTime += 3_600_000;
+
+    // Redis does not drop zset members when their score passes, and the lazy
+    // sweeps that normally do it are only reached through a room that no longer
+    // exists — so without trimming here the code stayed reserved forever.
+    assert.equal(await store.hasRoomResidue("ROOMLP"), false);
+  } finally {
+    await store.close();
+  }
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -965,3 +965,103 @@ test("redis runtime store releases a departed visitor from a room that never emp
     await store.close();
   }
 });
+
+test("redis runtime store leaves the local mirror untouched when a revoke fails", async () => {
+  // Durable-first. Mirroring before the shared write landed left a partial
+  // apply: the caller saw a rejection while this node had already dropped the
+  // token, so the member stayed connected holding one nothing would accept.
+  let failEval = false;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async eval() {
+      if (failEval) {
+        throw new Error("redis unavailable");
+      }
+      return 0;
+    },
+    async hgetall() {
+      return {};
+    },
+  };
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:partial:",
+    redisClient: fakeRedis,
+  });
+  const session = createSession("session-partial");
+  session.memberId = "member-partial";
+  session.memberToken = "token-partial";
+
+  try {
+    store.addMember("ROOMPT", "member-partial", session, "token-partial");
+    await store.flush?.();
+
+    failEval = true;
+    await assert.rejects(
+      Promise.resolve(store.revokeMemberToken("ROOMPT", "member-partial")),
+      /redis unavailable/,
+    );
+
+    // Nothing changed on this node either: no half-revoked identity to clean up.
+    // (Redis is empty in this fake, so `getRoom` falls back to the local mirror,
+    // which is exactly the state under test.)
+    failEval = false;
+    const room = await store.getRoom("ROOMPT");
+    assert.equal(room?.memberTokens.get("member-partial"), "token-partial");
+  } finally {
+    await store.flush?.();
+    await store.close();
+  }
+});
+
+test("redis runtime store starts the retention clock for bindings cleared at startup", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  let currentTime = 1_000;
+  const store = await createRedisRuntimeStore(REDIS_URL, {
+    keyPrefix,
+    now: () => currentTime,
+    memberTokenRetentionMs: 5_000,
+  });
+  const observer = await createRedisRuntimeStore(REDIS_URL, {
+    keyPrefix,
+    now: () => currentTime,
+  });
+  const session = createSession("session-crashed");
+  session.instanceId = "crashed-node";
+  session.memberId = "member-crashed";
+  session.memberToken = "token-crashed";
+
+  try {
+    store.registerSession(session);
+    store.markSessionJoinedRoom(session.id, "ROOMCR");
+    store.addMember("ROOMCR", session.memberId, session, session.memberToken);
+    await store.flush?.();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    // The process crashed and came back under the same instanceId.
+    assert.equal(await store.purgeSessionsByInstance?.("crashed-node"), 1);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    // The identity survives, so the client that is about to reconnect keeps it.
+    assert.equal(
+      await observer.findMemberIdByToken("ROOMCR", "token-crashed"),
+      "member-crashed",
+    );
+
+    // But it is on the clock like any other disconnect. `removeMember` never ran
+    // for this member, so without arming it here they would keep their token
+    // forever — the room can stay alive on another node indefinitely.
+    currentTime += 5_001;
+    assert.equal(
+      await observer.findMemberIdByToken("ROOMCR", "token-crashed"),
+      null,
+    );
+  } finally {
+    await store.close();
+    await observer.close();
+  }
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -770,3 +770,151 @@ test("redis runtime store empties a room in a single atomic step", async () => {
     await store.close();
   }
 });
+
+test("redis runtime store keeps tokens while a member binding exists but the session index has not caught up", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  const store = await createRedisRuntimeStore(REDIS_URL, {
+    keyPrefix,
+    memberTokenRetentionMs: 120,
+  });
+  const observer = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const session = createSession("session-window");
+  session.memberId = "member-window";
+  session.memberToken = "token-window";
+
+  try {
+    // A join writes the member binding first and the session index only after
+    // (`onRoomJoined` → `markSessionJoinedRoom`). Reproduce exactly that window.
+    store.addMember("ROOMWD", session.memberId, session, session.memberToken);
+    await store.flush?.();
+
+    // An old connection's cleanup lands right here. The room looks session-less
+    // but is very much in use, so nothing may be put on a clock.
+    store.markSessionLeftRoom("session-window", "ROOMWD");
+    await store.flush?.();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    assert.equal(
+      await observer.findMemberIdByToken("ROOMWD", "token-window"),
+      "member-window",
+    );
+  } finally {
+    await store.close();
+    await observer.close();
+  }
+});
+
+test("redis runtime store stops resolving a token revoked on another node", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  const nodeA = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const nodeB = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const onA = createSession("session-node-a");
+  onA.memberId = "member-roaming";
+  onA.memberToken = "token-roaming";
+
+  try {
+    // The member was hosted by A, so A's local mirror holds the mapping.
+    nodeA.addMember("ROOMND", onA.memberId, onA, onA.memberToken);
+    await nodeA.flush?.();
+    assert.equal(
+      await nodeA.findMemberIdByToken("ROOMND", "token-roaming"),
+      "member-roaming",
+    );
+
+    // They reconnect onto B and then leave / are kicked there. Only B and Redis
+    // learn about it — A is never told.
+    await nodeB.revokeMemberToken("ROOMND", "member-roaming");
+    await nodeB.flush?.();
+
+    // A must not re-accept it from its own cache: that would undo an explicit
+    // leave or a kick for anyone whose next join happens to land on A.
+    assert.equal(
+      await nodeA.findMemberIdByToken("ROOMND", "token-roaming"),
+      null,
+    );
+  } finally {
+    await nodeA.close();
+    await nodeB.close();
+  }
+});
+
+test("redis runtime store declines a revoke from a session that no longer owns the member", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const keyPrefix = createKeyPrefix();
+  const store = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const oldSession = createSession("session-old");
+  oldSession.memberId = "member-shared";
+  oldSession.memberToken = "token-shared";
+  const newSession = createSession("session-new");
+  newSession.memberId = "member-shared";
+  newSession.memberToken = "token-shared";
+
+  try {
+    store.addMember("ROOMOW", "member-shared", oldSession, "token-shared");
+    await store.flush?.();
+    // The member reconnected — possibly onto another node — and the shared
+    // binding now names the new session.
+    store.addMember("ROOMOW", "member-shared", newSession, "token-shared");
+    await store.flush?.();
+
+    // The stale session leaves. It must not revoke the identity its successor
+    // is using; the old node's local view still thinks it is the member, so the
+    // decision has to be made against the shared binding.
+    await store.revokeMemberToken("ROOMOW", "member-shared", oldSession);
+    await store.flush?.();
+
+    assert.equal(
+      await store.findMemberIdByToken("ROOMOW", "token-shared"),
+      "member-shared",
+    );
+
+    // The session that does own it still can.
+    await store.revokeMemberToken("ROOMOW", "member-shared", newSession);
+    await store.flush?.();
+    assert.equal(
+      await store.findMemberIdByToken("ROOMOW", "token-shared"),
+      null,
+    );
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store surfaces a failed member token revocation to the caller", async () => {
+  // The kick awaits this and then disconnects the socket and reports success.
+  // A revoke that resolves before the write landed — or swallows its failure —
+  // reports an eviction while the old token still resolves everywhere else.
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async eval() {
+      throw new Error("redis unavailable");
+    },
+  };
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:revoke-fail:",
+    redisClient: fakeRedis,
+  });
+
+  try {
+    await assert.rejects(
+      Promise.resolve(store.revokeMemberToken("ROOMRV", "member-rv")),
+      /redis unavailable/,
+    );
+  } finally {
+    await store.close();
+  }
+});

--- a/server/test/room-reaper.test.ts
+++ b/server/test/room-reaper.test.ts
@@ -19,7 +19,10 @@ test("room reaper deletes expired rooms through the store interface", async () =
 
   const reaper = createRoomReaper({
     intervalMs: 60_000,
-    deleteExpiredRooms: store.deleteExpiredRooms,
+    // The reaper counts; the store reports which rooms died so the caller can
+    // collect their runtime state. `room-service` adapts the two in production.
+    deleteExpiredRooms: async (currentTime) =>
+      (await store.deleteExpiredRooms(currentTime)).length,
     logEvent: () => undefined,
     now: () => 10,
   });

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -2167,6 +2167,11 @@ test("room service consults shared kick blocks when rejoining through another no
 test("room service reuses shared member identity during reconnect checks", async () => {
   const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
   let resolveMemberIdCalls = 0;
+  // The shared-view fixture below stands in for another node's runtime state.
+  // It must not exist before the room does: a code is only handed out while no
+  // runtime state remains under it, so a fixture that answers unconditionally
+  // would block the room from ever being created.
+  let sharedRoomExists = false;
   const service = createRoomService({
     config: getDefaultSecurityConfig(),
     persistence: getDefaultPersistenceConfig(),
@@ -2179,11 +2184,14 @@ test("room service reuses shared member identity during reconnect checks", async
     logEvent: (() => undefined) satisfies LogEvent,
     now: () => 1_000,
     createRoomCode: () => "ROOM11",
-    resolveActiveRoom: async () => ({
-      code: "ROOM11",
-      members: new Map(),
-      memberTokens: new Map([["shared-member", "shared-token"]]),
-    }),
+    resolveActiveRoom: async () =>
+      sharedRoomExists
+        ? {
+            code: "ROOM11",
+            members: new Map(),
+            memberTokens: new Map([["shared-member", "shared-token"]]),
+          }
+        : null,
     resolveMemberIdByToken: async (_roomCode, memberToken) => {
       resolveMemberIdCalls += 1;
       return memberToken === "shared-token" ? "shared-member" : null;
@@ -2192,6 +2200,7 @@ test("room service reuses shared member identity during reconnect checks", async
 
   const owner = createSession("owner");
   const created = await service.createRoomForSession(owner, "Alice");
+  sharedRoomExists = true;
   const reconnecting = createSession("reconnect");
   const joined = await service.joinRoomForSession(
     reconnecting,
@@ -2212,6 +2221,9 @@ test("room service enforces room capacity from shared room membership", async ()
     maxMembersPerRoom: 1,
   };
   const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  // Same reason as the test above: the shared-view fixture only exists once the
+  // room does, or the allocation-time residue check would refuse the code.
+  let sharedRoomExists = false;
   const service = createRoomService({
     config,
     persistence: getDefaultPersistenceConfig(),
@@ -2224,15 +2236,19 @@ test("room service enforces room capacity from shared room membership", async ()
     logEvent: (() => undefined) satisfies LogEvent,
     now: () => 1_000,
     createRoomCode: () => "ROOM12",
-    resolveActiveRoom: async () => ({
-      code: "ROOM12",
-      members: new Map([["member-a", createSession("member-a")]]),
-      memberTokens: new Map([["member-a", "token-a"]]),
-    }),
+    resolveActiveRoom: async () =>
+      sharedRoomExists
+        ? {
+            code: "ROOM12",
+            members: new Map([["member-a", createSession("member-a")]]),
+            memberTokens: new Map([["member-a", "token-a"]]),
+          }
+        : null,
   });
 
   const owner = createSession("owner");
   const created = await service.createRoomForSession(owner, "Alice");
+  sharedRoomExists = true;
   const joiner = createSession("joiner");
 
   await assert.rejects(
@@ -4028,12 +4044,16 @@ test("retries a failed runtime teardown on the next reaper pass", async () => {
   assert.equal(activeRooms.getRoom("ROOMRT"), null);
 });
 
-test("does not tear down runtime state for a room code already recycled", async () => {
+test("does not hand out a room code that still has runtime state under it", async () => {
   let currentTime = 1_000;
   const roomStore = createInMemoryRoomStore({ now: () => currentTime });
   const activeRooms = createActiveRoomRegistry();
-  const teardowns: string[] = [];
-  let blockTeardown = true;
+  let failTeardown = true;
+  // Offers ROOMA1 again for the second room's FIRST attempt. A sequential list
+  // would hand out ROOMA2 either way, so the test could not tell whether the
+  // residue check ran at all.
+  const offeredCodes: string[] = [];
+  const codeSequence = ["ROOMA1", "ROOMA1", "ROOMA2"];
   const service = createRoomService({
     config: getDefaultSecurityConfig(),
     persistence: getDefaultPersistenceConfig(),
@@ -4041,7 +4061,76 @@ test("does not tear down runtime state for a room code already recycled", async 
     activeRooms: {
       ...activeRooms,
       deleteRoom: async (code: string) => {
-        if (blockTeardown) {
+        if (failTeardown) {
+          throw new Error("redis unavailable");
+        }
+        activeRooms.deleteRoom(code);
+      },
+    },
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => {
+      const code = codeSequence.shift() ?? "ROOMAX";
+      offeredCodes.push(code);
+      return code;
+    },
+    resolveActiveRoom: async (code) => activeRooms.getRoom(code),
+  });
+
+  const first = createSession("first-owner");
+  const created = await service.createRoomForSession(first, "Alice");
+  assert.equal(created.room.code, "ROOMA1");
+  await service.leaveRoomForSession(first, "disconnect");
+
+  currentTime += getDefaultPersistenceConfig().emptyRoomTtlMs + 1;
+  // The teardown fails, so ROOMA1 still carries the previous occupant's tokens.
+  await service.deleteExpiredRooms();
+  assert.equal(await roomStore.getRoom("ROOMA1"), null);
+  assert.ok(activeRooms.getRoom("ROOMA1"));
+
+  // A code is only safe to hand out once nothing is left under it. Reusing
+  // ROOMA1 here would let the previous occupant's token resolve to their old
+  // memberId inside the new room; enforcing it at allocation is what removes
+  // the need for a clean-slate wipe and a recycled-code guard downstream.
+  failTeardown = false;
+  const second = createSession("second-owner");
+  const recreated = await service.createRoomForSession(second, "Bob");
+  assert.equal(recreated.room.code, "ROOMA2");
+  // ROOMA1 was offered again and had to be refused before ROOMA2 was tried.
+  assert.deepEqual(offeredCodes, ["ROOMA1", "ROOMA1", "ROOMA2"]);
+  assert.equal(
+    activeRooms.findMemberIdByToken("ROOMA2", created.memberToken),
+    null,
+  );
+});
+
+test("keeps an owed teardown when the room store cannot be read", async () => {
+  let currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const activeRooms = createActiveRoomRegistry();
+  let failTeardown = true;
+  let failRoomRead = false;
+  const teardowns: string[] = [];
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore: {
+      ...roomStore,
+      getRoom: async (code: string) => {
+        if (failRoomRead) {
+          throw new Error("redis unavailable");
+        }
+        return roomStore.getRoom(code);
+      },
+    },
+    activeRooms: {
+      ...activeRooms,
+      deleteRoom: async (code: string) => {
+        if (failTeardown) {
           throw new Error("redis unavailable");
         }
         teardowns.push(code);
@@ -4054,85 +4143,28 @@ test("does not tear down runtime state for a room code already recycled", async 
     })(),
     logEvent: (() => undefined) satisfies LogEvent,
     now: () => currentTime,
-    createRoomCode: () => "ROOMRU",
+    createRoomCode: () => "ROOMRD",
+    resolveActiveRoom: async (code) => activeRooms.getRoom(code),
   });
 
-  const first = createSession("first-owner");
-  const created = await service.createRoomForSession(first, "Alice");
-  await service.leaveRoomForSession(first, "disconnect");
+  const owner = createSession("owner");
+  await service.createRoomForSession(owner, "Alice");
+  await service.leaveRoomForSession(owner, "disconnect");
   currentTime += getDefaultPersistenceConfig().emptyRoomTtlMs + 1;
-  // Teardown fails, so the code is owed a retry.
-  assert.equal(await service.deleteExpiredRooms(), 1);
-  assert.equal(await roomStore.getRoom(created.room.code), null);
-
-  // The code is handed straight back out to a new room, which registers its own
-  // member state under it.
-  blockTeardown = false;
-  const second = createSession("second-owner");
-  const recreated = await service.createRoomForSession(second, "Bob");
-  assert.equal(recreated.room.code, created.room.code);
-  teardowns.length = 0;
-
   await service.deleteExpiredRooms();
 
-  // The owed teardown must NOT fire now: it would delete the new room's member
-  // and token state, leaving its owner with a session that says joined and a
-  // runtime that disagrees.
+  // The room store is unreadable on the retry pass. "Unknown" is not "absent":
+  // treating it as absent made the guard fail in exactly the conditions that
+  // queue teardowns in the first place, and it would then wipe whatever now
+  // owns the code.
+  failRoomRead = true;
+  failTeardown = false;
+  await service.deleteExpiredRooms();
   assert.deepEqual(teardowns, []);
-  assert.equal(
-    activeRooms.findMemberIdByToken(recreated.room.code, recreated.memberToken),
-    second.memberId,
-  );
-});
+  assert.ok(activeRooms.getRoom("ROOMRD"));
 
-test("a recreated room starts with no runtime state from the previous occupant", async () => {
-  let currentTime = 1_000;
-  let failReapTeardown = true;
-  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
-  const activeRooms = createActiveRoomRegistry();
-  const service = createRoomService({
-    config: getDefaultSecurityConfig(),
-    persistence: getDefaultPersistenceConfig(),
-    roomStore,
-    activeRooms: {
-      ...activeRooms,
-      deleteRoom: async (code: string) => {
-        // The reaping teardown fails, so the previous occupant's state is still
-        // there when the code comes back around.
-        if (failReapTeardown) {
-          throw new Error("redis unavailable");
-        }
-        activeRooms.deleteRoom(code);
-      },
-    },
-    generateToken: (() => {
-      let id = 0;
-      return () => `token-${++id}`.padEnd(16, "x");
-    })(),
-    logEvent: (() => undefined) satisfies LogEvent,
-    now: () => currentTime,
-    createRoomCode: () => "ROOMRS",
-  });
-
-  const first = createSession("first-owner");
-  const created = await service.createRoomForSession(first, "Alice");
-  await service.leaveRoomForSession(first, "disconnect");
-  currentTime += getDefaultPersistenceConfig().emptyRoomTtlMs + 1;
+  // Once it can be read again the debt is settled.
+  failRoomRead = false;
   await service.deleteExpiredRooms();
-  // Redis recovers before the code is handed back out.
-  failReapTeardown = false;
-
-  const second = createSession("second-owner");
-  const recreated = await service.createRoomForSession(second, "Bob");
-
-  // Creation clears the code first, so a member of the OLD room cannot have
-  // their token resolve to their old memberId inside the new one.
-  assert.equal(
-    activeRooms.findMemberIdByToken(recreated.room.code, created.memberToken),
-    null,
-  );
-  assert.equal(
-    activeRooms.findMemberIdByToken(recreated.room.code, recreated.memberToken),
-    second.memberId,
-  );
+  assert.deepEqual(teardowns, ["ROOMRD"]);
 });

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -3915,3 +3915,49 @@ test("restores the member when revoking their identity fails on leave", async ()
     true,
   );
 });
+
+test("reaper keeps collecting rooms when one runtime teardown fails", async () => {
+  let currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const activeRooms = createActiveRoomRegistry();
+  const failedFor: string[] = [];
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...activeRooms,
+      deleteRoom: async (code: string) => {
+        if (code === "ROOMF1") {
+          failedFor.push(code);
+          throw new Error("redis unavailable");
+        }
+        activeRooms.deleteRoom(code);
+      },
+    },
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: (() => {
+      const codes = ["ROOMF1", "ROOMF2"];
+      return () => codes.shift() ?? "ROOMFX";
+    })(),
+  });
+
+  for (const name of ["Alice", "Bob"]) {
+    const owner = createSession(`owner-${name}`);
+    const created = await service.createRoomForSession(owner, name);
+    await service.leaveRoomForSession(owner, "disconnect");
+    assert.ok(created.room.code);
+  }
+
+  currentTime += getDefaultPersistenceConfig().emptyRoomTtlMs + 1;
+  // Both rooms are collected even though the first teardown throws — one
+  // failure must not strand every room queued behind it.
+  assert.equal(await service.deleteExpiredRooms(), 2);
+  assert.deepEqual(failedFor, ["ROOMF1"]);
+  assert.equal(activeRooms.getRoom("ROOMF2"), null);
+});

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -919,6 +919,146 @@ test("an explicit leave revokes the identity", async () => {
   assert.notEqual(returning.memberId, originalMemberId);
 });
 
+test("a disconnected member does not get a free seat past the room limit", async () => {
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const activeRooms = createActiveRoomRegistry();
+  const service = createRoomService({
+    config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 2 },
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => 1_000,
+    createRoomCode: () => "ROOMCP",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+
+  const guest = createSession("guest");
+  await service.joinRoomForSession(
+    guest,
+    created.room.code,
+    created.room.joinToken,
+    "Bob",
+  );
+
+  // The owner drops. Their token survives (#234) — but a token is not a seat,
+  // and the seat they vacated is immediately taken by somebody else.
+  await service.leaveRoomForSession(owner, "disconnect");
+  const late = createSession("late");
+  await service.joinRoomForSession(
+    late,
+    created.room.code,
+    created.room.joinToken,
+    "Carol",
+  );
+
+  // Room is full again. The owner coming back with a still-valid token must
+  // queue behind the limit like anyone else, not be waved through as a
+  // "reconnect" — otherwise every disconnected member is an extra seat.
+  const returning = createSession("owner-returns");
+  await assert.rejects(
+    service.joinRoomForSession(
+      returning,
+      created.room.code,
+      created.room.joinToken,
+      "Alice",
+      created.memberToken,
+    ),
+    /room is full/i,
+  );
+});
+
+test("a reconnect that still holds its seat is admitted to a full room", async () => {
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const service = createRoomService({
+    config: { ...getDefaultSecurityConfig(), maxMembersPerRoom: 2 },
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: createActiveRoomRegistry(),
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => 1_000,
+    createRoomCode: () => "ROOMSE",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  const guest = createSession("guest");
+  await service.joinRoomForSession(
+    guest,
+    created.room.code,
+    created.room.joinToken,
+    "Bob",
+  );
+
+  // Control for the test above: a session replacement (the old socket has not
+  // been cleaned up yet) still occupies its seat, so the capacity check must
+  // keep exempting it or every flapping connection would be locked out.
+  const replacement = createSession("owner-replacement");
+  const rejoined = await service.joinRoomForSession(
+    replacement,
+    created.room.code,
+    created.room.joinToken,
+    "Alice",
+    created.memberToken,
+  );
+
+  assert.equal(replacement.memberId, owner.memberId);
+  assert.equal(rejoined.room.code, created.room.code);
+});
+
+test("expiring a room collects the runtime state that outlives it", async () => {
+  let currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const activeRooms = createActiveRoomRegistry();
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOMEX",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  // Captured before leaving: the leave clears it off the session.
+  const ownerMemberId = owner.memberId;
+  await service.leaveRoomForSession(owner, "disconnect");
+
+  // Survives the disconnect, as it must.
+  assert.equal(
+    activeRooms.findMemberIdByToken(created.room.code, created.memberToken),
+    ownerMemberId,
+  );
+
+  currentTime += getDefaultPersistenceConfig().emptyRoomTtlMs + 1;
+  assert.equal(await service.deleteExpiredRooms(), 1);
+
+  // The reaper is the only path that ever deletes a room nobody touches again.
+  // If it leaves the runtime state behind, tokens pile up for every abandoned
+  // room and a recycled room code inherits the previous room's identities.
+  assert.equal(activeRooms.getRoom(created.room.code), null);
+  assert.equal(
+    activeRooms.findMemberIdByToken(created.room.code, created.memberToken),
+    null,
+  );
+});
+
 test("room service updates member display name after join", async () => {
   const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
   const service = createRoomService({

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -1210,6 +1210,9 @@ test("room service flushes pending runtime store writes before exposing updated 
     revokeMemberToken(code, memberId) {
       activeRooms.revokeMemberToken(code, memberId);
     },
+    evictMemberToken(code, memberId, memberToken, blockedUntil) {
+      activeRooms.evictMemberToken(code, memberId, memberToken, blockedUntil);
+    },
     deleteRoom(code) {
       activeRooms.deleteRoom(code);
       clusterSessionsByRoom.delete(code);
@@ -2984,6 +2987,10 @@ test("join admission restores shared previous session when reconnect rollback ha
       local.revokeMemberToken(code, memberId);
       shared.revokeMemberToken(code, memberId);
     },
+    evictMemberToken: (code, memberId, memberToken, blockedUntil) => {
+      local.evictMemberToken(code, memberId, memberToken, blockedUntil);
+      shared.evictMemberToken(code, memberId, memberToken, blockedUntil);
+    },
     flush: async () => {
       await local.flush?.();
       await shared.flush?.();
@@ -3076,6 +3083,10 @@ test("join admission does not restore stale reconnect session over newer shared 
     revokeMemberToken: (code, memberId) => {
       local.revokeMemberToken(code, memberId);
       shared.revokeMemberToken(code, memberId);
+    },
+    evictMemberToken: (code, memberId, memberToken, blockedUntil) => {
+      local.evictMemberToken(code, memberId, memberToken, blockedUntil);
+      shared.evictMemberToken(code, memberId, memberToken, blockedUntil);
     },
     flush: async () => {
       await local.flush?.();
@@ -3947,6 +3958,8 @@ test("reaper keeps collecting rooms when one runtime teardown fails", async () =
     })(),
   });
 
+  // Room creation now wipes any runtime state left under a recycled code, which
+  // also goes through the failing stub; only the reaping phase is under test.
   for (const name of ["Alice", "Bob"]) {
     const owner = createSession(`owner-${name}`);
     const created = await service.createRoomForSession(owner, name);
@@ -3954,10 +3967,172 @@ test("reaper keeps collecting rooms when one runtime teardown fails", async () =
     assert.ok(created.room.code);
   }
 
+  failedFor.length = 0;
   currentTime += getDefaultPersistenceConfig().emptyRoomTtlMs + 1;
   // Both rooms are collected even though the first teardown throws — one
   // failure must not strand every room queued behind it.
   assert.equal(await service.deleteExpiredRooms(), 2);
   assert.deepEqual(failedFor, ["ROOMF1"]);
   assert.equal(activeRooms.getRoom("ROOMF2"), null);
+});
+
+test("retries a failed runtime teardown on the next reaper pass", async () => {
+  let currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const activeRooms = createActiveRoomRegistry();
+  let failTeardown = true;
+  const teardowns: string[] = [];
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...activeRooms,
+      deleteRoom: async (code: string) => {
+        if (failTeardown) {
+          throw new Error("redis unavailable");
+        }
+        teardowns.push(code);
+        activeRooms.deleteRoom(code);
+      },
+    },
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOMRT",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  const ownerMemberId = owner.memberId;
+  await service.leaveRoomForSession(owner, "disconnect");
+
+  currentTime += getDefaultPersistenceConfig().emptyRoomTtlMs + 1;
+  assert.equal(await service.deleteExpiredRooms(), 1);
+  // The persisted room and its expiry index are already gone, so nothing else
+  // will ever name this code again — a swallowed failure strands it for good.
+  assert.equal(
+    activeRooms.findMemberIdByToken(created.room.code, created.memberToken),
+    ownerMemberId,
+  );
+
+  failTeardown = false;
+  teardowns.length = 0;
+  // A later pass finds nothing newly expired, but must still work through what
+  // it owes.
+  assert.equal(await service.deleteExpiredRooms(), 0);
+  assert.deepEqual(teardowns, ["ROOMRT"]);
+  assert.equal(activeRooms.getRoom("ROOMRT"), null);
+});
+
+test("does not tear down runtime state for a room code already recycled", async () => {
+  let currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const activeRooms = createActiveRoomRegistry();
+  const teardowns: string[] = [];
+  let blockTeardown = true;
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...activeRooms,
+      deleteRoom: async (code: string) => {
+        if (blockTeardown) {
+          throw new Error("redis unavailable");
+        }
+        teardowns.push(code);
+        activeRooms.deleteRoom(code);
+      },
+    },
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOMRU",
+  });
+
+  const first = createSession("first-owner");
+  const created = await service.createRoomForSession(first, "Alice");
+  await service.leaveRoomForSession(first, "disconnect");
+  currentTime += getDefaultPersistenceConfig().emptyRoomTtlMs + 1;
+  // Teardown fails, so the code is owed a retry.
+  assert.equal(await service.deleteExpiredRooms(), 1);
+  assert.equal(await roomStore.getRoom(created.room.code), null);
+
+  // The code is handed straight back out to a new room, which registers its own
+  // member state under it.
+  blockTeardown = false;
+  const second = createSession("second-owner");
+  const recreated = await service.createRoomForSession(second, "Bob");
+  assert.equal(recreated.room.code, created.room.code);
+  teardowns.length = 0;
+
+  await service.deleteExpiredRooms();
+
+  // The owed teardown must NOT fire now: it would delete the new room's member
+  // and token state, leaving its owner with a session that says joined and a
+  // runtime that disagrees.
+  assert.deepEqual(teardowns, []);
+  assert.equal(
+    activeRooms.findMemberIdByToken(recreated.room.code, recreated.memberToken),
+    second.memberId,
+  );
+});
+
+test("a recreated room starts with no runtime state from the previous occupant", async () => {
+  let currentTime = 1_000;
+  let failReapTeardown = true;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const activeRooms = createActiveRoomRegistry();
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...activeRooms,
+      deleteRoom: async (code: string) => {
+        // The reaping teardown fails, so the previous occupant's state is still
+        // there when the code comes back around.
+        if (failReapTeardown) {
+          throw new Error("redis unavailable");
+        }
+        activeRooms.deleteRoom(code);
+      },
+    },
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOMRS",
+  });
+
+  const first = createSession("first-owner");
+  const created = await service.createRoomForSession(first, "Alice");
+  await service.leaveRoomForSession(first, "disconnect");
+  currentTime += getDefaultPersistenceConfig().emptyRoomTtlMs + 1;
+  await service.deleteExpiredRooms();
+  // Redis recovers before the code is handed back out.
+  failReapTeardown = false;
+
+  const second = createSession("second-owner");
+  const recreated = await service.createRoomForSession(second, "Bob");
+
+  // Creation clears the code first, so a member of the OLD room cannot have
+  // their token resolve to their old memberId inside the new one.
+  assert.equal(
+    activeRooms.findMemberIdByToken(recreated.room.code, created.memberToken),
+    null,
+  );
+  assert.equal(
+    activeRooms.findMemberIdByToken(recreated.room.code, recreated.memberToken),
+    second.memberId,
+  );
 });

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -3863,3 +3863,55 @@ test("room service sweeps expired playback authorities when recording new ones",
   assert.equal(service.getPlaybackAuthority(roomB.room.code)?.kind, "play");
   assert.equal(service.getPlaybackAuthority(roomA.room.code), null);
 });
+
+test("restores the member when revoking their identity fails on leave", async () => {
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const activeRooms = createActiveRoomRegistry();
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...activeRooms,
+      // The durable revoke now rejects when the write does not land.
+      revokeMemberToken: async () => {
+        throw new Error("redis unavailable");
+      },
+    },
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => 1_000,
+    createRoomCode: () => "ROOMRC",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  const guest = createSession("guest");
+  await service.joinRoomForSession(
+    guest,
+    created.room.code,
+    created.room.joinToken,
+    "Bob",
+  );
+  const guestMemberId = guest.memberId;
+
+  // Surfaced as the service's generic internal error, like every other failed
+  // leave — what matters is that the recovery path ran first.
+  await assert.rejects(
+    service.leaveRoomForSession(guest, "client-request"),
+    /internal server error/i,
+  );
+
+  // The failure must not leave the client holding a session that claims to be
+  // joined while the runtime has already dropped the membership behind it —
+  // every later request would then be rejected as "not in room".
+  assert.equal(guest.roomCode, created.room.code);
+  assert.equal(guest.memberId, guestMemberId);
+  assert.equal(
+    activeRooms.getRoom(created.room.code)?.members.has(guestMemberId!),
+    true,
+  );
+});

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -1223,8 +1223,8 @@ test("room service flushes pending runtime store writes before exposing updated 
       return activeRooms.markRoomGeneration(code, generation);
     },
     deleteRoom(code) {
-      activeRooms.deleteRoom(code);
       clusterSessionsByRoom.delete(code);
+      return activeRooms.deleteRoom(code);
     },
     async heartbeatNode() {},
     async listNodeStatuses() {
@@ -3968,7 +3968,7 @@ test("reaper keeps collecting rooms when one runtime teardown fails", async () =
           failedFor.push(code);
           throw new Error("redis unavailable");
         }
-        activeRooms.deleteRoom(code);
+        return activeRooms.deleteRoom(code);
       },
     },
     generateToken: (() => {
@@ -4018,7 +4018,7 @@ test("retries a failed runtime teardown on the next reaper pass", async () => {
           throw new Error("redis unavailable");
         }
         teardowns.push(code);
-        activeRooms.deleteRoom(code);
+        return activeRooms.deleteRoom(code);
       },
     },
     generateToken: (() => {
@@ -4073,7 +4073,7 @@ test("does not hand out a room code that still has runtime state under it", asyn
         if (failTeardown) {
           throw new Error("redis unavailable");
         }
-        activeRooms.deleteRoom(code);
+        return activeRooms.deleteRoom(code);
       },
     },
     generateToken: (() => {
@@ -4143,7 +4143,7 @@ test("keeps an owed teardown when the room store cannot be read", async () => {
           throw new Error("redis unavailable");
         }
         teardowns.push(code);
-        activeRooms.deleteRoom(code);
+        return activeRooms.deleteRoom(code);
       },
     },
     generateToken: (() => {
@@ -4200,7 +4200,7 @@ test("an owed teardown does not wipe a room that took the code in the meantime",
         if (gateTeardown) {
           await teardownGate;
         }
-        runtime.deleteRoom(code, expectedGeneration);
+        return runtime.deleteRoom(code, expectedGeneration);
       },
     },
     generateToken: (() => {
@@ -4334,8 +4334,61 @@ test("rolls the room back when its generation cannot be stamped", async () => {
 
   // Left behind, the room would have no members and no `expiresAt`, so the
   // reaper never collects it: the code is held and the room counted forever.
-  assert.equal(await roomStore.getRoom("ROOMRB"), null);
-  assert.equal(await roomStore.countRooms({ includeExpired: true }), 0);
+  // Expired rather than deleted, so the rollback can be conditional on the
+  // version we created — see the recycling test below.
+  assert.equal((await roomStore.getRoom("ROOMRB"))?.expiresAt, 1_000);
+  assert.equal(await roomStore.countRooms({ includeExpired: false }), 0);
+});
+
+test("a failed generation stamp does not roll back a room that recycled the code", async () => {
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const runtime = createInMemoryRuntimeStore(() => 1_000);
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...runtime,
+      markRoomGeneration: async () => {
+        // Concurrently: our memberless room is expired and reaped, and another
+        // request takes the freed code. Only then does our stamp fail.
+        await roomStore.deleteRoom("ROOMRC");
+        await roomStore.saveRoom({
+          code: "ROOMRC",
+          joinToken: "replacement-token",
+          ownerMemberId: "other-owner",
+          ownerDisplayName: "Bob",
+          createdAt: 2_000,
+          lastActiveAt: 2_000,
+          expiresAt: null,
+          version: 1,
+          sharedVideo: null,
+          playback: null,
+        });
+        await roomStore.updateRoom("ROOMRC", 1, { lastActiveAt: 2_500 });
+        throw new Error("redis unavailable");
+      },
+    },
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => 1_000,
+    createRoomCode: () => "ROOMRC",
+    resolveActiveRoom: async (code) => runtime.getRoom(code),
+  });
+
+  await assert.rejects(
+    service.createRoomForSession(createSession("owner"), "Alice"),
+    /internal server error/i,
+  );
+
+  // Rolling back by code deleted the replacement out from under an owner who
+  // had already been told their creation succeeded.
+  const replacement = await roomStore.getRoom("ROOMRC");
+  assert.equal(replacement?.joinToken, "replacement-token");
+  assert.equal(replacement?.expiresAt, null);
 });
 
 test("an admin teardown works through the retry backlog", async () => {
@@ -4355,7 +4408,7 @@ test("an admin teardown works through the retry backlog", async () => {
           throw new Error("redis unavailable");
         }
         teardowns.push(code);
-        runtime.deleteRoom(code, expectedGeneration);
+        return runtime.deleteRoom(code, expectedGeneration);
       },
     },
     generateToken: (() => {
@@ -4426,4 +4479,66 @@ test("does not hand out a code whose only leftover is a session index entry", as
 
   assert.equal(created.room.code, "ROOMS2");
   assert.deepEqual(offeredCodes, ["ROOMSI", "ROOMSI", "ROOMS2"]);
+});
+
+test("leave does not schedule expiry when the shared room still has members", async () => {
+  const local = createInMemoryRuntimeStore();
+  const shared = createInMemoryRuntimeStore();
+  const runtimeStore: RuntimeStore = {
+    ...local,
+    addMember: (code, memberId, session, memberToken) => {
+      const room = local.addMember(code, memberId, session, memberToken);
+      shared.addMember(code, memberId, session, memberToken);
+      return room;
+    },
+    removeMember: (code, memberId, session) => {
+      const removal = local.removeMember(code, memberId, session);
+      shared.removeMember(code, memberId, session);
+      return removal;
+    },
+  };
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    runtimeStore,
+    resolveActiveRoom: async (code) => shared.getRoom(code),
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => 1_000,
+    createRoomCode: () => "ROOMSE",
+  });
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+
+  // The same member reconnected onto another node: the shared binding is that
+  // node's session, while this node still holds the stale one it is about to
+  // clean up. Only this node's local view goes empty.
+  const reconnected = createSession("owner-elsewhere");
+  reconnected.roomCode = created.room.code;
+  reconnected.memberId = owner.memberId;
+  reconnected.memberToken = owner.memberToken;
+  shared.addMember(
+    created.room.code,
+    owner.memberId ?? "",
+    reconnected,
+    owner.memberToken ?? "",
+  );
+
+  const result = await service.leaveRoomForSession(owner, "disconnect");
+
+  assert.equal(local.getRoom(created.room.code)?.members.size, 0);
+  assert.equal(shared.getRoom(created.room.code)?.members.size, 1);
+  // Trusting this node's local emptiness wrote an `expiresAt` over the one the
+  // reconnect had just cleared, so the reaper deleted a room with members in it.
+  assert.equal(result.room?.expiresAt, null);
+  assert.equal(
+    (await roomStore.getRoom(created.room.code))?.expiresAt ?? null,
+    null,
+  );
 });

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -1213,6 +1213,9 @@ test("room service flushes pending runtime store writes before exposing updated 
     evictMemberToken(code, memberId, memberToken, blockedUntil) {
       activeRooms.evictMemberToken(code, memberId, memberToken, blockedUntil);
     },
+    hasRoomResidue(code) {
+      return activeRooms.hasRoomResidue(code);
+    },
     getRoomGeneration(code) {
       return activeRooms.getRoomGeneration(code);
     },
@@ -4384,4 +4387,43 @@ test("an admin teardown works through the retry backlog", async () => {
   failTeardown = false;
   await service.teardownRoomRuntime(other.room.code);
   assert.deepEqual(teardowns.sort(), ["ROOMB1", "ROOMB2"]);
+});
+
+test("does not hand out a code whose only leftover is a session index entry", async () => {
+  const currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const runtime = createInMemoryRuntimeStore(() => currentTime);
+  const offeredCodes: string[] = [];
+  const codeSequence = ["ROOMSI", "ROOMSI", "ROOMS2"];
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: runtime,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => {
+      const code = codeSequence.shift() ?? "ROOMSX";
+      offeredCodes.push(code);
+      return code;
+    },
+  });
+
+  // No members and no member tokens, so the members/tokens view reads as empty —
+  // but a stale session index entry is exactly the kind of leftover a new room
+  // would inherit as a ghost member.
+  const ghost = createSession("ghost-session");
+  runtime.registerSession(ghost);
+  runtime.markSessionJoinedRoom(ghost.id, "ROOMSI");
+  assert.equal(runtime.getRoom("ROOMSI"), null);
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+
+  assert.equal(created.room.code, "ROOMS2");
+  assert.deepEqual(offeredCodes, ["ROOMSI", "ROOMSI", "ROOMS2"]);
 });

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -839,6 +839,86 @@ test("room service reuses member identity when reconnecting with the same member
   assert.deepEqual(state.members, [{ id: originalMemberId, name: "Alice" }]);
 });
 
+function createIdentityService(roomStore: RoomStore, roomCode: string) {
+  return createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: createActiveRoomRegistry(),
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => 1_000,
+    createRoomCode: () => roomCode,
+  });
+}
+
+const IDENTITY_TEST_VIDEO: SharedVideo = {
+  videoId: "BV1Cx3q6gELa",
+  url: "https://www.bilibili.com/video/BV1Cx3q6gELa",
+  title: "Shared Video",
+};
+
+test("a disconnect keeps the identity that owns the shared video", async () => {
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const service = createIdentityService(roomStore, "ROOMID");
+
+  const sharer = createSession("sharer");
+  const created = await service.createRoomForSession(sharer, "Alice");
+  const sharerMemberId = sharer.memberId;
+  await service.shareVideoForSession(
+    sharer,
+    created.memberToken,
+    IDENTITY_TEST_VIDEO,
+  );
+
+  // A server restart closes every socket at once. That is a disconnect, not a
+  // departure: the client still holds the memberToken it persisted.
+  await service.leaveRoomForSession(sharer, "disconnect");
+
+  const reconnected = createSession("sharer-reconnect");
+  await service.joinRoomForSession(
+    reconnected,
+    created.room.code,
+    created.room.joinToken,
+    "Alice",
+    created.memberToken,
+  );
+
+  assert.equal(reconnected.memberId, sharerMemberId);
+  // The whole point: `sharedVideo.sharedByMemberId` is written once at share
+  // time and never rewritten, so if the reconnect had been issued a new
+  // memberId nobody in the room would match it and the room could no longer
+  // advance to the next video (#234).
+  const persisted = await roomStore.getRoom(created.room.code);
+  assert.equal(persisted?.sharedVideo?.sharedByMemberId, reconnected.memberId);
+});
+
+test("an explicit leave revokes the identity", async () => {
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const service = createIdentityService(roomStore, "ROOMLV");
+
+  const owner = createSession("owner");
+  const created = await service.createRoomForSession(owner, "Alice");
+  const originalMemberId = owner.memberId;
+
+  // The member said they were done, unlike the disconnect above.
+  await service.leaveRoomForSession(owner, "client-request");
+
+  const returning = createSession("owner-returns");
+  await service.joinRoomForSession(
+    returning,
+    created.room.code,
+    created.room.joinToken,
+    "Alice",
+    created.memberToken,
+  );
+
+  assert.notEqual(returning.memberId, originalMemberId);
+});
+
 test("room service updates member display name after join", async () => {
   const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
   const service = createRoomService({
@@ -986,6 +1066,9 @@ test("room service flushes pending runtime store writes before exposing updated 
     },
     removeMember(code, memberId, session) {
       return activeRooms.removeMember(code, memberId, session);
+    },
+    revokeMemberToken(code, memberId) {
+      activeRooms.revokeMemberToken(code, memberId);
     },
     deleteRoom(code) {
       activeRooms.deleteRoom(code);
@@ -2757,6 +2840,10 @@ test("join admission restores shared previous session when reconnect rollback ha
       shared.removeMember(code, memberId, session);
       return removal;
     },
+    revokeMemberToken: (code, memberId) => {
+      local.revokeMemberToken(code, memberId);
+      shared.revokeMemberToken(code, memberId);
+    },
     flush: async () => {
       await local.flush?.();
       await shared.flush?.();
@@ -2845,6 +2932,10 @@ test("join admission does not restore stale reconnect session over newer shared 
       const removal = local.removeMember(code, memberId, session);
       shared.removeMember(code, memberId, session);
       return removal;
+    },
+    revokeMemberToken: (code, memberId) => {
+      local.revokeMemberToken(code, memberId);
+      shared.revokeMemberToken(code, memberId);
     },
     flush: async () => {
       await local.flush?.();

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -4238,3 +4238,150 @@ test("an owed teardown does not wipe a room that took the code in the meantime",
     second.memberId,
   );
 });
+
+test("pins the teardown generation before checking whether the room is gone", async () => {
+  let currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const runtime = createInMemoryRuntimeStore(() => currentTime, 5_000);
+  let releaseRoomRead!: () => void;
+  const roomReadGate = new Promise<void>((resolve) => {
+    releaseRoomRead = resolve;
+  });
+  let gateRoomRead = false;
+
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore: {
+      ...roomStore,
+      // Stall the absence check itself. Reading the generation after this point
+      // hands the teardown the NEW room's value, which then matches.
+      getRoom: async (code: string) => {
+        const room = await roomStore.getRoom(code);
+        if (gateRoomRead) {
+          await roomReadGate;
+        }
+        return room;
+      },
+    },
+    activeRooms: runtime,
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOMPN",
+    resolveActiveRoom: async (code) => runtime.getRoom(code),
+  });
+
+  const first = createSession("first-owner");
+  await service.createRoomForSession(first, "Alice");
+  await service.leaveRoomForSession(first, "disconnect");
+
+  currentTime += getDefaultPersistenceConfig().emptyRoomTtlMs + 1;
+  gateRoomRead = true;
+  const reaping = service.deleteExpiredRooms();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // The previous occupant's identity expires, freeing the code, and a new room
+  // claims it — all while the absence check is still in flight.
+  currentTime += 5_001;
+  gateRoomRead = false;
+  const second = createSession("second-owner");
+  const recreated = await service.createRoomForSession(second, "Bob");
+  assert.equal(recreated.room.code, "ROOMPN");
+
+  releaseRoomRead();
+  await reaping;
+
+  assert.equal(
+    runtime.findMemberIdByToken("ROOMPN", recreated.memberToken),
+    second.memberId,
+  );
+});
+
+test("rolls the room back when its generation cannot be stamped", async () => {
+  const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
+  const runtime = createInMemoryRuntimeStore(() => 1_000);
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...runtime,
+      markRoomGeneration: async () => {
+        throw new Error("redis unavailable");
+      },
+    },
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => 1_000,
+    createRoomCode: () => "ROOMRB",
+    resolveActiveRoom: async (code) => runtime.getRoom(code),
+  });
+
+  await assert.rejects(
+    service.createRoomForSession(createSession("owner"), "Alice"),
+    /internal server error/i,
+  );
+
+  // Left behind, the room would have no members and no `expiresAt`, so the
+  // reaper never collects it: the code is held and the room counted forever.
+  assert.equal(await roomStore.getRoom("ROOMRB"), null);
+  assert.equal(await roomStore.countRooms({ includeExpired: true }), 0);
+});
+
+test("an admin teardown works through the retry backlog", async () => {
+  const currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const runtime = createInMemoryRuntimeStore(() => currentTime);
+  let failTeardown = true;
+  const teardowns: string[] = [];
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...runtime,
+      deleteRoom: async (code: string, expectedGeneration?: string | null) => {
+        if (failTeardown) {
+          throw new Error("redis unavailable");
+        }
+        teardowns.push(code);
+        runtime.deleteRoom(code, expectedGeneration);
+      },
+    },
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: (() => {
+      const codes = ["ROOMB1", "ROOMB2"];
+      return () => codes.shift() ?? "ROOMBX";
+    })(),
+    resolveActiveRoom: async (code) => runtime.getRoom(code),
+  });
+
+  const first = createSession("first-owner");
+  const owed = await service.createRoomForSession(first, "Alice");
+  await roomStore.deleteRoom(owed.room.code);
+  // An admin close whose teardown failed: the debt is queued.
+  await service.teardownRoomRuntime(owed.room.code);
+  assert.deepEqual(teardowns, []);
+
+  const second = createSession("second-owner");
+  const other = await service.createRoomForSession(second, "Bob");
+  await roomStore.deleteRoom(other.room.code);
+
+  // The standalone global-admin process never runs the reaper, so
+  // `deleteExpiredRooms` is not what drains this — every teardown has to.
+  failTeardown = false;
+  await service.teardownRoomRuntime(other.room.code);
+  assert.deepEqual(teardowns.sort(), ["ROOMB1", "ROOMB2"]);
+});

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -1213,6 +1213,12 @@ test("room service flushes pending runtime store writes before exposing updated 
     evictMemberToken(code, memberId, memberToken, blockedUntil) {
       activeRooms.evictMemberToken(code, memberId, memberToken, blockedUntil);
     },
+    getRoomGeneration(code) {
+      return activeRooms.getRoomGeneration(code);
+    },
+    markRoomGeneration(code, generation) {
+      return activeRooms.markRoomGeneration(code, generation);
+    },
     deleteRoom(code) {
       activeRooms.deleteRoom(code);
       clusterSessionsByRoom.delete(code);
@@ -4167,4 +4173,68 @@ test("keeps an owed teardown when the room store cannot be read", async () => {
   failRoomRead = false;
   await service.deleteExpiredRooms();
   assert.deepEqual(teardowns, ["ROOMRD"]);
+});
+
+test("an owed teardown does not wipe a room that took the code in the meantime", async () => {
+  let currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  // Short identity retention so the residue can expire on its own, which is
+  // what frees the code — and, unlike a teardown, leaves the generation behind.
+  const runtime = createInMemoryRuntimeStore(() => currentTime, 5_000);
+  let releaseTeardown!: () => void;
+  const teardownGate = new Promise<void>((resolve) => {
+    releaseTeardown = resolve;
+  });
+  let gateTeardown = false;
+
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...runtime,
+      deleteRoom: async (code: string, expectedGeneration?: string | null) => {
+        if (gateTeardown) {
+          await teardownGate;
+        }
+        runtime.deleteRoom(code, expectedGeneration);
+      },
+    },
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOMGR",
+    resolveActiveRoom: async (code) => runtime.getRoom(code),
+  });
+
+  const first = createSession("first-owner");
+  await service.createRoomForSession(first, "Alice");
+  await service.leaveRoomForSession(first, "disconnect");
+
+  currentTime += getDefaultPersistenceConfig().emptyRoomTtlMs + 1;
+  // The reaper clears the room-store guard and then stalls inside the delete —
+  // the exact gap the two check-then-act guards cannot cover.
+  gateTeardown = true;
+  const reaping = service.deleteExpiredRooms();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  // The previous occupant's identity retention runs out, which frees the code.
+  currentTime += 5_001;
+  const second = createSession("second-owner");
+  const recreated = await service.createRoomForSession(second, "Bob");
+  assert.equal(recreated.room.code, "ROOMGR");
+
+  releaseTeardown();
+  await reaping;
+
+  // The stale teardown was decided against the previous room instance, so the
+  // delete itself has to refuse. No arrangement of the guards around it helps:
+  // both had already passed before this room existed.
+  assert.equal(
+    runtime.findMemberIdByToken("ROOMGR", recreated.memberToken),
+    second.memberId,
+  );
 });

--- a/server/test/room-state-view.test.ts
+++ b/server/test/room-state-view.test.ts
@@ -67,7 +67,9 @@ test("room state query uses cluster sessions instead of only local active member
     async listClusterSessionsByRoom() {
       return [localOwner, remoteJoiner];
     },
-    deleteRoom() {},
+    deleteRoom() {
+      return true;
+    },
   } as Pick<
     RuntimeStore,
     "getRoom" | "listClusterSessionsByRoom" | "deleteRoom"

--- a/server/test/room-store.test.ts
+++ b/server/test/room-store.test.ts
@@ -42,8 +42,8 @@ test("room store persists create, update, delete, and expiry behaviors", async (
   );
   assert.deepEqual(conflict, { ok: false, reason: "version_conflict" });
 
-  assert.equal(await store.deleteExpiredRooms(500), 0);
-  assert.equal(await store.deleteExpiredRooms(999), 1);
+  assert.equal((await store.deleteExpiredRooms(500)).length, 0);
+  assert.equal((await store.deleteExpiredRooms(999)).length, 1);
   assert.equal(await store.getRoom(createdRoom.code), null);
 });
 

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -112,7 +112,15 @@ test("runtime index reaper clears sessions left behind by offline nodes", async 
 
     assert.equal(remainingSessions, 0);
     assert.equal(remainingRooms, 0);
-    assert.equal(await runtimeStore.getRoom("ROOM01"), null);
+    // The offline node's members are gone, but their identity is not: those
+    // clients are alive and reconnecting to a surviving node, and they must
+    // come back as the same members (#234). The token is what lets them.
+    const reapedRoom = await runtimeStore.getRoom("ROOM01");
+    assert.equal(reapedRoom?.members.size ?? 0, 0);
+    assert.equal(
+      await runtimeStore.findMemberIdByToken("ROOM01", "token-offline"),
+      "member-offline",
+    );
 
     let remainingStatuses: Awaited<
       ReturnType<typeof runtimeStore.listNodeStatuses>

--- a/server/test/runtime-store.test.ts
+++ b/server/test/runtime-store.test.ts
@@ -97,3 +97,50 @@ test("runtime store tracks node heartbeat state and derives health", async () =>
   statuses = await store.listNodeStatuses(currentTime);
   assert.equal(statuses[0]?.health, "offline");
 });
+
+test("in-memory runtime store bounds a disconnected identity without waiting for the room to empty", () => {
+  let currentTime = 1_000;
+  const store = createInMemoryRuntimeStore(() => currentTime, 5_000);
+  const host = createSession("session-host");
+  const visitor = createSession("session-visitor");
+
+  store.addMember("ROOMIM", "member-host", host, "token-host");
+  store.addMember("ROOMIM", "member-visitor", visitor, "token-visitor");
+
+  store.removeMember("ROOMIM", "member-visitor", visitor);
+  // Identity outlives the disconnect (#234) — that is the whole point.
+  assert.equal(
+    store.findMemberIdByToken("ROOMIM", "token-visitor"),
+    "member-visitor",
+  );
+
+  currentTime += 5_001;
+  // ...but it is bounded per identity, so a room that never empties — the host
+  // is still here — still releases the people who left it. Hanging retention off
+  // the room emptying leaked one token per visitor, forever (#237 review).
+  assert.equal(store.findMemberIdByToken("ROOMIM", "token-visitor"), null);
+  assert.equal(
+    store.findMemberIdByToken("ROOMIM", "token-host"),
+    "member-host",
+  );
+});
+
+test("in-memory runtime store lifts the retention clock when a member reconnects", () => {
+  let currentTime = 1_000;
+  const store = createInMemoryRuntimeStore(() => currentTime, 5_000);
+  const first = createSession("session-first");
+  const second = createSession("session-second");
+
+  store.addMember("ROOMIL", "member-back", first, "token-back");
+  store.removeMember("ROOMIL", "member-back", first);
+  currentTime += 2_000;
+  store.addMember("ROOMIL", "member-back", second, "token-back");
+
+  currentTime += 5_001;
+  // Lifted, not merely restarted: a member who is back must not lose their
+  // identity because of a clock started before they returned.
+  assert.equal(
+    store.findMemberIdByToken("ROOMIL", "token-back"),
+    "member-back",
+  );
+});


### PR DESCRIPTION
## 根因（比 issue 里写的更靠上一层）

Issue #234 提的修法是"把 memberToken 挪到 room store 让它更耐久"。动手排查后发现**存储位置本来就够耐久**（Redis 侧 `roomMemberTokensKey` 无 TTL），真正的缺陷在**吊销时机**：

`memberToken` 是身份凭证，却被放在 runtime store —— 那一层的语义是"谁此刻连着"，成员一断开，`removeMemberFromRoom` 就连 token 一起删（`runtime-store-state.ts:129`）。于是：

> **任何**断线都会换发 memberId。哪怕只是两秒的网络抖动。

平时看不出来，是因为重连若抢在旧 socket 的 close 清理之前完成，`findMemberIdByToken` 还查得到；服务端重启则毫无机会——所有 socket 一起关，清理必然先跑完。

而 `sharedVideo.sharedByMemberId` 只在 `video:share` 时写一次、之后从不重写（`room-service.ts:1197`），重启后它指向一个已不存在的成员：所有客户端算出的 `isLocalSharedSource()` 都是 false，全体在自然结束时 hold，房间再也过不去当前视频。线上房间 `35PPBA` 就是这样卡住的。

## 变更：把「在场」和「身份」拆开

| 操作 | 在场 | 身份 |
| --- | --- | --- |
| 断线 | 移除 | **保留** |
| 显式 `room:leave` | 移除 | 吊销 |
| 管理员踢人 | 移除 | 吊销 |
| 房间销毁 | 移除 | 吊销 |

- `removeMember` 只删在场；新增 `revokeMemberToken` 承担吊销
- `leaveRoom` 增加 `reason`，socket close 传 `"disconnect"`（`ws-session-handler.ts`）
- **吊销与移除共用同一道所有权门槛**（`removal.removed`）：被顶替的旧会话退出时，不能吊销新会话已经认领的身份。这条是写第一版时踩出来的——不加门槛会打红两条既有用例
- **踢人改为显式吊销**：断线不再代劳，不加这一步就等于削弱了封禁（60 秒一过就能以原身份回来）
- 启动清理 `purgeSessionsByInstance` 不再删 token —— 它恰好跑在那批客户端重连之前

## 保留期上限（新引入的问题，一并解决）

token 不再随断线消失，就没有东西回收它了：房间清空后无人再触碰，`resolveRoom` 的惰性清理永远不会触发，Redis 里的 token 哈希会永久残留。

处理方式是**在房间清空的那一刻给它上钟**，`memberTokenRetentionMs = emptyRoomTtlMs × 2`（token 应当比它所标识的房间活得久，而不是反过来）；重连时 `addMember` 用 `PERSIST` 解除。**在场期间完全不设 TTL**，所以长期连着的房间不会丢身份。本地镜像同时交还给 Redis，否则它没有钟、会一直答旧值。

## Codex 本地复审抓到的 P1（已修）

清空判定与两次写入原本是读后写，重连可以插进 `SCARD` 与 `PEXPIRE` 之间：把一个刚刚变活跃的房间移出索引，并给刚回来的人重新挂上过期。现已合成一段 Lua，检查与写入在同一次执行内完成。

## Test plan

逐处回退验证判别力，**七处全部打红**：

- [x] 断线重新删 token → `a disconnect keeps the identity that owns the shared video`
- [x] 显式退出不吊销 → `an explicit leave revokes the identity`（并连带打红一条既有用例）
- [x] 踢人不吊销 → admin consumer 踢人用例
- [x] 启动清理重新删 token → `can purge stale sessions for a restarted instance`
- [x] `removeMember` 重新删 token → `keeps the member token when only presence is dropped`
- [x] 不上钟 / 不解除钟 → 两条保留期用例（第二条最初无判别力，改用 observer 实例读 Redis 后才抓得住）
- [x] 退回非原子清理 → `empties a room in a single atomic step`
- [x] `format:check` / `lint` / `typecheck` / `build` / `test` / `audit` 全绿
- [x] **455 条服务端测试在真实 Redis 下全绿、零跳过**（本地起 `redis-server --port 6399` 跑的，非 CI 依赖）
- [ ] 真实重启复现（需在部署环境验证：重启后 `sharedVideo.sharedByMemberId` 仍匹配在线成员、连播恢复）

## 影响提示

`RuntimeStore` 新增 `revokeMemberToken`，`leaveRoomForSession` / `leaveRoom` 新增可选 `reason`。默认值保持旧语义（`"client-request"` → 吊销），只有 socket close 显式传 `"disconnect"`。

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
