### PR TITLE
fix: 纠偏期间广播房间基准倍率而非临时追赶倍率 (#238)

### DIFF
--- a/extension/src/content/gesture-tracker.ts
+++ b/extension/src/content/gesture-tracker.ts
@@ -55,8 +55,17 @@ function isEditableTarget(target: EventTarget | null): boolean {
  * re-creating the very rate pollution #238 is about. That exact sequence is in
  * the #238 logs: `3` twice, then `0.9223063476562674` twice, all explicit.
  *
- * A held ArrowRight during a catch-up therefore stays a purely local skim: the
- * session survives, so broadcasts keep reporting the room's base rate.
+ * What this buys is confined to the RATE: the session survives, so broadcasts
+ * keep reporting the room's base rate instead of 3x or the value restored on
+ * release. It is NOT a local-only skim. Each keydown still refreshes
+ * `lastUserGestureAt`, so the ratechange entering/leaving 3x is recorded as an
+ * explicit action, `shouldSuppressActiveSoftApplyBroadcast` lets the broadcast
+ * through, and its `currentTime` is the local playhead — by then seconds ahead.
+ * Peers follow that jump. They do so for any forward jump, with or without the
+ * `explicit-ratechange` tag: `playback-authority`'s timeline check only rejects
+ * updates that drift BACK behind the room (`driftsBackBehindCurrent`). Whether a
+ * fast-forward should move the room is a product question this fix does not
+ * touch — it behaves identically when no catch-up is running.
  */
 export function isRateControlGesture(event: Event): boolean {
   if (event.type !== "keydown" || isEditableTarget(event.target)) {

--- a/extension/src/content/gesture-tracker.ts
+++ b/extension/src/content/gesture-tracker.ts
@@ -45,20 +45,24 @@ function isEditableTarget(target: EventTarget | null): boolean {
  * we wrote" does not work — the player resets the live rate by itself while
  * recovering from a stall — so the signal has to come from the input itself.
  *
- * The hold-to-fast-forward key is matched only while it REPEATS. A short
- * ArrowRight press is a 5s seek and leaves the rate alone; only holding it
- * engages 3x, and holding is exactly what produces auto-repeat keydowns. Without
- * that distinction every arrow-key seek would count as a speed change and a
- * stall-reset landing next to one would be misread as a user takeover.
+ * Only PERSISTENT rate selections count. Bilibili's hold-ArrowRight 3x is
+ * deliberately excluded even though it is a speed gesture: it lasts only while
+ * the key is held, and on release the player restores the rate it saved when the
+ * hold began — which, mid-catch-up, is our temporary rate. Ending the session for
+ * it would drop the restore, leave `getActiveCorrectionBaseRate` empty, and let
+ * both the transient 3x and that restored temporary rate go out tagged
+ * `explicit-ratechange` (which the server's timeline check does not reject),
+ * re-creating the very rate pollution #238 is about. That exact sequence is in
+ * the #238 logs: `3` twice, then `0.9223063476562674` twice, all explicit.
+ *
+ * A held ArrowRight during a catch-up therefore stays a purely local skim: the
+ * session survives, so broadcasts keep reporting the room's base rate.
  */
 export function isRateControlGesture(event: Event): boolean {
   if (event.type !== "keydown" || isEditableTarget(event.target)) {
     return false;
   }
   const keyboardEvent = event as KeyboardEvent;
-  if (keyboardEvent.key === "ArrowRight") {
-    return keyboardEvent.repeat;
-  }
   return (
     keyboardEvent.shiftKey && RATE_CONTROL_SHIFT_CODES.has(keyboardEvent.code)
   );

--- a/extension/src/content/gesture-tracker.ts
+++ b/extension/src/content/gesture-tracker.ts
@@ -15,6 +15,55 @@ const EDITABLE_SELECTOR =
 // play intent for these (so Esc/Tab/typing do not authorize playback).
 const PLAY_TOGGLE_KEYS = new Set([" ", "Spacebar", "k", "K"]);
 
+// Physical keys that set a playback SPEED on Bilibili when combined with Shift
+// (Shift+1 → 1x, Shift+2 → 2x). Matched on `code` rather than `key` because
+// `key` carries the SHIFTED character — Shift+1 reports "!" on a US layout — so
+// a `key` comparison would silently never match. `code` is the physical key and
+// is layout-independent.
+const RATE_CONTROL_SHIFT_CODES = new Set(["Digit1", "Digit2"]);
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  return (
+    target.closest(EDITABLE_SELECTOR) !== null ||
+    (target as HTMLElement).isContentEditable
+  );
+}
+
+/**
+ * Whether a gesture is the user operating the player's playback-SPEED control.
+ *
+ * Deliberately separate from {@link isGestureInsidePlayer}: that predicate
+ * authorizes PLAYBACK on "load paused" pages, so widening it with speed keys
+ * would wave the page-load autoplay through. This one only ever ends a rate
+ * catch-up session, so the two must not share a key set.
+ *
+ * Its whole purpose is to be POSITIVE evidence that something other than our own
+ * catch-up moved the rate. Inferring that from "the element's rate is not the one
+ * we wrote" does not work — the player resets the live rate by itself while
+ * recovering from a stall — so the signal has to come from the input itself.
+ *
+ * The hold-to-fast-forward key is matched only while it REPEATS. A short
+ * ArrowRight press is a 5s seek and leaves the rate alone; only holding it
+ * engages 3x, and holding is exactly what produces auto-repeat keydowns. Without
+ * that distinction every arrow-key seek would count as a speed change and a
+ * stall-reset landing next to one would be misread as a user takeover.
+ */
+export function isRateControlGesture(event: Event): boolean {
+  if (event.type !== "keydown" || isEditableTarget(event.target)) {
+    return false;
+  }
+  const keyboardEvent = event as KeyboardEvent;
+  if (keyboardEvent.key === "ArrowRight") {
+    return keyboardEvent.repeat;
+  }
+  return (
+    keyboardEvent.shiftKey && RATE_CONTROL_SHIFT_CODES.has(keyboardEvent.code)
+  );
+}
+
 /**
  * Whether a user gesture event represents an intent to control the player
  * itself — a pointer/touch gesture inside the player container, or a play-toggle
@@ -48,7 +97,7 @@ export function isGestureInsidePlayer(event: Event): boolean {
 }
 
 export function startUserGestureTracking(
-  onGesture: (insidePlayer: boolean) => void,
+  onGesture: (insidePlayer: boolean, rateControl: boolean) => void,
 ): void {
   const gestureEvents: Array<keyof DocumentEventMap> = [
     "pointerdown",
@@ -59,7 +108,7 @@ export function startUserGestureTracking(
   ];
 
   const handleGesture = (event: Event) => {
-    onGesture(isGestureInsidePlayer(event));
+    onGesture(isGestureInsidePlayer(event), isRateControlGesture(event));
   };
 
   for (const eventName of gestureEvents) {
@@ -74,5 +123,5 @@ export function startUserGestureTracking(
   // emits `popstate`); otherwise a sharer using the browser back/forward
   // controls would auto-share the destination without the manual share step.
   // It is never an in-player play intent.
-  window.addEventListener("popstate", () => onGesture(false), true);
+  window.addEventListener("popstate", () => onGesture(false, false), true);
 }

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -164,6 +164,11 @@ const playbackBindingController = createPlaybackBindingController({
     syncController.cancelActiveSoftApply(video, reason),
   maintainActiveSoftApply: (video) =>
     syncController.maintainActiveSoftApply(video),
+  isRateUnexplainedByActiveCatchUp: (normalizedUrl, playbackRate) =>
+    syncController.isRateUnexplainedByActiveCatchUp(
+      normalizedUrl,
+      playbackRate,
+    ),
   applyPendingPlaybackApplication: (video) =>
     syncController.applyPendingPlaybackApplication(video),
   activatePauseHold,

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -164,11 +164,6 @@ const playbackBindingController = createPlaybackBindingController({
     syncController.cancelActiveSoftApply(video, reason),
   maintainActiveSoftApply: (video) =>
     syncController.maintainActiveSoftApply(video),
-  isRateUnexplainedByActiveCatchUp: (normalizedUrl, playbackRate) =>
-    syncController.isRateUnexplainedByActiveCatchUp(
-      normalizedUrl,
-      playbackRate,
-    ),
   applyPendingPlaybackApplication: (video) =>
     syncController.applyPendingPlaybackApplication(video),
   activatePauseHold,

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -246,11 +246,14 @@ function activatePauseHold(durationMs = PAUSE_HOLD_MS): void {
 }
 
 async function init(): Promise<void> {
-  startUserGestureTracking((insidePlayer) => {
+  startUserGestureTracking((insidePlayer, rateControl) => {
     const now = performance.now();
     runtimeState.lastUserGestureAt = now;
     if (insidePlayer) {
       runtimeState.lastUserGestureInPlayerAt = now;
+    }
+    if (rateControl) {
+      runtimeState.lastRateControlGestureAt = now;
     }
   });
   pageShareButtonController.start();

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -64,6 +64,8 @@ const shareController = createShareController({
   nextSeq: () => seq++,
   getFestivalSnapshot: () => festivalBridge.getSnapshot(),
   refreshFestivalBridge: (input) => festivalBridge.refreshSnapshot(input),
+  getActiveCorrectionBaseRate: (url) =>
+    syncController.getActiveCorrectionBaseRate(normalizeUrl(url)),
   debugLog,
 });
 const autoShareNextController = createAutoShareNextController({

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -151,8 +151,8 @@ export function createPlaybackBindingController(args: {
   const hasRecentUserGestureInPlayer = () =>
     monotonicNow() - args.runtimeState.lastUserGestureInPlayerAt <
     args.userGestureGraceMs;
-  // The user just operated the player's SPEED control (Shift+1 / Shift+2, or
-  // ArrowRight held for 3x).
+  // The user just PERSISTENTLY selected a playback speed (Shift+1 / Shift+2).
+  // Hold-to-fast-forward is deliberately not one — see `isRateControlGesture`.
   //
   // The `> 0` check is defensive, not load-bearing today: the field starts at 0
   // and `performance.now()` starts near it, so a bare freshness check would read

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -65,10 +65,6 @@ export function createPlaybackBindingController(args: {
     reason: string,
   ) => void;
   maintainActiveSoftApply: (video: HTMLVideoElement) => void;
-  isRateUnexplainedByActiveCatchUp: (
-    normalizedUrl: string | null,
-    playbackRate: number,
-  ) => boolean;
   applyPendingPlaybackApplication: (video: HTMLVideoElement) => void;
   activatePauseHold: (durationMs?: number) => void;
   debugLog: (message: string) => void;
@@ -1160,37 +1156,24 @@ export function createPlaybackBindingController(args: {
           // This prevents a stray page click near our own catch-up ratechange
           // from cancelling the self-restore and leaving the temporary rate stuck.
           //
-          // Gesture attribution alone cannot cover the whole input surface
-          // though: `isGestureInsidePlayer` deliberately counts only
-          // play-toggle keys, so a keyboard SPEED shortcut is never recognised
-          // as an in-player takeover. The second branch closes that hole with
-          // evidence rather than attribution — the rate on the element is not
-          // the one our own catch-up wrote, so someone else put it there.
-          // Without it the user's change is lost twice over: the broadcast
-          // reports the session's base rate, and the session timer then restores
-          // that base rate locally too.
+          // Known limitation, deliberately not "fixed" (#238/#239): a KEYBOARD
+          // speed shortcut is not an in-player gesture (`isGestureInsidePlayer`
+          // counts only play-toggle keys), so changing speed that way during a
+          // catch-up does not end the session and the change is undone when the
+          // session restores. The speed MENU is a pointer inside the player, so
+          // the common path is covered.
           //
-          // A rate mismatch alone is NOT enough, because the player resets the
-          // live rate by itself while recovering from a stall (see
-          // `cancelActiveSoftApply`). That reset also fails to match what the
-          // catch-up wrote, and cancelling it as `user-ratechange` would SKIP the
-          // restore and strand the elevated `defaultPlaybackRate` — the exact
-          // bug that restore exists to prevent. Requiring a recorded explicit
-          // ratechange keeps the branch to changes something outside this code
-          // deliberately made: `rememberExplicitUserAction` above only records
-          // one when a real gesture backs it.
-          const hasRecordedUserRateChange =
-            args.runtimeState.lastExplicitUserAction?.kind === "ratechange" &&
-            monotonicNow() - args.runtimeState.lastExplicitUserAction.at <
-              args.userGestureGraceMs;
-          if (
-            hasRecentUserGestureInPlayer() ||
-            (hasRecordedUserRateChange &&
-              args.isRateUnexplainedByActiveCatchUp(
-                args.normalizeUrl(args.getSharedVideo()?.url),
-                video.playbackRate,
-              ))
-          ) {
+          // Do not close it by inferring the takeover from "the element's rate is
+          // not the one the catch-up wrote". The player resets the live rate by
+          // itself while recovering from a stall, and `rememberExplicitUserAction`
+          // above records kind=`ratechange` off the EVENT type plus ANY recent
+          // document-level gesture — so that inference cannot separate the two,
+          // and a false positive cancels as `user-ratechange`, skipping the
+          // restore and stranding the elevated `defaultPlaybackRate` (see
+          // `cancelActiveSoftApply`). Closing it properly needs a real signal for
+          // "the user operated the speed control", which the document-level
+          // gesture tracker does not currently produce.
+          if (hasRecentUserGestureInPlayer()) {
             args.cancelActiveSoftApply(video, "user-ratechange");
           }
         }

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -65,6 +65,10 @@ export function createPlaybackBindingController(args: {
     reason: string,
   ) => void;
   maintainActiveSoftApply: (video: HTMLVideoElement) => void;
+  isRateUnexplainedByActiveCatchUp: (
+    normalizedUrl: string | null,
+    playbackRate: number,
+  ) => boolean;
   applyPendingPlaybackApplication: (video: HTMLVideoElement) => void;
   activatePauseHold: (durationMs?: number) => void;
   debugLog: (message: string) => void;
@@ -1155,7 +1159,38 @@ export function createPlaybackBindingController(args: {
           // (pointer in the player / play-toggle key, as the speed menu is) does.
           // This prevents a stray page click near our own catch-up ratechange
           // from cancelling the self-restore and leaving the temporary rate stuck.
-          if (hasRecentUserGestureInPlayer()) {
+          //
+          // Gesture attribution alone cannot cover the whole input surface
+          // though: `isGestureInsidePlayer` deliberately counts only
+          // play-toggle keys, so a keyboard SPEED shortcut is never recognised
+          // as an in-player takeover. The second branch closes that hole with
+          // evidence rather than attribution — the rate on the element is not
+          // the one our own catch-up wrote, so someone else put it there.
+          // Without it the user's change is lost twice over: the broadcast
+          // reports the session's base rate, and the session timer then restores
+          // that base rate locally too.
+          //
+          // A rate mismatch alone is NOT enough, because the player resets the
+          // live rate by itself while recovering from a stall (see
+          // `cancelActiveSoftApply`). That reset also fails to match what the
+          // catch-up wrote, and cancelling it as `user-ratechange` would SKIP the
+          // restore and strand the elevated `defaultPlaybackRate` — the exact
+          // bug that restore exists to prevent. Requiring a recorded explicit
+          // ratechange keeps the branch to changes something outside this code
+          // deliberately made: `rememberExplicitUserAction` above only records
+          // one when a real gesture backs it.
+          const hasRecordedUserRateChange =
+            args.runtimeState.lastExplicitUserAction?.kind === "ratechange" &&
+            monotonicNow() - args.runtimeState.lastExplicitUserAction.at <
+              args.userGestureGraceMs;
+          if (
+            hasRecentUserGestureInPlayer() ||
+            (hasRecordedUserRateChange &&
+              args.isRateUnexplainedByActiveCatchUp(
+                args.normalizeUrl(args.getSharedVideo()?.url),
+                video.playbackRate,
+              ))
+          ) {
             args.cancelActiveSoftApply(video, "user-ratechange");
           }
         }

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -151,6 +151,19 @@ export function createPlaybackBindingController(args: {
   const hasRecentUserGestureInPlayer = () =>
     monotonicNow() - args.runtimeState.lastUserGestureInPlayerAt <
     args.userGestureGraceMs;
+  // The user just operated the player's SPEED control (Shift+1 / Shift+2, or
+  // ArrowRight held for 3x).
+  //
+  // The `> 0` check is defensive, not load-bearing today: the field starts at 0
+  // and `performance.now()` starts near it, so a bare freshness check would read
+  // as true for the first `userGestureGraceMs` of the page — but
+  // `hasRecentUserGestureInPlayer` has the same 0 default and the same window,
+  // so that span is already covered by it and the difference is unobservable.
+  // Kept so the two cannot drift apart if either default or window changes.
+  const hasRecentRateControlGesture = () =>
+    args.runtimeState.lastRateControlGestureAt > 0 &&
+    monotonicNow() - args.runtimeState.lastRateControlGestureAt <
+      args.userGestureGraceMs;
   // A FRESH in-player play intent: an in-player gesture that also postdates the
   // last forced pause. While the page bridge resolves, the unconfirmed-context
   // hold force-pauses (updating `lastForcedPauseAt`); the SAME click that
@@ -1156,24 +1169,23 @@ export function createPlaybackBindingController(args: {
           // This prevents a stray page click near our own catch-up ratechange
           // from cancelling the self-restore and leaving the temporary rate stuck.
           //
-          // Known limitation, deliberately not "fixed" (#238/#239): a KEYBOARD
-          // speed shortcut is not an in-player gesture (`isGestureInsidePlayer`
-          // counts only play-toggle keys), so changing speed that way during a
-          // catch-up does not end the session and the change is undone when the
-          // session restores. The speed MENU is a pointer inside the player, so
-          // the common path is covered.
+          // The speed MENU is a pointer inside the player, so the predicate above
+          // already covers it. A KEYBOARD speed shortcut is not an in-player
+          // gesture (`isGestureInsidePlayer` counts only play-toggle keys), which
+          // is what `isRateControlGesture` is for — a signal kept deliberately
+          // separate so speed keys never authorize playback on a "load paused"
+          // page.
           //
-          // Do not close it by inferring the takeover from "the element's rate is
-          // not the one the catch-up wrote". The player resets the live rate by
-          // itself while recovering from a stall, and `rememberExplicitUserAction`
-          // above records kind=`ratechange` off the EVENT type plus ANY recent
-          // document-level gesture — so that inference cannot separate the two,
-          // and a false positive cancels as `user-ratechange`, skipping the
-          // restore and stranding the elevated `defaultPlaybackRate` (see
-          // `cancelActiveSoftApply`). Closing it properly needs a real signal for
-          // "the user operated the speed control", which the document-level
-          // gesture tracker does not currently produce.
-          if (hasRecentUserGestureInPlayer()) {
+          // Both branches are POSITIVE evidence about the input. Do NOT replace
+          // them by inferring the takeover from "the element's rate is not the one
+          // the catch-up wrote": the player resets the live rate by itself while
+          // recovering from a stall, and `rememberExplicitUserAction` above
+          // records kind=`ratechange` off the EVENT type plus ANY recent
+          // document-level gesture, so neither separates the two. A false
+          // positive cancels as `user-ratechange`, which SKIPS the restore and
+          // strands the elevated `defaultPlaybackRate` (see
+          // `cancelActiveSoftApply`).
+          if (hasRecentUserGestureInPlayer() || hasRecentRateControlGesture()) {
             args.cancelActiveSoftApply(video, "user-ratechange");
           }
         }

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -92,6 +92,16 @@ export interface ContentRuntimeState {
    * stray gesture cannot wave the page-load autoplay through.
    */
   lastUserGestureInPlayerAt: number;
+  /**
+   * Timestamp of the most recent gesture on the player's playback-SPEED control
+   * (Shift+1 / Shift+2, or ArrowRight held for 3x). Tracked separately from
+   * `lastUserGestureInPlayerAt` on purpose: that one authorizes playback on
+   * "load paused" pages, so speed keys must not feed it.
+   *
+   * This is the only positive evidence that something other than our own rate
+   * catch-up moved `playbackRate`; see `isRateControlGesture`. `0` means never.
+   */
+  lastRateControlGestureAt: number;
   lastExplicitPlaybackAction: ExplicitPlaybackAction | null;
   explicitNonSharedPlaybackUrl: string | null;
   suppressedLocalEndPauseUrl: string | null;
@@ -298,6 +308,7 @@ export interface ContentRuntimeState {
 export function resetUserGestureState(state: ContentRuntimeState): void {
   state.lastUserGestureAt = 0;
   state.lastUserGestureInPlayerAt = 0;
+  state.lastRateControlGestureAt = 0;
   state.lastExplicitPlaybackAction = null;
   state.lastExplicitUserAction = null;
   state.explicitSeekOriginPlayState = null;
@@ -326,6 +337,7 @@ export function createContentRuntimeState(): ContentRuntimeState {
     lastLocalIntentPlayState: null,
     lastUserGestureAt: 0,
     lastUserGestureInPlayerAt: 0,
+    lastRateControlGestureAt: 0,
     lastExplicitPlaybackAction: null,
     explicitNonSharedPlaybackUrl: null,
     suppressedLocalEndPauseUrl: null,

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -93,8 +93,9 @@ export interface ContentRuntimeState {
    */
   lastUserGestureInPlayerAt: number;
   /**
-   * Timestamp of the most recent gesture on the player's playback-SPEED control
-   * (Shift+1 / Shift+2, or ArrowRight held for 3x). Tracked separately from
+   * Timestamp of the most recent gesture that PERSISTENTLY selects a playback
+   * speed (Shift+1 / Shift+2). Hold-to-fast-forward is excluded — see
+   * `isRateControlGesture`. Tracked separately from
    * `lastUserGestureInPlayerAt` on purpose: that one authorizes playback on
    * "load paused" pages, so speed keys must not feed it.
    *

--- a/extension/src/content/share-controller.ts
+++ b/extension/src/content/share-controller.ts
@@ -53,6 +53,17 @@ export function createShareController(args: {
     pageUrl: string;
     maxAgeMs: number;
   }) => Promise<SharedVideo | null>;
+  /**
+   * The room's base playback rate while a rate catch-up is running for this url,
+   * or `null` when none is. A share payload must report it for the same reason a
+   * `playback:update` must: during a catch-up `video.playbackRate` is a temporary
+   * offset this client added to close its own drift, and the server persists
+   * whatever a `video:share` carries — so re-sharing mid-catch-up would write the
+   * temporary rate straight into room state (#238).
+   */
+  getActiveCorrectionBaseRate: (
+    url: string | undefined | null,
+  ) => number | null;
   debugLog: (message: string) => void;
 }): ShareController {
   function canUsePageSnapshot(pathname: string): boolean {
@@ -163,7 +174,9 @@ export function createShareController(args: {
       playback: video
         ? {
             currentTime: video.currentTime,
-            playbackRate: video.playbackRate,
+            playbackRate:
+              args.getActiveCorrectionBaseRate(sharedVideo.url) ??
+              video.playbackRate,
             playState: getPlayState(video, args.runtimeState.intendedPlayState),
           }
         : null,

--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -35,6 +35,8 @@ export interface SoftApplyController {
     options?: {
       armCooldownOnConverge?: boolean;
       relativeDriftClose?: { driftSeconds: number; rateOffsetSeconds: number };
+      /** See the implementation — the rate this apply wrote to the element. */
+      appliedPlaybackRate?: number;
     },
   ): void;
   shouldCancelActiveSoftApplyForPlayback(
@@ -70,6 +72,25 @@ export interface SoftApplyController {
    * windows the leak escaped through.
    */
   getActiveCorrectionBaseRate(normalizedUrl: string | null): number | null;
+  /**
+   * Whether `playbackRate` is a rate this client's own catch-up did not put on
+   * the element — i.e. positive evidence that something else (the user) changed
+   * it while a session was running.
+   *
+   * This exists because attributing a `ratechange` by GESTURE cannot cover the
+   * whole input surface: `isGestureInsidePlayer` deliberately counts only
+   * play-toggle keys, so a keyboard speed shortcut is never recognised as an
+   * in-player takeover, and the programmatic-apply window has usually expired by
+   * the time a late event arrives. Comparing against the rate the catch-up
+   * itself wrote answers the question directly instead of guessing at it.
+   *
+   * `false` when no session is running for this url: with no catch-up in flight
+   * there is nothing for a rate to be unexplained by.
+   */
+  isRateUnexplainedByActiveCatchUp(
+    normalizedUrl: string | null,
+    playbackRate: number,
+  ): boolean;
   shouldSuppressByCooldown(
     video: HTMLVideoElement,
     playback: PlaybackState,
@@ -119,6 +140,12 @@ export function createSoftApplyController(args: {
     // so any comparison against a *live* remote position has to age the
     // snapshot by the elapsed time first.
     startedAt: number;
+    // The rate this catch-up itself last wrote to the element. Kept so a later
+    // `ratechange` can be attributed by EVIDENCE rather than guessed at: a rate
+    // that is not this one was put there by someone else (the user), whatever
+    // the gesture tracker managed to observe. See
+    // `isRateUnexplainedByActiveCatchUp`.
+    appliedPlaybackRate: number;
   } | null = null;
   let activeSoftApplyTimer: number | null = null;
 
@@ -282,6 +309,12 @@ export function createSoftApplyController(args: {
     options: {
       armCooldownOnConverge?: boolean;
       relativeDriftClose?: { driftSeconds: number; rateOffsetSeconds: number };
+      /**
+       * The rate the apply that opened this session wrote to the element.
+       * Defaults to the base rate, which is what an apply that did not touch the
+       * rate leaves behind.
+       */
+      appliedPlaybackRate?: number;
     } = {},
   ): void {
     const armCooldownOnConverge = options.armCooldownOnConverge ?? true;
@@ -314,10 +347,11 @@ export function createSoftApplyController(args: {
       armCooldownOnConverge: nextArmCooldownOnConverge,
       convergeByRelativeDrift,
       startedAt: monotonicNow(),
+      appliedPlaybackRate: options.appliedPlaybackRate ?? playback.playbackRate,
     };
     scheduleActiveSoftApplyTimeout();
     args.debugLog(
-      `Started soft apply url=${normalizedUrl} target=${playback.currentTime.toFixed(2)} rate=${restorePlaybackRate.toFixed(2)} timeout=${timeoutMs} cooldown=${nextArmCooldownOnConverge} relativeDrift=${convergeByRelativeDrift}`,
+      `Started soft apply url=${normalizedUrl} target=${playback.currentTime.toFixed(2)} rate=${restorePlaybackRate.toFixed(2)} applied=${activeSoftApply.appliedPlaybackRate.toFixed(2)} timeout=${timeoutMs} cooldown=${nextArmCooldownOnConverge} relativeDrift=${convergeByRelativeDrift}`,
     );
   }
 
@@ -481,6 +515,20 @@ export function createSoftApplyController(args: {
     return getActiveCorrectionBaseRate(normalizedUrl) !== null;
   }
 
+  function isRateUnexplainedByActiveCatchUp(
+    normalizedUrl: string | null,
+    playbackRate: number,
+  ): boolean {
+    if (
+      activeSoftApply === null ||
+      normalizedUrl === null ||
+      normalizedUrl !== activeSoftApply.normalizedUrl
+    ) {
+      return false;
+    }
+    return Math.abs(playbackRate - activeSoftApply.appliedPlaybackRate) > 0.01;
+  }
+
   function shouldSuppressByCooldown(
     video: HTMLVideoElement,
     playback: PlaybackState,
@@ -534,6 +582,7 @@ export function createSoftApplyController(args: {
     isActiveRateOnlyCatchUp,
     hasActiveCorrectionSession,
     getActiveCorrectionBaseRate,
+    isRateUnexplainedByActiveCatchUp,
     shouldSuppressByCooldown,
     clearSoftApplyCooldown,
     destroy,

--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -53,6 +53,23 @@ export interface SoftApplyController {
    * that rate protected from being written back to the room's base value.
    */
   hasActiveCorrectionSession(normalizedUrl: string | null): boolean;
+  /**
+   * The room's base playback rate while a correction session is in flight for
+   * this url, or `null` when none is.
+   *
+   * This is what a broadcast must report, because `video.playbackRate` is NOT
+   * the room's rate during a session — it is a temporary offset this client is
+   * applying to close its own drift, and the room never asked for it. Publishing
+   * it makes peers adopt the offset as their base, correct against *that*, and
+   * publish a lower one still (#238: 1x ratcheted down to 0.53x). The temporary
+   * rate is a local implementation detail and must not reach the wire.
+   *
+   * Deliberately NOT gated on `deadlineAt`: past the deadline the session is
+   * still unrestored (the timer that restores it has not run yet), so the base
+   * rate is still the only correct thing to send. That gap is exactly one of the
+   * windows the leak escaped through.
+   */
+  getActiveCorrectionBaseRate(normalizedUrl: string | null): number | null;
   shouldSuppressByCooldown(
     video: HTMLVideoElement,
     playback: PlaybackState,
@@ -447,12 +464,21 @@ export function createSoftApplyController(args: {
     );
   }
 
+  function getActiveCorrectionBaseRate(
+    normalizedUrl: string | null,
+  ): number | null {
+    if (
+      activeSoftApply === null ||
+      normalizedUrl === null ||
+      normalizedUrl !== activeSoftApply.normalizedUrl
+    ) {
+      return null;
+    }
+    return activeSoftApply.restorePlaybackRate;
+  }
+
   function hasActiveCorrectionSession(normalizedUrl: string | null): boolean {
-    return (
-      activeSoftApply !== null &&
-      normalizedUrl !== null &&
-      normalizedUrl === activeSoftApply.normalizedUrl
-    );
+    return getActiveCorrectionBaseRate(normalizedUrl) !== null;
   }
 
   function shouldSuppressByCooldown(
@@ -507,6 +533,7 @@ export function createSoftApplyController(args: {
     shouldSuppressActiveSoftApplyBroadcast,
     isActiveRateOnlyCatchUp,
     hasActiveCorrectionSession,
+    getActiveCorrectionBaseRate,
     shouldSuppressByCooldown,
     clearSoftApplyCooldown,
     destroy,

--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -427,11 +427,12 @@ export function createSoftApplyController(args: {
     eventSource: LocalPlaybackEventSource;
     now: number;
   }): boolean {
+    // `normalizedCurrentUrl` is the LOCAL page's url, so it needs the alias-aware
+    // match — see `matchesActiveSession`.
     if (
       !activeSoftApply ||
       input.now >= activeSoftApply.deadlineAt ||
-      !input.normalizedCurrentUrl ||
-      input.normalizedCurrentUrl !== activeSoftApply.normalizedUrl
+      !matchesActiveSession(input.normalizedCurrentUrl)
     ) {
       return false;
     }
@@ -454,27 +455,53 @@ export function createSoftApplyController(args: {
   // suppress / pollute the authoritative state. A session that ran a real
   // soft-apply (sticky armCooldownOnConverge=true) is excluded: its delayed
   // seek echoes must still be suppressed.
+  // Callers pass urls from BOTH spaces — the room's (`pending.url`) and the local
+  // page's (`normalizedCurrentVideoUrl`) — so this needs the alias-aware match
+  // too; see `matchesActiveSession`.
   function isActiveRateOnlyCatchUp(normalizedUrl: string | null): boolean {
     return (
       activeSoftApply !== null &&
       activeSoftApply.convergeByRelativeDrift &&
       !activeSoftApply.armCooldownOnConverge &&
-      normalizedUrl !== null &&
-      normalizedUrl === activeSoftApply.normalizedUrl
+      matchesActiveSession(normalizedUrl)
+    );
+  }
+
+  /**
+   * Whether `normalizedUrl` names the video the active session is correcting.
+   *
+   * A session is keyed on the url the ROOM carries (`playback.url`). On an
+   * address-bar-opaque festival page that can be the bare `/festival/<id>` route
+   * the share was made with, which stays the room's identity until the room
+   * confirms a concrete video (see `resolvedSharedVideoUrl` and
+   * `navigation-controller`'s discovery branch). Meanwhile every local caller —
+   * the broadcast path's `currentVideo.url`, the share payload's
+   * `sharedVideo.url` — has the resolved `/video/...`. Two spellings of one
+   * video: comparing them raw makes the getter report "no session" for the very
+   * page the session is running on, and the temporary catch-up rate goes out.
+   *
+   * The alias is only honoured when the session is keyed on the room's CURRENT
+   * shared url, so a stale session for some other video cannot borrow it.
+   */
+  function matchesActiveSession(normalizedUrl: string | null): boolean {
+    if (activeSoftApply === null || normalizedUrl === null) {
+      return false;
+    }
+    if (normalizedUrl === activeSoftApply.normalizedUrl) {
+      return true;
+    }
+    return (
+      normalizedUrl === args.runtimeState.resolvedSharedVideoUrl &&
+      activeSoftApply.normalizedUrl === args.runtimeState.activeSharedUrl
     );
   }
 
   function getActiveCorrectionBaseRate(
     normalizedUrl: string | null,
   ): number | null {
-    if (
-      activeSoftApply === null ||
-      normalizedUrl === null ||
-      normalizedUrl !== activeSoftApply.normalizedUrl
-    ) {
-      return null;
-    }
-    return activeSoftApply.restorePlaybackRate;
+    return matchesActiveSession(normalizedUrl) && activeSoftApply !== null
+      ? activeSoftApply.restorePlaybackRate
+      : null;
   }
 
   function hasActiveCorrectionSession(normalizedUrl: string | null): boolean {

--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -35,8 +35,6 @@ export interface SoftApplyController {
     options?: {
       armCooldownOnConverge?: boolean;
       relativeDriftClose?: { driftSeconds: number; rateOffsetSeconds: number };
-      /** See the implementation — the rate this apply wrote to the element. */
-      appliedPlaybackRate?: number;
     },
   ): void;
   shouldCancelActiveSoftApplyForPlayback(
@@ -72,25 +70,6 @@ export interface SoftApplyController {
    * windows the leak escaped through.
    */
   getActiveCorrectionBaseRate(normalizedUrl: string | null): number | null;
-  /**
-   * Whether `playbackRate` is a rate this client's own catch-up did not put on
-   * the element — i.e. positive evidence that something else (the user) changed
-   * it while a session was running.
-   *
-   * This exists because attributing a `ratechange` by GESTURE cannot cover the
-   * whole input surface: `isGestureInsidePlayer` deliberately counts only
-   * play-toggle keys, so a keyboard speed shortcut is never recognised as an
-   * in-player takeover, and the programmatic-apply window has usually expired by
-   * the time a late event arrives. Comparing against the rate the catch-up
-   * itself wrote answers the question directly instead of guessing at it.
-   *
-   * `false` when no session is running for this url: with no catch-up in flight
-   * there is nothing for a rate to be unexplained by.
-   */
-  isRateUnexplainedByActiveCatchUp(
-    normalizedUrl: string | null,
-    playbackRate: number,
-  ): boolean;
   shouldSuppressByCooldown(
     video: HTMLVideoElement,
     playback: PlaybackState,
@@ -140,12 +119,6 @@ export function createSoftApplyController(args: {
     // so any comparison against a *live* remote position has to age the
     // snapshot by the elapsed time first.
     startedAt: number;
-    // The rate this catch-up itself last wrote to the element. Kept so a later
-    // `ratechange` can be attributed by EVIDENCE rather than guessed at: a rate
-    // that is not this one was put there by someone else (the user), whatever
-    // the gesture tracker managed to observe. See
-    // `isRateUnexplainedByActiveCatchUp`.
-    appliedPlaybackRate: number;
   } | null = null;
   let activeSoftApplyTimer: number | null = null;
 
@@ -309,12 +282,6 @@ export function createSoftApplyController(args: {
     options: {
       armCooldownOnConverge?: boolean;
       relativeDriftClose?: { driftSeconds: number; rateOffsetSeconds: number };
-      /**
-       * The rate the apply that opened this session wrote to the element.
-       * Defaults to the base rate, which is what an apply that did not touch the
-       * rate leaves behind.
-       */
-      appliedPlaybackRate?: number;
     } = {},
   ): void {
     const armCooldownOnConverge = options.armCooldownOnConverge ?? true;
@@ -347,11 +314,10 @@ export function createSoftApplyController(args: {
       armCooldownOnConverge: nextArmCooldownOnConverge,
       convergeByRelativeDrift,
       startedAt: monotonicNow(),
-      appliedPlaybackRate: options.appliedPlaybackRate ?? playback.playbackRate,
     };
     scheduleActiveSoftApplyTimeout();
     args.debugLog(
-      `Started soft apply url=${normalizedUrl} target=${playback.currentTime.toFixed(2)} rate=${restorePlaybackRate.toFixed(2)} applied=${activeSoftApply.appliedPlaybackRate.toFixed(2)} timeout=${timeoutMs} cooldown=${nextArmCooldownOnConverge} relativeDrift=${convergeByRelativeDrift}`,
+      `Started soft apply url=${normalizedUrl} target=${playback.currentTime.toFixed(2)} rate=${restorePlaybackRate.toFixed(2)} timeout=${timeoutMs} cooldown=${nextArmCooldownOnConverge} relativeDrift=${convergeByRelativeDrift}`,
     );
   }
 
@@ -515,20 +481,6 @@ export function createSoftApplyController(args: {
     return getActiveCorrectionBaseRate(normalizedUrl) !== null;
   }
 
-  function isRateUnexplainedByActiveCatchUp(
-    normalizedUrl: string | null,
-    playbackRate: number,
-  ): boolean {
-    if (
-      activeSoftApply === null ||
-      normalizedUrl === null ||
-      normalizedUrl !== activeSoftApply.normalizedUrl
-    ) {
-      return false;
-    }
-    return Math.abs(playbackRate - activeSoftApply.appliedPlaybackRate) > 0.01;
-  }
-
   function shouldSuppressByCooldown(
     video: HTMLVideoElement,
     playback: PlaybackState,
@@ -582,7 +534,6 @@ export function createSoftApplyController(args: {
     isActiveRateOnlyCatchUp,
     hasActiveCorrectionSession,
     getActiveCorrectionBaseRate,
-    isRateUnexplainedByActiveCatchUp,
     shouldSuppressByCooldown,
     clearSoftApplyCooldown,
     destroy,

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -52,10 +52,6 @@ export interface SyncController {
   hasRecentRemoteStopIntent(currentVideoUrl: string): boolean;
   cancelActiveSoftApply(video: HTMLVideoElement | null, reason: string): void;
   maintainActiveSoftApply(video: HTMLVideoElement): void;
-  isRateUnexplainedByActiveCatchUp(
-    normalizedUrl: string | null,
-    playbackRate: number,
-  ): boolean;
   applyPendingPlaybackApplication(video: HTMLVideoElement): void;
   broadcastPlayback(
     video: HTMLVideoElement,
@@ -432,10 +428,6 @@ export function createSyncController(args: {
                   rateOffsetSeconds:
                     adjustment.playbackRate - adjustment.restorePlaybackRate,
                 },
-            // What this apply just wrote to the element. Recorded so a later
-            // `ratechange` carrying a DIFFERENT rate can be attributed to the
-            // user by evidence rather than by gesture guessing.
-            appliedPlaybackRate: adjustment.playbackRate,
           });
           return;
         }
@@ -1699,8 +1691,6 @@ export function createSyncController(args: {
     hasRecentRemoteStopIntent,
     cancelActiveSoftApply: softApply.cancelActiveSoftApply,
     maintainActiveSoftApply: softApply.maintainActiveSoftApply,
-    isRateUnexplainedByActiveCatchUp:
-      softApply.isRateUnexplainedByActiveCatchUp,
     applyPendingPlaybackApplication,
     broadcastPlayback,
     applyRoomState: recordRoomConfirmedBroadcast,

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -1301,9 +1301,33 @@ export function createSyncController(args: {
       );
       return;
     }
+    // `video.playbackRate` is NOT the room's rate while a correction session is
+    // in flight — it carries a temporary offset this client added to close its
+    // own drift, which the room never asked for. Every value derived from the
+    // rate below (this guard, the duplicate collapse, `intendedPlaybackRate` and
+    // the payload) has to judge the base rate instead; see
+    // `getActiveCorrectionBaseRate` for what publishing the offset does to a
+    // room (#238).
+    const correctionBaseRate = softApply.getActiveCorrectionBaseRate(
+      normalizedCurrentVideoUrl,
+    );
+    // No `explicit-ratechange` exemption, deliberately. A real user rate change
+    // reaches the room through the session being GONE: an in-player gesture (the
+    // speed menu is one) makes `onRateChange` cancel the session before this
+    // runs, so there is no base rate to report and the user's own rate goes out.
+    //
+    // What is left over — a `ratechange` tagged explicit while a session is
+    // still alive — is the ambiguous case `playback-binding-controller` already
+    // refuses to act on: our own catch-up echo, reclassified as a user action
+    // because some unrelated page click landed inside the gesture grace window.
+    // Honouring it here would publish the temporary rate, which is exactly #238.
+    // Reporting the base rate instead costs nothing even when the rate change
+    // was genuine: the session restores that same base rate when it converges,
+    // so the element is headed there regardless.
+    const broadcastPlaybackRate = correctionBaseRate ?? video.playbackRate;
     if (
       shouldSuppressUnexpectedPlaybackRateBroadcast({
-        playbackRate: video.playbackRate,
+        playbackRate: broadcastPlaybackRate,
         currentVideoUrl: currentVideo.url,
         eventSource,
         now,
@@ -1497,10 +1521,11 @@ export function createSyncController(args: {
       duplicate.naturalEnd === (naturalEnd === true) &&
       Math.abs(duplicate.currentTime - video.currentTime) <=
         DUPLICATE_BROADCAST_TIME_EPSILON_SECONDS &&
-      Math.abs(duplicate.playbackRate - video.playbackRate) <= 0.01 &&
+      Math.abs(duplicate.playbackRate - broadcastPlaybackRate) <= 0.01 &&
       args.runtimeState.intendedPlayState === playState &&
-      Math.abs(args.runtimeState.intendedPlaybackRate - video.playbackRate) <=
-        0.01
+      Math.abs(
+        args.runtimeState.intendedPlaybackRate - broadcastPlaybackRate,
+      ) <= 0.01
     ) {
       // Skipping the *message* must not skip the local-intent guard. That
       // window (playback-apply's `ignore-local-guard`) is what stops a stale
@@ -1520,7 +1545,11 @@ export function createSyncController(args: {
 
     args.markBroadcastAt(now);
     args.runtimeState.intendedPlayState = playState;
-    args.runtimeState.intendedPlaybackRate = video.playbackRate;
+    // Must be the broadcast rate, not the live one. This is what
+    // `shouldSuppressUnexpectedPlaybackRateBroadcast` later treats as "expected",
+    // so writing the temporary catch-up rate here taught the guard to accept it
+    // and disarmed it for every subsequent leak (#238).
+    args.runtimeState.intendedPlaybackRate = broadcastPlaybackRate;
     args.runtimeState.lastLocalIntentAt = now;
     args.runtimeState.lastLocalIntentPlayState = playState;
     const payload = createPlaybackBroadcastPayload({
@@ -1530,7 +1559,7 @@ export function createSyncController(args: {
       syncIntent,
       naturalEnd,
       userInitiated,
-      playbackRate: video.playbackRate,
+      playbackRate: broadcastPlaybackRate,
       actorId: args.runtimeState.localMemberId ?? "local",
       seq: args.nextSeq(),
       // NOT `now`. `now` is this machine's monotonic reading, which every local

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -52,6 +52,10 @@ export interface SyncController {
   hasRecentRemoteStopIntent(currentVideoUrl: string): boolean;
   cancelActiveSoftApply(video: HTMLVideoElement | null, reason: string): void;
   maintainActiveSoftApply(video: HTMLVideoElement): void;
+  isRateUnexplainedByActiveCatchUp(
+    normalizedUrl: string | null,
+    playbackRate: number,
+  ): boolean;
   applyPendingPlaybackApplication(video: HTMLVideoElement): void;
   broadcastPlayback(
     video: HTMLVideoElement,
@@ -428,6 +432,10 @@ export function createSyncController(args: {
                   rateOffsetSeconds:
                     adjustment.playbackRate - adjustment.restorePlaybackRate,
                 },
+            // What this apply just wrote to the element. Recorded so a later
+            // `ratechange` carrying a DIFFERENT rate can be attributed to the
+            // user by evidence rather than by gesture guessing.
+            appliedPlaybackRate: adjustment.playbackRate,
           });
           return;
         }
@@ -1691,6 +1699,8 @@ export function createSyncController(args: {
     hasRecentRemoteStopIntent,
     cancelActiveSoftApply: softApply.cancelActiveSoftApply,
     maintainActiveSoftApply: softApply.maintainActiveSoftApply,
+    isRateUnexplainedByActiveCatchUp:
+      softApply.isRateUnexplainedByActiveCatchUp,
     applyPendingPlaybackApplication,
     broadcastPlayback,
     applyRoomState: recordRoomConfirmedBroadcast,

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -52,6 +52,14 @@ export interface SyncController {
   hasRecentRemoteStopIntent(currentVideoUrl: string): boolean;
   cancelActiveSoftApply(video: HTMLVideoElement | null, reason: string): void;
   maintainActiveSoftApply(video: HTMLVideoElement): void;
+  /**
+   * The room's base rate while a catch-up is running for this url, else `null`.
+   * Exposed because `playback:update` is not the only wire path that carries a
+   * playback rate — `video:share` does too, and the server persists it — so every
+   * payload builder has to be able to report the base rate instead of the
+   * element's temporary one (#238).
+   */
+  getActiveCorrectionBaseRate(normalizedUrl: string | null): number | null;
   applyPendingPlaybackApplication(video: HTMLVideoElement): void;
   broadcastPlayback(
     video: HTMLVideoElement,
@@ -1691,6 +1699,7 @@ export function createSyncController(args: {
     hasRecentRemoteStopIntent,
     cancelActiveSoftApply: softApply.cancelActiveSoftApply,
     maintainActiveSoftApply: softApply.maintainActiveSoftApply,
+    getActiveCorrectionBaseRate: softApply.getActiveCorrectionBaseRate,
     applyPendingPlaybackApplication,
     broadcastPlayback,
     applyRoomState: recordRoomConfirmedBroadcast,

--- a/extension/test/gesture-tracker.test.ts
+++ b/extension/test/gesture-tracker.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   isGestureInsidePlayer,
+  isRateControlGesture,
   startUserGestureTracking,
 } from "../src/content/gesture-tracker";
 
@@ -238,5 +239,164 @@ test("startUserGestureTracking treats browser history popstate as a user gesture
     assert.equal(gestures, 1);
   } finally {
     stubs.restore();
+  }
+});
+
+function fakeRateKeyEvent(
+  options: {
+    key?: string;
+    code?: string;
+    shiftKey?: boolean;
+    repeat?: boolean;
+    target?: unknown;
+    type?: string;
+  } = {},
+): Event {
+  return {
+    type: options.type ?? "keydown",
+    target: options.target ?? new FakeElement({}),
+    key: options.key,
+    code: options.code,
+    shiftKey: options.shiftKey ?? false,
+    repeat: options.repeat ?? false,
+  } as unknown as Event;
+}
+
+test("isRateControlGesture matches Bilibili's Shift+1 / Shift+2 speed keys", () => {
+  withElementStub(() => {
+    // Matched on `code`: with Shift held, `key` is the SHIFTED character ("!"
+    // on a US layout), so a `key` comparison would never fire.
+    assert.equal(
+      isRateControlGesture(
+        fakeRateKeyEvent({ code: "Digit1", key: "!", shiftKey: true }),
+      ),
+      true,
+    );
+    assert.equal(
+      isRateControlGesture(
+        fakeRateKeyEvent({ code: "Digit2", key: "@", shiftKey: true }),
+      ),
+      true,
+    );
+    // Without Shift the same physical keys do nothing to the rate.
+    assert.equal(
+      isRateControlGesture(fakeRateKeyEvent({ code: "Digit1", key: "1" })),
+      false,
+    );
+    // Unrelated shifted key.
+    assert.equal(
+      isRateControlGesture(
+        fakeRateKeyEvent({ code: "Digit3", key: "#", shiftKey: true }),
+      ),
+      false,
+    );
+  });
+});
+
+test("isRateControlGesture counts a held ArrowRight but not a short press", () => {
+  withElementStub(() => {
+    // Holding ArrowRight engages 3x, and holding is what produces auto-repeat.
+    assert.equal(
+      isRateControlGesture(
+        fakeRateKeyEvent({ key: "ArrowRight", repeat: true }),
+      ),
+      true,
+    );
+    // A short press is a 5s SEEK and leaves the rate alone. Counting it would
+    // make every arrow-key seek look like a speed change, so a stall-reset
+    // landing next to one would be misread as a user takeover.
+    assert.equal(
+      isRateControlGesture(
+        fakeRateKeyEvent({ key: "ArrowRight", repeat: false }),
+      ),
+      false,
+    );
+  });
+});
+
+test("isRateControlGesture ignores speed keys typed into an editable target", () => {
+  withElementStub(() => {
+    assert.equal(
+      isRateControlGesture(
+        fakeRateKeyEvent({
+          code: "Digit2",
+          key: "@",
+          shiftKey: true,
+          target: new FakeElement({ [EDITABLE_SELECTOR]: true }),
+        }),
+      ),
+      false,
+    );
+    assert.equal(
+      isRateControlGesture(
+        fakeRateKeyEvent({
+          key: "ArrowRight",
+          repeat: true,
+          target: new FakeElement({}, true),
+        }),
+      ),
+      false,
+    );
+  });
+});
+
+test("isRateControlGesture ignores non-keydown events", () => {
+  withElementStub(() => {
+    assert.equal(
+      isRateControlGesture(
+        fakeRateKeyEvent({ type: "click", key: "ArrowRight", repeat: true }),
+      ),
+      false,
+    );
+  });
+});
+
+test("startUserGestureTracking reports the rate-control flag separately", () => {
+  const originalDocument = globalThis.document;
+  const originalWindow = globalThis.window;
+  const listeners: Array<{ type: string; handler: (event: Event) => void }> =
+    [];
+  Object.assign(globalThis, {
+    document: {
+      addEventListener(type: string, handler: (event: Event) => void) {
+        listeners.push({ type, handler });
+      },
+    },
+    window: {
+      addEventListener(type: string, handler: (event: Event) => void) {
+        listeners.push({ type, handler });
+      },
+    },
+  });
+  const reports: Array<{ insidePlayer: boolean; rateControl: boolean }> = [];
+
+  try {
+    withElementStub(() => {
+      startUserGestureTracking((insidePlayer, rateControl) => {
+        reports.push({ insidePlayer, rateControl });
+      });
+      const keydownHandler = listeners.find(
+        (entry) => entry.type === "keydown",
+      )?.handler;
+      assert.ok(keydownHandler);
+
+      // A speed key is a rate-control gesture but NOT an in-player play intent:
+      // feeding it into that predicate would authorize the page-load autoplay.
+      keydownHandler?.(
+        fakeRateKeyEvent({ code: "Digit2", key: "@", shiftKey: true }),
+      );
+      // A play-toggle key is the opposite.
+      keydownHandler?.(fakeRateKeyEvent({ key: "k" }));
+
+      assert.deepEqual(reports, [
+        { insidePlayer: false, rateControl: true },
+        { insidePlayer: true, rateControl: false },
+      ]);
+    });
+  } finally {
+    Object.assign(globalThis, {
+      document: originalDocument,
+      window: originalWindow,
+    });
   }
 });

--- a/extension/test/gesture-tracker.test.ts
+++ b/extension/test/gesture-tracker.test.ts
@@ -293,18 +293,21 @@ test("isRateControlGesture matches Bilibili's Shift+1 / Shift+2 speed keys", () 
   });
 });
 
-test("isRateControlGesture counts a held ArrowRight but not a short press", () => {
+test("isRateControlGesture excludes ArrowRight entirely, held or not", () => {
   withElementStub(() => {
-    // Holding ArrowRight engages 3x, and holding is what produces auto-repeat.
+    // Holding ArrowRight engages 3x, but only while held: on release the player
+    // restores the rate it saved when the hold began, which mid-catch-up is our
+    // TEMPORARY rate. Treating the hold as a takeover would end the session,
+    // drop its restore, and let both the transient 3x and that temporary rate go
+    // out tagged `explicit-ratechange` — exactly the pollution #238 is about
+    // (its logs show `3`, `3`, `0.9223063476562674`, `0.9223063476562674`).
     assert.equal(
       isRateControlGesture(
         fakeRateKeyEvent({ key: "ArrowRight", repeat: true }),
       ),
-      true,
+      false,
     );
-    // A short press is a 5s SEEK and leaves the rate alone. Counting it would
-    // make every arrow-key seek look like a speed change, so a stall-reset
-    // landing next to one would be misread as a user takeover.
+    // A short press is a 5s seek and never touches the rate at all.
     assert.equal(
       isRateControlGesture(
         fakeRateKeyEvent({ key: "ArrowRight", repeat: false }),
@@ -330,8 +333,9 @@ test("isRateControlGesture ignores speed keys typed into an editable target", ()
     assert.equal(
       isRateControlGesture(
         fakeRateKeyEvent({
-          key: "ArrowRight",
-          repeat: true,
+          code: "Digit1",
+          key: "!",
+          shiftKey: true,
           target: new FakeElement({}, true),
         }),
       ),
@@ -344,7 +348,7 @@ test("isRateControlGesture ignores non-keydown events", () => {
   withElementStub(() => {
     assert.equal(
       isRateControlGesture(
-        fakeRateKeyEvent({ type: "click", key: "ArrowRight", repeat: true }),
+        fakeRateKeyEvent({ type: "click", code: "Digit2", shiftKey: true }),
       ),
       false,
     );

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -4285,3 +4285,54 @@ test("playback binding controller does not treat any recent gesture as a rate ta
     dom.restore();
   }
 });
+
+test("playback binding controller ends the catch-up for a keyboard speed shortcut", () => {
+  // Shift+1 / Shift+2 / held ArrowRight are not in-player gestures
+  // (`isGestureInsidePlayer` counts only play-toggle keys), so before the
+  // dedicated signal existed the session survived, the broadcast reported the
+  // session's base rate and the restore timer put that base rate back — the
+  // user's choice was lost both locally and in the room (#238/#239).
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 4_500;
+  // Nothing in-player: a speed key must never feed that predicate.
+  runtimeState.lastUserGestureInPlayerAt = 1_000;
+  runtimeState.lastRateControlGestureAt = 4_500;
+  const reasons: string[] = [];
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => ({
+      videoId: "BV1xx411c7mD",
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      title: "Video",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: (_video, reason) => {
+      reasons.push(reason);
+    },
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => 5_000,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("ratechange")!(new Event("ratechange"));
+
+    assert.deepEqual(reasons, ["user-ratechange"]);
+  } finally {
+    dom.restore();
+  }
+});

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -71,7 +71,6 @@ test("playback binding controller forwards ratechange event source", async () =>
   const events: string[] = [];
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -120,7 +119,6 @@ test("playback binding controller cancels active soft apply on pause and seek", 
   const reasons: string[] = [];
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -162,7 +160,6 @@ test("playback binding controller does not cancel active soft apply for programm
   const reasons: string[] = [];
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -204,7 +201,6 @@ test("playback binding controller preserves explicit seek intent across immediat
   let now = 1_100;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -255,7 +251,6 @@ test("playback binding controller does not mark programmatic ratechange as expli
   const events: string[] = [];
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -307,7 +302,6 @@ test("playback binding controller re-pauses seek-triggered autoplay when intende
   const originalSetTimeout = globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -372,7 +366,6 @@ test("playback binding controller keeps hydration pause guard when shared url is
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -461,7 +454,6 @@ test("playback binding controller keeps hydration guard after direct room switch
   });
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -540,7 +532,6 @@ test("playback binding controller keeps hydration pause guard for unstable festi
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -609,7 +600,6 @@ test("playback binding controller reapplies pause hold for unstable identity aft
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -680,7 +670,6 @@ test("playback binding controller reapplies pause hold for unstable room shared 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -745,7 +734,6 @@ test("playback binding controller clears explicit seek intent after seek-trigger
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -808,7 +796,6 @@ test("playback binding controller allows manual play after a newer gesture follo
   const events: string[] = [];
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -876,7 +863,6 @@ test("playback binding controller holds a page-load autoplay authorized only by 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -973,7 +959,6 @@ test("playback binding controller still holds the delayed autoplay when the only
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1052,7 +1037,6 @@ test("playback binding controller holds a seek-triggered non-shared autoplay, th
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1138,7 +1122,6 @@ test("playback binding controller allows explicit play on a non-shared page", as
   const events: string[] = [];
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1199,7 +1182,6 @@ test("playback binding controller suppresses auto-resumed non-shared broadcast a
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1281,7 +1263,6 @@ test("playback binding controller pauses delayed non-sharer autoplay into a non-
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1356,7 +1337,6 @@ test("playback binding controller pauses delayed non-sharer autoplay even after 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1430,7 +1410,6 @@ test("playback binding controller lets the user watch an explicitly opened local
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1501,7 +1480,6 @@ test("playback binding controller pauses an unmarked non-shared page reached by 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1579,7 +1557,6 @@ test("playback binding controller pauses a non-shared video even when room inten
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1645,7 +1622,6 @@ test("playback binding controller periodic tick pauses a non-shared video alread
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1739,7 +1715,6 @@ test("playback binding controller holds a play while the page bridge is resolvin
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1836,7 +1811,6 @@ test("playback binding controller stops force-pausing an unresolved non-shared p
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1915,7 +1889,6 @@ test("playback binding controller does not re-pause an authorized non-shared pla
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2005,7 +1978,6 @@ test("playback binding controller preserves the explicit non-shared authorizatio
   const originalSetTimeout = globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2077,7 +2049,6 @@ test("playback binding controller re-pauses a pre-pause stale gesture while the 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2145,7 +2116,6 @@ test("playback binding controller still holds an unsolicited autoplay while the 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2208,7 +2178,6 @@ test("playback binding controller allows manual play on non-shared page after au
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2299,7 +2268,6 @@ test("playback binding controller suppresses non-shared autoplay replayed after 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2372,7 +2340,6 @@ test("playback binding controller holds a non-sharer at the shared video natural
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2449,7 +2416,6 @@ test("playback binding controller does not pause the sharer at the shared video 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2515,7 +2481,6 @@ test("playback binding controller does not pause a non-sharer before the shared 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2583,7 +2548,6 @@ test("playback binding controller re-pauses non-sharer multi-part autoplay after
   const originalSetTimeout = globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2653,7 +2617,6 @@ test("playback binding controller classifies pause as buffer when waiting fired 
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2698,7 +2661,6 @@ test("playback binding controller treats pause as user-initiated when fresh gest
   runtimeState.lastForcedPauseAt = 0;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2742,7 +2704,6 @@ test("playback binding controller clears buffer-pause classification on resume",
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2809,7 +2770,6 @@ test("playback binding controller does not classify pause as buffer-induced insi
   }) as typeof globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2870,7 +2830,6 @@ test("playback binding controller still classifies pause as buffer-induced when 
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2924,7 +2883,6 @@ test("playback binding controller re-broadcasts paused after buffer-pause upgrad
   }) as typeof globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2992,7 +2950,6 @@ test("playback binding controller suppresses the natural-end pause for a non-sha
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3068,7 +3025,6 @@ test("playback binding controller suppresses the natural-end pause broadcast for
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3156,7 +3112,6 @@ test("playback binding controller records the seek-to-end flag when a seek prece
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3222,7 +3177,6 @@ test("playback binding controller flushes the sharer's terminal paused state whe
   }) as unknown as typeof globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3302,7 +3256,6 @@ test("playback binding controller does not flush a sharer end state once autopla
   }) as unknown as typeof globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3367,7 +3320,6 @@ test("playback binding controller does not arm sharer end suppression for a non-
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3422,7 +3374,6 @@ test("playback binding controller classifies a stall on a rebuilt element as buf
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3468,7 +3419,6 @@ test("playback binding controller does not reclassify a user pause when transpor
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3517,7 +3467,6 @@ test("playback binding controller leaves an unobserved pause alone when the room
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3559,7 +3508,6 @@ test("playback binding controller classifies a pause right after a video rebind 
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3620,7 +3568,6 @@ test("playback binding controller upgrades an unobserved stall to paused after t
   }) as typeof globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3673,7 +3620,6 @@ function createEchoHarness(
   getMonotonicNow: () => number,
 ) {
   return createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3834,7 +3780,6 @@ test("a user seek that cancels an active rate catch-up is still recorded", async
   const events: string[] = [];
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3896,7 +3841,6 @@ test("a user pause that cancels an active rate catch-up is still recorded", () =
   runtimeState.lastUserGestureInPlayerAt = 1_000;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3957,7 +3901,6 @@ test("a ratechange is enough to classify an unobserved pause as buffering", () =
   runtimeState.lastUserGestureAt = 0;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3999,7 +3942,6 @@ test("a real user pause is not reclassified by the shared broadcast path", () =>
   runtimeState.lastUserGestureInPlayerAt = 9_900;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -4039,7 +3981,6 @@ test("playback binding controller keeps the seek origin across seeking and seeke
   let now = 1_100;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -4090,7 +4031,6 @@ test("playback binding controller re-snapshots the origin for a new seek gesture
   let now = 1_100;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -4139,7 +4079,6 @@ test("playback binding controller re-samples the seek origin after a forced paus
   let now = 1_100;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -4195,7 +4134,6 @@ test("playback binding controller reports a newly bound video element once", () 
   let bindings = 0;
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -4247,7 +4185,6 @@ test("records explicit user actions on the monotonic clock by default", async ()
   const events: string[] = [];
 
   const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -4290,26 +4227,23 @@ test("records explicit user actions on the monotonic clock by default", async ()
   }
 });
 
-test("playback binding controller ends the catch-up for a keyboard speed shortcut", () => {
-  // `isGestureInsidePlayer` deliberately counts only play-toggle keys, so a
-  // keyboard SPEED shortcut leaves `lastUserGestureInPlayerAt` untouched and the
-  // in-player predicate cannot see the takeover. The rate on the element is the
-  // evidence: it is not the one our catch-up wrote. Without acting on it the
-  // user's choice is lost twice — the broadcast reports the session's base rate,
-  // and the session timer then restores that base rate locally too (#238).
+test("playback binding controller does not treat any recent gesture as a rate takeover", () => {
+  // The player resets the live rate by itself while recovering from a stall. If
+  // an unrelated page click happened to land inside the gesture grace window,
+  // `rememberExplicitUserAction` still records kind=`ratechange` — it reads the
+  // EVENT type, not what the user actually operated. Cancelling on that
+  // combination would skip the restore and strand the elevated
+  // `defaultPlaybackRate`, resurrecting the temporary rate on the next media
+  // load (#239). Only a real in-player gesture may end the session.
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();
+  // Recent document-level gesture (a click on blank space)…
   runtimeState.lastUserGestureAt = 4_500;
-  // Document-level gesture only; the in-player one is far enough in the past
-  // that `hasRecentUserGestureInPlayer()` is false. Leaving it at the default 0
-  // would sit INSIDE the grace window at these clock values and cancel via the
-  // old in-player branch, making this test pass for the wrong reason.
+  // …but nothing in-player for far longer than the grace window.
   runtimeState.lastUserGestureInPlayerAt = 1_000;
   const reasons: string[] = [];
 
   const controller = createPlaybackBindingController({
-    // The catch-up wrote 0.84; the element now reads 1.5.
-    isRateUnexplainedByActiveCatchUp: () => true,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -4340,106 +4274,12 @@ test("playback binding controller ends the catch-up for a keyboard speed shortcu
     controller.attachPlaybackListeners();
     dom.listeners.get("ratechange")!(new Event("ratechange"));
 
-    assert.deepEqual(reasons, ["user-ratechange"]);
-  } finally {
-    dom.restore();
-  }
-});
-
-test("playback binding controller keeps the catch-up alive for its own rate echo", () => {
-  // The other half of the same ambiguity: the element still carries exactly the
-  // rate our catch-up wrote, so this `ratechange` is our own echo however recent
-  // an unrelated page click was. Cancelling here would strand the temporary rate
-  // and drop the self-restore.
-  const dom = installDomStub();
-  const runtimeState = createContentRuntimeState();
-  runtimeState.lastUserGestureAt = 4_500;
-  runtimeState.lastUserGestureInPlayerAt = 1_000;
-  const reasons: string[] = [];
-
-  const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => false,
-    runtimeState,
-    videoBindIntervalMs: 250,
-    userGestureGraceMs: 1_200,
-    initialRoomStatePauseHoldMs: 3_000,
-    bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
-    videoRebindBufferSignalMs: 1_000,
-    getSharedVideo: () => ({
-      videoId: "BV1xx411c7mD",
-      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
-      title: "Video",
-    }),
-    hasRecentRemoteStopIntent: () => false,
-    normalizeUrl: (url) => url ?? null,
-    getLastBroadcastAt: () => 0,
-    broadcastPlayback: async () => {},
-    cancelActiveSoftApply: (_video, reason) => {
-      reasons.push(reason);
-    },
-    maintainActiveSoftApply: () => {},
-    applyPendingPlaybackApplication: () => {},
-    activatePauseHold: () => {},
-    debugLog: () => {},
-    getMonotonicNow: () => 5_000,
-  });
-
-  try {
-    controller.attachPlaybackListeners();
-    dom.listeners.get("ratechange")!(new Event("ratechange"));
-
-    assert.deepEqual(reasons, []);
-  } finally {
-    dom.restore();
-  }
-});
-
-test("playback binding controller keeps the catch-up alive when the player resets the rate itself", () => {
-  // The player resets the live rate on its own while recovering from a stall.
-  // That rate does not match what the catch-up wrote either, but no user did
-  // anything — and cancelling as `user-ratechange` SKIPS the restore, stranding
-  // the elevated `defaultPlaybackRate` (the bug that restore exists to prevent).
-  const dom = installDomStub();
-  const runtimeState = createContentRuntimeState();
-  // No recent gesture at all, so `rememberExplicitUserAction` records nothing.
-  runtimeState.lastUserGestureAt = 1_000;
-  runtimeState.lastUserGestureInPlayerAt = 1_000;
-  const reasons: string[] = [];
-
-  const controller = createPlaybackBindingController({
-    isRateUnexplainedByActiveCatchUp: () => true,
-    runtimeState,
-    videoBindIntervalMs: 250,
-    userGestureGraceMs: 1_200,
-    initialRoomStatePauseHoldMs: 3_000,
-    bufferSignalWindowMs: 300,
-    bufferPauseUpgradeMs: 1_500,
-    videoRebindBufferSignalMs: 1_000,
-    getSharedVideo: () => ({
-      videoId: "BV1xx411c7mD",
-      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
-      title: "Video",
-    }),
-    hasRecentRemoteStopIntent: () => false,
-    normalizeUrl: (url) => url ?? null,
-    getLastBroadcastAt: () => 0,
-    broadcastPlayback: async () => {},
-    cancelActiveSoftApply: (_video, reason) => {
-      reasons.push(reason);
-    },
-    maintainActiveSoftApply: () => {},
-    applyPendingPlaybackApplication: () => {},
-    activatePauseHold: () => {},
-    debugLog: () => {},
-    getMonotonicNow: () => 5_000,
-  });
-
-  try {
-    controller.attachPlaybackListeners();
-    dom.listeners.get("ratechange")!(new Event("ratechange"));
-
-    assert.deepEqual(runtimeState.lastExplicitUserAction, null);
+    // The ambiguous state really was reached: the action got recorded off the
+    // event type alone. That is precisely why it must not authorize a cancel.
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "ratechange",
+      at: 5_000,
+    });
     assert.deepEqual(reasons, []);
   } finally {
     dom.restore();

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -71,6 +71,7 @@ test("playback binding controller forwards ratechange event source", async () =>
   const events: string[] = [];
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -119,6 +120,7 @@ test("playback binding controller cancels active soft apply on pause and seek", 
   const reasons: string[] = [];
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -160,6 +162,7 @@ test("playback binding controller does not cancel active soft apply for programm
   const reasons: string[] = [];
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -201,6 +204,7 @@ test("playback binding controller preserves explicit seek intent across immediat
   let now = 1_100;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -251,6 +255,7 @@ test("playback binding controller does not mark programmatic ratechange as expli
   const events: string[] = [];
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -302,6 +307,7 @@ test("playback binding controller re-pauses seek-triggered autoplay when intende
   const originalSetTimeout = globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -366,6 +372,7 @@ test("playback binding controller keeps hydration pause guard when shared url is
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -454,6 +461,7 @@ test("playback binding controller keeps hydration guard after direct room switch
   });
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -532,6 +540,7 @@ test("playback binding controller keeps hydration pause guard for unstable festi
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -600,6 +609,7 @@ test("playback binding controller reapplies pause hold for unstable identity aft
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -670,6 +680,7 @@ test("playback binding controller reapplies pause hold for unstable room shared 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -734,6 +745,7 @@ test("playback binding controller clears explicit seek intent after seek-trigger
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -796,6 +808,7 @@ test("playback binding controller allows manual play after a newer gesture follo
   const events: string[] = [];
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -863,6 +876,7 @@ test("playback binding controller holds a page-load autoplay authorized only by 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -959,6 +973,7 @@ test("playback binding controller still holds the delayed autoplay when the only
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1037,6 +1052,7 @@ test("playback binding controller holds a seek-triggered non-shared autoplay, th
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1122,6 +1138,7 @@ test("playback binding controller allows explicit play on a non-shared page", as
   const events: string[] = [];
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1182,6 +1199,7 @@ test("playback binding controller suppresses auto-resumed non-shared broadcast a
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1263,6 +1281,7 @@ test("playback binding controller pauses delayed non-sharer autoplay into a non-
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1337,6 +1356,7 @@ test("playback binding controller pauses delayed non-sharer autoplay even after 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1410,6 +1430,7 @@ test("playback binding controller lets the user watch an explicitly opened local
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1480,6 +1501,7 @@ test("playback binding controller pauses an unmarked non-shared page reached by 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1557,6 +1579,7 @@ test("playback binding controller pauses a non-shared video even when room inten
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1622,6 +1645,7 @@ test("playback binding controller periodic tick pauses a non-shared video alread
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1715,6 +1739,7 @@ test("playback binding controller holds a play while the page bridge is resolvin
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1811,6 +1836,7 @@ test("playback binding controller stops force-pausing an unresolved non-shared p
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1889,6 +1915,7 @@ test("playback binding controller does not re-pause an authorized non-shared pla
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -1978,6 +2005,7 @@ test("playback binding controller preserves the explicit non-shared authorizatio
   const originalSetTimeout = globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2049,6 +2077,7 @@ test("playback binding controller re-pauses a pre-pause stale gesture while the 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2116,6 +2145,7 @@ test("playback binding controller still holds an unsolicited autoplay while the 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2178,6 +2208,7 @@ test("playback binding controller allows manual play on non-shared page after au
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2268,6 +2299,7 @@ test("playback binding controller suppresses non-shared autoplay replayed after 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2340,6 +2372,7 @@ test("playback binding controller holds a non-sharer at the shared video natural
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2416,6 +2449,7 @@ test("playback binding controller does not pause the sharer at the shared video 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2481,6 +2515,7 @@ test("playback binding controller does not pause a non-sharer before the shared 
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2548,6 +2583,7 @@ test("playback binding controller re-pauses non-sharer multi-part autoplay after
   const originalSetTimeout = globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2617,6 +2653,7 @@ test("playback binding controller classifies pause as buffer when waiting fired 
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2661,6 +2698,7 @@ test("playback binding controller treats pause as user-initiated when fresh gest
   runtimeState.lastForcedPauseAt = 0;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2704,6 +2742,7 @@ test("playback binding controller clears buffer-pause classification on resume",
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2770,6 +2809,7 @@ test("playback binding controller does not classify pause as buffer-induced insi
   }) as typeof globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2830,6 +2870,7 @@ test("playback binding controller still classifies pause as buffer-induced when 
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2883,6 +2924,7 @@ test("playback binding controller re-broadcasts paused after buffer-pause upgrad
   }) as typeof globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -2950,6 +2992,7 @@ test("playback binding controller suppresses the natural-end pause for a non-sha
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3025,6 +3068,7 @@ test("playback binding controller suppresses the natural-end pause broadcast for
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3112,6 +3156,7 @@ test("playback binding controller records the seek-to-end flag when a seek prece
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3177,6 +3222,7 @@ test("playback binding controller flushes the sharer's terminal paused state whe
   }) as unknown as typeof globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3256,6 +3302,7 @@ test("playback binding controller does not flush a sharer end state once autopla
   }) as unknown as typeof globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3320,6 +3367,7 @@ test("playback binding controller does not arm sharer end suppression for a non-
   const originalPause = dom.video.pause;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3374,6 +3422,7 @@ test("playback binding controller classifies a stall on a rebuilt element as buf
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3419,6 +3468,7 @@ test("playback binding controller does not reclassify a user pause when transpor
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3467,6 +3517,7 @@ test("playback binding controller leaves an unobserved pause alone when the room
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3508,6 +3559,7 @@ test("playback binding controller classifies a pause right after a video rebind 
   let now = 5_000;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3568,6 +3620,7 @@ test("playback binding controller upgrades an unobserved stall to paused after t
   }) as typeof globalThis.window.setTimeout;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3620,6 +3673,7 @@ function createEchoHarness(
   getMonotonicNow: () => number,
 ) {
   return createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3780,6 +3834,7 @@ test("a user seek that cancels an active rate catch-up is still recorded", async
   const events: string[] = [];
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3841,6 +3896,7 @@ test("a user pause that cancels an active rate catch-up is still recorded", () =
   runtimeState.lastUserGestureInPlayerAt = 1_000;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3901,6 +3957,7 @@ test("a ratechange is enough to classify an unobserved pause as buffering", () =
   runtimeState.lastUserGestureAt = 0;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3942,6 +3999,7 @@ test("a real user pause is not reclassified by the shared broadcast path", () =>
   runtimeState.lastUserGestureInPlayerAt = 9_900;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -3981,6 +4039,7 @@ test("playback binding controller keeps the seek origin across seeking and seeke
   let now = 1_100;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -4031,6 +4090,7 @@ test("playback binding controller re-snapshots the origin for a new seek gesture
   let now = 1_100;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -4079,6 +4139,7 @@ test("playback binding controller re-samples the seek origin after a forced paus
   let now = 1_100;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -4134,6 +4195,7 @@ test("playback binding controller reports a newly bound video element once", () 
   let bindings = 0;
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -4185,6 +4247,7 @@ test("records explicit user actions on the monotonic clock by default", async ()
   const events: string[] = [];
 
   const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
     runtimeState,
     videoBindIntervalMs: 250,
     userGestureGraceMs: 1_200,
@@ -4223,6 +4286,162 @@ test("records explicit user actions on the monotonic clock by default", async ()
     assert.deepEqual(events, ["ratechange"]);
   } finally {
     clock.restore();
+    dom.restore();
+  }
+});
+
+test("playback binding controller ends the catch-up for a keyboard speed shortcut", () => {
+  // `isGestureInsidePlayer` deliberately counts only play-toggle keys, so a
+  // keyboard SPEED shortcut leaves `lastUserGestureInPlayerAt` untouched and the
+  // in-player predicate cannot see the takeover. The rate on the element is the
+  // evidence: it is not the one our catch-up wrote. Without acting on it the
+  // user's choice is lost twice — the broadcast reports the session's base rate,
+  // and the session timer then restores that base rate locally too (#238).
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 4_500;
+  // Document-level gesture only; the in-player one is far enough in the past
+  // that `hasRecentUserGestureInPlayer()` is false. Leaving it at the default 0
+  // would sit INSIDE the grace window at these clock values and cancel via the
+  // old in-player branch, making this test pass for the wrong reason.
+  runtimeState.lastUserGestureInPlayerAt = 1_000;
+  const reasons: string[] = [];
+
+  const controller = createPlaybackBindingController({
+    // The catch-up wrote 0.84; the element now reads 1.5.
+    isRateUnexplainedByActiveCatchUp: () => true,
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => ({
+      videoId: "BV1xx411c7mD",
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      title: "Video",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: (_video, reason) => {
+      reasons.push(reason);
+    },
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => 5_000,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("ratechange")!(new Event("ratechange"));
+
+    assert.deepEqual(reasons, ["user-ratechange"]);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller keeps the catch-up alive for its own rate echo", () => {
+  // The other half of the same ambiguity: the element still carries exactly the
+  // rate our catch-up wrote, so this `ratechange` is our own echo however recent
+  // an unrelated page click was. Cancelling here would strand the temporary rate
+  // and drop the self-restore.
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 4_500;
+  runtimeState.lastUserGestureInPlayerAt = 1_000;
+  const reasons: string[] = [];
+
+  const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => false,
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => ({
+      videoId: "BV1xx411c7mD",
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      title: "Video",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: (_video, reason) => {
+      reasons.push(reason);
+    },
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => 5_000,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("ratechange")!(new Event("ratechange"));
+
+    assert.deepEqual(reasons, []);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller keeps the catch-up alive when the player resets the rate itself", () => {
+  // The player resets the live rate on its own while recovering from a stall.
+  // That rate does not match what the catch-up wrote either, but no user did
+  // anything — and cancelling as `user-ratechange` SKIPS the restore, stranding
+  // the elevated `defaultPlaybackRate` (the bug that restore exists to prevent).
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  // No recent gesture at all, so `rememberExplicitUserAction` records nothing.
+  runtimeState.lastUserGestureAt = 1_000;
+  runtimeState.lastUserGestureInPlayerAt = 1_000;
+  const reasons: string[] = [];
+
+  const controller = createPlaybackBindingController({
+    isRateUnexplainedByActiveCatchUp: () => true,
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => ({
+      videoId: "BV1xx411c7mD",
+      url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+      title: "Video",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: (_video, reason) => {
+      reasons.push(reason);
+    },
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => 5_000,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("ratechange")!(new Event("ratechange"));
+
+    assert.deepEqual(runtimeState.lastExplicitUserAction, null);
+    assert.deepEqual(reasons, []);
+  } finally {
     dom.restore();
   }
 });

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -4287,7 +4287,7 @@ test("playback binding controller does not treat any recent gesture as a rate ta
 });
 
 test("playback binding controller ends the catch-up for a keyboard speed shortcut", () => {
-  // Shift+1 / Shift+2 / held ArrowRight are not in-player gestures
+  // Shift+1 / Shift+2 are not in-player gestures
   // (`isGestureInsidePlayer` counts only play-toggle keys), so before the
   // dedicated signal existed the session survived, the broadcast reported the
   // session's base rate and the restore timer put that base rate back — the

--- a/extension/test/share-controller.test.ts
+++ b/extension/test/share-controller.test.ts
@@ -118,6 +118,7 @@ test("share controller keeps playback snapshot while switching to another shared
 
   const debugLogs: string[] = [];
   const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
     runtimeState,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 7,
@@ -162,6 +163,7 @@ test("share controller resolves bangumi season pages through page snapshot", asy
   runtimeState.intendedPlayState = "paused";
 
   const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
     runtimeState,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 3,
@@ -205,6 +207,7 @@ test("share controller does not reuse cached bangumi snapshot synchronously", ()
 
   const runtimeState = createContentRuntimeState();
   const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
     runtimeState,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 4,
@@ -248,6 +251,7 @@ test("share controller reuses matching cached bangumi snapshot for current page 
 
   const runtimeState = createContentRuntimeState();
   const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
     runtimeState,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 5,
@@ -295,6 +299,7 @@ test("share controller reuses cached bangumi snapshot by active episode id witho
 
   const runtimeState = createContentRuntimeState();
   const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
     runtimeState,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 6,
@@ -341,6 +346,7 @@ test("share controller reuses cached bangumi snapshot by active cid without titl
 
   const runtimeState = createContentRuntimeState();
   const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
     runtimeState,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 7,
@@ -387,6 +393,7 @@ test("share controller rejects same-title cached bangumi snapshot from another p
 
   const runtimeState = createContentRuntimeState();
   const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
     runtimeState,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 6,
@@ -431,6 +438,7 @@ test("share controller rejects cached bangumi snapshot on festival page", () => 
 
   const runtimeState = createContentRuntimeState();
   const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
     runtimeState,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 8,
@@ -473,6 +481,7 @@ test("share controller reuses cached festival snapshot across trailing slash pat
 
   const runtimeState = createContentRuntimeState();
   const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
     runtimeState,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 9,
@@ -497,6 +506,98 @@ test("share controller reuses cached festival snapshot across trailing slash pat
     assert.equal(
       payload.video.url,
       "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123",
+    );
+  } finally {
+    dom.restore();
+  }
+});
+
+test("share controller reports the room's base rate while a catch-up is running", () => {
+  // `video:share` is a second wire path that carries a playback rate, and the
+  // server persists whatever it carries. During a catch-up `video.playbackRate`
+  // is a temporary offset this client added to close its own drift, so
+  // re-sharing mid-catch-up would write that temporary rate straight into room
+  // state — the same pollution `playback:update` was fixed for (#238).
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/video/BV199W9zEEcH",
+    pathname: "/video/BV199W9zEEcH",
+    title: "New Video_哔哩哔哩",
+    video: {
+      currentTime: 95.03,
+      // The catch-up lowered the element to 0.84; the room is at 1.
+      playbackRate: 0.84,
+      paused: false,
+      readyState: 4,
+    } as HTMLVideoElement,
+  });
+
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BV1xx411c7mD";
+  runtimeState.intendedPlayState = "playing";
+
+  const requestedUrls: Array<string | undefined | null> = [];
+  const controller = createShareController({
+    getActiveCorrectionBaseRate: (url) => {
+      requestedUrls.push(url);
+      return 1;
+    },
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 7,
+    getFestivalSnapshot: () => null,
+    refreshFestivalBridge: async () => null,
+    debugLog: () => {},
+  });
+
+  try {
+    const payload = controller.getCurrentSharePayload();
+
+    assert.ok(payload);
+    assert.equal(payload?.playback?.playbackRate, 1);
+    assert.notEqual(payload?.playback?.playbackRate, 0.84);
+    // Asked about the video being shared, not some other url.
+    assert.deepEqual(requestedUrls, [
+      "https://www.bilibili.com/video/BV199W9zEEcH",
+    ]);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("share controller falls back to the element rate with no catch-up running", () => {
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/video/BV199W9zEEcH",
+    pathname: "/video/BV199W9zEEcH",
+    title: "New Video_哔哩哔哩",
+    video: {
+      currentTime: 95.03,
+      playbackRate: 1.5,
+      paused: false,
+      readyState: 4,
+    } as HTMLVideoElement,
+  });
+
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BV1xx411c7mD";
+  runtimeState.intendedPlayState = "playing";
+
+  const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 7,
+    getFestivalSnapshot: () => null,
+    refreshFestivalBridge: async () => null,
+    debugLog: () => {},
+  });
+
+  try {
+    // The user's own 1.5x must still reach the room when nothing is correcting.
+    assert.equal(
+      controller.getCurrentSharePayload()?.playback?.playbackRate,
+      1.5,
     );
   } finally {
     dom.restore();

--- a/extension/test/soft-apply-controller.test.ts
+++ b/extension/test/soft-apply-controller.test.ts
@@ -687,3 +687,102 @@ test("getActiveCorrectionBaseRate reports the room's base rate for the whole lif
     windowStub.restore();
   }
 });
+
+test("the correction session is found through a festival bare-route alias", () => {
+  const windowStub = installWindowStub();
+  try {
+    const runtimeState = createContentRuntimeState();
+    const bareRoute = "https://www.bilibili.com/festival/2024ns";
+    const resolved = "https://www.bilibili.com/video/BV1xx411c7mD?p=1";
+    // The room was shared before the page bridge could resolve a bvid/cid, so
+    // its identity is the unstable route; the bridge has since resolved the
+    // concrete video locally.
+    runtimeState.activeSharedUrl = bareRoute;
+    runtimeState.resolvedSharedVideoUrl = resolved;
+
+    const video = createVideo({
+      currentTime: 24.7,
+      defaultPlaybackRate: 0.84,
+      playbackRate: 0.84,
+    });
+    const controller = createSoftApplyController({
+      runtimeState,
+      normalizeUrl: (url) => url?.trim() ?? null,
+      getVideoElement: () => video,
+      debugLog: () => {},
+      userGestureGraceMs: 300,
+      programmaticApplyWindowMs: 700,
+      getMonotonicNow: () => 10_000,
+      armProgrammaticApplyWindow: () => {},
+    });
+
+    // The session is keyed on what the ROOM carries — the bare route.
+    controller.upsertActiveSoftApply(
+      createPlayback({ url: bareRoute, playbackRate: 1 }),
+      0.7,
+      {
+        armCooldownOnConverge: false,
+        relativeDriftClose: { driftSeconds: 0.7, rateOffsetSeconds: -0.16 },
+      },
+    );
+
+    // Local callers (broadcast payload, share payload) hold the resolved url.
+    // Without the alias they read "no session" and publish the element's
+    // temporary 0.84 as the room's rate (#238).
+    assert.equal(controller.getActiveCorrectionBaseRate(resolved), 1);
+    assert.equal(controller.hasActiveCorrectionSession(resolved), true);
+    assert.equal(controller.isActiveRateOnlyCatchUp(resolved), true);
+    // The room-space url still matches directly.
+    assert.equal(controller.getActiveCorrectionBaseRate(bareRoute), 1);
+
+    // An unrelated video must not borrow the alias.
+    assert.equal(
+      controller.getActiveCorrectionBaseRate(
+        "https://www.bilibili.com/video/BV1other",
+      ),
+      null,
+    );
+  } finally {
+    windowStub.restore();
+  }
+});
+
+test("a stale session cannot borrow the festival alias of another share", () => {
+  const windowStub = installWindowStub();
+  try {
+    const runtimeState = createContentRuntimeState();
+    const resolved = "https://www.bilibili.com/video/BV1xx411c7mD?p=1";
+    // The room has since moved on to a different bare route, so the session's
+    // url is no longer the room's identity — the alias must not apply.
+    runtimeState.activeSharedUrl = "https://www.bilibili.com/festival/other";
+    runtimeState.resolvedSharedVideoUrl = resolved;
+
+    const video = createVideo({ currentTime: 24.7, playbackRate: 0.84 });
+    const controller = createSoftApplyController({
+      runtimeState,
+      normalizeUrl: (url) => url?.trim() ?? null,
+      getVideoElement: () => video,
+      debugLog: () => {},
+      userGestureGraceMs: 300,
+      programmaticApplyWindowMs: 700,
+      getMonotonicNow: () => 10_000,
+      armProgrammaticApplyWindow: () => {},
+    });
+
+    controller.upsertActiveSoftApply(
+      createPlayback({
+        url: "https://www.bilibili.com/festival/2024ns",
+        playbackRate: 1,
+      }),
+      0.7,
+      {
+        armCooldownOnConverge: false,
+        relativeDriftClose: { driftSeconds: 0.7, rateOffsetSeconds: -0.16 },
+      },
+    );
+
+    assert.equal(controller.getActiveCorrectionBaseRate(resolved), null);
+  } finally {
+    windowStub.restore();
+  }
+});

--- a/extension/test/soft-apply-controller.test.ts
+++ b/extension/test/soft-apply-controller.test.ts
@@ -638,3 +638,52 @@ test("arms the soft-apply cooldown on the monotonic clock by default", () => {
     windowStub.restore();
   }
 });
+
+test("getActiveCorrectionBaseRate reports the room's base rate for the whole life of a session", () => {
+  const windowStub = installWindowStub();
+  try {
+    const runtimeState = createContentRuntimeState();
+    // The element already carries the temporary catch-up rate the session is
+    // about to manage; the room's rate is 1.
+    const video = createVideo({
+      currentTime: 24.7,
+      defaultPlaybackRate: 0.84,
+      playbackRate: 0.84,
+    });
+    let now = 10_000;
+    const controller = createSoftApplyController({
+      runtimeState,
+      normalizeUrl: (url) => url?.trim() ?? null,
+      getVideoElement: () => video,
+      debugLog: () => {},
+      userGestureGraceMs: 300,
+      programmaticApplyWindowMs: 700,
+      getMonotonicNow: () => now,
+      armProgrammaticApplyWindow: () => {},
+    });
+    const url = "https://www.bilibili.com/video/BV1xx411c7mD?p=1";
+
+    controller.upsertActiveSoftApply(createPlayback({ playbackRate: 1 }), 0.7, {
+      armCooldownOnConverge: false,
+      relativeDriftClose: { driftSeconds: 0.7, rateOffsetSeconds: -0.16 },
+    });
+
+    assert.equal(controller.getActiveCorrectionBaseRate(url), 1);
+    assert.equal(
+      controller.getActiveCorrectionBaseRate("https://example.com/other"),
+      null,
+    );
+    assert.equal(controller.getActiveCorrectionBaseRate(null), null);
+
+    // Past the deadline but before the restore timer has run: the element is
+    // still on the temporary rate, so the base rate is still what a broadcast
+    // must report. This gap is one of the windows the leak escaped through.
+    now = 20_000;
+    assert.equal(controller.getActiveCorrectionBaseRate(url), 1);
+
+    windowStub.flushTimers();
+    assert.equal(controller.getActiveCorrectionBaseRate(url), null);
+  } finally {
+    windowStub.restore();
+  }
+});

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -2715,3 +2715,133 @@ test("sync controller does not reuse a pre-apply seek intent for programmatic ec
   // with `playing` and restart the room.
   assert.notEqual(lastBroadcastPlayState(harness), "playing");
 });
+
+/**
+ * A client mid-catch-up: the room is at 1x, this client is 0.7s ahead, so the
+ * rate-only reconcile lowers `video.playbackRate` to close the gap.
+ *
+ * The returned harness is positioned at the moment the leak happened in
+ * production (#238): the programmatic-apply window has expired, an unrelated
+ * explicit user action is inside the gesture grace window (which opens both the
+ * soft-apply and the unexpected-rate gate), and the correction session is still
+ * running.
+ */
+async function createActiveCatchUpHarness() {
+  const windowStub = installWindowStub();
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.activeSharedUrl = sharedVideo.url;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setNow(20_000);
+  const video = createVideo({ paused: false, currentTime: 24.7 });
+  harness.setVideoElement(video);
+
+  await harness.controller.applyRoomState(
+    createRoomState({
+      actorId: "remote-member",
+      seq: 1,
+      serverTime: 19_900,
+      currentTime: 24,
+      playState: "playing",
+      playbackRate: 1,
+    }),
+  );
+
+  // Precondition, not the assertion under test: the catch-up must actually have
+  // elevated the local rate, otherwise the regression below proves nothing.
+  assert.ok(
+    Math.abs(video.playbackRate - 1) > 0.01,
+    `expected an active catch-up rate, got ${video.playbackRate}`,
+  );
+
+  // Past programmaticApplyWindowMs (700) so the programmatic gate is shut, and
+  // well inside the session's relative-drift restore window.
+  harness.setNow(20_800);
+  return { harness, video, sharedVideo, windowStub };
+}
+
+function lastBroadcastPayload(harness: { runtimeMessages: Array<unknown> }) {
+  const message = harness.runtimeMessages.at(-1) as {
+    payload: PlaybackState;
+  };
+  return message.payload;
+}
+
+test("sync controller broadcasts the room's base rate, not the temporary catch-up rate", async () => {
+  const { harness, video, windowStub } = await createActiveCatchUpHarness();
+  try {
+    // An unrelated gesture (a seek moments ago) — this is what opened both the
+    // soft-apply and the unexpected-rate gate in production.
+    harness.runtimeState.lastExplicitUserAction = { kind: "seek", at: 20_800 };
+
+    await harness.controller.broadcastPlayback(video, "playing");
+
+    assert.equal(harness.runtimeMessages.length, 1);
+    assert.equal(lastBroadcastPayload(harness).playbackRate, 1);
+    // The other half of the bug: writing the temporary rate here taught
+    // `shouldSuppressUnexpectedPlaybackRateBroadcast` to accept it, disarming
+    // the guard for every later leak.
+    assert.equal(harness.runtimeState.intendedPlaybackRate, 1);
+  } finally {
+    windowStub.restore();
+  }
+});
+
+test("sync controller broadcasts a user's rate change once their gesture ends the catch-up", async () => {
+  const { harness, video, windowStub } = await createActiveCatchUpHarness();
+  try {
+    // How a real rate change arrives: the user opens the player's speed menu,
+    // which is an in-player gesture, so `onRateChange` tears the session down
+    // before any broadcast runs. With no session left there is no base rate to
+    // report and the user's own rate goes out.
+    harness.controller.cancelActiveSoftApply(video, "user-ratechange");
+    video.playbackRate = 1.5;
+    harness.runtimeState.lastExplicitUserAction = {
+      kind: "ratechange",
+      at: 20_800,
+    };
+
+    await harness.controller.broadcastPlayback(video, "ratechange");
+
+    assert.equal(harness.runtimeMessages.length, 1);
+    const payload = lastBroadcastPayload(harness);
+    assert.equal(payload.syncIntent, "explicit-ratechange");
+    assert.equal(payload.playbackRate, 1.5);
+  } finally {
+    windowStub.restore();
+  }
+});
+
+test("sync controller keeps the temporary rate off the wire even when a ratechange looks explicit", async () => {
+  const { harness, video, windowStub } = await createActiveCatchUpHarness();
+  try {
+    // The dangerous half of the same ambiguity: our own catch-up `ratechange`,
+    // reclassified as a user action because an unrelated page click landed
+    // inside the gesture grace window. There was no in-player gesture, so the
+    // session is still alive — and the rate on the element is still ours, not a
+    // user's choice. Honouring the tag here is exactly what ratcheted a room
+    // from 1x down to 0.53x (#238).
+    const temporaryRate = video.playbackRate;
+    harness.runtimeState.lastExplicitUserAction = {
+      kind: "ratechange",
+      at: 20_800,
+    };
+
+    await harness.controller.broadcastPlayback(video, "ratechange");
+
+    assert.equal(harness.runtimeMessages.length, 1);
+    assert.equal(lastBroadcastPayload(harness).playbackRate, 1);
+    assert.notEqual(lastBroadcastPayload(harness).playbackRate, temporaryRate);
+    assert.equal(harness.runtimeState.intendedPlaybackRate, 1);
+  } finally {
+    windowStub.restore();
+  }
+});


### PR DESCRIPTION
Fixes #238

## 问题

内容脚本为收敛播放漂移会临时改写 `video.playbackRate`，但广播 payload 一直直接取该实时倍率（`sync-controller.ts` 原 `:1533`）。纠偏会话进行中，这个值不是房间的倍率，而是本机为追赶自己漂移加的临时偏移 —— 协议层从来没有区分过"房间基准倍率"和"本机此刻实际播放倍率"。

对端收到后把它当作房间基准采纳（`room-state-apply-controller.ts:887,998` 写 `intendedPlaybackRate`，`soft-apply-controller.ts:283` 写 `restorePlaybackRate`），在此基础上再纠偏，并在会话结束时把这个已污染的基准回写广播出去。于是形成递归衰减，生产实测：

```
1 → 0.9223063476562674 → 0.8460347530528087 → 0.7731734687158314
  → 0.6952413151174550 → 0.6171563518884067 → 0.5388563042381428
```

每级恰好是"以上一级为基准的一次减速纠偏"（≈ −0.077），持续约 20 分钟，直到用户显式选择 `1x` 才恢复；另一房间、另一对成员独立复现。

衰减单向向下有系统性原因：落后端提速追赶产生的更新，其 `currentTime` 本就落后，被服务端按时间线回退拒收；只有超前端的减速更新能通过校验写入房间状态。所以污染不会被对称的提速抵消，无法自愈。

## 改动

纠偏会话存活期间，广播一律报会话基准倍率 `restorePlaybackRate`，而不是 `video.playbackRate`。

- `soft-apply-controller.ts`：新增 `getActiveCorrectionBaseRate()`。刻意**不**按 `deadlineAt` 设限 —— 过了截止时刻但恢复定时器尚未跑到时，会话仍未恢复，基准倍率依然是唯一正确的上报值，而这段空隙正是泄漏的窗口之一。
- `sync-controller.ts`：payload、去重合并、`intendedPlaybackRate` 三处统一改用广播倍率。其中 `intendedPlaybackRate` 此前写入实时倍率，会让 `shouldSuppressUnexpectedPlaybackRateBroadcast` 把临时倍率当成"预期倍率"，第一次泄漏之后该守卫对同类泄漏即告失效。

### 关于 `explicit-ratechange`

**没有**加豁免，这是刻意的。真实的用户改速通过"会话已被取消"这条路生效：播放器内手势（倍速菜单即是）会让 `onRateChange` 先 `cancelActiveSoftApply`（`playback-binding-controller.ts:1158`），到广播时无会话可查，发出去的就是用户自己的倍率。

剩下"会话仍存活却带 `explicit-ratechange` 标记"的情形，恰恰是 `playback-binding-controller` 已明确拒绝采信的歧义：我们自己的追赶回声，因为某次无关页面点击落在手势宽限期内而被重分类成用户动作。采信它就会把临时倍率送上线 —— 正是本 issue。即便那次改速是真的，报基准倍率也不损失什么：会话收敛时本来就会把元素恢复到同一个基准。

中途试过两版更复杂的写法（一次性豁免、给会话迁移基准），本地 Codex 复审分别指出"下一次心跳会把旧基准推回去覆盖用户选择"和"弱证据下迁移基准等于把 bug 搬进会话内部、且未重锚 `targetTime`"。第三版收敛为上面这条单一规则后复审无缺陷 —— 也符合 AGENTS.md「不要在既有抑制上再加一层」。

## 验证

- 完整预提交序列全绿：`format:check` / `lint` / `typecheck` / `build` / `test`（623 项）/ `audit`。
- 新增 4 条回归，其中 3 条已确认在修复前失败（`cp` 备份后回退源文件验证，非 `git checkout`）：
  - `getActiveCorrectionBaseRate reports the room's base rate for the whole life of a session` — 含"过了 deadline 但未恢复"这段空隙
  - `sync controller broadcasts the room's base rate, not the temporary catch-up rate` — 复刻泄漏形态（程序化窗口已过期 + 无关显式动作撑开守卫 + 会话仍在跑）
  - `sync controller keeps the temporary rate off the wire even when a ratechange looks explicit` — 回声误判路径
  - `sync controller broadcasts a user's rate change once their gesture ends the catch-up` — 这条修复前后都通过，它防的是本次改动过度收紧、把真实用户改速一并吞掉，不是复现缺陷

## 未覆盖

接收端仍无法从线上判断对端是否正处于纠偏中 —— 要做到需要新增协议字段并升版本。本次在**源头**消除：线上不再出现临时倍率，因此接收端也就没有可采纳的污染值。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
