### PR TITLE
fix: 排队写入失败不再被静默丢弃，读回判断有了可确认的依据 (#242)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,9 +208,12 @@ decides something has to know which of the two questions it is asking (#242):
   unbounded, so a pin taken there can already name the code's NEXT occupant and
   the check waves the write straight through. A mismatch is a
   `NonRetryableWriteError` (a generation only moves forward, so no later attempt
-  can find its way back), and an unreadable generation refuses the join rather
-  than re-reading later, since a second read is a second chance to pin the wrong
-  instance. A new write that seats or moves anything by room code needs the same
+  can find its way back). An unreadable generation refuses the join rather than
+  re-reading later, since a second read is a second chance to pin the wrong
+  instance — and so does an ABSENT one, because a teardown leaves the key absent
+  too, so `""` would match a deleted room as happily as a legacy one.
+  `createRoomForSession` awaits `markRoomGeneration` and expires the room if it
+  fails, so every joinable room has one. A new write that seats or moves anything by room code needs the same
   pin; one that only touches keys named after the session does not, because
   session ids are never reused.
 - **Every retry budget is sized against the shutdown step that drains it.**
@@ -259,7 +262,11 @@ one-shot, and both lose the room permanently when the bus rejects them (#242):
   budget is just a slower way to discard a notification nothing else will
   re-send — so `drain` is unbounded by design and the shutdown call passes
   `{ final: true }`, which calls `stopRetrying` first and leaves at most one
-  in-flight attempt to wait for.
+  in-flight attempt to wait for. A record never starts a second publish while
+  its first has not answered: the attempt cap races the bus call, it does not
+  abort it, so an unbounded retry loop over a hung bus would otherwise pile up
+  one live Redis command per retry — the same "a timeout is not a cancel"
+  reasoning as the write queue's `settle`.
 - The **runtime index reaper's** announcement is the only thing that tells a
   room a dead node's members are gone. Once the sweep has cleaned the indexes,
   `listClusterSessions` no longer returns those sessions, so a later sweep has

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,21 @@ one-shot, and both lose the room permanently when the bus rejects them (#242):
   START the next record bounds nothing when the bus hangs instead of rejecting.
   Sweeps also no longer overlap: they share that set, and `stop()` awaits only
   the sweep it knows about.
+  What creates a record is the other half of this: a room is announced only
+  once THAT session's cleanup writes are confirmed, and the session record is
+  what makes a retry possible at all. The sweep's steps are ordered by what
+  they destroy — the member removal needs `roomCode` and `memberId`,
+  `markSessionLeftRoom` blanks `roomCode`, `unregisterSession` deletes the
+  record — so each runs only after the previous one is confirmed, and a step
+  that did not land (failed, capped, or cut short by `stop`) leaves the record
+  untouched for the next sweep to redo from the top. Every step is idempotent,
+  which is what makes redoing it free. #235 answered this the other way — it
+  announced regardless, since `unregisterSession` cleaned the same key anyway
+  and gating "left the next pass nothing to retry" — and that reasoning only
+  held while the sweep unregistered unconditionally. `unregisterSession` is the
+  one write nothing gates on, because it returns `void` (so `confirmWrites` is
+  the only place its outcome is visible) and because failing it leaves the room
+  index already clean and merely re-runs a no-op next sweep.
 
 ## Engineering Constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,16 @@ advances the room. Three rules keep it working, none enforced by a type:
   `room:state` build site must go through it. The persisted room keeps the
   original id on purpose: it is the _preferred_ owner, so a sharer whose socket
   merely blipped reclaims the share on reconnect instead of losing it for good.
+- **A full `room:state` may only be published where the index is provably
+  clean.** A room switch leaves the old room inside `createRoomForSession` /
+  `joinRoomForSession`, and `releasePreviousRoom` reports whether `onRoomLeft`
+  actually cleared the index. The `room_member_left` delta goes out regardless —
+  it reads no state — but the full state is published only where the switcher
+  cannot come back: on the success path AFTER `runRoomJoinedHook`, whose write
+  re-stamps the whole session record under the NEW room code, and on the
+  create/join FAILURE path only when the hook succeeded, since nothing later
+  carries the old code there. "The session hash already names the new room" is
+  not something to assume: that hash is written by `onRoomLeft` itself (#242).
 - **A membership delta that moves ownership owes a full `room:state`.**
   Protocol >= 2 clients get `room:member-joined` / `room:member-left`, which edit
   the recipient's member list and nothing else — their cached `sharedVideo` still
@@ -246,11 +256,16 @@ one-shot, and both lose the room permanently when the bus rejects them (#242):
   `listClusterSessions` no longer returns those sessions, so a later sweep has
   nothing to rediscover the room from. The reaper keeps its own record set and
   retries it at the START of every sweep — before the "no offline nodes" early
-  return — dropping a record only once the publish succeeds. There is no cap:
-  evicting an unpublished record loses exactly what the set exists to keep, so
-  a backlog is logged, never shed. The set is memory-only, so `stop()` takes one
-  last pass over it, and sweeps no longer overlap: they share that set, and
-  `stop()` awaits only the sweep it knows about.
+  return — dropping a record only once the publish succeeds. Neither this queue
+  nor `pending-resync-queue` caps its backlog: evicting or refusing an
+  unpublished record loses exactly what they exist to keep, so a backlog is
+  logged, never shed. Because it is uncapped, the shutdown pass is the one that
+  must be bounded — `stop()` drains with bounded concurrency against its own
+  deadline, comfortably inside the step timeout, since an overrun step is
+  recorded as a failure AND lets the bus close under in-flight publishes that
+  then delete their records as if they had landed. Sweeps also no longer
+  overlap: they share that set, and `stop()` awaits only the sweep it knows
+  about.
 
 ## Engineering Constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,10 +213,15 @@ decides something has to know which of the two questions it is asking (#242):
   instance. An ABSENT generation still pins as `""`, which is why the teardown
   leaves a TOMBSTONE in that key rather than deleting it: deleting made "torn
   down" indistinguishable from "never stamped", so a pin of `""` matched the
-  room it was about to resurrect. The tombstone expires, and `hasRoomResidue`
-  ignores it, so it never keeps a code reserved. A new write that seats or moves anything by room code needs the same
-  pin; one that only touches keys named after the session does not, because
-  session ids are never reused.
+  room it was about to resurrect. The tombstone does NOT expire — a TTL would
+  have to outlive every write that could still be holding the old pin, and
+  nothing bounds those, so a lapsed tombstone lets a `""` pin match an absent
+  key all over again. What reclaims it is the next occupant's
+  `markRoomGeneration`. Pinning the tombstone ITSELF is refused, or a pin taken
+  after the teardown would match it. `hasRoomResidue` ignores the key, so a
+  tombstone never keeps a code reserved. A new write that seats or moves
+  anything by room code needs the same pin; one that only touches keys named
+  after the session does not, because session ids are never reused.
 - **Every retry budget is sized against the shutdown step that drains it.**
   `close_shared_runtime_store` and `flush_pending_room_event_publishes` carry
   explicit timeouts, and an overrun is recorded as a FAILED step — so a shutdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,11 +149,12 @@ advances the room. Three rules keep it working, none enforced by a type:
   `joinRoomForSession`, and `releasePreviousRoom` reports whether `onRoomLeft`
   actually cleared the index. The `room_member_left` delta goes out regardless —
   it reads no state — but the full state is published only where the switcher
-  cannot come back: on the success path AFTER `runRoomJoinedHook`, whose write
-  re-stamps the whole session record under the NEW room code, and on the
-  create/join FAILURE path only when the hook succeeded, since nothing later
-  carries the old code there. "The session hash already names the new room" is
-  not something to assume: that hash is written by `onRoomLeft` itself (#242).
+  cannot come back — `publishPreviousRoomResync` holds both licences: the join
+  was seated (its write re-stamps the whole session record under the NEW room
+  code) OR `onRoomLeft` itself landed. A refused join still owes the old room
+  its state on the second licence, since the rollback only unwinds the new room.
+  "The session hash already names the new room" is not something to assume: that
+  hash is written by `onRoomLeft` itself (#242).
 - **A membership delta that moves ownership owes a full `room:state`.**
   Protocol >= 2 clients get `room:member-joined` / `room:member-left`, which edit
   the recipient's member list and nothing else — their cached `sharedVideo` still
@@ -246,11 +247,11 @@ one-shot, and both lose the room permanently when the bus rejects them (#242):
   through `pending-resync-queue`, which retries with backoff behind a `request`
   that returns immediately; `firePublishRoomEvent` deliberately does not await
   its wrapper, and making the leave/join handlers block on the bus would be the
-  worse trade. `flushPendingPublishes` must drain that queue too, or shutdown
-  tears the bus down with records still owed — and the shutdown call passes
-  `{ final: true }`, which stops each record after the batch it is on. A request
-  that lands mid-batch earns a fresh retry budget, which is right at runtime and
-  is two budgets in a step sized for one at shutdown.
+  worse trade. A record retries until the bus takes it — a per-record attempt
+  budget is just a slower way to discard a notification nothing else will
+  re-send — so `drain` is unbounded by design and the shutdown call passes
+  `{ final: true }`, which calls `stopRetrying` first and leaves at most one
+  in-flight attempt to wait for.
 - The **runtime index reaper's** announcement is the only thing that tells a
   room a dead node's members are gone. Once the sweep has cleaned the indexes,
   `listClusterSessions` no longer returns those sessions, so a later sweep has
@@ -259,13 +260,15 @@ one-shot, and both lose the room permanently when the bus rejects them (#242):
   return — dropping a record only once the publish succeeds. Neither this queue
   nor `pending-resync-queue` caps its backlog: evicting or refusing an
   unpublished record loses exactly what they exist to keep, so a backlog is
-  logged, never shed. Because it is uncapped, the shutdown pass is the one that
-  must be bounded — `stop()` drains with bounded concurrency against its own
-  deadline, comfortably inside the step timeout, since an overrun step is
-  recorded as a failure AND lets the bus close under in-flight publishes that
-  then delete their records as if they had landed. Sweeps also no longer
-  overlap: they share that set, and `stop()` awaits only the sweep it knows
-  about.
+  logged, never shed. Because it is uncapped, every SHUTDOWN path over it has to
+  be bounded, and there are two: `stop()` drains with bounded concurrency
+  against its own deadline, and it sets `stopping` BEFORE awaiting the sweep in
+  flight so that sweep's serial drain gives way instead of running the whole
+  backlog first. Bounding only the second one leaves the budget just as blown.
+  An overrun step is recorded as a failure AND lets the bus close under
+  in-flight publishes, which then delete their records as if they had landed.
+  Sweeps also no longer overlap: they share that set, and `stop()` awaits only
+  the sweep it knows about.
 
 ## Engineering Constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,7 +237,10 @@ one-shot, and both lose the room permanently when the bus rejects them (#242):
   that returns immediately; `firePublishRoomEvent` deliberately does not await
   its wrapper, and making the leave/join handlers block on the bus would be the
   worse trade. `flushPendingPublishes` must drain that queue too, or shutdown
-  tears the bus down with records still owed.
+  tears the bus down with records still owed — and the shutdown call passes
+  `{ final: true }`, which stops each record after the batch it is on. A request
+  that lands mid-batch earns a fresh retry budget, which is right at runtime and
+  is two budgets in a step sized for one at shutdown.
 - The **runtime index reaper's** announcement is the only thing that tells a
   room a dead node's members are gone. Once the sweep has cleaned the indexes,
   `listClusterSessions` no longer returns those sessions, so a later sweep has

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,18 +191,25 @@ decides something has to know which of the two questions it is asking (#242):
   `durable-write-queue` gives every queued write a bounded, backed-off retry
   budget. That reopens the room-code recycling hazard #237 closed: a retry that
   lands after the code changed hands would write into the new room. Only the
-  join write ADDS a session to a room, so only it needs the guard — it pins the
-  room generation BEFORE its first attempt and carries it into the script, and
-  a mismatch is a `NonRetryableWriteError` (a generation only moves forward, so
-  no later attempt can find its way back). A new write that seats or moves
-  anything by room code needs the same pin; one that only touches keys named
-  after the session does not, because session ids are never reused.
-  Every retry budget is sized against the shutdown step that has to drain it —
-  a close step gets 5s, `flush_pending_room_event_publishes` 30s — and a drain
-  that overruns is recorded as a FAILED step, so the process exits non-zero.
-  `close()` therefore calls `stopRetrying()` first, which cancels the backoffs
-  in flight rather than waiting them out. Raising `maxAttempts` or a delay
-  means re-checking that arithmetic.
+  join write ADDS a session to a room, so only it needs the guard — and the pin
+  is read when `markSessionJoinedRoom` is CALLED, never inside the retryable
+  body: the body does not run until the session's chain drains, which is
+  unbounded, so a pin taken there can already name the code's NEXT occupant and
+  the check waves the write straight through. A mismatch is a
+  `NonRetryableWriteError` (a generation only moves forward, so no later attempt
+  can find its way back), and an unreadable generation refuses the join rather
+  than re-reading later, since a second read is a second chance to pin the wrong
+  instance. A new write that seats or moves anything by room code needs the same
+  pin; one that only touches keys named after the session does not, because
+  session ids are never reused.
+- **Every retry budget is sized against the shutdown step that drains it.**
+  `close_shared_runtime_store` and `flush_pending_room_event_publishes` carry
+  explicit timeouts, and an overrun is recorded as a FAILED step — so a shutdown
+  that merely waited out a retry exits the process non-zero. `close()` calls
+  `stopRetrying()` first, which cuts the backoffs in flight short AND drops
+  writes that have not started, leaving at most ONE in-flight attempt; the step
+  budget must exceed that attempt's own timeout. Raising `maxAttempts` or a
+  delay means redoing that arithmetic.
 - **A retry is abandoned when a newer write for the same session is queued.**
   Retrying past that point fights the newer write. This is only sound because
   the join write re-writes the WHOLE session record rather than patching
@@ -236,10 +243,11 @@ one-shot, and both lose the room permanently when the bus rejects them (#242):
   `listClusterSessions` no longer returns those sessions, so a later sweep has
   nothing to rediscover the room from. The reaper keeps its own record set and
   retries it at the START of every sweep — before the "no offline nodes" early
-  return — dropping a record only once the publish succeeds. The set is
-  memory-only, so `stop()` takes one last pass over it, and sweeps no longer
-  overlap: they share that set, and `stop()` awaits only the sweep it knows
-  about.
+  return — dropping a record only once the publish succeeds. There is no cap:
+  evicting an unpublished record loses exactly what the set exists to keep, so
+  a backlog is logged, never shed. The set is memory-only, so `stop()` takes one
+  last pass over it, and sweeps no longer overlap: they share that set, and
+  `stop()` awaits only the sweep it knows about.
 
 ## Engineering Constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,74 @@ advances the room. Three rules keep it working, none enforced by a type:
     changed, or a failure that never got as far as leaving would broadcast a
     room the member never left.
 
+### The runtime store is write-behind, so "drained" never means "written"
+
+`registerSession`, `markSessionJoinedRoom`, `markSessionLeftRoom` and
+`unregisterSession` update this node's own maps synchronously and queue the
+shared write behind them. Everything downstream that writes, reads back, and
+decides something has to know which of the two questions it is asking (#242):
+
+- **`flush()` says the queue emptied. `confirmWrites()` says the writes landed.**
+  `flush` waits on error-swallowed copies, so a failed write drains exactly like
+  a successful one. Use `flush` when the point is ordering ("my own writes are
+  visible to the read I am about to do") and `confirmWrites` when the point is
+  durability. `confirmWrites` is store-wide and clears what it reports, so the
+  answer is "since you last asked"; a caller that only needs its OWN write
+  confirmed should await that write, since all four report their real outcome.
+- **Queued writes are retried with backoff, and a retry can outlive its room.**
+  `durable-write-queue` gives every queued write a bounded, backed-off retry
+  budget. That reopens the room-code recycling hazard #237 closed: a retry that
+  lands after the code changed hands would write into the new room. Only the
+  join write ADDS a session to a room, so only it needs the guard — it pins the
+  room generation BEFORE its first attempt and carries it into the script, and
+  a mismatch is a `NonRetryableWriteError` (a generation only moves forward, so
+  no later attempt can find its way back). A new write that seats or moves
+  anything by room code needs the same pin; one that only touches keys named
+  after the session does not, because session ids are never reused.
+  Every retry budget is sized against the shutdown step that has to drain it —
+  a close step gets 5s, `flush_pending_room_event_publishes` 30s — and a drain
+  that overruns is recorded as a FAILED step, so the process exits non-zero.
+  `close()` therefore calls `stopRetrying()` first, which cancels the backoffs
+  in flight rather than waiting them out. Raising `maxAttempts` or a delay
+  means re-checking that arithmetic.
+- **A retry is abandoned when a newer write for the same session is queued.**
+  Retrying past that point fights the newer write. This is only sound because
+  the join write re-writes the WHOLE session record rather than patching
+  `roomCode` — so a lost `registerSession` is repaired by the next join instead
+  of leaving a hash with no `id`, which `loadSession` reads as no session at
+  all. A new session write that carries a strict subset of the record must not
+  rely on an earlier one having landed.
+- **A join whose index write fails is aborted, not seated.** `runRoomJoinedHook`
+  reports failure and the handler rolls the join back through
+  `leaveRoom(session, "disconnect")` — `"disconnect"` so a reconnecting member
+  keeps the identity the ownership rule depends on. Everything a join sends next
+  is read back off the index this write maintains, so a member the room cannot
+  see is worse than a refused join the client retries.
+
+### One-shot broadcasts need a retry trail; repeated ones do not
+
+Nearly every `room_state_updated` is re-sent by the next `video:share` /
+`playback:update` / `profile:update`, so dropping one costs a moment. Two are
+one-shot, and both lose the room permanently when the bus rejects them (#242):
+
+- The **share-ownership resync** (`publishSharedOwnerResync`) fires precisely
+  because the room stopped advancing, so nothing follows it, and an idle room
+  never sends `sync:request` either — only a page reload recovers. It goes
+  through `pending-resync-queue`, which retries with backoff behind a `request`
+  that returns immediately; `firePublishRoomEvent` deliberately does not await
+  its wrapper, and making the leave/join handlers block on the bus would be the
+  worse trade. `flushPendingPublishes` must drain that queue too, or shutdown
+  tears the bus down with records still owed.
+- The **runtime index reaper's** announcement is the only thing that tells a
+  room a dead node's members are gone. Once the sweep has cleaned the indexes,
+  `listClusterSessions` no longer returns those sessions, so a later sweep has
+  nothing to rediscover the room from. The reaper keeps its own record set and
+  retries it at the START of every sweep — before the "no offline nodes" early
+  return — dropping a record only once the publish succeeds. The set is
+  memory-only, so `stop()` takes one last pass over it, and sweeps no longer
+  overlap: they share that set, and `stop()` awaits only the sweep it knows
+  about.
+
 ## Engineering Constraints
 
 - Repository-wide contribution and refactoring constraints are defined in [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,16 @@ decides something has to know which of the two questions it is asking (#242):
   writes that have not started, leaving at most ONE in-flight attempt; the step
   budget must exceed that attempt's own timeout. Raising `maxAttempts` or a
   delay means redoing that arithmetic.
+- **The retry timing lives in `retry-pacer`, not in each facility.** The
+  backoff schedule, the shutdown-cancellable wait, the per-attempt cap that
+  does not cancel the call, and the record of calls that outlived one are ONE
+  implementation shared by `durable-write-queue`, `pending-resync-queue`,
+  `runtime-index-reaper` and the store's command wrapper. They used to be four
+  hand-rolled copies, and six of #242's review findings were the same defect in
+  whichever copy the previous round had not touched. A new retrying facility
+  uses the pacer; it does not grow a fifth copy. What stays local is what
+  genuinely differs: ordering/supersession/confirmation, dedupe, and who decides
+  to retry.
 - **A timeout answers the caller; it does not cancel the command.** This one
   bites in three places, and fixing one of them is not fixing it:
   - The session's key is released only once every command the write started has

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,14 +225,21 @@ decides something has to know which of the two questions it is asking (#242):
   writes that have not started, leaving at most ONE in-flight attempt; the step
   budget must exceed that attempt's own timeout. Raising `maxAttempts` or a
   delay means redoing that arithmetic.
-- **A timeout answers the caller; it does not cancel the command.** So the
-  session's key is released only once every command the write started has
-  really finished (`DurableWriteRequest.settle`). Releasing it when the caller
-  is answered lets the compensating write — queued on that same key — run
-  first, and the abandoned command then lands on top of its own rollback,
-  leaving a member the client was told does not exist and who can win the share
-  back. `drain` waits for those releases; `confirm` deliberately does not, since
-  a command still in flight has already reported whether it can be confirmed.
+- **A timeout answers the caller; it does not cancel the command.** This one
+  bites in three places, and fixing one of them is not fixing it:
+  - The session's key is released only once every command the write started has
+    really finished (`DurableWriteRequest.settle`). Releasing it when the caller
+    is answered lets the compensating write — queued on that same key — run
+    first, and the abandoned command then lands on top of its own rollback,
+    leaving a member the client was told does not exist and who can win the
+    share back. `drain` waits for those releases; `confirm` deliberately does
+    not, since a command still in flight has already reported its verdict.
+  - Nothing starts a second call while the first has not answered — not the
+    write queue, not `pending-resync-queue`, not the reaper's per-room publish.
+    Otherwise a hung dependency accumulates one live command per retry.
+  - Nothing that closes a connection or a bus does so under a live call:
+    `close()` drains the chain (bounded) before `quit`, and the resync drain
+    waits out its abandoned calls (bounded) before shutdown closes the bus.
 - **A retry is abandoned when a newer write for the same session is queued.**
   Retrying past that point fights the newer write. This is only sound because
   the join write re-writes the WHOLE session record rather than patching
@@ -245,7 +252,10 @@ decides something has to know which of the two questions it is asking (#242):
   `leaveRoom(session, "disconnect")` — `"disconnect"` so a reconnecting member
   keeps the identity the ownership rule depends on. Everything a join sends next
   is read back off the index this write maintains, so a member the room cannot
-  see is worse than a refused join the client retries.
+  see is worse than a refused join the client retries. And if the ROLLBACK
+  fails, the socket is dropped: `leaveCurrentRoom` restores the member when its
+  own persistence fails and the socket is open, so reporting the join refused
+  while the server still holds the seat leaves the two disagreeing.
 
 ### One-shot broadcasts need a retry trail; repeated ones do not
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,10 +210,11 @@ decides something has to know which of the two questions it is asking (#242):
   `NonRetryableWriteError` (a generation only moves forward, so no later attempt
   can find its way back). An unreadable generation refuses the join rather than
   re-reading later, since a second read is a second chance to pin the wrong
-  instance — and so does an ABSENT one, because a teardown leaves the key absent
-  too, so `""` would match a deleted room as happily as a legacy one.
-  `createRoomForSession` awaits `markRoomGeneration` and expires the room if it
-  fails, so every joinable room has one. A new write that seats or moves anything by room code needs the same
+  instance. An ABSENT generation still pins as `""`, which is why the teardown
+  leaves a TOMBSTONE in that key rather than deleting it: deleting made "torn
+  down" indistinguishable from "never stamped", so a pin of `""` matched the
+  room it was about to resurrect. The tombstone expires, and `hasRoomResidue`
+  ignores it, so it never keeps a code reserved. A new write that seats or moves anything by room code needs the same
   pin; one that only touches keys named after the session does not, because
   session ids are never reused.
 - **Every retry budget is sized against the shutdown step that drains it.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,14 @@ decides something has to know which of the two questions it is asking (#242):
   writes that have not started, leaving at most ONE in-flight attempt; the step
   budget must exceed that attempt's own timeout. Raising `maxAttempts` or a
   delay means redoing that arithmetic.
+- **A timeout answers the caller; it does not cancel the command.** So the
+  session's key is released only once every command the write started has
+  really finished (`DurableWriteRequest.settle`). Releasing it when the caller
+  is answered lets the compensating write — queued on that same key — run
+  first, and the abandoned command then lands on top of its own rollback,
+  leaving a member the client was told does not exist and who can win the share
+  back. `drain` waits for those releases; `confirm` deliberately does not, since
+  a command still in flight has already reported whether it can be confirmed.
 - **A retry is abandoned when a newer write for the same session is queued.**
   Retrying past that point fights the newer write. This is only sound because
   the join write re-writes the WHOLE session record rather than patching
@@ -267,6 +275,8 @@ one-shot, and both lose the room permanently when the bus rejects them (#242):
   backlog first. Bounding only the second one leaves the budget just as blown.
   An overrun step is recorded as a failure AND lets the bus close under
   in-flight publishes, which then delete their records as if they had landed.
+  Each publish is capped on its own too: a deadline that only decides whether to
+  START the next record bounds nothing when the bus hangs instead of rejecting.
   Sweeps also no longer overlap: they share that set, and `stop()` awaits only
   the sweep it knows about.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,15 @@ decides something has to know which of the two questions it is asking (#242):
   uses the pacer; it does not grow a fifth copy. What stays local is what
   genuinely differs: ordering/supersession/confirmation, dedupe, and who decides
   to retry.
+- **A shutdown step that ran out of its budget is DEGRADED, not failed.** Only
+  a step that threw exits the process non-zero (`graceful-shutdown.ts`). The
+  budgets exist because these steps wait on I/O this process cannot cancel, so
+  giving up on it is the designed outcome. Treating an overrun as a failure
+  turned every "what if this particular call hangs?" into a correctness claim —
+  a question with no last answer, because each bounded wait added to satisfy it
+  becomes a new call site to ask it about. Ten of #242's review findings were
+  that one question re-asked. Both outcomes are still logged at error level; a
+  drain that gives up must stay visible.
 - **A timeout answers the caller; it does not cancel the command.** This one
   bites in three places, and fixing one of them is not fixing it:
   - The session's key is released only once every command the write started has

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -249,24 +249,25 @@ export async function createSyncServer(
     instanceId: persistenceConfig.instanceId,
     metricsCollector,
     onRoomJoined: async (session, roomCode) => {
-      runtimeStore.registerSession(session);
-      // Awaited for its REAL outcome, and retried once. The bootstrap
-      // `room:state` sent right after this is rebuilt from the index this write
-      // maintains, so a write that has not landed produces a state missing the
-      // member who just joined — and the ownership decision taken from it is
-      // then wrong in the one case it exists for, the stored sharer reconnecting
-      // (#235 review). The write is idempotent (`HSET` + `SADD`), so retrying it
-      // is safe; a second failure propagates and fails the join rather than
-      // seating a member the room cannot see.
-      try {
-        await runtimeStore.markSessionJoinedRoom(session.id, roomCode);
-      } catch {
-        await runtimeStore.markSessionJoinedRoom(session.id, roomCode);
-      }
+      // Not awaited, and deliberately so: `markSessionJoinedRoom` writes the
+      // WHOLE session record under the same key, so a registration that failed
+      // is repaired by the very next line and blocking on its retries would only
+      // delay the join (#242). Its outcome is still reported — the store marks
+      // the rejection handled, the log carries it.
+      void runtimeStore.registerSession(session);
+      // Awaited for its REAL outcome; the retries live in the store's write
+      // queue now, so the ad-hoc second try this used to do is gone. The
+      // bootstrap `room:state` sent right after this is rebuilt from the index
+      // this write maintains, so a write that has not landed produces a state
+      // missing the member who just joined — and the ownership decision taken
+      // from it is then wrong in the one case it exists for, the stored sharer
+      // reconnecting (#235 review). A failure propagates and ABORTS the join
+      // rather than seating a member the room cannot see (#242).
+      await runtimeStore.markSessionJoinedRoom(session.id, roomCode);
       await runtimeStore.flush?.();
     },
     onRoomLeft: async (session, roomCode) => {
-      runtimeStore.registerSession(session);
+      void runtimeStore.registerSession(session);
       // Awaited for its REAL outcome, so a failure reaches the handler and
       // suppresses the full `room:state` it would otherwise publish. Everything
       // published next is read back off the room index this write clears, so a

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -404,6 +404,10 @@ export async function createSyncServer(
           },
           {
             name: "stop_runtime_index_reaper",
+            // Bigger than the reaper's own shutdown budget for its pending
+            // resync announcements, which is what stops that last pass from
+            // being cut short and recorded as a failed step (#242 review).
+            timeoutMs: 10_000,
             run: () => runtimeIndexReaper.stop(),
           },
           {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -503,7 +503,7 @@ export async function createSyncServer(
             // close_room_event_consumer / close_room_event_bus tears the bus down,
             // so we don't lose final broadcasts under Redis backpressure.
             timeoutMs: 30_000,
-            run: () => messageHandler.flushPendingPublishes(),
+            run: () => messageHandler.flushPendingPublishes({ final: true }),
           },
           {
             name: "close_admin_command_consumer",

--- a/server/src/bootstrap/graceful-shutdown.ts
+++ b/server/src/bootstrap/graceful-shutdown.ts
@@ -130,7 +130,7 @@ export function installGracefulShutdown(
 
   const runShutdown = (close: ShutdownCloseTarget): void => {
     void (async () => {
-      let exitCode = 0;
+      let exitCode: number;
       try {
         const failures = (await close()) ?? [];
         if (failures.length > 0) {
@@ -139,10 +139,22 @@ export function installGracefulShutdown(
               .map((failure) => `${failure.step} (${failure.result})`)
               .join(", ")}.`,
           );
-          exitCode = 1;
         } else {
           log(`${name} shutdown complete.`);
         }
+        // A step that THREW got something wrong and the operator should hear
+        // about it as a failed shutdown. A step that merely ran out of its
+        // budget did not: the budget exists because the work it waits on is
+        // I/O this process cannot cancel — a Redis command, a bus publish —
+        // and giving up on it is the designed outcome, not a fault. Exiting
+        // non-zero for that made every "what if this particular call hangs?"
+        // a correctness claim, which is a question with no last answer: every
+        // bounded wait added to satisfy it becomes a new call site to ask it
+        // about (#242). Both are still logged at error level; only the exit
+        // code distinguishes them.
+        exitCode = failures.some((failure) => failure.result === "error")
+          ? 1
+          : 0;
       } catch (error) {
         logError(`${name} shutdown failed:`, error);
         exitCode = 1;

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -17,7 +17,10 @@ import { createMirroredRuntimeStore } from "../mirrored-runtime-store.js";
 import { createRedisAdminCommandBus } from "../redis-admin-command-bus.js";
 import { createRedisRoomEventBus } from "../redis-room-event-bus.js";
 import { createRedisRoomStore } from "../redis-room-store.js";
-import { createRedisRuntimeStore } from "../redis-runtime-store.js";
+import {
+  createRedisRuntimeStore,
+  type PendingOperationLogContext,
+} from "../redis-runtime-store.js";
 import {
   getRedisAdminCommandChannelPrefix,
   getRedisAdminCommandResultChannelPrefix,
@@ -88,12 +91,6 @@ export type ServerBootstrapDependencies = {
   serviceVersion?: string;
   logLevel?: LogLevel;
   logSampling?: Record<string, number>;
-};
-
-type PendingOperationLogContext = {
-  operationName: string;
-  pendingCount: number;
-  reason: "backpressure" | "timeout" | "failed";
 };
 
 type BootstrapLoggingHooks = {

--- a/server/src/bootstrap/server-bootstrap.ts
+++ b/server/src/bootstrap/server-bootstrap.ts
@@ -468,6 +468,13 @@ export function createSharedServerShutdownSteps(args: {
   if (args.runtimeStore) {
     steps.push({
       name: args.runtimeStoreStepName ?? "close_runtime_store",
+      // Must exceed ONE `pendingOperationTimeoutMs` (5s by default), which is
+      // what a wound-down write queue can still be holding: `close` stops the
+      // retries and drops writes that have not started, but a Redis command
+      // already in flight only ends when its own timeout fires. On the default
+      // step budget the two are equal and the step — which started first —
+      // times out and reports a failed shutdown (#242 review).
+      timeoutMs: DEFAULT_CLOSE_STEP_TIMEOUT_MS * 3,
       run: () =>
         hasClose(args.runtimeStore) ? args.runtimeStore.close() : undefined,
     });

--- a/server/src/durable-write-queue.ts
+++ b/server/src/durable-write-queue.ts
@@ -214,6 +214,17 @@ export function createDurableWriteQueue(
           error,
         });
         await pacer.wait(delayMs);
+        // The attempt that just failed may have failed by TIMEOUT, which races
+        // its command rather than aborting it. Starting the next attempt now
+        // would leave up to `maxAttempts` uncancellable commands out at once
+        // for a single write — and the internal retries never go back through
+        // `ensurePendingCapacity`, so the configured cap would not see them
+        // (#242 review). `settle` is exactly "every command started so far has
+        // answered"; the stop signal is what keeps shutdown from waiting on it.
+        await Promise.race([
+          request.settle?.() ?? Promise.resolve(),
+          pacer.whenStopped(),
+        ]);
         if (isSuperseded()) {
           throw new SupersededWriteError(request.key, request.operationName);
         }

--- a/server/src/durable-write-queue.ts
+++ b/server/src/durable-write-queue.ts
@@ -98,13 +98,16 @@ export type DurableWriteQueue = {
    */
   confirm: () => Promise<void>;
   /**
-   * Let every outstanding write finish its CURRENT attempt and then give up,
-   * instead of backing off for another one. Irreversible.
+   * Wind down: writes already running finish the attempt they are on, backoffs
+   * in flight are cut short, and writes that have not started yet are dropped
+   * without one. Irreversible.
    *
-   * Shutdown needs it. A close step gets a few seconds; a queue that kept
-   * retrying through a Redis outage would spend the whole retry budget there
-   * and the step would be recorded as failed, so the process exits non-zero
-   * over writes that were never going to land anyway (#242).
+   * Shutdown needs it, and needs all three. A close step gets a few seconds; a
+   * queue that kept retrying through a Redis outage — or that let each queued
+   * write open one more attempt of its own — would overrun that step, and an
+   * overrun step is recorded as a FAILURE, so the process exits non-zero over
+   * writes that were never going to land anyway (#242). What is left after
+   * this call is bounded by ONE attempt.
    */
   stopRetrying: () => void;
   /** Writes still in flight or waiting to retry. */
@@ -191,11 +194,21 @@ export function createDurableWriteQueue(
     request: DurableWriteRequest,
     isSuperseded: () => boolean,
   ): Promise<void> {
+    // Shutdown is the one thing that stops a write before it has tried at all.
+    // A queue can hold several writes for one session, and each would otherwise
+    // still start an attempt and hold the close step for a whole attempt
+    // timeout apiece — so the step times out and the process exits non-zero
+    // over writes nobody is waiting for any more (#242 review).
+    if (retriesStopped) {
+      throw new Error(
+        `Durable write ${request.operationName} for ${request.key} was dropped: the queue is shutting down.`,
+      );
+    }
     let lastError: unknown;
-    // Every write gets its FIRST attempt regardless of supersession: the queue
-    // cannot know that a newer write covers the same fields, and skipping the
-    // attempt outright would silently lose writes that touch disjoint state.
-    // Only the retries are given up.
+    // Supersession, by contrast, never skips the FIRST attempt: the queue
+    // cannot know that the newer write covers the same fields, and skipping
+    // outright would silently lose writes that touch disjoint state. Only the
+    // retries are given up.
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       try {
         await request.run();

--- a/server/src/durable-write-queue.ts
+++ b/server/src/durable-write-queue.ts
@@ -1,0 +1,313 @@
+/**
+ * Ordered, retrying, confirmable writes to a write-behind store.
+ *
+ * The runtime store updates this node's own maps synchronously and queues the
+ * shared write behind them. Before this queue existed a queued write got exactly
+ * one attempt: a transient Redis error dropped it on the floor, and every
+ * "write, then read it back and decide something" path downstream could act on
+ * data that never landed (#242).
+ *
+ * Three properties, none of which the old chain had:
+ *
+ * - **Retries with backoff.** A failed attempt is retried rather than dropped,
+ *   so a blip no longer costs a write.
+ * - **A real outcome.** `enqueue` resolves only once the write is confirmed and
+ *   rejects when it is not. `drain` and `confirm` say two different things, so
+ *   a caller can ask either "has the queue emptied" or "did everything land".
+ * - **Order, per key.** Writes for one key never overlap, and a retry cannot
+ *   overtake a newer write for the same key — see {@link SupersededWriteError}.
+ */
+
+/** A write that must not be retried, however many attempts are left. */
+export class NonRetryableWriteError extends Error {
+  constructor(
+    message: string,
+    readonly reason: string,
+  ) {
+    super(message);
+    this.name = "NonRetryableWriteError";
+  }
+}
+
+/**
+ * A newer write for the same key arrived while this one was waiting to retry.
+ *
+ * Retrying past that point would fight the newer write instead of helping it:
+ * the writes this queue carries are ordered edits to one session's keys, so the
+ * newest one describes the state the caller actually wants. It is reported as a
+ * distinct error because it is NOT a durability failure — {@link
+ * DurableWriteQueue.confirm} deliberately ignores it.
+ */
+export class SupersededWriteError extends Error {
+  constructor(
+    readonly key: string,
+    readonly operationName: string,
+  ) {
+    super(
+      `Durable write ${operationName} for ${key} was superseded by a newer write.`,
+    );
+    this.name = "SupersededWriteError";
+  }
+}
+
+export type DurableWriteRetryInfo = {
+  key: string;
+  operationName: string;
+  /** 1-based index of the attempt that just failed. */
+  attempt: number;
+  delayMs: number;
+  error: unknown;
+};
+
+export type DurableWriteRequest = {
+  /** Writes sharing a key are serialized and may supersede one another. */
+  key: string;
+  operationName: string;
+  run: () => Promise<void>;
+};
+
+export type DurableWriteQueueOptions = {
+  /** Total attempts, including the first. */
+  maxAttempts?: number;
+  initialRetryDelayMs?: number;
+  maxRetryDelayMs?: number;
+  /** Injectable so tests do not pay the backoff in wall-clock time. */
+  sleep?: (delayMs: number) => Promise<void>;
+  onRetryScheduled?: (info: DurableWriteRetryInfo) => void;
+};
+
+export type DurableWriteQueue = {
+  /**
+   * Run `request.run()`, retrying it on failure. Resolves once the write is
+   * confirmed; rejects with the last error when it is not, and with a
+   * {@link SupersededWriteError} when a newer write for the same key took over.
+   */
+  enqueue: (request: DurableWriteRequest) => Promise<void>;
+  /** Every write queued so far has settled, however it settled. */
+  drain: () => Promise<void>;
+  /**
+   * Every write is CONFIRMED: the outstanding ones have landed, and none has
+   * been given up on since the last call. Rejects with an `AggregateError`
+   * carrying the ones that were not.
+   *
+   * The counterpart to {@link DurableWriteQueue.drain}, which only ever says
+   * that the queue emptied — the distinction #242 exists to draw. A failure is
+   * remembered rather than only observable while the write is still in the
+   * queue, because the caller with the most reason to ask is the one who just
+   * drained it; reading clears it, so the answer is "since you last asked".
+   */
+  confirm: () => Promise<void>;
+  /**
+   * Let every outstanding write finish its CURRENT attempt and then give up,
+   * instead of backing off for another one. Irreversible.
+   *
+   * Shutdown needs it. A close step gets a few seconds; a queue that kept
+   * retrying through a Redis outage would spend the whole retry budget there
+   * and the step would be recorded as failed, so the process exits non-zero
+   * over writes that were never going to land anyway (#242).
+   */
+  stopRetrying: () => void;
+  /** Writes still in flight or waiting to retry. */
+  size: () => number;
+};
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_INITIAL_RETRY_DELAY_MS = 50;
+const DEFAULT_MAX_RETRY_DELAY_MS = 1_000;
+const MAX_REMEMBERED_FAILURES = 64;
+
+/**
+ * A backoff that can be cut short.
+ *
+ * Deliberately NOT `unref`'d: the timer is the only thing keeping a retry
+ * alive, and unrefing it lets an otherwise idle event loop drain, silently
+ * losing the write. That makes it the caller's job to end the wait — hence
+ * `cancel`, which {@link DurableWriteQueue.stopRetrying} uses so a shutdown
+ * does not have to sit through a backoff for a write it has already given up
+ * on.
+ */
+type RetryWait = { promise: Promise<void>; cancel: () => void };
+
+function startRetryWait(delayMs: number): RetryWait {
+  let cancel = (): void => {};
+  const promise = new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, delayMs);
+    cancel = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+  });
+  return { promise, cancel };
+}
+
+type ChainEntry = {
+  settled: Promise<void>;
+  supersede: () => void;
+};
+
+export function createDurableWriteQueue(
+  options: DurableWriteQueueOptions = {},
+): DurableWriteQueue {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+  const initialRetryDelayMs =
+    options.initialRetryDelayMs ?? DEFAULT_INITIAL_RETRY_DELAY_MS;
+  const maxRetryDelayMs = options.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
+
+  const chains = new Map<string, ChainEntry>();
+  /** The REAL outcomes, each pre-marked handled so a rejection stays quiet. */
+  const outcomes = new Set<Promise<void>>();
+  /**
+   * Writes given up on since the last {@link DurableWriteQueue.confirm}. Capped
+   * so a store-wide outage cannot turn the record of it into a leak; the count
+   * that matters is "any", and the first few carry the diagnosis.
+   */
+  const abandoned: unknown[] = [];
+  /** `cancel` for every backoff currently being waited out. */
+  const pendingWaits = new Set<() => void>();
+  let retriesStopped = false;
+
+  /**
+   * An injected `sleep` is a test clock and resolves on its own, so it needs no
+   * canceller — stopping the LOOP is enough there. The real timer does need
+   * one; see {@link startRetryWait}.
+   */
+  function waitBeforeRetry(delayMs: number): Promise<void> {
+    if (options.sleep) {
+      return options.sleep(delayMs);
+    }
+    const wait = startRetryWait(delayMs);
+    pendingWaits.add(wait.cancel);
+    return wait.promise.finally(() => {
+      pendingWaits.delete(wait.cancel);
+    });
+  }
+
+  function retryDelayMs(attempt: number): number {
+    const backoff = initialRetryDelayMs * 2 ** (attempt - 1);
+    return Math.min(backoff, maxRetryDelayMs);
+  }
+
+  async function runWithRetries(
+    request: DurableWriteRequest,
+    isSuperseded: () => boolean,
+  ): Promise<void> {
+    let lastError: unknown;
+    // Every write gets its FIRST attempt regardless of supersession: the queue
+    // cannot know that a newer write covers the same fields, and skipping the
+    // attempt outright would silently lose writes that touch disjoint state.
+    // Only the retries are given up.
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        await request.run();
+        return;
+      } catch (error) {
+        lastError = error;
+        if (error instanceof NonRetryableWriteError) {
+          throw error;
+        }
+        if (attempt === maxAttempts || retriesStopped) {
+          break;
+        }
+        if (isSuperseded()) {
+          throw new SupersededWriteError(request.key, request.operationName);
+        }
+        const delayMs = retryDelayMs(attempt);
+        options.onRetryScheduled?.({
+          key: request.key,
+          operationName: request.operationName,
+          attempt,
+          delayMs,
+          error,
+        });
+        await waitBeforeRetry(delayMs);
+        if (isSuperseded()) {
+          throw new SupersededWriteError(request.key, request.operationName);
+        }
+        // Re-checked after the wait, not only before it: a write already parked
+        // in its backoff when the queue was told to stop would otherwise wake up
+        // and start one more attempt — which is exactly the attempt the close
+        // step has no time for.
+        if (retriesStopped) {
+          break;
+        }
+      }
+    }
+    throw lastError;
+  }
+
+  return {
+    enqueue(request) {
+      const previous = chains.get(request.key);
+      previous?.supersede();
+
+      let superseded = false;
+      const outcome = (previous?.settled ?? Promise.resolve()).then(() =>
+        runWithRetries(request, () => superseded),
+      );
+      const settled = outcome.then(
+        () => undefined,
+        (error: unknown) => {
+          // A superseded write is not an unconfirmed one: the newer write for
+          // that key is what the caller wanted written, and it is queued behind
+          // this one.
+          if (
+            !(error instanceof SupersededWriteError) &&
+            abandoned.length < MAX_REMEMBERED_FAILURES
+          ) {
+            abandoned.push(error);
+          }
+        },
+      );
+      const entry: ChainEntry = {
+        settled,
+        supersede: () => {
+          superseded = true;
+        },
+      };
+      chains.set(request.key, entry);
+
+      outcomes.add(outcome);
+      // Marks the rejection handled without consuming it, so a caller that DOES
+      // await `enqueue` still sees it while a fire-and-forget caller does not
+      // crash the process.
+      void outcome.catch(() => undefined);
+      void settled.then(() => {
+        outcomes.delete(outcome);
+        if (chains.get(request.key) === entry) {
+          chains.delete(request.key);
+        }
+      });
+      return outcome;
+    },
+    async drain() {
+      await Promise.allSettled(Array.from(outcomes));
+    },
+    async confirm() {
+      // Settling the outstanding writes first is what folds THEIR failures into
+      // `abandoned`, so the check below covers both the writes that had already
+      // been given up on and the ones still running when this was called.
+      await Promise.allSettled(Array.from(outcomes));
+      if (abandoned.length === 0) {
+        return;
+      }
+      const failures = abandoned.splice(0, abandoned.length);
+      throw new AggregateError(
+        failures,
+        `${failures.length} durable write(s) were not confirmed.`,
+      );
+    },
+    stopRetrying() {
+      retriesStopped = true;
+      // Cut the backoffs short as well as refusing new ones: a write already
+      // parked in one would otherwise hold `drain` for the full delay, which is
+      // the very wait the close step has no time for.
+      for (const cancel of Array.from(pendingWaits)) {
+        cancel();
+      }
+      pendingWaits.clear();
+    },
+    size() {
+      return outcomes.size;
+    },
+  };
+}

--- a/server/src/durable-write-queue.ts
+++ b/server/src/durable-write-queue.ts
@@ -18,6 +18,8 @@
  *   overtake a newer write for the same key — see {@link SupersededWriteError}.
  */
 
+import { createRetryPacer } from "./retry-pacer.js";
+
 /** A write that must not be retried, however many attempts are left. */
 export class NonRetryableWriteError extends Error {
   constructor(
@@ -136,30 +138,6 @@ const DEFAULT_INITIAL_RETRY_DELAY_MS = 50;
 const DEFAULT_MAX_RETRY_DELAY_MS = 1_000;
 const MAX_REMEMBERED_FAILURES = 64;
 
-/**
- * A backoff that can be cut short.
- *
- * Deliberately NOT `unref`'d: the timer is the only thing keeping a retry
- * alive, and unrefing it lets an otherwise idle event loop drain, silently
- * losing the write. That makes it the caller's job to end the wait — hence
- * `cancel`, which {@link DurableWriteQueue.stopRetrying} uses so a shutdown
- * does not have to sit through a backoff for a write it has already given up
- * on.
- */
-type RetryWait = { promise: Promise<void>; cancel: () => void };
-
-function startRetryWait(delayMs: number): RetryWait {
-  let cancel = (): void => {};
-  const promise = new Promise<void>((resolve) => {
-    const timer = setTimeout(resolve, delayMs);
-    cancel = () => {
-      clearTimeout(timer);
-      resolve();
-    };
-  });
-  return { promise, cancel };
-}
-
 type ChainEntry = {
   settled: Promise<void>;
   supersede: () => void;
@@ -169,9 +147,13 @@ export function createDurableWriteQueue(
   options: DurableWriteQueueOptions = {},
 ): DurableWriteQueue {
   const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
-  const initialRetryDelayMs =
-    options.initialRetryDelayMs ?? DEFAULT_INITIAL_RETRY_DELAY_MS;
-  const maxRetryDelayMs = options.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
+
+  const pacer = createRetryPacer({
+    initialDelayMs:
+      options.initialRetryDelayMs ?? DEFAULT_INITIAL_RETRY_DELAY_MS,
+    maxDelayMs: options.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS,
+    sleep: options.sleep,
+  });
 
   const chains = new Map<string, ChainEntry>();
   /** The REAL outcomes, each pre-marked handled so a rejection stays quiet. */
@@ -189,31 +171,6 @@ export function createDurableWriteQueue(
    * that matters is "any", and the first few carry the diagnosis.
    */
   const abandoned: unknown[] = [];
-  /** `cancel` for every backoff currently being waited out. */
-  const pendingWaits = new Set<() => void>();
-  let retriesStopped = false;
-
-  /**
-   * An injected `sleep` is a test clock and resolves on its own, so it needs no
-   * canceller — stopping the LOOP is enough there. The real timer does need
-   * one; see {@link startRetryWait}.
-   */
-  function waitBeforeRetry(delayMs: number): Promise<void> {
-    if (options.sleep) {
-      return options.sleep(delayMs);
-    }
-    const wait = startRetryWait(delayMs);
-    pendingWaits.add(wait.cancel);
-    return wait.promise.finally(() => {
-      pendingWaits.delete(wait.cancel);
-    });
-  }
-
-  function retryDelayMs(attempt: number): number {
-    const backoff = initialRetryDelayMs * 2 ** (attempt - 1);
-    return Math.min(backoff, maxRetryDelayMs);
-  }
-
   async function runWithRetries(
     request: DurableWriteRequest,
     isSuperseded: () => boolean,
@@ -223,7 +180,7 @@ export function createDurableWriteQueue(
     // still start an attempt and hold the close step for a whole attempt
     // timeout apiece — so the step times out and the process exits non-zero
     // over writes nobody is waiting for any more (#242 review).
-    if (retriesStopped) {
+    if (pacer.stopped()) {
       throw new Error(
         `Durable write ${request.operationName} for ${request.key} was dropped: the queue is shutting down.`,
       );
@@ -242,13 +199,13 @@ export function createDurableWriteQueue(
         if (error instanceof NonRetryableWriteError) {
           throw error;
         }
-        if (attempt === maxAttempts || retriesStopped) {
+        if (attempt === maxAttempts || pacer.stopped()) {
           break;
         }
         if (isSuperseded()) {
           throw new SupersededWriteError(request.key, request.operationName);
         }
-        const delayMs = retryDelayMs(attempt);
+        const delayMs = pacer.delayFor(attempt);
         options.onRetryScheduled?.({
           key: request.key,
           operationName: request.operationName,
@@ -256,7 +213,7 @@ export function createDurableWriteQueue(
           delayMs,
           error,
         });
-        await waitBeforeRetry(delayMs);
+        await pacer.wait(delayMs);
         if (isSuperseded()) {
           throw new SupersededWriteError(request.key, request.operationName);
         }
@@ -264,7 +221,7 @@ export function createDurableWriteQueue(
         // in its backoff when the queue was told to stop would otherwise wake up
         // and start one more attempt — which is exactly the attempt the close
         // step has no time for.
-        if (retriesStopped) {
+        if (pacer.stopped()) {
           break;
         }
       }
@@ -349,14 +306,7 @@ export function createDurableWriteQueue(
       );
     },
     stopRetrying() {
-      retriesStopped = true;
-      // Cut the backoffs short as well as refusing new ones: a write already
-      // parked in one would otherwise hold `drain` for the full delay, which is
-      // the very wait the close step has no time for.
-      for (const cancel of Array.from(pendingWaits)) {
-        cancel();
-      }
-      pendingWaits.clear();
+      pacer.stop();
     },
     size() {
       return released.size;

--- a/server/src/durable-write-queue.ts
+++ b/server/src/durable-write-queue.ts
@@ -64,6 +64,18 @@ export type DurableWriteRequest = {
   key: string;
   operationName: string;
   run: () => Promise<void>;
+  /**
+   * Awaited before the KEY is released to the next write — never before the
+   * caller is answered.
+   *
+   * A `run` that gives up on a command it cannot cancel (a timeout races the
+   * command, it does not abort it) must report that here, or the command lands
+   * AFTER whatever the caller did about the failure. That is not a harmless
+   * duplicate: the caller's compensating write is queued on this same key, so
+   * an abandoned join would be re-applied on top of its own rollback and leave
+   * a member the client was told does not exist (#242 review).
+   */
+  settle?: () => Promise<void>;
 };
 
 export type DurableWriteQueueOptions = {
@@ -83,7 +95,12 @@ export type DurableWriteQueue = {
    * {@link SupersededWriteError} when a newer write for the same key took over.
    */
   enqueue: (request: DurableWriteRequest) => Promise<void>;
-  /** Every write queued so far has settled, however it settled. */
+  /**
+   * Every write queued so far has released its key — which is later than "its
+   * caller was answered", because a command a timeout gave up on is still in
+   * flight until Redis answers. Use it when the point is that the store is
+   * quiet; `confirm` is the one that reports.
+   */
   drain: () => Promise<void>;
   /**
    * Every write is CONFIRMED: the outstanding ones have landed, and none has
@@ -159,6 +176,13 @@ export function createDurableWriteQueue(
   const chains = new Map<string, ChainEntry>();
   /** The REAL outcomes, each pre-marked handled so a rejection stays quiet. */
   const outcomes = new Set<Promise<void>>();
+  /**
+   * One per write, resolving when its KEY is released — i.e. after `settle`.
+   * `drain` waits on these rather than on `outcomes`, because a write whose
+   * command is still in flight has not finished with the store just because its
+   * caller has been answered.
+   */
+  const released = new Set<Promise<void>>();
   /**
    * Writes given up on since the last {@link DurableWriteQueue.confirm}. Capped
    * so a store-wide outage cannot turn the record of it into a leak; the count
@@ -257,7 +281,7 @@ export function createDurableWriteQueue(
       const outcome = (previous?.settled ?? Promise.resolve()).then(() =>
         runWithRetries(request, () => superseded),
       );
-      const settled = outcome.then(
+      const reported = outcome.then(
         () => undefined,
         (error: unknown) => {
           // A superseded write is not an unconfirmed one: the newer write for
@@ -271,6 +295,14 @@ export function createDurableWriteQueue(
           }
         },
       );
+      // The chain is released only once the underlying commands have really
+      // finished — see `settle`. The caller still gets `outcome` on time.
+      const settled = reported
+        .then(() => request.settle?.())
+        .then(
+          () => undefined,
+          () => undefined,
+        );
       const entry: ChainEntry = {
         settled,
         supersede: () => {
@@ -280,12 +312,14 @@ export function createDurableWriteQueue(
       chains.set(request.key, entry);
 
       outcomes.add(outcome);
+      released.add(settled);
       // Marks the rejection handled without consuming it, so a caller that DOES
       // await `enqueue` still sees it while a fire-and-forget caller does not
       // crash the process.
       void outcome.catch(() => undefined);
       void settled.then(() => {
         outcomes.delete(outcome);
+        released.delete(settled);
         if (chains.get(request.key) === entry) {
           chains.delete(request.key);
         }
@@ -293,12 +327,17 @@ export function createDurableWriteQueue(
       return outcome;
     },
     async drain() {
-      await Promise.allSettled(Array.from(outcomes));
+      while (released.size > 0) {
+        await Promise.allSettled(Array.from(released));
+      }
     },
     async confirm() {
       // Settling the outstanding writes first is what folds THEIR failures into
       // `abandoned`, so the check below covers both the writes that had already
       // been given up on and the ones still running when this was called.
+      // The callers' answers, not the key releases: a command that is still in
+      // flight has already reported whether it can be confirmed, and waiting
+      // for it to finish would make this hang exactly when the store is sick.
       await Promise.allSettled(Array.from(outcomes));
       if (abandoned.length === 0) {
         return;
@@ -320,7 +359,7 @@ export function createDurableWriteQueue(
       pendingWaits.clear();
     },
     size() {
-      return outcomes.size;
+      return released.size;
     },
   };
 }

--- a/server/src/durable-write-queue.ts
+++ b/server/src/durable-write-queue.ts
@@ -246,9 +246,23 @@ export function createDurableWriteQueue(
       previous?.supersede();
 
       let superseded = false;
-      const outcome = (previous?.settled ?? Promise.resolve()).then(() =>
-        runWithRetries(request, () => superseded),
-      );
+      const previousSettled = previous?.settled ?? Promise.resolve();
+      const outcome = (async () => {
+        // The caller is answered as soon as the queue is told to stop, even
+        // while still queued behind a key whose command has not come back.
+        // Waiting on `previousSettled` alone put every queued write out of
+        // reach of the stop check below, so `close()` sat on outcomes that
+        // could never settle and the shutdown step was guaranteed to overrun
+        // (#242 review). The KEY chain still waits — ordering is unchanged.
+        await Promise.race([previousSettled, pacer.whenStopped()]);
+        if (pacer.stopped()) {
+          throw new Error(
+            `Durable write ${request.operationName} for ${request.key} was dropped: the queue is shutting down.`,
+          );
+        }
+        await previousSettled;
+        return runWithRetries(request, () => superseded);
+      })();
       const reported = outcome.then(
         () => undefined,
         (error: unknown) => {
@@ -266,6 +280,11 @@ export function createDurableWriteQueue(
       // The chain is released only once the underlying commands have really
       // finished — see `settle`. The caller still gets `outcome` on time.
       const settled = reported
+        .then(() => previousSettled)
+        .then(
+          () => undefined,
+          () => undefined,
+        )
         .then(() => request.settle?.())
         .then(
           () => undefined,

--- a/server/src/global-admin-app.ts
+++ b/server/src/global-admin-app.ts
@@ -115,6 +115,10 @@ export async function createGlobalAdminServer(
             : []),
           {
             name: "stop_runtime_index_reaper",
+            // Bigger than the reaper's own shutdown budget for its pending
+            // resync announcements, which is what stops that last pass from
+            // being cut short and recorded as a failed step (#242 review).
+            timeoutMs: 10_000,
             run: () => runtimeIndexReaper.stop(),
           },
           ...createSharedServerShutdownSteps({

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -30,6 +30,9 @@ type RoomEventBusPublishInput<T> = T extends unknown
   ? Omit<T, "sourceInstanceId" | "emittedAt">
   : never;
 
+/** RFC 6455 "internal error": the server could not put the session back. */
+const CLOSE_CODE_JOIN_ROLLBACK_FAILED = 1011;
+
 export function createMessageHandler(options: {
   config: {
     maxMembersPerRoom: number;
@@ -217,9 +220,11 @@ export function createMessageHandler(options: {
     roomCode: string,
     socket: WebSocket,
   ): Promise<void> {
+    let rolledBack = true;
     try {
       await leaveRoom(session, "disconnect");
     } catch (error) {
+      rolledBack = false;
       logEvent("room_join_rollback_failed", {
         sessionId: session.id,
         roomCode,
@@ -236,8 +241,30 @@ export function createMessageHandler(options: {
       origin: session.origin,
       result: "rejected",
       reason: "room_index_write_failed",
+      rolledBack,
     });
     sendError(socket, "internal_error", INTERNAL_SERVER_ERROR_MESSAGE);
+    if (rolledBack) {
+      return;
+    }
+    // The seat did not come back. `leaveCurrentRoom` RESTORES the member when
+    // its own persistence fails and the socket is still open, so telling the
+    // client the join failed while the server still holds it as a member leaves
+    // the two disagreeing — and that connection can go on sharing and driving
+    // playback from a seat the shared index never received (#242 review).
+    //
+    // Dropping the socket is the only honest end: `cleanupSessionAfterClose`
+    // runs the leave again with no socket to restore into, and unregisters the
+    // session either way.
+    if (
+      hasAttachedSocket(session) &&
+      session.socket.readyState === session.socket.OPEN
+    ) {
+      session.socket.close(
+        CLOSE_CODE_JOIN_ROLLBACK_FAILED,
+        "join_rollback_failed",
+      );
+    }
   }
 
   /**

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -159,7 +159,7 @@ export function createMessageHandler(options: {
    * will present it on the next join to reclaim the same `memberId` (#234).
    */
   leaveRoom: (session: Session, reason?: LeaveRoomReason) => Promise<void>;
-  flushPendingPublishes: () => Promise<void>;
+  flushPendingPublishes: (options?: { final?: boolean }) => Promise<void>;
 } {
   const { config, roomService, logEvent, send, sendError } = options;
   const now = options.now ?? Date.now;
@@ -477,8 +477,18 @@ export function createMessageHandler(options: {
    * Drains the retrying resync records too, not just the one-shot wrappers.
    * Shutdown calls this before the bus is torn down, and a record left behind
    * is the one broadcast nothing else will ever re-send (#242).
+   *
+   * `final` marks the shutdown call. Without it the drain is unbounded in the
+   * number of retry BATCHES a record may run — a request that arrived mid-batch
+   * earns a fresh budget, which is right at runtime and, at shutdown, is two
+   * budgets in a step sized for one (#242 review).
    */
-  async function flushPendingPublishes(): Promise<void> {
+  async function flushPendingPublishes(options?: {
+    final?: boolean;
+  }): Promise<void> {
+    if (options?.final) {
+      sharedOwnerResyncQueue.stopAfterCurrentBatch();
+    }
     while (pendingPublishes.size > 0 || sharedOwnerResyncQueue.size() > 0) {
       await Promise.allSettled([
         ...Array.from(pendingPublishes),

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -12,12 +12,14 @@ import {
   WINDOW_MINUTE_MS,
 } from "./rate-limit.js";
 import {
+  INTERNAL_SERVER_ERROR_MESSAGE,
   MEMBER_TOKEN_INVALID_MESSAGE,
   RATE_LIMITED_MESSAGE,
   UNSUPPORTED_PROTOCOL_VERSION_MESSAGE,
   MIN_PROTOCOL_VERSION,
   CURRENT_PROTOCOL_VERSION,
 } from "./messages.js";
+import { createPendingResyncQueue } from "./pending-resync-queue.js";
 import { RoomServiceError, type LeaveRoomReason } from "./room-service.js";
 import { withPlaybackAge } from "./room-state-age.js";
 import type { RoomEventBusMessage } from "./room-event-bus.js";
@@ -113,6 +115,25 @@ export function createMessageHandler(options: {
   maxPendingPublishes?: number;
   backpressureWaitMs?: number;
   publishTimeoutMs?: number;
+  /**
+   * Retry policy for the share-ownership resync, the one broadcast in this file
+   * that nothing else repeats. See `pending-resync-queue`.
+   */
+  sharedOwnerResyncRetry?: {
+    maxAttempts?: number;
+    initialRetryDelayMs?: number;
+    maxRetryDelayMs?: number;
+    sleep?: (delayMs: number) => Promise<void>;
+  };
+  /**
+   * Rejecting ABORTS the join. Its implementation puts the session into the room
+   * index, and everything the join sends next is read back off that index: the
+   * bootstrap `room:state` would be missing the member who just joined, and the
+   * ownership decision taken from it is then wrong in the one case it exists
+   * for — the stored sharer reconnecting (#235). Seating a member the room
+   * cannot see is worse than refusing the join, which the client simply retries
+   * (#242).
+   */
   onRoomJoined?: (
     session: Session,
     roomCode: string,
@@ -148,13 +169,21 @@ export function createMessageHandler(options: {
   const backpressureWaitMs = options.backpressureWaitMs ?? 5_000;
   const publishTimeoutMs = options.publishTimeoutMs ?? 5_000;
 
+  /**
+   * Returns whether the session was actually seated. A `false` here used to be
+   * swallowed and the join carried on regardless: the member was absent from
+   * the room index, so the bootstrap state they were handed did not contain
+   * them, and the stored sharer reconnecting into that room was handed a
+   * stand-in owner with no full state to follow (#242).
+   */
   async function runRoomJoinedHook(
     session: Session,
     roomCode: string,
     previousRoomCode: string | null,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await options.onRoomJoined?.(session, roomCode, previousRoomCode);
+      return true;
     } catch (error) {
       logEvent("room_join_hook_failed", {
         sessionId: session.id,
@@ -165,7 +194,51 @@ export function createMessageHandler(options: {
         result: "error",
         error: error instanceof Error ? error.message : String(error),
       });
+      return false;
     }
+  }
+
+  /**
+   * Undo a join whose index write never landed.
+   *
+   * `applyJoinedSessionState` and `addMember` have both already taken effect by
+   * the time the hook runs, so refusing the join means unwinding them — and
+   * `leaveRoom` is the one path that does that completely: it drops the member,
+   * clears the session's room state, releases the room's own bookkeeping and
+   * publishes whatever the departure owes.
+   *
+   * `"disconnect"`, not `"client-request"`: the member's identity has to
+   * survive so the client's retry reclaims the same `memberId` with the token it
+   * was never given. It has none yet — the join is refused before `room:joined`
+   * is sent — so on a first join it simply comes back as a new member, while a
+   * RECONNECTING member keeps the seat the whole ownership rule depends on.
+   */
+  async function abortJoin(
+    session: Session,
+    roomCode: string,
+    socket: WebSocket,
+  ): Promise<void> {
+    try {
+      await leaveRoom(session, "disconnect");
+    } catch (error) {
+      logEvent("room_join_rollback_failed", {
+        sessionId: session.id,
+        roomCode,
+        remoteAddress: session.remoteAddress,
+        origin: session.origin,
+        result: "error",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    logEvent("room_join_aborted", {
+      sessionId: session.id,
+      roomCode,
+      remoteAddress: session.remoteAddress,
+      origin: session.origin,
+      result: "rejected",
+      reason: "room_index_write_failed",
+    });
+    sendError(socket, "internal_error", INTERNAL_SERVER_ERROR_MESSAGE);
   }
 
   /**
@@ -400,9 +473,17 @@ export function createMessageHandler(options: {
     });
   }
 
+  /**
+   * Drains the retrying resync records too, not just the one-shot wrappers.
+   * Shutdown calls this before the bus is torn down, and a record left behind
+   * is the one broadcast nothing else will ever re-send (#242).
+   */
   async function flushPendingPublishes(): Promise<void> {
-    while (pendingPublishes.size > 0) {
-      await Promise.allSettled(Array.from(pendingPublishes));
+    while (pendingPublishes.size > 0 || sharedOwnerResyncQueue.size() > 0) {
+      await Promise.allSettled([
+        ...Array.from(pendingPublishes),
+        sharedOwnerResyncQueue.drain(),
+      ]);
     }
   }
 
@@ -427,7 +508,7 @@ export function createMessageHandler(options: {
     const publishResync = needsRoomStateResync === true && roomIndexCleaned;
     if (!memberRemoved && !notifyRoom) {
       if (publishResync) {
-        await publishSharedOwnerResync(session, roomCode);
+        publishSharedOwnerResync(roomCode);
       }
       return;
     }
@@ -452,7 +533,7 @@ export function createMessageHandler(options: {
     // every roster. The full state is the one that must not be built on an
     // index we failed to clean (#235 review).
     if (publishResync) {
-      await publishSharedOwnerResync(session, roomCode);
+      publishSharedOwnerResync(roomCode);
     }
   }
 
@@ -465,24 +546,59 @@ export function createMessageHandler(options: {
    * is where ownership is resolved (`roomStateFromSessions`). Sent AFTER the
    * delta so the authoritative state is the last word — the two ride the same
    * channel, so their order survives.
+   *
+   * Retried, unlike every other publish in this file, because it is the only
+   * ONE-SHOT one. The rest are re-sent by the next `video:share` /
+   * `playback:update` / `profile:update`, so dropping one costs a moment. This
+   * one goes out precisely because the room has stopped advancing, so nothing
+   * follows it to correct it, and an idle room never sends `sync:request`
+   * either — the user has to reload the page (#242).
    */
-  async function publishSharedOwnerResync(
-    session: Session,
-    roomCode: string,
-    reason = "shared_owner_resync_broadcast_failed",
-  ): Promise<void> {
-    await firePublishRoomEvent(
-      {
+  const sharedOwnerResyncQueue = createPendingResyncQueue({
+    ...options.sharedOwnerResyncRetry,
+    attemptTimeoutMs: publishTimeoutMs,
+    publish: (roomCode) =>
+      options.publishRoomEvent({
         type: "room_state_updated",
         roomCode,
-      },
-      {
-        reason,
-        sessionId: session.id,
-        remoteAddress: session.remoteAddress,
-        origin: session.origin,
-      },
-    );
+        sourceInstanceId: options.instanceId,
+        emittedAt: now(),
+      }),
+    onAttemptFailed: ({ roomCode, attempt, delayMs, error }) => {
+      logEvent("shared_owner_resync_retry_scheduled", {
+        roomCode,
+        attempt,
+        delayMs,
+        result: "error",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    },
+    onAbandoned: ({ roomCode, attempts, error }) => {
+      logEvent("shared_owner_resync_abandoned", {
+        roomCode,
+        attempts,
+        result: "dropped",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    },
+    onRejected: ({ roomCode, pendingRooms }) => {
+      logEvent("shared_owner_resync_rejected", {
+        roomCode,
+        pendingRooms,
+        result: "rejected",
+        reason: "pending_resync_overflow",
+      });
+    },
+  });
+
+  /**
+   * Returns immediately, exactly like `firePublishRoomEvent`: the leave and join
+   * handlers would otherwise block on the bus for up to `publishTimeoutMs`, and
+   * `firePublishRoomEvent` was written not to await its wrapper for that very
+   * reason. The retry lives inside the queue instead.
+   */
+  function publishSharedOwnerResync(roomCode: string): void {
+    sharedOwnerResyncQueue.request(roomCode);
   }
 
   /**
@@ -556,11 +672,7 @@ export function createMessageHandler(options: {
         origin: session.origin,
       },
     );
-    await publishSharedOwnerResync(
-      session,
-      previous.roomCode,
-      "room_switch_resync_broadcast_failed",
-    );
+    publishSharedOwnerResync(previous.roomCode);
   }
 
   function handleRateLimitedMessage(
@@ -705,7 +817,12 @@ export function createMessageHandler(options: {
           if (previousRoom && previousRoom.roomCode !== room.code) {
             await releasePreviousRoom(session, previousRoom);
           }
-          await runRoomJoinedHook(session, room.code, previousRoomCode);
+          if (
+            !(await runRoomJoinedHook(session, room.code, previousRoomCode))
+          ) {
+            await abortJoin(session, room.code, socket);
+            return;
+          }
           send(socket, {
             type: "room:created",
             payload: {
@@ -777,7 +894,12 @@ export function createMessageHandler(options: {
             if (previousRoom && previousRoom.roomCode !== room.code) {
               await releasePreviousRoom(session, previousRoom);
             }
-            await runRoomJoinedHook(session, room.code, previousRoomCode);
+            if (
+              !(await runRoomJoinedHook(session, room.code, previousRoomCode))
+            ) {
+              await abortJoin(session, room.code, socket);
+              return;
+            }
             const joinedRoomCode = room.code;
             const joinedMemberId = session.memberId ?? session.id;
             const joinedDisplayName = session.displayName;
@@ -851,7 +973,7 @@ export function createMessageHandler(options: {
               bootstrapState.sharedOwnerId === joinedMemberId ||
               previousRoom?.roomCode === joinedRoomCode
             ) {
-              await publishSharedOwnerResync(session, joinedRoomCode);
+              publishSharedOwnerResync(joinedRoomCode);
             }
             logEvent("room_joined", {
               sessionId: session.id,

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -591,12 +591,12 @@ export function createMessageHandler(options: {
         error: error instanceof Error ? error.message : String(error),
       });
     },
-    onRejected: ({ roomCode, pendingRooms }) => {
-      logEvent("shared_owner_resync_rejected", {
+    onBacklog: ({ roomCode, pendingRooms }) => {
+      logEvent("shared_owner_resync_backlog", {
         roomCode,
         pendingRooms,
-        result: "rejected",
-        reason: "pending_resync_overflow",
+        result: "degraded",
+        reason: "shared_owner_resync_publish_backlog",
       });
     },
   });
@@ -635,7 +635,13 @@ export function createMessageHandler(options: {
       return await enter();
     } catch (error) {
       if (previous && session.roomCode !== previous.roomCode) {
-        await releasePreviousRoom(session, previous);
+        // Gated: the create/join FAILED, so no later write will re-stamp this
+        // session's room code. If the hook could not clear the index, a state
+        // built from it still lists the switcher and hands them the share back
+        // (#242 review).
+        if (await releasePreviousRoom(session, previous)) {
+          publishSharedOwnerResync(previous.roomCode);
+        }
       }
       throw error;
     }
@@ -650,24 +656,24 @@ export function createMessageHandler(options: {
    * The identity is passed in because the caller captured it BEFORE the switch —
    * by now `session.memberId` names the new room's seat.
    *
-   * Both events go out even when the index write failed, which is where this
-   * differs from an explicit leave. A switcher's session hash already names the
-   * NEW room, so `roomStateFromSessions` drops it from the old room's roster on
-   * its own and the state is correct regardless. Withholding it instead lost the
-   * announcement permanently: nothing afterwards carries the old room code, so
-   * there is no retry (#235 review). `leaveRoom` keeps its gate because a leaver
-   * ends up with no room code at all, which reads as missing information rather
-   * than as residue — a state published there really could put them back.
+   * `room_member_left` goes out even when the index write failed — it carries no
+   * state read, so a dirty index cannot corrupt it, and withholding it lost the
+   * announcement permanently since nothing afterwards carries the old room code
+   * (#235 review).
    *
-   * Unconditional otherwise: the internal leave's verdict never reaches here,
-   * and a switch is rare enough that one broadcast is cheaper than plumbing it
-   * out.
+   * The full `room:state` does NOT, and that is what changed in #242. The old
+   * reasoning was that "a switcher's session hash already names the NEW room, so
+   * `roomStateFromSessions` drops it from the old room's roster on its own" —
+   * but that hash is written by `onRoomLeft`'s own `registerSession`, so when the
+   * hook fails the hash can still name the OLD room and the state hands the
+   * switcher straight back into it, share and all. Returning the verdict lets
+   * each caller publish it where it is provably safe; see the call sites.
    */
   async function releasePreviousRoom(
     session: Session,
     previous: { roomCode: string; memberId: string; displayName: string },
-  ): Promise<void> {
-    await runRoomLeftHook(session, previous.roomCode);
+  ): Promise<boolean> {
+    const indexCleaned = await runRoomLeftHook(session, previous.roomCode);
     await firePublishRoomEvent(
       {
         type: "room_member_left",
@@ -682,7 +688,7 @@ export function createMessageHandler(options: {
         origin: session.origin,
       },
     );
-    publishSharedOwnerResync(previous.roomCode);
+    return indexCleaned;
   }
 
   function handleRateLimitedMessage(
@@ -833,6 +839,14 @@ export function createMessageHandler(options: {
             await abortJoin(session, room.code, socket);
             return;
           }
+          // AFTER the join hook, and unconditional. Its write re-stamps the
+          // whole session record under the NEW room code, so the old room's
+          // rebuild drops this session as index residue whatever `onRoomLeft`
+          // managed to write — which is what makes publishing safe here and not
+          // inside `releasePreviousRoom` (#242 review).
+          if (previousRoom && previousRoom.roomCode !== room.code) {
+            publishSharedOwnerResync(previousRoom.roomCode);
+          }
           send(socket, {
             type: "room:created",
             payload: {
@@ -909,6 +923,11 @@ export function createMessageHandler(options: {
             ) {
               await abortJoin(session, room.code, socket);
               return;
+            }
+            // AFTER the join hook, and unconditional — see the same call in
+            // `room:create` for why that ordering is what makes it safe.
+            if (previousRoom && previousRoom.roomCode !== room.code) {
+              publishSharedOwnerResync(previousRoom.roomCode);
             }
             const joinedRoomCode = room.code;
             const joinedMemberId = session.memberId ?? session.id;

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -32,6 +32,11 @@ type RoomEventBusPublishInput<T> = T extends unknown
 
 /** RFC 6455 "internal error": the server could not put the session back. */
 const CLOSE_CODE_JOIN_ROLLBACK_FAILED = 1011;
+/**
+ * How long a refused join waits for its own rollback before answering the
+ * client anyway. The rollback keeps running, ordered on the session's key.
+ */
+const JOIN_ROLLBACK_TIMEOUT_MS = 5_000;
 
 export function createMessageHandler(options: {
   config: {
@@ -136,6 +141,11 @@ export function createMessageHandler(options: {
    * cannot see is worse than refusing the join, which the client simply retries
    * (#242).
    */
+  /**
+   * How long a refused join waits for its own rollback before answering the
+   * client anyway. Injectable so tests do not pay it in wall-clock time.
+   */
+  joinRollbackTimeoutMs?: number;
   onRoomJoined?: (
     session: Session,
     roomCode: string,
@@ -224,7 +234,42 @@ export function createMessageHandler(options: {
     try {
       // The RETURNED verdict, not merely "it did not throw": the cleanup is
       // skipped on two paths that resolve normally (#242 review).
-      rolledBack = await leaveRoom(session, "disconnect");
+      //
+      // Bounded, because the rollback's own index write queues behind the join
+      // write's command — and a command that never answers neither resolves nor
+      // rejects. Waiting on it left the client parked on a join that had
+      // already failed, with the error and the socket close unreachable (#242
+      // review). Timing out means the same thing a failed rollback means: the
+      // seat did not provably come back, so the socket goes. The rollback is
+      // NOT cancelled; it stays ordered on the session's key and completes
+      // behind the scenes.
+      const rollback = leaveRoom(session, "disconnect");
+      rollback.catch(() => undefined);
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const verdict = await Promise.race([
+        rollback,
+        new Promise<"timeout">((resolve) => {
+          timer = setTimeout(
+            () => resolve("timeout"),
+            options.joinRollbackTimeoutMs ?? JOIN_ROLLBACK_TIMEOUT_MS,
+          );
+        }),
+      ]);
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+      if (verdict === "timeout") {
+        logEvent("room_join_rollback_timeout", {
+          sessionId: session.id,
+          roomCode,
+          remoteAddress: session.remoteAddress,
+          origin: session.origin,
+          result: "timeout",
+          timeoutMs: options.joinRollbackTimeoutMs ?? JOIN_ROLLBACK_TIMEOUT_MS,
+        });
+      } else {
+        rolledBack = verdict;
+      }
     } catch (error) {
       logEvent("room_join_rollback_failed", {
         sessionId: session.id,

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -120,7 +120,6 @@ export function createMessageHandler(options: {
    * that nothing else repeats. See `pending-resync-queue`.
    */
   sharedOwnerResyncRetry?: {
-    maxAttempts?: number;
     initialRetryDelayMs?: number;
     maxRetryDelayMs?: number;
     sleep?: (delayMs: number) => Promise<void>;
@@ -479,15 +478,14 @@ export function createMessageHandler(options: {
    * is the one broadcast nothing else will ever re-send (#242).
    *
    * `final` marks the shutdown call. Without it the drain is unbounded in the
-   * number of retry BATCHES a record may run — a request that arrived mid-batch
-   * earns a fresh budget, which is right at runtime and, at shutdown, is two
-   * budgets in a step sized for one (#242 review).
+   * time it takes: records retry until the bus takes them, which is the point
+   * of the queue and no bound at all for a shutdown step (#242 review).
    */
   async function flushPendingPublishes(options?: {
     final?: boolean;
   }): Promise<void> {
     if (options?.final) {
-      sharedOwnerResyncQueue.stopAfterCurrentBatch();
+      sharedOwnerResyncQueue.stopRetrying();
     }
     while (pendingPublishes.size > 0 || sharedOwnerResyncQueue.size() > 0) {
       await Promise.allSettled([
@@ -583,14 +581,6 @@ export function createMessageHandler(options: {
         error: error instanceof Error ? error.message : String(error),
       });
     },
-    onAbandoned: ({ roomCode, attempts, error }) => {
-      logEvent("shared_owner_resync_abandoned", {
-        roomCode,
-        attempts,
-        result: "dropped",
-        error: error instanceof Error ? error.message : String(error),
-      });
-    },
     onBacklog: ({ roomCode, pendingRooms }) => {
       logEvent("shared_owner_resync_backlog", {
         roomCode,
@@ -639,9 +629,11 @@ export function createMessageHandler(options: {
         // session's room code. If the hook could not clear the index, a state
         // built from it still lists the switcher and hands them the share back
         // (#242 review).
-        if (await releasePreviousRoom(session, previous)) {
-          publishSharedOwnerResync(previous.roomCode);
-        }
+        const indexCleaned = await releasePreviousRoom(session, previous);
+        publishPreviousRoomResync(previous, "", {
+          seated: false,
+          indexCleaned,
+        });
       }
       throw error;
     }
@@ -689,6 +681,31 @@ export function createMessageHandler(options: {
       },
     );
     return indexCleaned;
+  }
+
+  /**
+   * Publish the old room's full `room:state` — but only where the switcher
+   * provably cannot come back into it.
+   *
+   * Two ways to know that. `seated` means `runRoomJoinedHook` succeeded, and
+   * its write re-stamps the whole session record under the NEW room code, so
+   * the old room's rebuild drops this session as index residue whatever
+   * `onRoomLeft` managed to write. `indexCleaned` means `onRoomLeft` itself
+   * landed. Either is enough; neither is optional, because a state built on an
+   * index nobody cleared hands the leaver their share straight back (#242
+   * review).
+   */
+  function publishPreviousRoomResync(
+    previousRoom: { roomCode: string } | null,
+    joinedRoomCode: string,
+    outcome: { seated: boolean; indexCleaned: boolean },
+  ): void {
+    if (!previousRoom || previousRoom.roomCode === joinedRoomCode) {
+      return;
+    }
+    if (outcome.seated || outcome.indexCleaned) {
+      publishSharedOwnerResync(previousRoom.roomCode);
+    }
   }
 
   function handleRateLimitedMessage(
@@ -830,23 +847,32 @@ export function createMessageHandler(options: {
                 message.payload?.displayName,
               ),
           );
+          let previousRoomIndexCleaned = false;
           if (previousRoom && previousRoom.roomCode !== room.code) {
-            await releasePreviousRoom(session, previousRoom);
+            previousRoomIndexCleaned = await releasePreviousRoom(
+              session,
+              previousRoom,
+            );
           }
-          if (
-            !(await runRoomJoinedHook(session, room.code, previousRoomCode))
-          ) {
+          const seated = await runRoomJoinedHook(
+            session,
+            room.code,
+            previousRoomCode,
+          );
+          if (!seated) {
             await abortJoin(session, room.code, socket);
+            // The refused join is the NEW room's problem; the old room is still
+            // owed its state, and a clean index is the licence to send it.
+            publishPreviousRoomResync(previousRoom, room.code, {
+              seated,
+              indexCleaned: previousRoomIndexCleaned,
+            });
             return;
           }
-          // AFTER the join hook, and unconditional. Its write re-stamps the
-          // whole session record under the NEW room code, so the old room's
-          // rebuild drops this session as index residue whatever `onRoomLeft`
-          // managed to write — which is what makes publishing safe here and not
-          // inside `releasePreviousRoom` (#242 review).
-          if (previousRoom && previousRoom.roomCode !== room.code) {
-            publishSharedOwnerResync(previousRoom.roomCode);
-          }
+          publishPreviousRoomResync(previousRoom, room.code, {
+            seated,
+            indexCleaned: previousRoomIndexCleaned,
+          });
           send(socket, {
             type: "room:created",
             payload: {
@@ -915,20 +941,30 @@ export function createMessageHandler(options: {
                   message.payload.memberToken,
                 ),
             );
+            let previousRoomIndexCleaned = false;
             if (previousRoom && previousRoom.roomCode !== room.code) {
-              await releasePreviousRoom(session, previousRoom);
+              previousRoomIndexCleaned = await releasePreviousRoom(
+                session,
+                previousRoom,
+              );
             }
-            if (
-              !(await runRoomJoinedHook(session, room.code, previousRoomCode))
-            ) {
+            const seated = await runRoomJoinedHook(
+              session,
+              room.code,
+              previousRoomCode,
+            );
+            if (!seated) {
               await abortJoin(session, room.code, socket);
+              publishPreviousRoomResync(previousRoom, room.code, {
+                seated,
+                indexCleaned: previousRoomIndexCleaned,
+              });
               return;
             }
-            // AFTER the join hook, and unconditional — see the same call in
-            // `room:create` for why that ordering is what makes it safe.
-            if (previousRoom && previousRoom.roomCode !== room.code) {
-              publishSharedOwnerResync(previousRoom.roomCode);
-            }
+            publishPreviousRoomResync(previousRoom, room.code, {
+              seated,
+              indexCleaned: previousRoomIndexCleaned,
+            });
             const joinedRoomCode = room.code;
             const joinedMemberId = session.memberId ?? session.id;
             const joinedDisplayName = session.displayName;

--- a/server/src/message-handler.ts
+++ b/server/src/message-handler.ts
@@ -160,7 +160,7 @@ export function createMessageHandler(options: {
    * must pass `"disconnect"`: the client still holds its `memberToken` and
    * will present it on the next join to reclaim the same `memberId` (#234).
    */
-  leaveRoom: (session: Session, reason?: LeaveRoomReason) => Promise<void>;
+  leaveRoom: (session: Session, reason?: LeaveRoomReason) => Promise<boolean>;
   flushPendingPublishes: (options?: { final?: boolean }) => Promise<void>;
 } {
   const { config, roomService, logEvent, send, sendError } = options;
@@ -220,11 +220,12 @@ export function createMessageHandler(options: {
     roomCode: string,
     socket: WebSocket,
   ): Promise<void> {
-    let rolledBack = true;
+    let rolledBack = false;
     try {
-      await leaveRoom(session, "disconnect");
+      // The RETURNED verdict, not merely "it did not throw": the cleanup is
+      // skipped on two paths that resolve normally (#242 review).
+      rolledBack = await leaveRoom(session, "disconnect");
     } catch (error) {
-      rolledBack = false;
       logEvent("room_join_rollback_failed", {
         sessionId: session.id,
         roomCode,
@@ -522,17 +523,31 @@ export function createMessageHandler(options: {
     }
   }
 
+  /**
+   * Returns whether the session is provably out of the room's index.
+   *
+   * `abortJoin` acts on it, so the three ways the cleanup can be skipped all
+   * have to answer `false` — not just the one that throws (#242 review):
+   * the service call rejecting, the early return that never reaches the hook,
+   * and the hook itself reporting failure.
+   */
   async function leaveRoom(
     session: Session,
     reason: LeaveRoomReason = "client-request",
-  ): Promise<void> {
+  ): Promise<boolean> {
     const roomCode = session.roomCode;
     const memberId = session.memberId ?? session.id;
     const displayName = session.displayName;
     const { room, notifyRoom, memberRemoved, needsRoomStateResync } =
       await roomService.leaveRoomForSession(session, reason);
-    if (!roomCode || (!room && !notifyRoom)) {
-      return;
+    if (!roomCode) {
+      // In no room to begin with; there is nothing to have failed.
+      return true;
+    }
+    if (!room && !notifyRoom) {
+      // The service released the room but this path never runs the hook, so
+      // `markSessionLeftRoom` never went out and the index still lists us.
+      return false;
     }
     const roomIndexCleaned = await runRoomLeftHook(session, roomCode);
     // Two independent questions, so two independent gates. `memberRemoved` is
@@ -545,7 +560,7 @@ export function createMessageHandler(options: {
       if (publishResync) {
         publishSharedOwnerResync(roomCode);
       }
-      return;
+      return roomIndexCleaned;
     }
 
     await firePublishRoomEvent(
@@ -570,6 +585,7 @@ export function createMessageHandler(options: {
     if (publishResync) {
       publishSharedOwnerResync(roomCode);
     }
+    return roomIndexCleaned;
   }
 
   /**
@@ -1092,7 +1108,11 @@ export function createMessageHandler(options: {
             );
             return;
           }
-          await measureMessageHandling("room:leave", () => leaveRoom(session));
+          await measureMessageHandling("room:leave", async () => {
+            // The verdict is for `abortJoin`; an explicit leave already gates
+            // its own publishing on it inside `leaveRoom`.
+            await leaveRoom(session);
+          });
           return;
         }
         case "profile:update": {

--- a/server/src/mirrored-runtime-store.ts
+++ b/server/src/mirrored-runtime-store.ts
@@ -84,12 +84,20 @@ export function createMirroredRuntimeStore(
   sharedRuntimeStore: RuntimeStore,
 ): RuntimeStore {
   return {
-    registerSession: mirrorVoidWrite(
-      localRuntimeStore.registerSession,
-      sharedRuntimeStore.registerSession,
-    ),
+    // Local-first, unlike the awaited writes: every read in this file goes to
+    // the local mirror, so the session has to be visible here before anything
+    // can look for it. The shared promise is RETURNED rather than dropped —
+    // `mirrorVoidWrite` would throw the durable outcome away, which is how a
+    // failed registration used to become invisible (#242).
+    registerSession: (session) => {
+      localRuntimeStore.registerSession(session);
+      return sharedRuntimeStore.registerSession(session);
+    },
     flush: sharedRuntimeStore.flush
       ? readShared(sharedRuntimeStore.flush)
+      : undefined,
+    confirmWrites: sharedRuntimeStore.confirmWrites
+      ? readShared(sharedRuntimeStore.confirmWrites)
       : undefined,
     purgeSessionsByInstance: sharedRuntimeStore.purgeSessionsByInstance
       ? readShared(sharedRuntimeStore.purgeSessionsByInstance)

--- a/server/src/pending-resync-queue.ts
+++ b/server/src/pending-resync-queue.ts
@@ -22,6 +22,8 @@
  * announced was visible.
  */
 
+import { createRetryPacer } from "./retry-pacer.js";
+
 export type PendingResyncFailureInfo = {
   roomCode: string;
   /** 1-based index of the attempt that just failed. */
@@ -135,91 +137,40 @@ export function createPendingResyncQueue(
   const backlogWarnThreshold =
     options.backlogWarnThreshold ?? DEFAULT_BACKLOG_WARN_THRESHOLD;
 
-  const records = new Map<string, PendingRecord>();
-  /** `cancel` for every backoff currently being waited out. */
-  const pendingWaits = new Set<() => void>();
-  let retriesStopped = false;
-  /**
-   * Publishes that were given up on but are still on their way to the bus.
-   *
-   * `drain` waits for these after the loops have stopped: the very next
-   * shutdown step closes the bus, and "we stopped retrying" is not the same as
-   * "the call came back" (#242 review).
-   */
-  const abandonedCalls = new Set<Promise<void>>();
-  let signalStopped = (): void => {};
-  /** Resolves when {@link PendingResyncQueue.stopRetrying} is called. */
-  const stopped = new Promise<void>((resolve) => {
-    signalStopped = resolve;
+  const pacer = createRetryPacer({
+    initialDelayMs: initialRetryDelayMs,
+    maxDelayMs: maxRetryDelayMs,
+    sleep: options.sleep,
   });
 
-  /**
-   * An injected `sleep` is a test clock and resolves on its own; the real timer
-   * has to be cancellable, or `stopRetrying` would still have to sit through a
-   * 30s backoff before shutdown could move on.
-   */
-  function waitBeforeRetry(delayMs: number): Promise<void> {
-    if (options.sleep) {
-      return options.sleep(delayMs);
-    }
-    let cancel = (): void => {};
-    const promise = new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, delayMs);
-      cancel = () => {
-        clearTimeout(timer);
-        resolve();
-      };
-    });
-    pendingWaits.add(cancel);
-    return promise.finally(() => {
-      pendingWaits.delete(cancel);
-    });
-  }
-
-  function retryDelayMs(attempt: number): number {
-    return Math.min(initialRetryDelayMs * 2 ** (attempt - 1), maxRetryDelayMs);
-  }
+  const records = new Map<string, PendingRecord>();
 
   /**
-   * Runs one publish, capped, and reports the underlying call so the caller can
-   * refuse to start another while it is still out there.
+   * Runs one publish under the attempt cap, and reports the underlying call so
+   * the caller can refuse to start another while it is still out there.
    *
    * The cap races the call; it cannot abort it. With an unbounded retry loop
    * behind it, starting a fresh publish on every timeout piles up one in-flight
    * Redis command per retry for as long as the bus stays hung, and every one of
-   * them then spills into `roomEventBus.close()` (#242 review).
+   * them then spills into `roomEventBus.close()` (#242 review). The pacer keeps
+   * the ones that outlived their cap so `drain` can wait them out.
    */
   async function publishOnce(
     roomCode: string,
     track: (call: Promise<void>) => void,
   ): Promise<void> {
-    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
     const call = options.publish(roomCode);
-    const settled = call.then(
-      () => undefined,
-      () => undefined,
+    track(
+      call.then(
+        () => undefined,
+        () => undefined,
+      ),
     );
-    abandonedCalls.add(settled);
-    void settled.finally(() => {
-      abandonedCalls.delete(settled);
-    });
-    track(settled);
-    try {
-      await Promise.race([
-        call,
-        new Promise<never>((_resolve, reject) => {
-          timeoutHandle = setTimeout(() => {
-            reject(
-              new Error(`Room state resync publish timed out for ${roomCode}.`),
-            );
-          }, attemptTimeoutMs);
-        }),
-      ]);
-    } finally {
-      if (timeoutHandle !== null) {
-        clearTimeout(timeoutHandle);
-      }
-    }
+    await pacer.capAttempt(
+      call,
+      attemptTimeoutMs,
+      () => new Error(`Room state resync publish timed out for ${roomCode}.`),
+    );
   }
 
   /**
@@ -239,7 +190,7 @@ export function createPendingResyncQueue(
     /** The publish this record started that has not answered yet, if any. */
     let inFlight: Promise<void> | null = null;
     try {
-      while (record.pending && !retriesStopped) {
+      while (record.pending && !pacer.stopped()) {
         record.pending = false;
         for (let attempt = 1; ; attempt += 1) {
           if (inFlight) {
@@ -247,8 +198,8 @@ export function createPendingResyncQueue(
             // another on top — at most ONE publish per room is ever out there.
             // `stopRetrying` cuts the wait short so shutdown is not pinned by
             // a bus that has stopped answering.
-            await Promise.race([inFlight, stopped]);
-            if (retriesStopped) {
+            await Promise.race([inFlight, pacer.whenStopped()]);
+            if (pacer.stopped()) {
               return;
             }
           }
@@ -260,13 +211,13 @@ export function createPendingResyncQueue(
             });
             break;
           } catch (error) {
-            const delayMs = retryDelayMs(attempt);
+            const delayMs = pacer.delayFor(attempt);
             options.onAttemptFailed?.({ roomCode, attempt, delayMs, error });
-            if (retriesStopped) {
+            if (pacer.stopped()) {
               return;
             }
-            await waitBeforeRetry(delayMs);
-            if (retriesStopped) {
+            await pacer.wait(delayMs);
+            if (pacer.stopped()) {
               return;
             }
           }
@@ -296,14 +247,7 @@ export function createPendingResyncQueue(
       void record.settled.catch(() => undefined);
     },
     stopRetrying() {
-      retriesStopped = true;
-      signalStopped();
-      // Cut the backoffs short too: a record parked on the 30s ceiling would
-      // otherwise hold the drain for that long.
-      for (const cancel of Array.from(pendingWaits)) {
-        cancel();
-      }
-      pendingWaits.clear();
+      pacer.stop();
     },
     async drain() {
       while (records.size > 0) {
@@ -312,21 +256,8 @@ export function createPendingResyncQueue(
         );
       }
       // The records are done, but a call one of them gave up on may still be
-      // out there — and the bus is closed straight after this. Bounded: an
-      // unbounded wait here would only move the overrun from the bus close to
-      // this step.
-      if (abandonedCalls.size > 0) {
-        let handle: ReturnType<typeof setTimeout> | null = null;
-        await Promise.race([
-          Promise.allSettled(Array.from(abandonedCalls)),
-          new Promise<void>((resolve) => {
-            handle = setTimeout(resolve, abandonedDrainTimeoutMs);
-          }),
-        ]);
-        if (handle !== null) {
-          clearTimeout(handle);
-        }
-      }
+      // out there — and the bus is closed straight after this.
+      await pacer.settleTracked(abandonedDrainTimeoutMs);
     },
     size() {
       return records.size;

--- a/server/src/pending-resync-queue.ts
+++ b/server/src/pending-resync-queue.ts
@@ -44,6 +44,12 @@ export type PendingResyncQueueOptions = {
    * underlying publish is left running, exactly as `firePublishRoomEvent` does.
    */
   attemptTimeoutMs?: number;
+  /**
+   * How long {@link PendingResyncQueue.drain} waits for calls that were given
+   * up on but are still out there. Sized against the shutdown step that runs
+   * the drain, NOT against a single attempt — which is why it is its own knob.
+   */
+  abandonedDrainTimeoutMs?: number;
   /** Backlog size that triggers {@link PendingResyncQueueOptions.onBacklog}. */
   backlogWarnThreshold?: number;
   /** Injectable so tests do not pay the backoff in wall-clock time. */
@@ -124,6 +130,8 @@ export function createPendingResyncQueue(
   const maxRetryDelayMs = options.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
   const attemptTimeoutMs =
     options.attemptTimeoutMs ?? DEFAULT_ATTEMPT_TIMEOUT_MS;
+  const abandonedDrainTimeoutMs =
+    options.abandonedDrainTimeoutMs ?? attemptTimeoutMs;
   const backlogWarnThreshold =
     options.backlogWarnThreshold ?? DEFAULT_BACKLOG_WARN_THRESHOLD;
 
@@ -131,6 +139,14 @@ export function createPendingResyncQueue(
   /** `cancel` for every backoff currently being waited out. */
   const pendingWaits = new Set<() => void>();
   let retriesStopped = false;
+  /**
+   * Publishes that were given up on but are still on their way to the bus.
+   *
+   * `drain` waits for these after the loops have stopped: the very next
+   * shutdown step closes the bus, and "we stopped retrying" is not the same as
+   * "the call came back" (#242 review).
+   */
+  const abandonedCalls = new Set<Promise<void>>();
   let signalStopped = (): void => {};
   /** Resolves when {@link PendingResyncQueue.stopRetrying} is called. */
   const stopped = new Promise<void>((resolve) => {
@@ -179,12 +195,15 @@ export function createPendingResyncQueue(
   ): Promise<void> {
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
     const call = options.publish(roomCode);
-    track(
-      call.then(
-        () => undefined,
-        () => undefined,
-      ),
+    const settled = call.then(
+      () => undefined,
+      () => undefined,
     );
+    abandonedCalls.add(settled);
+    void settled.finally(() => {
+      abandonedCalls.delete(settled);
+    });
+    track(settled);
     try {
       await Promise.race([
         call,
@@ -291,6 +310,22 @@ export function createPendingResyncQueue(
         await Promise.allSettled(
           Array.from(records.values(), (record) => record.settled),
         );
+      }
+      // The records are done, but a call one of them gave up on may still be
+      // out there — and the bus is closed straight after this. Bounded: an
+      // unbounded wait here would only move the overrun from the bus close to
+      // this step.
+      if (abandonedCalls.size > 0) {
+        let handle: ReturnType<typeof setTimeout> | null = null;
+        await Promise.race([
+          Promise.allSettled(Array.from(abandonedCalls)),
+          new Promise<void>((resolve) => {
+            handle = setTimeout(resolve, abandonedDrainTimeoutMs);
+          }),
+        ]);
+        if (handle !== null) {
+          clearTimeout(handle);
+        }
       }
     },
     size() {

--- a/server/src/pending-resync-queue.ts
+++ b/server/src/pending-resync-queue.ts
@@ -52,6 +52,17 @@ export type PendingResyncQueueOptions = {
    * the drain, NOT against a single attempt — which is why it is its own knob.
    */
   abandonedDrainTimeoutMs?: number;
+  /**
+   * How many rooms may have a publish out at the same time.
+   *
+   * The backlog is deliberately uncapped, so without this a bus that recovers
+   * after a long outage turns every retained record into a simultaneous Redis
+   * publish — an unbounded backlog becoming an unbounded burst, and one that
+   * bypasses `firePublishRoomEvent`'s own `maxPendingPublishes` because these
+   * records do not go through it (#242 review). Records still all survive;
+   * only the attempts are paced.
+   */
+  maxConcurrentPublishes?: number;
   /** Backlog size that triggers {@link PendingResyncQueueOptions.onBacklog}. */
   backlogWarnThreshold?: number;
   /** Injectable so tests do not pay the backoff in wall-clock time. */
@@ -117,6 +128,7 @@ const DEFAULT_INITIAL_RETRY_DELAY_MS = 250;
 const DEFAULT_MAX_RETRY_DELAY_MS = 30_000;
 const DEFAULT_ATTEMPT_TIMEOUT_MS = 5_000;
 const DEFAULT_BACKLOG_WARN_THRESHOLD = 256;
+const DEFAULT_MAX_CONCURRENT_PUBLISHES = 8;
 
 type PendingRecord = {
   /** Another publish is owed once the current attempt finishes. */
@@ -136,6 +148,42 @@ export function createPendingResyncQueue(
     options.abandonedDrainTimeoutMs ?? attemptTimeoutMs;
   const backlogWarnThreshold =
     options.backlogWarnThreshold ?? DEFAULT_BACKLOG_WARN_THRESHOLD;
+  const maxConcurrentPublishes = Math.max(
+    1,
+    options.maxConcurrentPublishes ?? DEFAULT_MAX_CONCURRENT_PUBLISHES,
+  );
+
+  /**
+   * Admission to the publish slots, shared across rooms.
+   *
+   * A plain counter plus a queue of waiters: every waiter is released by the
+   * publish that finishes, and `stopRetrying` releases them all so shutdown is
+   * never parked behind a slot that a hung bus will not give back.
+   */
+  let activePublishes = 0;
+  const slotWaiters: Array<() => void> = [];
+
+  function releaseSlot(): void {
+    activePublishes -= 1;
+    const next = slotWaiters.shift();
+    if (next) {
+      next();
+    }
+  }
+
+  async function acquireSlot(): Promise<void> {
+    if (activePublishes < maxConcurrentPublishes || pacer.stopped()) {
+      activePublishes += 1;
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      slotWaiters.push(resolve);
+      void pacer.whenStopped().then(() => {
+        resolve();
+      });
+    });
+    activePublishes += 1;
+  }
 
   const pacer = createRetryPacer({
     initialDelayMs: initialRetryDelayMs,
@@ -159,7 +207,9 @@ export function createPendingResyncQueue(
     roomCode: string,
     track: (call: Promise<void>) => void,
   ): Promise<void> {
+    await acquireSlot();
     const call = options.publish(roomCode);
+    void call.then(releaseSlot, releaseSlot);
     track(
       call.then(
         () => undefined,

--- a/server/src/pending-resync-queue.ts
+++ b/server/src/pending-resync-queue.ts
@@ -48,17 +48,32 @@ export type PendingResyncQueueOptions = {
    * underlying publish is left running, exactly as `firePublishRoomEvent` does.
    */
   attemptTimeoutMs?: number;
-  /** Refuse new room codes past this many outstanding records. */
-  maxPendingRooms?: number;
+  /** Backlog size that triggers {@link PendingResyncQueueOptions.onBacklog}. */
+  backlogWarnThreshold?: number;
   /** Injectable so tests do not pay the backoff in wall-clock time. */
   sleep?: (delayMs: number) => Promise<void>;
   onAttemptFailed?: (info: PendingResyncFailureInfo) => void;
   onAbandoned?: (info: PendingResyncAbandonInfo) => void;
-  onRejected?: (info: { roomCode: string; pendingRooms: number }) => void;
+  /**
+   * The backlog crossed {@link PendingResyncQueueOptions.backlogWarnThreshold}.
+   * Reported, never used to shed: see `request`.
+   */
+  onBacklog?: (info: { roomCode: string; pendingRooms: number }) => void;
 };
 
 export type PendingResyncQueue = {
-  /** Ask for a resync of `roomCode`. Returns immediately. */
+  /**
+   * Ask for a resync of `roomCode`. Returns immediately, and never refuses.
+   *
+   * There is deliberately no cap. This notification fires precisely because a
+   * room stopped advancing, so a room turned away here has nothing else coming
+   * to fix a `sharedByMemberId` naming a member who is gone — dropping it is the
+   * permanent loss the queue exists to prevent, and a log line does not restore
+   * anyone's playback (#242 review). Growth is bounded by the number of rooms
+   * whose ownership moved while the bus was rejecting publishes, each entry is
+   * a room code, and the set drains as soon as the bus recovers; if that ever
+   * stops being enough the answer is to persist the records, not to refuse them.
+   */
   request: (roomCode: string) => void;
   /** Every outstanding record has settled, however it settled. */
   drain: () => Promise<void>;
@@ -95,7 +110,7 @@ const DEFAULT_MAX_ATTEMPTS = 4;
 const DEFAULT_INITIAL_RETRY_DELAY_MS = 250;
 const DEFAULT_MAX_RETRY_DELAY_MS = 5_000;
 const DEFAULT_ATTEMPT_TIMEOUT_MS = 5_000;
-const DEFAULT_MAX_PENDING_ROOMS = 256;
+const DEFAULT_BACKLOG_WARN_THRESHOLD = 256;
 
 /**
  * Deliberately NOT `unref`'d. The backoff timer is the only thing keeping a
@@ -123,7 +138,8 @@ export function createPendingResyncQueue(
   const maxRetryDelayMs = options.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
   const attemptTimeoutMs =
     options.attemptTimeoutMs ?? DEFAULT_ATTEMPT_TIMEOUT_MS;
-  const maxPendingRooms = options.maxPendingRooms ?? DEFAULT_MAX_PENDING_ROOMS;
+  const backlogWarnThreshold =
+    options.backlogWarnThreshold ?? DEFAULT_BACKLOG_WARN_THRESHOLD;
   const sleep = options.sleep ?? defaultSleep;
 
   const records = new Map<string, PendingRecord>();
@@ -196,9 +212,8 @@ export function createPendingResyncQueue(
         existing.pending = true;
         return;
       }
-      if (records.size >= maxPendingRooms) {
-        options.onRejected?.({ roomCode, pendingRooms: records.size });
-        return;
+      if (records.size >= backlogWarnThreshold) {
+        options.onBacklog?.({ roomCode, pendingRooms: records.size });
       }
       const record: PendingRecord = {
         pending: true,

--- a/server/src/pending-resync-queue.ts
+++ b/server/src/pending-resync-queue.ts
@@ -62,6 +62,23 @@ export type PendingResyncQueue = {
   request: (roomCode: string) => void;
   /** Every outstanding record has settled, however it settled. */
   drain: () => Promise<void>;
+  /**
+   * Let each record finish the batch it is on and stop there, instead of
+   * running another for the requests that arrived mid-batch. Irreversible.
+   *
+   * A drain is otherwise unbounded in the number of batches, and each batch
+   * costs a full retry budget: two of them exceed the shutdown step that has to
+   * wait for them, and an overrun step is a FAILED step — after which the bus
+   * is torn down anyway, so the publish is lost AND the process exits non-zero
+   * (#242 review). Batches for DIFFERENT rooms run concurrently, so bounding
+   * each record to one batch bounds the whole drain to one.
+   *
+   * The cost is the mid-batch request itself: at shutdown it is dropped rather
+   * than given the fresh budget it would get at runtime. Session cleanup has
+   * already drained by the time this is called, so there should be nothing left
+   * to make one.
+   */
+  stopAfterCurrentBatch: () => void;
   /** Room codes with an outstanding record. */
   size: () => number;
 };
@@ -110,6 +127,7 @@ export function createPendingResyncQueue(
   const sleep = options.sleep ?? defaultSleep;
 
   const records = new Map<string, PendingRecord>();
+  let stoppedAfterCurrentBatch = false;
 
   function retryDelayMs(attempt: number): number {
     return Math.min(initialRetryDelayMs * 2 ** (attempt - 1), maxRetryDelayMs);
@@ -144,7 +162,7 @@ export function createPendingResyncQueue(
    */
   async function drive(roomCode: string, record: PendingRecord): Promise<void> {
     try {
-      while (record.pending) {
+      while (record.pending && !stoppedAfterCurrentBatch) {
         record.pending = false;
         for (let attempt = 1; ; attempt += 1) {
           try {
@@ -189,6 +207,9 @@ export function createPendingResyncQueue(
       records.set(roomCode, record);
       record.settled = drive(roomCode, record);
       void record.settled.catch(() => undefined);
+    },
+    stopAfterCurrentBatch() {
+      stoppedAfterCurrentBatch = true;
     },
     async drain() {
       while (records.size > 0) {

--- a/server/src/pending-resync-queue.ts
+++ b/server/src/pending-resync-queue.ts
@@ -131,6 +131,11 @@ export function createPendingResyncQueue(
   /** `cancel` for every backoff currently being waited out. */
   const pendingWaits = new Set<() => void>();
   let retriesStopped = false;
+  let signalStopped = (): void => {};
+  /** Resolves when {@link PendingResyncQueue.stopRetrying} is called. */
+  const stopped = new Promise<void>((resolve) => {
+    signalStopped = resolve;
+  });
 
   /**
    * An injected `sleep` is a test clock and resolves on its own; the real timer
@@ -159,11 +164,30 @@ export function createPendingResyncQueue(
     return Math.min(initialRetryDelayMs * 2 ** (attempt - 1), maxRetryDelayMs);
   }
 
-  async function publishOnce(roomCode: string): Promise<void> {
+  /**
+   * Runs one publish, capped, and reports the underlying call so the caller can
+   * refuse to start another while it is still out there.
+   *
+   * The cap races the call; it cannot abort it. With an unbounded retry loop
+   * behind it, starting a fresh publish on every timeout piles up one in-flight
+   * Redis command per retry for as long as the bus stays hung, and every one of
+   * them then spills into `roomEventBus.close()` (#242 review).
+   */
+  async function publishOnce(
+    roomCode: string,
+    track: (call: Promise<void>) => void,
+  ): Promise<void> {
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    const call = options.publish(roomCode);
+    track(
+      call.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
     try {
       await Promise.race([
-        options.publish(roomCode),
+        call,
         new Promise<never>((_resolve, reject) => {
           timeoutHandle = setTimeout(() => {
             reject(
@@ -193,12 +217,28 @@ export function createPendingResyncQueue(
    * — there is no await between the final check and the `delete`.
    */
   async function drive(roomCode: string, record: PendingRecord): Promise<void> {
+    /** The publish this record started that has not answered yet, if any. */
+    let inFlight: Promise<void> | null = null;
     try {
       while (record.pending && !retriesStopped) {
         record.pending = false;
         for (let attempt = 1; ; attempt += 1) {
+          if (inFlight) {
+            // The previous call never came back. Wait for it rather than pile
+            // another on top — at most ONE publish per room is ever out there.
+            // `stopRetrying` cuts the wait short so shutdown is not pinned by
+            // a bus that has stopped answering.
+            await Promise.race([inFlight, stopped]);
+            if (retriesStopped) {
+              return;
+            }
+          }
           try {
-            await publishOnce(roomCode);
+            await publishOnce(roomCode, (call) => {
+              inFlight = call.finally(() => {
+                inFlight = null;
+              });
+            });
             break;
           } catch (error) {
             const delayMs = retryDelayMs(attempt);
@@ -238,6 +278,7 @@ export function createPendingResyncQueue(
     },
     stopRetrying() {
       retriesStopped = true;
+      signalStopped();
       // Cut the backoffs short too: a record parked on the 30s ceiling would
       // otherwise hold the drain for that long.
       for (const cancel of Array.from(pendingWaits)) {

--- a/server/src/pending-resync-queue.ts
+++ b/server/src/pending-resync-queue.ts
@@ -161,14 +161,20 @@ export function createPendingResyncQueue(
    * never parked behind a slot that a hung bus will not give back.
    */
   let activePublishes = 0;
-  const slotWaiters: Array<() => void> = [];
+  /** `true` hands the slot over; `false` means the queue is stopping. */
+  const slotWaiters: Array<(granted: boolean) => void> = [];
 
   function releaseSlot(): void {
-    activePublishes -= 1;
     const next = slotWaiters.shift();
     if (next) {
-      next();
+      // Handed over, so the count does NOT drop. Decrementing first and waking
+      // afterwards left the slot unowned for a continuation, and a `request`
+      // arriving in that gap took it while the woken waiter incremented
+      // anyway — two publishes at once with the cap set to one (#242 review).
+      next(true);
+      return;
     }
+    activePublishes -= 1;
   }
 
   /**
@@ -194,13 +200,18 @@ export function createPendingResyncQueue(
     // by `releaseSlot` could not take it off again — so every wait the server
     // ever performed stayed retained for its whole lifetime (#242 review).
     // `stopRetrying` releases these waiters directly instead.
-    await new Promise<void>((resolve) => {
+    const granted = await new Promise<boolean>((resolve) => {
       slotWaiters.push(resolve);
     });
-    if (pacer.stopped()) {
+    if (!granted) {
       return false;
     }
-    activePublishes += 1;
+    if (pacer.stopped()) {
+      // The slot was handed to us but the queue is stopping; give it back so
+      // the count does not strand.
+      releaseSlot();
+      return false;
+    }
     return true;
   }
 
@@ -324,7 +335,7 @@ export function createPendingResyncQueue(
       // Wake everything parked on a slot: the bus may never hand one back, and
       // they answer `false` now that the queue is stopping.
       while (slotWaiters.length > 0) {
-        slotWaiters.shift()?.();
+        slotWaiters.shift()?.(false);
       }
     },
     async drain() {

--- a/server/src/pending-resync-queue.ts
+++ b/server/src/pending-resync-queue.ts
@@ -171,10 +171,23 @@ export function createPendingResyncQueue(
     }
   }
 
-  async function acquireSlot(): Promise<void> {
-    if (activePublishes < maxConcurrentPublishes || pacer.stopped()) {
+  /**
+   * Returns whether a slot was taken. `false` means the queue stopped while
+   * waiting — the caller must NOT publish.
+   *
+   * The stop signal releases the waiters so shutdown is not parked behind a
+   * slot a hung bus will never give back, but releasing them used to GRANT the
+   * slot: every waiter then published, turning the whole uncapped backlog into
+   * one simultaneous burst at shutdown and defeating the very cap this function
+   * exists to apply (#242 review).
+   */
+  async function acquireSlot(): Promise<boolean> {
+    if (pacer.stopped()) {
+      return false;
+    }
+    if (activePublishes < maxConcurrentPublishes) {
       activePublishes += 1;
-      return;
+      return true;
     }
     await new Promise<void>((resolve) => {
       slotWaiters.push(resolve);
@@ -182,7 +195,11 @@ export function createPendingResyncQueue(
         resolve();
       });
     });
+    if (pacer.stopped()) {
+      return false;
+    }
     activePublishes += 1;
+    return true;
   }
 
   const pacer = createRetryPacer({
@@ -207,7 +224,11 @@ export function createPendingResyncQueue(
     roomCode: string,
     track: (call: Promise<void>) => void,
   ): Promise<void> {
-    await acquireSlot();
+    if (!(await acquireSlot())) {
+      throw new Error(
+        `Room state resync publish for ${roomCode} was dropped: the queue is stopping.`,
+      );
+    }
     const call = options.publish(roomCode);
     void call.then(releaseSlot, releaseSlot);
     track(

--- a/server/src/pending-resync-queue.ts
+++ b/server/src/pending-resync-queue.ts
@@ -1,0 +1,204 @@
+/**
+ * At-least-once delivery for the one-shot `room_state_updated` broadcasts.
+ *
+ * Almost every `room_state_updated` is self-healing: `video:share`,
+ * `playback:update` and `profile:update` all publish one, so losing a single
+ * send is corrected by the next one. The share-ownership resync is the
+ * exception. It goes out precisely because the room has stopped advancing, so
+ * nothing follows it — and the extension only sends `sync:request` while a
+ * content script hydrates, which an idle room never triggers. A dropped resync
+ * therefore leaves every client caching a `sharedVideo.sharedByMemberId` that
+ * names nobody until the user reloads the page (#242).
+ *
+ * Publishing cannot simply be awaited by its caller instead: the leave and join
+ * handlers would then block on the bus for up to its publish timeout. So the
+ * retry lives here, behind a `request` that returns immediately.
+ *
+ * Requests are deduplicated per room code because the event carries no payload
+ * — the consumer rebuilds and broadcasts the room's CURRENT state — so one
+ * successful publish satisfies every request made before it. A request that
+ * arrives while an attempt is already in flight still schedules another
+ * publish: that attempt may have been consumed before the change being
+ * announced was visible.
+ */
+
+export type PendingResyncFailureInfo = {
+  roomCode: string;
+  /** 1-based index of the attempt that just failed. */
+  attempt: number;
+  delayMs: number;
+  error: unknown;
+};
+
+export type PendingResyncAbandonInfo = {
+  roomCode: string;
+  attempts: number;
+  error: unknown;
+};
+
+export type PendingResyncQueueOptions = {
+  publish: (roomCode: string) => Promise<void>;
+  /** Total attempts per publish, including the first. */
+  maxAttempts?: number;
+  initialRetryDelayMs?: number;
+  maxRetryDelayMs?: number;
+  /**
+   * Caps a single attempt so a bus call that never settles cannot pin a record
+   * forever. A timed-out attempt counts as a failure and is retried; the
+   * underlying publish is left running, exactly as `firePublishRoomEvent` does.
+   */
+  attemptTimeoutMs?: number;
+  /** Refuse new room codes past this many outstanding records. */
+  maxPendingRooms?: number;
+  /** Injectable so tests do not pay the backoff in wall-clock time. */
+  sleep?: (delayMs: number) => Promise<void>;
+  onAttemptFailed?: (info: PendingResyncFailureInfo) => void;
+  onAbandoned?: (info: PendingResyncAbandonInfo) => void;
+  onRejected?: (info: { roomCode: string; pendingRooms: number }) => void;
+};
+
+export type PendingResyncQueue = {
+  /** Ask for a resync of `roomCode`. Returns immediately. */
+  request: (roomCode: string) => void;
+  /** Every outstanding record has settled, however it settled. */
+  drain: () => Promise<void>;
+  /** Room codes with an outstanding record. */
+  size: () => number;
+};
+
+/**
+ * The budget is sized against the shutdown step that drains this queue.
+ * `flush_pending_room_event_publishes` gets 30s, and a drain has to fit inside
+ * it or shutdown records a failed step and the process exits non-zero — so the
+ * worst case (every attempt hanging its full timeout, plus the backoff between
+ * them) has to stay under that: 4 × 5s + 1.75s ≈ 22s. Raising either constant
+ * means revisiting that step's timeout in `app.ts`.
+ */
+const DEFAULT_MAX_ATTEMPTS = 4;
+const DEFAULT_INITIAL_RETRY_DELAY_MS = 250;
+const DEFAULT_MAX_RETRY_DELAY_MS = 5_000;
+const DEFAULT_ATTEMPT_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_PENDING_ROOMS = 256;
+
+/**
+ * Deliberately NOT `unref`'d. The backoff timer is the only thing keeping a
+ * retry alive; unrefing it lets an otherwise idle event loop drain and the
+ * write is silently lost — the exact failure this queue exists to prevent.
+ */
+function defaultSleep(delayMs: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+type PendingRecord = {
+  /** Another publish is owed once the current attempt finishes. */
+  pending: boolean;
+  settled: Promise<void>;
+};
+
+export function createPendingResyncQueue(
+  options: PendingResyncQueueOptions,
+): PendingResyncQueue {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+  const initialRetryDelayMs =
+    options.initialRetryDelayMs ?? DEFAULT_INITIAL_RETRY_DELAY_MS;
+  const maxRetryDelayMs = options.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
+  const attemptTimeoutMs =
+    options.attemptTimeoutMs ?? DEFAULT_ATTEMPT_TIMEOUT_MS;
+  const maxPendingRooms = options.maxPendingRooms ?? DEFAULT_MAX_PENDING_ROOMS;
+  const sleep = options.sleep ?? defaultSleep;
+
+  const records = new Map<string, PendingRecord>();
+
+  function retryDelayMs(attempt: number): number {
+    return Math.min(initialRetryDelayMs * 2 ** (attempt - 1), maxRetryDelayMs);
+  }
+
+  async function publishOnce(roomCode: string): Promise<void> {
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    try {
+      await Promise.race([
+        options.publish(roomCode),
+        new Promise<never>((_resolve, reject) => {
+          timeoutHandle = setTimeout(() => {
+            reject(
+              new Error(`Room state resync publish timed out for ${roomCode}.`),
+            );
+          }, attemptTimeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeoutHandle !== null) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+  }
+
+  /**
+   * Drives one room's record to completion.
+   *
+   * The `pending` flag is re-read synchronously after each publish settles, so
+   * a request that landed mid-flight is picked up before the record is dropped
+   * — there is no await between the final check and the `delete`.
+   */
+  async function drive(roomCode: string, record: PendingRecord): Promise<void> {
+    try {
+      while (record.pending) {
+        record.pending = false;
+        for (let attempt = 1; ; attempt += 1) {
+          try {
+            await publishOnce(roomCode);
+            break;
+          } catch (error) {
+            if (attempt >= maxAttempts) {
+              options.onAbandoned?.({ roomCode, attempts: attempt, error });
+              // `break`, not `return`: a request that arrived while this batch
+              // was retrying describes a LATER change and is owed a publish of
+              // its own. Returning here dropped it along with the exhausted
+              // batch, which is the same permanent loss this queue exists to
+              // prevent — and the outer loop is what gives it a fresh budget.
+              break;
+            }
+            const delayMs = retryDelayMs(attempt);
+            options.onAttemptFailed?.({ roomCode, attempt, delayMs, error });
+            await sleep(delayMs);
+          }
+        }
+      }
+    } finally {
+      records.delete(roomCode);
+    }
+  }
+
+  return {
+    request(roomCode) {
+      const existing = records.get(roomCode);
+      if (existing) {
+        existing.pending = true;
+        return;
+      }
+      if (records.size >= maxPendingRooms) {
+        options.onRejected?.({ roomCode, pendingRooms: records.size });
+        return;
+      }
+      const record: PendingRecord = {
+        pending: true,
+        settled: Promise.resolve(),
+      };
+      records.set(roomCode, record);
+      record.settled = drive(roomCode, record);
+      void record.settled.catch(() => undefined);
+    },
+    async drain() {
+      while (records.size > 0) {
+        await Promise.allSettled(
+          Array.from(records.values(), (record) => record.settled),
+        );
+      }
+    },
+    size() {
+      return records.size;
+    },
+  };
+}

--- a/server/src/pending-resync-queue.ts
+++ b/server/src/pending-resync-queue.ts
@@ -189,11 +189,13 @@ export function createPendingResyncQueue(
       activePublishes += 1;
       return true;
     }
+    // No per-wait listener on the stop signal. Registering one was a reaction
+    // on a promise that only settles at shutdown, and a waiter woken normally
+    // by `releaseSlot` could not take it off again — so every wait the server
+    // ever performed stayed retained for its whole lifetime (#242 review).
+    // `stopRetrying` releases these waiters directly instead.
     await new Promise<void>((resolve) => {
       slotWaiters.push(resolve);
-      void pacer.whenStopped().then(() => {
-        resolve();
-      });
     });
     if (pacer.stopped()) {
       return false;
@@ -319,6 +321,11 @@ export function createPendingResyncQueue(
     },
     stopRetrying() {
       pacer.stop();
+      // Wake everything parked on a slot: the bus may never hand one back, and
+      // they answer `false` now that the queue is stopping.
+      while (slotWaiters.length > 0) {
+        slotWaiters.shift()?.();
+      }
     },
     async drain() {
       while (records.size > 0) {

--- a/server/src/pending-resync-queue.ts
+++ b/server/src/pending-resync-queue.ts
@@ -30,17 +30,13 @@ export type PendingResyncFailureInfo = {
   error: unknown;
 };
 
-export type PendingResyncAbandonInfo = {
-  roomCode: string;
-  attempts: number;
-  error: unknown;
-};
-
 export type PendingResyncQueueOptions = {
   publish: (roomCode: string) => Promise<void>;
-  /** Total attempts per publish, including the first. */
-  maxAttempts?: number;
   initialRetryDelayMs?: number;
+  /**
+   * The backoff ceiling, and therefore the pace at which a stranded record
+   * keeps knocking. There is no attempt LIMIT — see `request`.
+   */
   maxRetryDelayMs?: number;
   /**
    * Caps a single attempt so a bus call that never settles cannot pin a record
@@ -53,7 +49,6 @@ export type PendingResyncQueueOptions = {
   /** Injectable so tests do not pay the backoff in wall-clock time. */
   sleep?: (delayMs: number) => Promise<void>;
   onAttemptFailed?: (info: PendingResyncFailureInfo) => void;
-  onAbandoned?: (info: PendingResyncAbandonInfo) => void;
   /**
    * The backlog crossed {@link PendingResyncQueueOptions.backlogWarnThreshold}.
    * Reported, never used to shed: see `request`.
@@ -73,55 +68,47 @@ export type PendingResyncQueue = {
    * whose ownership moved while the bus was rejecting publishes, each entry is
    * a room code, and the set drains as soon as the bus recovers; if that ever
    * stops being enough the answer is to persist the records, not to refuse them.
+   *
+   * For the same reason there is no attempt limit either. A per-record budget
+   * is just a slower way to discard the notification: the room is idle by
+   * definition, so nothing follows the give-up (#242 review). Records retry at
+   * `maxRetryDelayMs` until they land or {@link PendingResyncQueue.stopRetrying}
+   * ends them.
    */
   request: (roomCode: string) => void;
-  /** Every outstanding record has settled, however it settled. */
+  /**
+   * Every outstanding record has been published.
+   *
+   * Unbounded by design, because the retries are: it terminates when the bus
+   * accepts the records or when {@link PendingResyncQueue.stopRetrying} has
+   * been called, and shutdown does the latter first.
+   */
   drain: () => Promise<void>;
   /**
-   * Let each record finish the batch it is on and stop there, instead of
-   * running another for the requests that arrived mid-batch. Irreversible.
+   * Let each record finish the attempt it is on and stop there: no further
+   * retries, no further batches, and the backoffs in flight are cut short.
+   * Irreversible.
    *
-   * A drain is otherwise unbounded in the number of batches, and each batch
-   * costs a full retry budget: two of them exceed the shutdown step that has to
-   * wait for them, and an overrun step is a FAILED step — after which the bus
-   * is torn down anyway, so the publish is lost AND the process exits non-zero
-   * (#242 review). Batches for DIFFERENT rooms run concurrently, so bounding
-   * each record to one batch bounds the whole drain to one.
-   *
-   * The cost is the mid-batch request itself: at shutdown it is dropped rather
-   * than given the fresh budget it would get at runtime. Session cleanup has
-   * already drained by the time this is called, so there should be nothing left
-   * to make one.
+   * This is what bounds shutdown. `drain` is deliberately unbounded — records
+   * retry until they land — so the shutdown step calls this first, leaving at
+   * most ONE in-flight attempt to wait for. An overrun step is not a harmless
+   * delay: it is recorded as a FAILURE, and shutdown then closes the bus under
+   * whatever was still trying (#242 review).
    */
-  stopAfterCurrentBatch: () => void;
+  stopRetrying: () => void;
   /** Room codes with an outstanding record. */
   size: () => number;
 };
 
-/**
- * The budget is sized against the shutdown step that drains this queue.
- * `flush_pending_room_event_publishes` gets 30s, and a drain has to fit inside
- * it or shutdown records a failed step and the process exits non-zero — so the
- * worst case (every attempt hanging its full timeout, plus the backoff between
- * them) has to stay under that: 4 × 5s + 1.75s ≈ 22s. Raising either constant
- * means revisiting that step's timeout in `app.ts`.
- */
-const DEFAULT_MAX_ATTEMPTS = 4;
 const DEFAULT_INITIAL_RETRY_DELAY_MS = 250;
-const DEFAULT_MAX_RETRY_DELAY_MS = 5_000;
+/**
+ * The pace a stranded record settles into. Long enough that a room nobody can
+ * reach is not a busy loop against a dead bus, short enough that recovery is
+ * measured in seconds.
+ */
+const DEFAULT_MAX_RETRY_DELAY_MS = 30_000;
 const DEFAULT_ATTEMPT_TIMEOUT_MS = 5_000;
 const DEFAULT_BACKLOG_WARN_THRESHOLD = 256;
-
-/**
- * Deliberately NOT `unref`'d. The backoff timer is the only thing keeping a
- * retry alive; unrefing it lets an otherwise idle event loop drain and the
- * write is silently lost — the exact failure this queue exists to prevent.
- */
-function defaultSleep(delayMs: number): Promise<void> {
-  return new Promise<void>((resolve) => {
-    setTimeout(resolve, delayMs);
-  });
-}
 
 type PendingRecord = {
   /** Another publish is owed once the current attempt finishes. */
@@ -132,7 +119,6 @@ type PendingRecord = {
 export function createPendingResyncQueue(
   options: PendingResyncQueueOptions,
 ): PendingResyncQueue {
-  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
   const initialRetryDelayMs =
     options.initialRetryDelayMs ?? DEFAULT_INITIAL_RETRY_DELAY_MS;
   const maxRetryDelayMs = options.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
@@ -140,10 +126,34 @@ export function createPendingResyncQueue(
     options.attemptTimeoutMs ?? DEFAULT_ATTEMPT_TIMEOUT_MS;
   const backlogWarnThreshold =
     options.backlogWarnThreshold ?? DEFAULT_BACKLOG_WARN_THRESHOLD;
-  const sleep = options.sleep ?? defaultSleep;
 
   const records = new Map<string, PendingRecord>();
-  let stoppedAfterCurrentBatch = false;
+  /** `cancel` for every backoff currently being waited out. */
+  const pendingWaits = new Set<() => void>();
+  let retriesStopped = false;
+
+  /**
+   * An injected `sleep` is a test clock and resolves on its own; the real timer
+   * has to be cancellable, or `stopRetrying` would still have to sit through a
+   * 30s backoff before shutdown could move on.
+   */
+  function waitBeforeRetry(delayMs: number): Promise<void> {
+    if (options.sleep) {
+      return options.sleep(delayMs);
+    }
+    let cancel = (): void => {};
+    const promise = new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, delayMs);
+      cancel = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+    });
+    pendingWaits.add(cancel);
+    return promise.finally(() => {
+      pendingWaits.delete(cancel);
+    });
+  }
 
   function retryDelayMs(attempt: number): number {
     return Math.min(initialRetryDelayMs * 2 ** (attempt - 1), maxRetryDelayMs);
@@ -170,7 +180,13 @@ export function createPendingResyncQueue(
   }
 
   /**
-   * Drives one room's record to completion.
+   * Drives one room's record until the bus takes it.
+   *
+   * The attempt loop has no give-up branch on purpose. A per-record budget is
+   * just a slower way to discard the notification — the room is idle by
+   * definition, so nothing follows the give-up and the clients keep a
+   * `sharedByMemberId` naming a member who left, until someone reloads (#242
+   * review). Only `stopRetrying` ends it, and only at shutdown.
    *
    * The `pending` flag is re-read synchronously after each publish settles, so
    * a request that landed mid-flight is picked up before the record is dropped
@@ -178,25 +194,22 @@ export function createPendingResyncQueue(
    */
   async function drive(roomCode: string, record: PendingRecord): Promise<void> {
     try {
-      while (record.pending && !stoppedAfterCurrentBatch) {
+      while (record.pending && !retriesStopped) {
         record.pending = false;
         for (let attempt = 1; ; attempt += 1) {
           try {
             await publishOnce(roomCode);
             break;
           } catch (error) {
-            if (attempt >= maxAttempts) {
-              options.onAbandoned?.({ roomCode, attempts: attempt, error });
-              // `break`, not `return`: a request that arrived while this batch
-              // was retrying describes a LATER change and is owed a publish of
-              // its own. Returning here dropped it along with the exhausted
-              // batch, which is the same permanent loss this queue exists to
-              // prevent — and the outer loop is what gives it a fresh budget.
-              break;
-            }
             const delayMs = retryDelayMs(attempt);
             options.onAttemptFailed?.({ roomCode, attempt, delayMs, error });
-            await sleep(delayMs);
+            if (retriesStopped) {
+              return;
+            }
+            await waitBeforeRetry(delayMs);
+            if (retriesStopped) {
+              return;
+            }
           }
         }
       }
@@ -223,8 +236,14 @@ export function createPendingResyncQueue(
       record.settled = drive(roomCode, record);
       void record.settled.catch(() => undefined);
     },
-    stopAfterCurrentBatch() {
-      stoppedAfterCurrentBatch = true;
+    stopRetrying() {
+      retriesStopped = true;
+      // Cut the backoffs short too: a record parked on the 30s ceiling would
+      // otherwise hold the drain for that long.
+      for (const cancel of Array.from(pendingWaits)) {
+        cancel();
+      }
+      pendingWaits.clear();
     },
     async drain() {
       while (records.size > 0) {

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -1005,14 +1005,30 @@ export async function createRedisRuntimeStore(
       // caller goes on to read or broadcast from an index the write never
       // reached (#242 review). Callers that cannot act on it swallow it
       // explicitly at their own call site.
-      await commandPacer.capAttempt(
-        sessionWriteQueue.drain(),
-        pendingOperationTimeoutMs,
-        () =>
-          new Error(
-            "Redis runtime store flush timed out before the session keys were released.",
-          ),
-      );
+      // Deliberately NOT through `commandPacer`. This wait is a pure ordering
+      // barrier, not a Redis command — routing it through the tracker made
+      // every concurrent `flush` register as another unanswered command, so a
+      // single slow write could be amplified by its waiters until unrelated
+      // registrations hit backpressure (#242 review).
+      let barrier: ReturnType<typeof setTimeout> | null = null;
+      try {
+        await Promise.race([
+          sessionWriteQueue.drain(),
+          new Promise<never>((_resolve, reject) => {
+            barrier = setTimeout(() => {
+              reject(
+                new Error(
+                  "Redis runtime store flush timed out before the session keys were released.",
+                ),
+              );
+            }, pendingOperationTimeoutMs);
+          }),
+        ]);
+      } finally {
+        if (barrier !== null) {
+          clearTimeout(barrier);
+        }
+      }
     },
     /**
      * Unlike `flush`, this REPORTS. `flush` waits on error-swallowed copies, so

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -691,7 +691,12 @@ export async function createRedisRuntimeStore(
   function ensurePendingCapacity(operationName: string): void {
     if (
       pendingOperations.size < maxPendingOperations &&
-      heldCommandCapacity.size < maxPendingOperations
+      heldCommandCapacity.size < maxPendingOperations &&
+      // Commands that outlived their cap count too. Tracking them only for
+      // draining let a join whose generation read timed out release its pending
+      // slot and start another read every timeout window, past the configured
+      // cap without limit (#242 review).
+      commandPacer.trackedCount() < maxPendingOperations
     ) {
       return;
     }
@@ -914,8 +919,18 @@ export async function createRedisRuntimeStore(
     sessionId: string,
     operationName: string,
     operation: () => Promise<void>,
+    /**
+     * Runs once, synchronously, immediately after admission — for work that
+     * must happen at ENQUEUE time rather than per attempt, and that starts a
+     * Redis command of its own. Putting it here rather than in the caller is
+     * what keeps admission the single point where capacity is checked, so a
+     * write cannot be refused because of a command it started itself (#242
+     * review).
+     */
+    onAdmitted?: () => void,
   ): Promise<void> {
     ensurePendingCapacity(operationName);
+    onAdmitted?.();
     const startedAt = performance.now();
     const outcome = sessionWriteQueue.enqueue({
       key: sessionId,
@@ -1109,7 +1124,6 @@ export async function createRedisRuntimeStore(
       });
     },
     markSessionJoinedRoom(sessionId: string, roomCode: string) {
-      ensurePendingCapacity("mark_session_joined_room");
       void localRuntimeStore.markSessionJoinedRoom(sessionId, roomCode);
       // Read HERE, at the moment the join is made — not inside the operation
       // body, and not per attempt.
@@ -1126,48 +1140,53 @@ export async function createRedisRuntimeStore(
       // later, for the same reason: a second read is a second chance to pin the
       // wrong instance. The join is refused and the client retries it, which is
       // the trade this path already makes for the index write itself.
-      const pinnedGeneration = commandPacer
-        .capAttempt(
-          redis.get(roomGenerationKey(keyPrefix, roomCode)),
-          pendingOperationTimeoutMs,
-          () =>
-            new Error(`Timed out reading the generation of room ${roomCode}.`),
-        )
-        .then((generation) => {
-          // The tombstone is the teardown's answer to "this code is dead", so
-          // pinning it would make the script's comparison SUCCEED and rebuild
-          // the indexes of a room that no longer exists. Two ways in, and the
-          // Lua guard only ever covered the first: a pin taken BEFORE the
-          // teardown no longer matches the key afterwards, but a pin taken
-          // AFTER it reads the tombstone and matches itself. It also covers the
-          // recycling window — a new occupant that has passed the residue check
-          // but not yet stamped its generation still has the tombstone in place
-          // (#242 review).
-          if (generation === ROOM_GENERATION_TOMBSTONE) {
+      let pinnedGeneration!: Promise<string>;
+      const pinGeneration = (): void => {
+        pinnedGeneration = commandPacer
+          .capAttempt(
+            redis.get(roomGenerationKey(keyPrefix, roomCode)),
+            pendingOperationTimeoutMs,
+            () =>
+              new Error(
+                `Timed out reading the generation of room ${roomCode}.`,
+              ),
+          )
+          .then((generation) => {
+            // The tombstone is the teardown's answer to "this code is dead", so
+            // pinning it would make the script's comparison SUCCEED and rebuild
+            // the indexes of a room that no longer exists. Two ways in, and the
+            // Lua guard only ever covered the first: a pin taken BEFORE the
+            // teardown no longer matches the key afterwards, but a pin taken
+            // AFTER it reads the tombstone and matches itself. It also covers the
+            // recycling window — a new occupant that has passed the residue check
+            // but not yet stamped its generation still has the tombstone in place
+            // (#242 review).
+            if (generation === ROOM_GENERATION_TOMBSTONE) {
+              throw new NonRetryableWriteError(
+                `Room ${roomCode} was torn down before the join index write was pinned.`,
+                "room_deleted",
+              );
+            }
+            // An absent generation pins as `""`, which a room that predates #237
+            // still matches.
+            return generation ?? "";
+          })
+          .catch((error: unknown) => {
+            // Verdicts pass through: this handler is here for the READ failing,
+            // and re-wrapping would relabel "the room is gone" as "we could not
+            // read the generation".
+            if (error instanceof NonRetryableWriteError) {
+              throw error;
+            }
             throw new NonRetryableWriteError(
-              `Room ${roomCode} was torn down before the join index write was pinned.`,
-              "room_deleted",
+              `Could not pin the generation of room ${roomCode}: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+              "room_generation_unreadable",
             );
-          }
-          // An absent generation pins as `""`, which a room that predates #237
-          // still matches.
-          return generation ?? "";
-        })
-        .catch((error: unknown) => {
-          // Verdicts pass through: this handler is here for the READ failing,
-          // and re-wrapping would relabel "the room is gone" as "we could not
-          // read the generation".
-          if (error instanceof NonRetryableWriteError) {
-            throw error;
-          }
-          throw new NonRetryableWriteError(
-            `Could not pin the generation of room ${roomCode}: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-            "room_generation_unreadable",
-          );
-        });
-      pinnedGeneration.catch(() => undefined);
+          });
+        pinnedGeneration.catch(() => undefined);
+      };
       return queueSessionOperation(
         sessionId,
         "mark_session_joined_room",
@@ -1231,6 +1250,7 @@ export async function createRedisRuntimeStore(
             );
           }
         },
+        pinGeneration,
       );
     },
     markSessionLeftRoom(sessionId: string, roomCode?: string | null) {
@@ -1272,6 +1292,12 @@ export async function createRedisRuntimeStore(
           await redis
             .multi()
             .hset(sessionKey(keyPrefix, sessionId), record)
+            // The registration's OTHER side effect. Writing the full hash was
+            // only half of it: `listClusterSessions`, the connection counts and
+            // the per-instance purge all enumerate this set, and a superseded
+            // registration left the connection missing from every one of them
+            // until its next successful join (#242 review).
+            .sadd(`${keyPrefix}sessions`, sessionId)
             .srem(roomSessionsKey(keyPrefix, targetRoomCode), sessionId)
             .exec();
           await cleanupEmptyRoomIndex(

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -247,12 +247,17 @@ function nodeStatusKey(prefix: string, instanceId: string): string {
  * a room whose persisted record was gone, stranding the code with them (#242
  * review). Generations are UUIDs, so this value can never be mistaken for one.
  *
- * It expires rather than lingering: it only has to outlive an in-flight write,
- * and a new occupant's `markRoomGeneration` overwrites it anyway. Deliberately
- * NOT counted by `hasRoomResidue`, so a tombstone never keeps a code reserved.
+ * It does NOT expire. A TTL would have to outlive every write that could still
+ * be holding the old pin, and nothing bounds those: a session chain waits on a
+ * command that was never cancelled, and that command ends when Redis answers,
+ * not when a timer says so. A tombstone that lapsed first would let the join's
+ * `""` pin match an absent key all over again, which is the whole hazard (#242
+ * review). What reclaims it instead is the next occupant: `markRoomGeneration`
+ * overwrites the key, so the cost is one short string per room code that has
+ * been deleted and not yet reused. Deliberately NOT counted by
+ * `hasRoomResidue`, so a tombstone never keeps a code reserved.
  */
 const ROOM_GENERATION_TOMBSTONE = "deleted";
-const ROOM_GENERATION_TOMBSTONE_TTL_MS = 10 * 60_000;
 
 const DEFAULT_MAX_PENDING_OPERATIONS = 256;
 const DEFAULT_PENDING_OPERATION_TIMEOUT_MS = 5_000;
@@ -387,7 +392,7 @@ end
 for index = 3, #KEYS do
   redis.call("DEL", KEYS[index])
 end
-redis.call("SET", KEYS[1], ARGV[3], "PX", ARGV[4])
+redis.call("SET", KEYS[1], ARGV[3])
 redis.call("SREM", KEYS[2], ARGV[2])
 return 1
 `;
@@ -620,6 +625,13 @@ export async function createRedisRuntimeStore(
   const metricsCollector = options.metricsCollector;
   const localRuntimeStore = createInMemoryRuntimeStore(now);
   const pendingOperations = new Set<Promise<unknown>>();
+  /**
+   * One entry per queued write, released only once every command it started has
+   * really finished. Checked alongside `pendingOperations` rather than merged
+   * into it: `flush` must keep meaning "the queue drained" and must not start
+   * waiting on a command nobody can cancel.
+   */
+  const heldCommandCapacity = new Set<Promise<void>>();
 
   await redis.connect();
 
@@ -677,7 +689,10 @@ export async function createRedisRuntimeStore(
   }
 
   function ensurePendingCapacity(operationName: string): void {
-    if (pendingOperations.size < maxPendingOperations) {
+    if (
+      pendingOperations.size < maxPendingOperations &&
+      heldCommandCapacity.size < maxPendingOperations
+    ) {
       return;
     }
     const error = new Error(
@@ -849,7 +864,7 @@ export async function createRedisRuntimeStore(
   function withAttemptTimeout(
     operationName: string,
     operation: () => Promise<void>,
-  ): Pick<DurableWriteRequest, "run" | "settle"> {
+  ): Required<Pick<DurableWriteRequest, "run" | "settle">> {
     // Every command this write ever started, error-swallowed. The timeout races
     // a command, it cannot abort one, so a "failed" attempt may still be on its
     // way to Redis — and the queue must not hand this session's key to the
@@ -857,12 +872,21 @@ export async function createRedisRuntimeStore(
     const started: Array<Promise<void>> = [];
     const run = async () => {
       const command = operation();
-      started.push(
-        command.then(
-          () => undefined,
-          () => undefined,
-        ),
+      const answered = command.then(
+        () => undefined,
+        () => undefined,
       );
+      started.push(answered);
+      // Capacity is held per COMMAND, released as each one answers — not when
+      // the caller was answered. A write whose attempts all timed out rejects
+      // long before its commands stop running, and freeing the slot there let
+      // the next session's write take it and leave one more uncancellable
+      // command behind, so the configured cap stopped bounding anything (#242
+      // review).
+      heldCommandCapacity.add(answered);
+      void answered.finally(() => {
+        heldCommandCapacity.delete(answered);
+      });
       await commandPacer.capAttempt(command, pendingOperationTimeoutMs, () => {
         const error = new Error(
           `Redis runtime store operation timed out: ${operationName}.`,
@@ -907,6 +931,7 @@ export async function createRedisRuntimeStore(
         performance.now() - startedAt,
       );
     });
+
     const reported = outcome.catch((error: unknown) => {
       metricsCollector?.observeRedisRuntimeStoreFailure(operationName);
       logPendingOperationError(
@@ -1079,8 +1104,13 @@ export async function createRedisRuntimeStore(
       // later, for the same reason: a second read is a second chance to pin the
       // wrong instance. The join is refused and the client retries it, which is
       // the trade this path already makes for the index write itself.
-      const pinnedGeneration = redis
-        .get(roomGenerationKey(keyPrefix, roomCode))
+      const pinnedGeneration = commandPacer
+        .capAttempt(
+          redis.get(roomGenerationKey(keyPrefix, roomCode)),
+          pendingOperationTimeoutMs,
+          () =>
+            new Error(`Timed out reading the generation of room ${roomCode}.`),
+        )
         // An absent generation pins as `""`, which a room that predates #237
         // still matches. What it must NOT match is a room deleted since the
         // pin — see `ROOM_GENERATION_TOMBSTONE`, which is what the teardown
@@ -1565,7 +1595,6 @@ export async function createRedisRuntimeStore(
             expectedGeneration === undefined ? "*" : (expectedGeneration ?? ""),
             code,
             ROOM_GENERATION_TOMBSTONE,
-            String(ROOM_GENERATION_TOMBSTONE_TTL_MS),
           );
         })(),
       ).then((applied) => {

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -976,6 +976,27 @@ export async function createRedisRuntimeStore(
     },
     async flush() {
       await Promise.allSettled(Array.from(pendingOperations));
+      // The key releases too, bounded. `pendingOperations` holds the CALLERS'
+      // answers, and an attempt that timed out answered long before its command
+      // did — so `flush` could return while the session's key was still held
+      // and the very next read or broadcast saw stale data. A profile update
+      // publishes `room_state_updated` immediately, and a `registerSession`
+      // landing after it has no second event to correct the display name (#242
+      // review).
+      //
+      // Bounded because the command cannot be cancelled: this is an ordering
+      // barrier, not a durability one, and hanging it on a dead Redis would
+      // block every caller that only wanted its own writes visible.
+      let barrier: ReturnType<typeof setTimeout> | null = null;
+      await Promise.race([
+        sessionWriteQueue.drain(),
+        new Promise<void>((resolve) => {
+          barrier = setTimeout(resolve, pendingOperationTimeoutMs);
+        }),
+      ]);
+      if (barrier !== null) {
+        clearTimeout(barrier);
+      }
     },
     /**
      * Unlike `flush`, this REPORTS. `flush` waits on error-swallowed copies, so
@@ -1150,12 +1171,15 @@ export async function createRedisRuntimeStore(
         sessionId,
         "mark_session_joined_room",
         async () => {
-          // Concurrent with the session read, so the guard costs no extra
-          // round trip on the path a join actually waits for.
-          const [storedSession, expectedGeneration] = await Promise.all([
-            loadSession(redis, keyPrefix, sessionId),
-            pinnedGeneration,
-          ]);
+          // Sequential, not `Promise.all`. Starting the session read in
+          // parallel meant that when the pin rejected first — a tombstone, a
+          // failed read, a timeout — the outer operation rejected while that
+          // `HGETALL` was still running, in no tracking set and waited for by
+          // nobody: repeated failing joins could accumulate Redis commands past
+          // the backpressure cap and `close()` would quit under them (#242
+          // review). Costs one round trip on a path that is not hot.
+          const expectedGeneration = await pinnedGeneration;
+          const storedSession = await loadSession(redis, keyPrefix, sessionId);
           const localSession = localRuntimeStore.getSession(sessionId);
           const roomCodeToLeave = getPreviousRoomToLeave(
             storedSession?.roomCode ?? null,
@@ -1490,28 +1514,34 @@ export async function createRedisRuntimeStore(
       // reconnect can reclaim this `memberId` (#234) — but it goes on its own
       // clock, so a room that never empties still releases the people who left
       // it. The script starts that clock only while a token is actually there.
-      // `trackAwaitedOperation` rather than `trackOperation`: it registers the
-      // write for backpressure exactly the same way, but hands back the REAL
-      // outcome instead of the error-swallowed copy, so `durable` can reject
-      // (#235 review).
-      const durable = trackAwaitedOperation(
+      // Through the write queue, like every other durable write. It used to get
+      // ONE attempt: a transient error made `durable` reject for good, the
+      // member binding stayed in Redis with no retention clock armed, and the
+      // reaper grew a latch to compensate for a failure a retry would have
+      // healed (#242 review). Keyed by the MEMBER, not the session — two
+      // removals of the same seat must serialize, and a session's own writes
+      // must not queue behind them.
+      //
+      // `durable` still reports the REAL outcome, so a caller that acts on it
+      // (`leaveCurrentRoom` elects the next share owner) sees a rejection, and
+      // `queueSessionOperation` already marks it handled for the callers that
+      // decide nothing from it.
+      const durable = queueSessionOperation(
+        `member:${code}:${memberId}`,
         "remove_member",
-        redis.eval(
-          REMOVE_MEMBER_LUA,
-          3,
-          roomMembersKey(keyPrefix, code),
-          roomMemberTokensKey(keyPrefix, code),
-          roomMemberTokenExpiryKey(keyPrefix, code),
-          memberId,
-          session?.id ?? "",
-          String(now() + memberTokenRetentionMs),
-        ),
-      ).then(() => undefined);
-      // Marks `durable` handled without consuming it: callers that DO await it
-      // still see the rejection, while the reaper and the join-rollback — which
-      // decide nothing from this write — no longer turn a Redis hiccup into an
-      // unhandled rejection.
-      void durable.catch(() => undefined);
+        async () => {
+          await redis.eval(
+            REMOVE_MEMBER_LUA,
+            3,
+            roomMembersKey(keyPrefix, code),
+            roomMemberTokensKey(keyPrefix, code),
+            roomMemberTokenExpiryKey(keyPrefix, code),
+            memberId,
+            session?.id ?? "",
+            String(now() + memberTokenRetentionMs),
+          );
+        },
+      );
       return { ...removal, durable };
     },
     evictMemberToken(

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -237,6 +237,22 @@ function nodeStatusKey(prefix: string, instanceId: string): string {
   return `${prefix}node:${instanceId}`;
 }
 
+/**
+ * What a teardown leaves in the generation key instead of deleting it.
+ *
+ * Deleting made "this room was torn down" indistinguishable from "this room
+ * never had a generation", so a join that pinned `""` against a legacy room
+ * matched just as well after the room was deleted — and rebuilt the indexes of
+ * a room whose persisted record was gone, stranding the code with them (#242
+ * review). Generations are UUIDs, so this value can never be mistaken for one.
+ *
+ * It expires rather than lingering: it only has to outlive an in-flight write,
+ * and a new occupant's `markRoomGeneration` overwrites it anyway. Deliberately
+ * NOT counted by `hasRoomResidue`, so a tombstone never keeps a code reserved.
+ */
+const ROOM_GENERATION_TOMBSTONE = "deleted";
+const ROOM_GENERATION_TOMBSTONE_TTL_MS = 10 * 60_000;
+
 const DEFAULT_MAX_PENDING_OPERATIONS = 256;
 const DEFAULT_PENDING_OPERATION_TIMEOUT_MS = 5_000;
 // Floor TTL applied only when the caller's expiresAt is already non-positive
@@ -370,7 +386,7 @@ end
 for index = 3, #KEYS do
   redis.call("DEL", KEYS[index])
 end
-redis.call("DEL", KEYS[1])
+redis.call("SET", KEYS[1], ARGV[3], "PX", ARGV[4])
 redis.call("SREM", KEYS[2], ARGV[2])
 return 1
 `;
@@ -1066,27 +1082,12 @@ export async function createRedisRuntimeStore(
       // the trade this path already makes for the index write itself.
       const pinnedGeneration = redis
         .get(roomGenerationKey(keyPrefix, roomCode))
-        .then((generation) => {
-          if (generation === null) {
-            // An ABSENT generation is not a value to pin, because a teardown
-            // leaves the key absent too: pinning `""` would match a room that
-            // was deleted in the meantime just as happily as one that never had
-            // a generation, and the write would rebuild the indexes of a room
-            // whose persisted record is gone — stranding its code as well
-            // (#242 review). Every joinable room has one: `createRoomForSession`
-            // awaits `markRoomGeneration` and expires the room if it fails, so
-            // this only refuses rooms that predate #237.
-            throw new NonRetryableWriteError(
-              `Room ${roomCode} has no generation to pin the join index write against.`,
-              "room_generation_missing",
-            );
-          }
-          return generation;
-        })
+        // An absent generation pins as `""`, which a room that predates #237
+        // still matches. What it must NOT match is a room deleted since the
+        // pin — see `ROOM_GENERATION_TOMBSTONE`, which is what the teardown
+        // leaves behind instead of an absent key (#242 review).
+        .then((generation) => generation ?? "")
         .catch((error: unknown) => {
-          if (error instanceof NonRetryableWriteError) {
-            throw error;
-          }
           throw new NonRetryableWriteError(
             `Could not pin the generation of room ${roomCode}: ${
               error instanceof Error ? error.message : String(error)
@@ -1564,6 +1565,8 @@ export async function createRedisRuntimeStore(
             ...keys,
             expectedGeneration === undefined ? "*" : (expectedGeneration ?? ""),
             code,
+            ROOM_GENERATION_TOMBSTONE,
+            String(ROOM_GENERATION_TOMBSTONE_TTL_MS),
           );
         })(),
       ).then((applied) => {

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -1585,6 +1585,22 @@ export async function createRedisRuntimeStore(
       // and exit the process non-zero (#242).
       sessionWriteQueue.stopRetrying();
       await Promise.allSettled(Array.from(pendingOperations));
+      // `pendingOperations` holds the CALLERS' answers, and a write that timed
+      // out answered long before its command did. Quitting on that alone closes
+      // the connection under commands still in flight, which is the same
+      // "a timeout is not a cancel" gap `settle` closes for the session chain —
+      // so wait for the chain releases too, bounded so a dead Redis cannot
+      // stretch the close step (#242 review).
+      let drainTimer: ReturnType<typeof setTimeout> | null = null;
+      await Promise.race([
+        sessionWriteQueue.drain(),
+        new Promise<void>((resolve) => {
+          drainTimer = setTimeout(resolve, pendingOperationTimeoutMs);
+        }),
+      ]);
+      if (drainTimer !== null) {
+        clearTimeout(drainTimer);
+      }
       await redis.quit();
     },
     async heartbeatNode(status: ClusterNodeStatus) {

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -17,6 +17,7 @@ import {
   createDurableWriteQueue,
   NonRetryableWriteError,
   type DurableWriteQueueOptions,
+  type DurableWriteRequest,
 } from "./durable-write-queue.js";
 
 type RedisMulti = {
@@ -818,12 +819,24 @@ export async function createRedisRuntimeStore(
   function withAttemptTimeout(
     operationName: string,
     operation: () => Promise<void>,
-  ): () => Promise<void> {
-    return async () => {
+  ): Pick<DurableWriteRequest, "run" | "settle"> {
+    // Every command this write ever started, error-swallowed. The timeout races
+    // a command, it cannot abort one, so a "failed" attempt may still be on its
+    // way to Redis — and the queue must not hand this session's key to the
+    // compensating write until it has landed (#242 review).
+    const started: Array<Promise<void>> = [];
+    const run = async () => {
       let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+      const command = operation();
+      started.push(
+        command.then(
+          () => undefined,
+          () => undefined,
+        ),
+      );
       try {
         await Promise.race([
-          operation(),
+          command,
           new Promise<never>((_resolve, reject) => {
             timeoutHandle = setTimeout(() => {
               const error = new Error(
@@ -850,6 +863,12 @@ export async function createRedisRuntimeStore(
         }
       }
     };
+    return {
+      run,
+      settle: async () => {
+        await Promise.all(started);
+      },
+    };
   }
 
   function queueSessionOperation(
@@ -862,7 +881,7 @@ export async function createRedisRuntimeStore(
     const outcome = sessionWriteQueue.enqueue({
       key: sessionId,
       operationName,
-      run: withAttemptTimeout(operationName, operation),
+      ...withAttemptTimeout(operationName, operation),
     });
     const settled = outcome.catch(() => undefined);
     pendingOperations.add(settled);

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -984,19 +984,20 @@ export async function createRedisRuntimeStore(
       // landing after it has no second event to correct the display name (#242
       // review).
       //
-      // Bounded because the command cannot be cancelled: this is an ordering
-      // barrier, not a durability one, and hanging it on a dead Redis would
-      // block every caller that only wanted its own writes visible.
-      let barrier: ReturnType<typeof setTimeout> | null = null;
-      await Promise.race([
+      // Bounded because the command cannot be cancelled — but the bound
+      // REJECTS. Resolving on it would report the barrier held when it had not,
+      // which is the failure mode this whole method exists to prevent: the
+      // caller goes on to read or broadcast from an index the write never
+      // reached (#242 review). Callers that cannot act on it swallow it
+      // explicitly at their own call site.
+      await commandPacer.capAttempt(
         sessionWriteQueue.drain(),
-        new Promise<void>((resolve) => {
-          barrier = setTimeout(resolve, pendingOperationTimeoutMs);
-        }),
-      ]);
-      if (barrier !== null) {
-        clearTimeout(barrier);
-      }
+        pendingOperationTimeoutMs,
+        () =>
+          new Error(
+            "Redis runtime store flush timed out before the session keys were released.",
+          ),
+      );
     },
     /**
      * Unlike `flush`, this REPORTS. `flush` waits on error-swallowed copies, so
@@ -1518,16 +1519,22 @@ export async function createRedisRuntimeStore(
       // ONE attempt: a transient error made `durable` reject for good, the
       // member binding stayed in Redis with no retention clock armed, and the
       // reaper grew a latch to compensate for a failure a retry would have
-      // healed (#242 review). Keyed by the MEMBER, not the session — two
-      // removals of the same seat must serialize, and a session's own writes
-      // must not queue behind them.
+      // healed (#242 review). Keyed by the member AND the session that is being
+      // removed. Not by the member alone: `REMOVE_MEMBER_LUA` is guarded on
+      // `session.id`, so a removal for a DIFFERENT session succeeds by doing
+      // nothing — and if it superseded a still-retrying removal for the session
+      // that actually holds the binding, that binding stayed and its retention
+      // clock was never armed. Supersession is only sound when the newer write
+      // covers the older one, which two differently-guarded removals never do.
+      // Not by the session alone either: a session's own writes must not queue
+      // behind a removal of somebody else's seat.
       //
       // `durable` still reports the REAL outcome, so a caller that acts on it
       // (`leaveCurrentRoom` elects the next share owner) sees a rejection, and
       // `queueSessionOperation` already marks it handled for the callers that
       // decide nothing from it.
       const durable = queueSessionOperation(
-        `member:${code}:${memberId}`,
+        `member:${code}:${memberId}:${session?.id ?? ""}`,
         "remove_member",
         async () => {
           await redis.eval(

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -13,6 +13,7 @@ import {
   getPreviousRoomToLeave,
   resolveRoomCodeToLeave,
 } from "./runtime-store-state.js";
+import { createRetryPacer } from "./retry-pacer.js";
 import {
   createDurableWriteQueue,
   NonRetryableWriteError,
@@ -627,6 +628,19 @@ export async function createRedisRuntimeStore(
    * with backoff, and confirmable. Before #242 a queued write got one attempt
    * and its failure was swallowed, so a blip silently cost the write.
    */
+  /**
+   * Caps each Redis command and remembers the ones that outlive their cap.
+   *
+   * Only the cap and the tracking are used — the retry SCHEDULE belongs to
+   * `sessionWriteQueue`, which drives the retries. Sharing the primitive is
+   * what keeps "a timeout is not a cancel" from having a fourth private
+   * implementation here (#242 review).
+   */
+  const commandPacer = createRetryPacer({
+    initialDelayMs: pendingOperationTimeoutMs,
+    maxDelayMs: pendingOperationTimeoutMs,
+  });
+
   const sessionWriteQueue = createDurableWriteQueue({
     ...options.writeRetry,
     onRetryScheduled: (info) => {
@@ -842,7 +856,6 @@ export async function createRedisRuntimeStore(
     // compensating write until it has landed (#242 review).
     const started: Array<Promise<void>> = [];
     const run = async () => {
-      let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
       const command = operation();
       started.push(
         command.then(
@@ -850,34 +863,20 @@ export async function createRedisRuntimeStore(
           () => undefined,
         ),
       );
-      try {
-        await Promise.race([
-          command,
-          new Promise<never>((_resolve, reject) => {
-            timeoutHandle = setTimeout(() => {
-              const error = new Error(
-                `Redis runtime store operation timed out: ${operationName}.`,
-              );
-              logPendingOperationError(
-                {
-                  operationName,
-                  pendingCount: pendingOperations.size,
-                  reason: "timeout",
-                },
-                error,
-              );
-              reject(error);
-              // Not `unref`'d: it is the only thing that can end a hung
-              // command, so letting an idle event loop drain past it would
-              // leave the write pinned forever.
-            }, pendingOperationTimeoutMs);
-          }),
-        ]);
-      } finally {
-        if (timeoutHandle !== null) {
-          clearTimeout(timeoutHandle);
-        }
-      }
+      await commandPacer.capAttempt(command, pendingOperationTimeoutMs, () => {
+        const error = new Error(
+          `Redis runtime store operation timed out: ${operationName}.`,
+        );
+        logPendingOperationError(
+          {
+            operationName,
+            pendingCount: pendingOperations.size,
+            reason: "timeout",
+          },
+          error,
+        );
+        return error;
+      });
     };
     return {
       run,
@@ -1591,16 +1590,7 @@ export async function createRedisRuntimeStore(
       // "a timeout is not a cancel" gap `settle` closes for the session chain —
       // so wait for the chain releases too, bounded so a dead Redis cannot
       // stretch the close step (#242 review).
-      let drainTimer: ReturnType<typeof setTimeout> | null = null;
-      await Promise.race([
-        sessionWriteQueue.drain(),
-        new Promise<void>((resolve) => {
-          drainTimer = setTimeout(resolve, pendingOperationTimeoutMs);
-        }),
-      ]);
-      if (drainTimer !== null) {
-        clearTimeout(drainTimer);
-      }
+      await commandPacer.settleTracked(pendingOperationTimeoutMs);
       await redis.quit();
     },
     async heartbeatNode(status: ClusterNodeStatus) {

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -474,7 +474,7 @@ return 1
  * 5 rooms set, 6 (optional) previous room sessions.
  * ARGV: 1 expected generation, 2 sessionId, 3 roomCode, 4.. hash field/value pairs.
  */
-const JOIN_ROOM_INDEX_LUA = `
+export const JOIN_ROOM_INDEX_LUA = `
 if (redis.call("GET", KEYS[1]) or "") ~= ARGV[1] then
   return 0
 end
@@ -1111,12 +1111,33 @@ export async function createRedisRuntimeStore(
           () =>
             new Error(`Timed out reading the generation of room ${roomCode}.`),
         )
-        // An absent generation pins as `""`, which a room that predates #237
-        // still matches. What it must NOT match is a room deleted since the
-        // pin — see `ROOM_GENERATION_TOMBSTONE`, which is what the teardown
-        // leaves behind instead of an absent key (#242 review).
-        .then((generation) => generation ?? "")
+        .then((generation) => {
+          // The tombstone is the teardown's answer to "this code is dead", so
+          // pinning it would make the script's comparison SUCCEED and rebuild
+          // the indexes of a room that no longer exists. Two ways in, and the
+          // Lua guard only ever covered the first: a pin taken BEFORE the
+          // teardown no longer matches the key afterwards, but a pin taken
+          // AFTER it reads the tombstone and matches itself. It also covers the
+          // recycling window — a new occupant that has passed the residue check
+          // but not yet stamped its generation still has the tombstone in place
+          // (#242 review).
+          if (generation === ROOM_GENERATION_TOMBSTONE) {
+            throw new NonRetryableWriteError(
+              `Room ${roomCode} was torn down before the join index write was pinned.`,
+              "room_deleted",
+            );
+          }
+          // An absent generation pins as `""`, which a room that predates #237
+          // still matches.
+          return generation ?? "";
+        })
         .catch((error: unknown) => {
+          // Verdicts pass through: this handler is here for the READ failing,
+          // and re-wrapping would relabel "the room is gone" as "we could not
+          // read the generation".
+          if (error instanceof NonRetryableWriteError) {
+            throw error;
+          }
           throw new NonRetryableWriteError(
             `Could not pin the generation of room ${roomCode}: ${
               error instanceof Error ? error.message : String(error)
@@ -1207,9 +1228,25 @@ export async function createRedisRuntimeStore(
           if (!targetRoomCode) {
             return;
           }
+          // The WHOLE record, not just `roomCode`. This write supersedes any
+          // earlier one for the same session, and a strict subset superseding
+          // a full `registerSession` that had failed left the hash missing
+          // every other field — a renamed member's `displayName` never landed
+          // and `confirm()` still reported success (#242 review). Writing the
+          // full snapshot makes the supersession sound, exactly as it does for
+          // the join.
+          //
+          // `roomCode` is still blanked unconditionally, which is this write's
+          // established meaning ("this session left"). A switcher is blanked
+          // for the moment between here and its join write, exactly as before;
+          // that write re-stamps the whole record anyway.
+          const localSession = localRuntimeStore.getSession(sessionId);
+          const record = localSession
+            ? sessionHashRecord(localSession, "")
+            : { roomCode: "" };
           await redis
             .multi()
-            .hset(sessionKey(keyPrefix, sessionId), "roomCode", "")
+            .hset(sessionKey(keyPrefix, sessionId), record)
             .srem(roomSessionsKey(keyPrefix, targetRoomCode), sessionId)
             .exec();
           await cleanupEmptyRoomIndex(

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -1066,8 +1066,27 @@ export async function createRedisRuntimeStore(
       // the trade this path already makes for the index write itself.
       const pinnedGeneration = redis
         .get(roomGenerationKey(keyPrefix, roomCode))
-        .then((generation) => generation ?? "")
+        .then((generation) => {
+          if (generation === null) {
+            // An ABSENT generation is not a value to pin, because a teardown
+            // leaves the key absent too: pinning `""` would match a room that
+            // was deleted in the meantime just as happily as one that never had
+            // a generation, and the write would rebuild the indexes of a room
+            // whose persisted record is gone — stranding its code as well
+            // (#242 review). Every joinable room has one: `createRoomForSession`
+            // awaits `markRoomGeneration` and expires the room if it fails, so
+            // this only refuses rooms that predate #237.
+            throw new NonRetryableWriteError(
+              `Room ${roomCode} has no generation to pin the join index write against.`,
+              "room_generation_missing",
+            );
+          }
+          return generation;
+        })
         .catch((error: unknown) => {
+          if (error instanceof NonRetryableWriteError) {
+            throw error;
+          }
           throw new NonRetryableWriteError(
             `Could not pin the generation of room ${roomCode}: ${
               error instanceof Error ? error.message : String(error)

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -1030,28 +1030,43 @@ export async function createRedisRuntimeStore(
     markSessionJoinedRoom(sessionId: string, roomCode: string) {
       ensurePendingCapacity("mark_session_joined_room");
       void localRuntimeStore.markSessionJoinedRoom(sessionId, roomCode);
-      // Pinned before the first attempt writes anything, and carried by every
-      // attempt including that one. A retry is the obvious way this write can
-      // outlive the room instance it was meant for, and room codes are recycled
-      // — so without it a slow-to-land join could seat its session in whichever
-      // room took the code over (#242, #237). Reading it here rather than
-      // inside the script is what makes the pin survive a failed attempt: a
-      // generation the script only reported on success could never constrain
-      // the retry that follows a failure.
-      let expectedGeneration: string | undefined;
+      // Read HERE, at the moment the join is made — not inside the operation
+      // body, and not per attempt.
+      //
+      // Room codes are recycled, and the guard only works if the pinned value
+      // predates any recycle of the room instance this join is for. The body
+      // does not run until the session's chain drains, which is unbounded: a
+      // prior write for the same session may still be retrying. Pinning in
+      // there would read whatever generation existed by then — including the
+      // NEW occupant's, after which the Lua check passes and this join seats
+      // its session in a room it never joined (#242 review, #237).
+      //
+      // A failed read makes the write non-retryable rather than re-reading it
+      // later, for the same reason: a second read is a second chance to pin the
+      // wrong instance. The join is refused and the client retries it, which is
+      // the trade this path already makes for the index write itself.
+      const pinnedGeneration = redis
+        .get(roomGenerationKey(keyPrefix, roomCode))
+        .then((generation) => generation ?? "")
+        .catch((error: unknown) => {
+          throw new NonRetryableWriteError(
+            `Could not pin the generation of room ${roomCode}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+            "room_generation_unreadable",
+          );
+        });
+      pinnedGeneration.catch(() => undefined);
       return queueSessionOperation(
         sessionId,
         "mark_session_joined_room",
         async () => {
           // Concurrent with the session read, so the guard costs no extra
           // round trip on the path a join actually waits for.
-          const [storedSession, generation] = await Promise.all([
+          const [storedSession, expectedGeneration] = await Promise.all([
             loadSession(redis, keyPrefix, sessionId),
-            expectedGeneration === undefined
-              ? redis.get(roomGenerationKey(keyPrefix, roomCode))
-              : Promise.resolve(expectedGeneration),
+            pinnedGeneration,
           ]);
-          expectedGeneration = generation ?? "";
           const localSession = localRuntimeStore.getSession(sessionId);
           const roomCodeToLeave = getPreviousRoomToLeave(
             storedSession?.roomCode ?? null,

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -13,6 +13,11 @@ import {
   getPreviousRoomToLeave,
   resolveRoomCodeToLeave,
 } from "./runtime-store-state.js";
+import {
+  createDurableWriteQueue,
+  NonRetryableWriteError,
+  type DurableWriteQueueOptions,
+} from "./durable-write-queue.js";
 
 type RedisMulti = {
   sadd: (...args: string[]) => RedisMulti;
@@ -56,10 +61,15 @@ type RedisClient = {
   get: (key: string) => Promise<string | null>;
 };
 
-type PendingOperationLogContext = {
+/**
+ * Exported so the bootstrap's logging hook shares this exact union rather than
+ * re-declaring it: a structurally identical copy diverges silently the moment a
+ * new reason is added here.
+ */
+export type PendingOperationLogContext = {
   operationName: string;
   pendingCount: number;
-  reason: "backpressure" | "timeout" | "failed";
+  reason: "backpressure" | "timeout" | "failed" | "retry";
 };
 
 type RedisRuntimeSession = {
@@ -86,6 +96,16 @@ type RuntimeStoreOptions = {
   now?: () => number;
   maxPendingOperations?: number;
   pendingOperationTimeoutMs?: number;
+  /**
+   * Retry policy for the queued session writes. Bounded on purpose: a room code
+   * that has been recycled must not inherit an ancient write, and the writes are
+   * ordered per session, so a queue that retried forever would also stall every
+   * later write for that session. See `durable-write-queue`.
+   */
+  writeRetry?: Pick<
+    DurableWriteQueueOptions,
+    "maxAttempts" | "initialRetryDelayMs" | "maxRetryDelayMs" | "sleep"
+  >;
   redisClient?: RedisClient;
   onPendingOperationError?: (
     context: PendingOperationLogContext,
@@ -100,6 +120,7 @@ type RuntimeStoreOptions = {
 const RUNTIME_STORE_METHOD_NAMES = [
   "registerSession",
   "flush",
+  "confirmWrites",
   "unregisterSession",
   "markSessionJoinedRoom",
   "markSessionLeftRoom",
@@ -237,6 +258,36 @@ function serializeSession(session: Session): RedisRuntimeSession {
   };
 }
 
+/**
+ * The complete session record as Redis hash fields.
+ *
+ * Shared by `registerSession` and the join write so the two cannot describe a
+ * session differently — a join that wrote a strict subset was how a lost
+ * registration turned into a permanently unreadable session hash (#242).
+ */
+function sessionHashRecord(
+  session: Session,
+  roomCodeOverride?: string,
+): Record<string, string> {
+  const serialized = serializeSession(session);
+  return {
+    id: serialized.id,
+    instanceId: encodeNullable(serialized.instanceId),
+    remoteAddress: encodeNullable(serialized.remoteAddress),
+    origin: encodeNullable(serialized.origin),
+    roomCode: roomCodeOverride ?? encodeNullable(serialized.roomCode),
+    memberId: encodeNullable(serialized.memberId),
+    displayName: serialized.displayName,
+    memberToken: encodeNullable(serialized.memberToken),
+    joinedAt: serialized.joinedAt === null ? "" : String(serialized.joinedAt),
+    invalidMessageCount: String(serialized.invalidMessageCount),
+  };
+}
+
+function flattenHashRecord(record: Record<string, string>): string[] {
+  return Object.entries(record).flat();
+}
+
 function deserializeSession(fields: Record<string, string>): Session | null {
   if (!fields.id) {
     return null;
@@ -372,6 +423,54 @@ redis.call("SET", KEYS[1], ARGV[1])
 return 1
 `;
 
+/**
+ * Seat a session in a room: full session record, session index, room index.
+ *
+ * One script rather than a transaction, for two reasons that only matter once
+ * the write can be RETRIED (#242):
+ *
+ * - **The whole session record travels with it.** `registerSession` is a
+ *   separate queued write and can have failed; a join that patched only
+ *   `roomCode` on top of that left a hash with no \`id\`, which `loadSession`
+ *   reads as no session at all — so the joiner was missing from every state
+ *   built off the shared view, and the stored sharer's reconnect handed the
+ *   share to a stand-in. Writing the full record makes the join self-healing.
+ * - **It is conditional on the room generation.** Room codes are recycled, so a
+ *   retry of this write must never land on the room that took the code over in
+ *   the meantime. Reading the generation and writing under it in one script is
+ *   what makes the check sound: a read-then-write from the client leaves a
+ *   window that the recycle can fit through — the same reasoning as
+ *   \`DELETE_ROOM_LUA\` (#237 review).
+ *
+ * \`ARGV[1]\` is the generation the caller pinned before its FIRST attempt — an
+ * empty string for a room that predates generations, which matches only an
+ * absent key. Every attempt carries it, so even the first is protected against
+ * a recycle that happens between reading it and writing.
+ *
+ * KEYS: 1 generation, 2 session hash, 3 sessions set, 4 room sessions,
+ * 5 rooms set, 6 (optional) previous room sessions.
+ * ARGV: 1 expected generation, 2 sessionId, 3 roomCode, 4.. hash field/value pairs.
+ */
+const JOIN_ROOM_INDEX_LUA = `
+if (redis.call("GET", KEYS[1]) or "") ~= ARGV[1] then
+  return 0
+end
+if #KEYS >= 6 then
+  redis.call("SREM", KEYS[6], ARGV[2])
+end
+local fields = {}
+for index = 4, #ARGV do
+  fields[#fields + 1] = ARGV[index]
+end
+if #fields > 0 then
+  redis.call("HSET", KEYS[2], unpack(fields))
+end
+redis.call("SADD", KEYS[3], ARGV[2])
+redis.call("SADD", KEYS[4], ARGV[2])
+redis.call("SADD", KEYS[5], ARGV[3])
+return 1
+`;
+
 async function loadSession(
   redis: RedisClient,
   prefix: string,
@@ -503,9 +602,27 @@ export async function createRedisRuntimeStore(
   const metricsCollector = options.metricsCollector;
   const localRuntimeStore = createInMemoryRuntimeStore(now);
   const pendingOperations = new Set<Promise<unknown>>();
-  const sessionOperationChains = new Map<string, Promise<void>>();
 
   await redis.connect();
+
+  /**
+   * Every session-scoped write goes through here: ordered per session, retried
+   * with backoff, and confirmable. Before #242 a queued write got one attempt
+   * and its failure was swallowed, so a blip silently cost the write.
+   */
+  const sessionWriteQueue = createDurableWriteQueue({
+    ...options.writeRetry,
+    onRetryScheduled: (info) => {
+      logPendingOperationError(
+        {
+          operationName: info.operationName,
+          pendingCount: pendingOperations.size,
+          reason: "retry",
+        },
+        info.error,
+      );
+    },
+  });
 
   function logPendingOperationError(
     context: PendingOperationLogContext,
@@ -675,60 +792,139 @@ export async function createRedisRuntimeStore(
   }
 
   /**
-   * Returns the chained promise with its REAL outcome, so a caller that acts on
-   * whether the write landed can await it. `trackOperation` deliberately
-   * swallows the rejection for backpressure accounting, and `flush` waits on
-   * those swallowed copies with `Promise.allSettled` — so awaiting the queue
-   * says only that it drained, never that the write succeeded (#235 review).
+   * Returns the queued write's REAL outcome, so a caller that acts on whether it
+   * landed can await it. `trackOperation` deliberately swallows the rejection
+   * for backpressure accounting, and `flush` waits on those swallowed copies
+   * with `Promise.allSettled` — so awaiting the queue says only that it drained,
+   * never that the write succeeded (#235 review). `confirmWrites` is the one
+   * that answers the second question (#242).
+   *
+   * The retries themselves live in `sessionWriteQueue`; this wrapper only adds
+   * the backpressure accounting and the failure log. `trackAwaitedOperation` is
+   * deliberately not reused: its timeout would fire mid-backoff and report a
+   * write failed while the queue was still working on it.
    */
+  /**
+   * Caps ONE attempt, not the whole write.
+   *
+   * A hung Redis command has to stop pinning a pending slot, which is what the
+   * old per-operation timeout did — but there it also ended the write, so a
+   * command that was merely slow landed afterwards with the caller already told
+   * it had failed. Applied per attempt it becomes a retry trigger instead: every
+   * queued write here is idempotent (`HSET`/`SADD`/`SREM`, and an `EVAL` guarded
+   * by the room generation), so re-running one that secretly landed changes
+   * nothing (#242).
+   */
+  function withAttemptTimeout(
+    operationName: string,
+    operation: () => Promise<void>,
+  ): () => Promise<void> {
+    return async () => {
+      let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+      try {
+        await Promise.race([
+          operation(),
+          new Promise<never>((_resolve, reject) => {
+            timeoutHandle = setTimeout(() => {
+              const error = new Error(
+                `Redis runtime store operation timed out: ${operationName}.`,
+              );
+              logPendingOperationError(
+                {
+                  operationName,
+                  pendingCount: pendingOperations.size,
+                  reason: "timeout",
+                },
+                error,
+              );
+              reject(error);
+              // Not `unref`'d: it is the only thing that can end a hung
+              // command, so letting an idle event loop drain past it would
+              // leave the write pinned forever.
+            }, pendingOperationTimeoutMs);
+          }),
+        ]);
+      } finally {
+        if (timeoutHandle !== null) {
+          clearTimeout(timeoutHandle);
+        }
+      }
+    };
+  }
+
   function queueSessionOperation(
     sessionId: string,
     operationName: string,
     operation: () => Promise<void>,
   ): Promise<void> {
     ensurePendingCapacity(operationName);
-    const previous = sessionOperationChains.get(sessionId) ?? Promise.resolve();
-    const next = previous
-      .catch(() => {})
-      .then(operation)
-      .finally(() => {
-        if (sessionOperationChains.get(sessionId) === next) {
-          sessionOperationChains.delete(sessionId);
-        }
-      });
-    sessionOperationChains.set(sessionId, next);
-    void trackOperation(operationName, next);
-    return next;
+    const startedAt = performance.now();
+    const outcome = sessionWriteQueue.enqueue({
+      key: sessionId,
+      operationName,
+      run: withAttemptTimeout(operationName, operation),
+    });
+    const settled = outcome.catch(() => undefined);
+    pendingOperations.add(settled);
+    void settled.finally(() => {
+      pendingOperations.delete(settled);
+      metricsCollector?.observeRedisRuntimeStoreDuration(
+        operationName,
+        performance.now() - startedAt,
+      );
+    });
+    const reported = outcome.catch((error: unknown) => {
+      metricsCollector?.observeRedisRuntimeStoreFailure(operationName);
+      logPendingOperationError(
+        {
+          operationName,
+          pendingCount: pendingOperations.size,
+          reason: "failed",
+        },
+        error,
+      );
+      throw error;
+    });
+    // `reported` is a NEW promise, so the queue's own handled-marker does not
+    // cover it. Callers that drop it — `unregisterSession`, and any test that
+    // fires a write without awaiting — would otherwise crash the process on an
+    // unhandled rejection. Marking it here rather than at each call site is
+    // what keeps a future fire-and-forget caller safe by default.
+    void reported.catch(() => undefined);
+    return reported;
   }
 
   const store = {
     registerSession(session: Session) {
-      ensurePendingCapacity("register_session");
       localRuntimeStore.registerSession(session);
-      const serialized = serializeSession(session);
-      void trackOperation(
+      // Queued like every other session write, so it is ordered against them and
+      // retried on failure instead of dropped. The returned promise carries the
+      // real outcome; nothing is obliged to await it, and `queueSessionOperation`
+      // already marks the rejection handled (#242).
+      const record = sessionHashRecord(session);
+      const outcome = queueSessionOperation(
+        session.id,
         "register_session",
-        redis
-          .multi()
-          .sadd(`${keyPrefix}sessions`, session.id)
-          .hset(sessionKey(keyPrefix, session.id), {
-            id: serialized.id,
-            instanceId: encodeNullable(serialized.instanceId),
-            remoteAddress: encodeNullable(serialized.remoteAddress),
-            origin: encodeNullable(serialized.origin),
-            roomCode: encodeNullable(serialized.roomCode),
-            memberId: encodeNullable(serialized.memberId),
-            displayName: serialized.displayName,
-            memberToken: encodeNullable(serialized.memberToken),
-            joinedAt:
-              serialized.joinedAt === null ? "" : String(serialized.joinedAt),
-            invalidMessageCount: String(serialized.invalidMessageCount),
-          })
-          .exec(),
+        async () => {
+          await redis
+            .multi()
+            .sadd(`${keyPrefix}sessions`, session.id)
+            .hset(sessionKey(keyPrefix, session.id), record)
+            .exec();
+        },
       );
+      return outcome;
     },
     async flush() {
       await Promise.allSettled(Array.from(pendingOperations));
+    },
+    /**
+     * Unlike `flush`, this REPORTS. `flush` waits on error-swallowed copies, so
+     * a failed write drains exactly like a successful one; callers that need to
+     * know the shared view is complete have to ask this instead (#242).
+     */
+    async confirmWrites() {
+      await sessionWriteQueue.confirm();
     },
     async purgeSessionsByInstance(instanceId: string) {
       await store.flush();
@@ -834,31 +1030,69 @@ export async function createRedisRuntimeStore(
     markSessionJoinedRoom(sessionId: string, roomCode: string) {
       ensurePendingCapacity("mark_session_joined_room");
       void localRuntimeStore.markSessionJoinedRoom(sessionId, roomCode);
+      // Pinned before the first attempt writes anything, and carried by every
+      // attempt including that one. A retry is the obvious way this write can
+      // outlive the room instance it was meant for, and room codes are recycled
+      // — so without it a slow-to-land join could seat its session in whichever
+      // room took the code over (#242, #237). Reading it here rather than
+      // inside the script is what makes the pin survive a failed attempt: a
+      // generation the script only reported on success could never constrain
+      // the retry that follows a failure.
+      let expectedGeneration: string | undefined;
       return queueSessionOperation(
         sessionId,
         "mark_session_joined_room",
         async () => {
-          const previousRoomCode =
-            (await loadSession(redis, keyPrefix, sessionId))?.roomCode ?? null;
+          // Concurrent with the session read, so the guard costs no extra
+          // round trip on the path a join actually waits for.
+          const [storedSession, generation] = await Promise.all([
+            loadSession(redis, keyPrefix, sessionId),
+            expectedGeneration === undefined
+              ? redis.get(roomGenerationKey(keyPrefix, roomCode))
+              : Promise.resolve(expectedGeneration),
+          ]);
+          expectedGeneration = generation ?? "";
+          const localSession = localRuntimeStore.getSession(sessionId);
           const roomCodeToLeave = getPreviousRoomToLeave(
-            previousRoomCode,
+            storedSession?.roomCode ?? null,
             roomCode,
           );
-          const transaction = redis.multi();
-          if (roomCodeToLeave) {
-            transaction.srem(
-              roomSessionsKey(keyPrefix, roomCodeToLeave),
-              sessionId,
+          // The local mirror is this node's own live session, so it is the
+          // authority on every field but the room code. Falling back to what
+          // Redis already has keeps a re-seat from blanking a record we cannot
+          // reconstruct; an empty record would be worse than a stale one.
+          const record = localSession
+            ? sessionHashRecord(localSession, roomCode)
+            : storedSession
+              ? sessionHashRecord(storedSession, roomCode)
+              : { id: sessionId, roomCode };
+          const keys = [
+            roomGenerationKey(keyPrefix, roomCode),
+            sessionKey(keyPrefix, sessionId),
+            `${keyPrefix}sessions`,
+            roomSessionsKey(keyPrefix, roomCode),
+            `${keyPrefix}rooms`,
+            ...(roomCodeToLeave
+              ? [roomSessionsKey(keyPrefix, roomCodeToLeave)]
+              : []),
+          ];
+          const applied = await redis.eval(
+            JOIN_ROOM_INDEX_LUA,
+            keys.length,
+            ...keys,
+            expectedGeneration,
+            sessionId,
+            roomCode,
+            ...flattenHashRecord(record),
+          );
+          if (Number(applied) !== 1) {
+            // Not retryable: a generation only ever moves forward, so no later
+            // attempt can find its way back to the room this write was for.
+            throw new NonRetryableWriteError(
+              `Room ${roomCode} changed hands before the join index write landed.`,
+              "room_generation_changed",
             );
           }
-          transaction.hset(
-            sessionKey(keyPrefix, sessionId),
-            "roomCode",
-            roomCode,
-          );
-          transaction.sadd(roomSessionsKey(keyPrefix, roomCode), sessionId);
-          transaction.sadd(`${keyPrefix}rooms`, roomCode);
-          await transaction.exec();
           if (roomCodeToLeave) {
             await cleanupEmptyRoomIndex(
               redis,
@@ -873,6 +1107,12 @@ export async function createRedisRuntimeStore(
     markSessionLeftRoom(sessionId: string, roomCode?: string | null) {
       ensurePendingCapacity("mark_session_left_room");
       void localRuntimeStore.markSessionLeftRoom(sessionId, roomCode);
+      // No generation guard, unlike its join sibling: every write here is keyed
+      // by THIS session's id, and session ids are never reused. A retry that
+      // lands after the code has been recycled removes a session the new room
+      // never had and blanks a room code on a hash the new room does not own —
+      // both no-ops. Only the join ADDS the session to a room, which is the
+      // write a recycled code could turn into a ghost member (#242).
       return queueSessionOperation(
         sessionId,
         "mark_session_left_room",
@@ -1282,6 +1522,12 @@ export async function createRedisRuntimeStore(
       });
     },
     async close() {
+      // Let outstanding writes finish the attempt they are on and give up
+      // rather than back off again: the shutdown step that calls this gets a
+      // few seconds, and spending the whole retry budget here on writes that a
+      // dead Redis was never going to accept would record the step as failed
+      // and exit the process non-zero (#242).
+      sessionWriteQueue.stopRetrying();
       await Promise.allSettled(Array.from(pendingOperations));
       await redis.quit();
     },

--- a/server/src/retry-pacer.ts
+++ b/server/src/retry-pacer.ts
@@ -1,0 +1,176 @@
+/**
+ * The timing rules every retrying facility in this server needs, in one place.
+ *
+ * `durable-write-queue`, `pending-resync-queue` and `runtime-index-reaper` all
+ * retry work against a dependency that can hang, and all three have to wind
+ * down inside a shutdown step. They grew their own copies of the same four
+ * mechanisms, and #242's review found the same defect in whichever copy the
+ * previous round had not touched — six times. A fix has to land once.
+ *
+ * What is shared:
+ *
+ * - **The backoff schedule.** Exponential from `initialDelayMs`, capped at
+ *   `maxDelayMs`.
+ * - **A wait that shutdown can cut short.** The backoff timer is the only thing
+ *   keeping a retry alive, so it is never `unref`'d; `stop` is what ends it
+ *   early, or a close step sits through the whole delay.
+ * - **A per-attempt cap that does NOT cancel the call.** Racing a timeout
+ *   against a dependency call gives up on the wrapper, never on the call. Every
+ *   caller therefore has to answer two questions the cap cannot: do not start
+ *   another call while this one is unanswered, and do not close the connection
+ *   under it. {@link RetryPacer.settleTracked} is the second answer.
+ * - **One stop switch**, readable as a flag and awaitable as a promise, because
+ *   callers need both (`if (stopped())` in a loop, `race([call, whenStopped()])`
+ *   when parked on someone else's promise).
+ *
+ * What is NOT here, on purpose: ordering, supersession, confirmation, dedupe,
+ * and who decides to retry. Those differ per facility and belong to it.
+ */
+
+export type RetryPacerOptions = {
+  initialDelayMs: number;
+  maxDelayMs: number;
+  /** Injectable so tests do not pay the backoff in wall-clock time. */
+  sleep?: (delayMs: number) => Promise<void>;
+};
+
+export type RetryPacer = {
+  /** Exponential, capped. `attempt` is 1-based. */
+  delayFor: (attempt: number) => number;
+  /**
+   * Wait out a backoff. Resolves EARLY — not rejects — once {@link RetryPacer.stop}
+   * is called, so callers keep one shape: wait, then re-check `stopped()`.
+   */
+  wait: (delayMs: number) => Promise<void>;
+  /**
+   * Run `call` under a cap, and remember it until it really answers.
+   *
+   * Rejects with `makeTimeoutError()` when the cap wins; `call` keeps running,
+   * which is the whole reason {@link RetryPacer.settleTracked} exists.
+   */
+  capAttempt: <T>(
+    call: Promise<T>,
+    timeoutMs: number,
+    makeTimeoutError: () => Error,
+  ) => Promise<T>;
+  /** Calls that have not answered yet. */
+  trackedCount: () => number;
+  /**
+   * Wait, bounded, for the calls that outlived their cap.
+   *
+   * Bounded because an unbounded wait only moves a shutdown overrun from
+   * whatever closes next to this step instead.
+   */
+  settleTracked: (timeoutMs: number) => Promise<void>;
+  stopped: () => boolean;
+  /** Resolves once {@link RetryPacer.stop} is called; never rejects. */
+  whenStopped: () => Promise<void>;
+  /** Stop retrying and cut short every backoff in flight. Irreversible. */
+  stop: () => void;
+};
+
+export function createRetryPacer(options: RetryPacerOptions): RetryPacer {
+  const { initialDelayMs, maxDelayMs } = options;
+  /** `resolve` for every backoff currently being waited out. */
+  const pendingWaits = new Set<() => void>();
+  /** Calls still owed an answer, each error-swallowed so it stays quiet. */
+  const trackedCalls = new Set<Promise<void>>();
+  let isStopped = false;
+  let signalStopped = (): void => {};
+  const stoppedSignal = new Promise<void>((resolve) => {
+    signalStopped = resolve;
+  });
+
+  function bounded<T>(
+    work: Promise<T>,
+    timeoutMs: number,
+    onTimeout: (resolve: () => void, reject: (error: Error) => void) => void,
+  ): Promise<T | void> {
+    let handle: ReturnType<typeof setTimeout> | null = null;
+    return Promise.race([
+      work,
+      new Promise<void>((resolve, reject) => {
+        handle = setTimeout(
+          () => {
+            onTimeout(resolve, reject);
+          },
+          Math.max(timeoutMs, 1),
+        );
+      }),
+    ]).finally(() => {
+      if (handle !== null) {
+        clearTimeout(handle);
+      }
+    });
+  }
+
+  return {
+    delayFor(attempt) {
+      return Math.min(initialDelayMs * 2 ** (attempt - 1), maxDelayMs);
+    },
+    wait(delayMs) {
+      if (options.sleep) {
+        // A test clock resolves on its own; there is nothing to cancel, and
+        // re-checking `stopped()` after it is enough.
+        return options.sleep(delayMs);
+      }
+      let release = (): void => {};
+      const waited = new Promise<void>((resolve) => {
+        // Deliberately NOT `unref`'d: this timer is the only thing keeping the
+        // retry alive, and an idle event loop would otherwise drain past it and
+        // lose the work silently.
+        const timer = setTimeout(resolve, delayMs);
+        release = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+      });
+      pendingWaits.add(release);
+      return waited.finally(() => {
+        pendingWaits.delete(release);
+      });
+    },
+    async capAttempt(call, timeoutMs, makeTimeoutError) {
+      const answered = call.then(
+        () => undefined,
+        () => undefined,
+      );
+      trackedCalls.add(answered);
+      void answered.finally(() => {
+        trackedCalls.delete(answered);
+      });
+      return (await bounded(call, timeoutMs, (_resolve, reject) => {
+        reject(makeTimeoutError());
+      })) as Awaited<typeof call>;
+    },
+    trackedCount() {
+      return trackedCalls.size;
+    },
+    async settleTracked(timeoutMs) {
+      if (trackedCalls.size === 0) {
+        return;
+      }
+      await bounded(
+        Promise.allSettled(Array.from(trackedCalls)).then(() => undefined),
+        timeoutMs,
+        (resolve) => {
+          resolve();
+        },
+      );
+    },
+    stopped() {
+      return isStopped;
+    },
+    whenStopped() {
+      return stoppedSignal;
+    },
+    stop() {
+      isStopped = true;
+      signalStopped();
+      for (const release of Array.from(pendingWaits)) {
+        release();
+      }
+      pendingWaits.clear();
+    },
+  };
+}

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -356,7 +356,7 @@ export function createRoomService(options: {
     }
 
     session.displayName = nextDisplayName;
-    runtimeStore.registerSession?.(session);
+    void runtimeStore.registerSession?.(session);
     return true;
   }
 

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -417,7 +417,10 @@ export function createRoomService(options: {
       args.snapshot.memberToken,
     );
     restoreJoinedSession(args.session, args.snapshot);
-    await runtimeStore.flush?.();
+    // Swallowed here alone: this runs while an earlier failure is being
+    // compensated, and letting the barrier's own rejection escape would replace
+    // the error the caller is reporting (#242 review).
+    await runtimeStore.flush?.().catch(() => undefined);
 
     logEvent("room_leave_recovered", {
       sessionId: args.session.id,
@@ -1423,7 +1426,10 @@ export function createRoomService(options: {
           // leftover binding is harmless either way: the client whose join failed
           // reclaims the same memberId when it retries with the same token, which
           // is what we want.
-          await runtimeStore.flush?.();
+          //
+          // Swallowed: we are already unwinding a failed join and about to
+          // rethrow its error.
+          await runtimeStore.flush?.().catch(() => undefined);
 
           const currentRuntimeSession =
             (await resolveActiveRoom(joinedRoom.code))?.members.get(
@@ -1440,7 +1446,7 @@ export function createRoomService(options: {
               previousRuntimeSession,
               joinIdentity.memberToken,
             );
-            await runtimeStore.flush?.();
+            await runtimeStore.flush?.().catch(() => undefined);
           }
           throw error;
         }

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -56,11 +56,11 @@ const SHUTDOWN_RESYNC_CONCURRENCY = 8;
  */
 const RESYNC_PUBLISH_TIMEOUT_MS = 2_000;
 /**
- * Caps the sweep's own wait on one session's index write.
+ * Caps the sweep's own wait on ONE of a session's cleanup writes.
  *
  * The write keeps going — the store retries it on its own budget — but the
  * sweep must not inherit that budget, or one unreachable session holds `stop()`
- * past the whole shutdown step.
+ * past the whole shutdown step and starves the dead node's other sessions.
  */
 const SESSION_INDEX_WRITE_TIMEOUT_MS = 2_000;
 
@@ -241,6 +241,61 @@ export function createRuntimeIndexReaper(options: {
     }
   }
 
+  /**
+   * Await one cleanup write and say whether it really landed.
+   *
+   * The sweep's steps are ordered by what they destroy: the member removal
+   * needs the session's `roomCode` and `memberId`, the index removal needs its
+   * `roomCode`, and `unregisterSession` throws the whole record away. That
+   * record is the ONLY trail back to this work — once it is gone
+   * `listClusterSessions` stops returning the session and no later sweep can
+   * rediscover the room. So each step runs only after the previous one is
+   * confirmed, and a step that did not land leaves the record untouched for the
+   * next sweep to redo from the top. Every one of them is idempotent.
+   *
+   * Capped, because a write that never answers must not hold the OTHER
+   * sessions of a dead node hostage; the write itself keeps going on the
+   * store's own retry budget. A cap that expires is simply "not confirmed" —
+   * which is now a safe answer rather than a reason to compensate.
+   */
+  async function confirmCleanupWrite(
+    write: Promise<void>,
+    session: { id: string },
+    step: string,
+  ): Promise<boolean> {
+    const settled = pacer
+      .capAttempt(
+        write,
+        SESSION_INDEX_WRITE_TIMEOUT_MS,
+        () =>
+          new Error(
+            `Runtime index reaper gave up waiting for the ${step} of ${session.id}.`,
+          ),
+      )
+      .then(
+        () => true,
+        (error: unknown) => {
+          // Retries are exhausted or the cap expired. Either way this session
+          // keeps its record and its place in the cluster index, so saying so
+          // is all that is left to do here.
+          options.logEvent?.("runtime_index_cleanup_unconfirmed", {
+            sessionId: session.id,
+            step,
+            result: "error",
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return false;
+        },
+      );
+    await Promise.race([settled, pacer.whenStopped()]);
+    // Stopping is not a verdict on the write. Treating it as "unconfirmed"
+    // hands the session to the next instance intact, which is exactly what a
+    // half-finished cleanup needs — the alternative was announcing a room
+    // rebuilt from an index this sweep had not finished cleaning, and that
+    // announcement is one-shot (#242 review).
+    return pacer.stopped() ? false : await settled;
+  }
+
   async function sweep(): Promise<number> {
     if (!options.enabled) {
       return 0;
@@ -263,8 +318,6 @@ export function createRuntimeIndexReaper(options: {
     const sessions = await options.runtimeStore.listClusterSessions();
     let cleanedSessions = 0;
     const roomsToResync = new Set<string>();
-    /** Durable results of this sweep's member removals; see the push below. */
-    const memberRemovals: Array<Promise<void>> = [];
     for (const session of sessions) {
       if (pacer.stopped()) {
         // The same rule as the confirmation wait below: stopping is the only
@@ -290,91 +343,78 @@ export function createRuntimeIndexReaper(options: {
           session.memberId,
           session,
         );
-        // The removal's own durable write is NOT part of `confirmWrites`, which
-        // only ever sees the session write queue. Publishing before it lands
-        // announces a state rebuilt from a member map that still holds the dead
-        // seat (#242 review).
-        if (removal.durable) {
-          // The REAL outcome goes into the confirmation set — swallowing it
-          // here turned a refused `REMOVE_MEMBER_LUA` into a confirmed write,
-          // so the sweep published and then dropped the room's only resync
-          // record while the stale member binding was still in Redis and its
-          // token retention had never been armed (#242 review). Marked handled
-          // separately so a rejection before `Promise.all` reads it stays quiet.
-          void removal.durable.catch(() => undefined);
-          memberRemovals.push(removal.durable);
+        // Confirmed BEFORE anything else touches this session, because
+        // `markSessionLeftRoom` blanks the record's `roomCode` and
+        // `unregisterSession` deletes the record outright — and a retry of this
+        // removal needs both `roomCode` and `memberId` to exist. Running ahead
+        // of it left the stale member binding in Redis with its token retention
+        // never armed, nothing to rediscover it from, and `hasRoomResidue`
+        // keeping the code reserved for good (#242 review).
+        if (
+          removal.durable &&
+          !(await confirmCleanupWrite(
+            removal.durable,
+            session,
+            "member removal",
+          ))
+        ) {
+          continue;
         }
       }
       if (session.roomCode) {
-        // Swallowed, and NOT used to gate the announcement. One unwritable entry
-        // must not abandon the rest of the sweep, and gating on it lost the
-        // announcement for good: `unregisterSession` below deletes the session
-        // hash and SREMs the same room-sessions key on its own, so the room ends
-        // up clean either way — while the session disappears from
-        // `listClusterSessions`, leaving the next pass nothing to retry (#235
-        // review). In the rare case both writes fail, announcing is still no
-        // worse than silence: the rebuilt state names the dead member, which is
-        // exactly what every client already caches.
-        // Capped, and by the reaper's own stop signal. This is the sweep's
-        // only direct `await` on a store write, and the store's write queue
-        // runs its FULL normal retry budget — five attempts of up to the
-        // pending-operation timeout each, per session, serially. One
-        // unreachable session was therefore enough to hold `stop()` past its
-        // step budget, because `stop` waits for the sweep in flight before its
-        // own bounded pass ever starts (#242 review).
-        await Promise.race([
-          pacer
-            .capAttempt(
-              options.runtimeStore.markSessionLeftRoom(
-                session.id,
-                session.roomCode,
-              ),
-              SESSION_INDEX_WRITE_TIMEOUT_MS,
-              () =>
-                new Error(
-                  `Runtime index reaper gave up waiting for the index write of ${session.id}.`,
-                ),
-            )
-            .catch(() => undefined),
-          pacer.whenStopped(),
-        ]);
+        // Gates the announcement, because the announcement is one-shot: it is
+        // dropped as soon as the publish succeeds, so spending it on a state
+        // rebuilt from an index this write has not cleaned strands the room
+        // pointing at the dead member for good. The #235-era reasoning for
+        // announcing anyway — "`unregisterSession` cleans the same key, and
+        // gating leaves the next pass nothing to retry" — only held because
+        // this sweep unregistered regardless; it no longer does.
+        if (
+          !(await confirmCleanupWrite(
+            options.runtimeStore.markSessionLeftRoom(
+              session.id,
+              session.roomCode,
+            ),
+            session,
+            "index write",
+          ))
+        ) {
+          continue;
+        }
         roomsToResync.add(session.roomCode);
       }
 
+      // Last, and only now: this is what makes the session unrediscoverable.
       options.runtimeStore.unregisterSession(session.id);
       cleanedSessions += 1;
     }
 
-    // Both cleanups are queued writes, so the announcement has to wait for them
-    // to drain — otherwise the consumer rebuilds `room:state` from an index that
-    // still lists the sessions this sweep just reaped.
+    // Everything the announcement depends on was confirmed per session above.
+    // What is left over is `unregisterSession`, and it alone: the contract
+    // returns `void`, so a store-wide confirmation is the only place its
+    // outcome is visible at all.
+    //
+    // It gates nothing, and may not — `markSessionLeftRoom` already SREM'd this
+    // session out of the room index, so a failed unregister leaves the room
+    // clean and only the session hash behind. The next sweep still finds that
+    // hash in the cluster index, sees an empty `roomCode`, and unregisters it
+    // again. That is the whole difference from the writes above, which are
+    // gated precisely BECAUSE failing to redo them costs the room its one-shot
+    // announcement (#242 review).
     //
     // `confirmWrites` rather than `flush` where the store offers it: draining
-    // says only that the queue emptied, and this sweep is about to announce a
-    // state rebuilt from those very writes (#242). It does NOT gate the
-    // announcement — see the `markSessionLeftRoom` comment above for why
-    // announcing is still better than silence — but an unconfirmed sweep is
-    // worth saying out loud.
-    // Waited for, not merely sampled. The 2s cap this used to carry was itself
-    // the first patch — put there for the shutdown budget — and everything
-    // above it (the latch map, the re-confirmation pass, the re-issued removal)
-    // existed to compensate for giving up early. A sweep is a background timer
-    // task with no deadline of its own, and the writes it waits on are already
-    // bounded by the store's retry budget, so it can simply wait. Shutdown is
-    // the only thing that cuts it short, and `stop`'s own bounded pass takes
-    // the records from there (#242).
+    // says only that the queue emptied, so a failed write drains exactly like a
+    // successful one. Waited for, not merely sampled — the 2s cap this used to
+    // carry was itself the first patch, put there for the shutdown budget, and
+    // the latch map and re-confirmation pass above it existed to compensate for
+    // giving up early. A sweep is a background timer task with no deadline of
+    // its own; shutdown is the only thing that cuts it short (#242).
     const confirmation = options.runtimeStore.confirmWrites
-      ? Promise.all([
-          options.runtimeStore.confirmWrites(),
-          ...memberRemovals,
-        ]).then(() => undefined)
+      ? options.runtimeStore.confirmWrites()
       : (options.runtimeStore.flush?.() ?? Promise.resolve());
     void confirmation.catch(() => undefined);
     await Promise.race([
       confirmation.catch((error: unknown) => {
-        // Retries are exhausted, so no later announcement can clean the index
-        // either — only saying so is left. The record still goes out: silence
-        // leaves every client naming a member who is gone.
         options.logEvent?.("runtime_index_writes_unconfirmed", {
           result: "error",
           error: error instanceof Error ? error.message : String(error),

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -266,6 +266,15 @@ export function createRuntimeIndexReaper(options: {
     /** Durable results of this sweep's member removals; see the push below. */
     const memberRemovals: Array<Promise<void>> = [];
     for (const session of sessions) {
+      if (pacer.stopped()) {
+        // The same rule as the confirmation wait below: stopping is the only
+        // thing that cuts this sweep short. Without it each remaining session
+        // still spent its own bounded wait on the index write, and five of them
+        // were enough to outlast the whole shutdown step (#242 review). What is
+        // left is picked up by the next instance — these sessions are still in
+        // the cluster index precisely because this sweep did not get to them.
+        break;
+      }
       if (!session.instanceId || !offlineInstanceIds.has(session.instanceId)) {
         continue;
       }
@@ -313,19 +322,22 @@ export function createRuntimeIndexReaper(options: {
         // unreachable session was therefore enough to hold `stop()` past its
         // step budget, because `stop` waits for the sweep in flight before its
         // own bounded pass ever starts (#242 review).
-        await pacer
-          .capAttempt(
-            options.runtimeStore.markSessionLeftRoom(
-              session.id,
-              session.roomCode,
-            ),
-            SESSION_INDEX_WRITE_TIMEOUT_MS,
-            () =>
-              new Error(
-                `Runtime index reaper gave up waiting for the index write of ${session.id}.`,
+        await Promise.race([
+          pacer
+            .capAttempt(
+              options.runtimeStore.markSessionLeftRoom(
+                session.id,
+                session.roomCode,
               ),
-          )
-          .catch(() => undefined);
+              SESSION_INDEX_WRITE_TIMEOUT_MS,
+              () =>
+                new Error(
+                  `Runtime index reaper gave up waiting for the index write of ${session.id}.`,
+                ),
+            )
+            .catch(() => undefined),
+          pacer.whenStopped(),
+        ]);
         roomsToResync.add(session.roomCode);
       }
 

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -22,14 +22,21 @@ export type RuntimeIndexReaperStore = Pick<
   Partial<Pick<RuntimeStore, "flush" | "confirmWrites">>;
 
 /**
- * How many rooms may be waiting for a resync announcement at once.
+ * Backlog size that gets logged, NOT a cap.
  *
- * The records are the only retry trail there is, so they are kept until the
- * publish succeeds — but a bus that is down for a long time must not turn that
- * into unbounded growth. Overflow drops the OLDEST record: the newest ones name
- * the rooms whose members most recently lost a seat.
+ * There is deliberately no eviction. A record is the only trail back to its
+ * room: the offline sessions are already out of the cluster index, so a dropped
+ * record means that room's clients keep a dead `sharedByMemberId` until someone
+ * reloads the page — the exact loss this set exists to prevent, now caused by
+ * the thing meant to bound it (#242 review). Shedding load by discarding
+ * unpublished one-shot notifications is not a trade this can make.
+ *
+ * Growth is bounded in practice by the number of distinct rooms that held a
+ * dead node's members while the bus was rejecting publishes, and each entry is
+ * a room code; the set drains as soon as the bus recovers. If that ever stops
+ * being true the answer is to persist the records, not to evict them.
  */
-const MAX_PENDING_RESYNC_ROOMS = 512;
+const PENDING_RESYNC_BACKLOG_WARN_THRESHOLD = 512;
 
 export function createRuntimeIndexReaper(options: {
   enabled: boolean;
@@ -66,22 +73,20 @@ export function createRuntimeIndexReaper(options: {
   const roomsAwaitingResync = new Set<string>();
 
   function rememberResync(roomCode: string): void {
-    if (
-      !roomsAwaitingResync.has(roomCode) &&
-      roomsAwaitingResync.size >= MAX_PENDING_RESYNC_ROOMS
-    ) {
-      const oldest = roomsAwaitingResync.values().next();
-      if (!oldest.done) {
-        roomsAwaitingResync.delete(oldest.value);
-        options.logEvent?.("runtime_index_resync_dropped", {
-          roomCode: oldest.value,
-          pendingRooms: roomsAwaitingResync.size,
-          result: "dropped",
-          reason: "pending_resync_overflow",
-        });
-      }
-    }
+    const isNew = !roomsAwaitingResync.has(roomCode);
     roomsAwaitingResync.add(roomCode);
+    if (
+      isNew &&
+      roomsAwaitingResync.size >= PENDING_RESYNC_BACKLOG_WARN_THRESHOLD
+    ) {
+      // Reported, never evicted — see the threshold's own comment.
+      options.logEvent?.("runtime_index_resync_backlog", {
+        pendingRooms: roomsAwaitingResync.size,
+        threshold: PENDING_RESYNC_BACKLOG_WARN_THRESHOLD,
+        result: "degraded",
+        reason: "room_state_resync_publish_backlog",
+      });
+    }
   }
 
   /**

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -116,6 +116,18 @@ export function createRuntimeIndexReaper(options: {
    * difference is only that here the retries are driven by the sweep timer.
    */
   const inFlightResyncByRoom = new Map<string, Promise<void>>();
+  /**
+   * Rooms whose CLEANUP writes were never confirmed.
+   *
+   * A record here may be announced but must not be dropped on that
+   * announcement: the state it triggers can still be rebuilt from an index the
+   * cleanup has not reached. `keepRecords` used to be applied only in the sweep
+   * that created the record, so the very next sweep's opening flush published
+   * and deleted it before anything had been re-confirmed — and if the cleanup
+   * landed in between, that sweep found no offline session to rebuild the
+   * record from either (#242 review).
+   */
+  const resyncAwaitingWrites = new Set<string>();
 
   function rememberResync(roomCode: string): void {
     const isNew = !roomsAwaitingResync.has(roomCode);
@@ -164,7 +176,7 @@ export function createRuntimeIndexReaper(options: {
             new Error(`Room state resync publish timed out for ${roomCode}.`),
         );
       }
-      if (!keepRecord) {
+      if (!keepRecord && !resyncAwaitingWrites.has(roomCode)) {
         roomsAwaitingResync.delete(roomCode);
       }
     } catch (error) {
@@ -258,6 +270,23 @@ export function createRuntimeIndexReaper(options: {
       return 0;
     }
 
+    // Writes owed by earlier sweeps: once the store confirms them, the records
+    // they were gating are safe to publish AND drop.
+    if (options.runtimeStore.confirmWrites && resyncAwaitingWrites.size > 0) {
+      await pacer
+        .capAttempt(
+          options.runtimeStore.confirmWrites(),
+          WRITE_CONFIRMATION_TIMEOUT_MS,
+          () =>
+            new Error(
+              "Runtime index reaper gave up re-confirming earlier sweeps' writes.",
+            ),
+        )
+        .then(() => {
+          resyncAwaitingWrites.clear();
+        })
+        .catch(() => undefined);
+    }
     await flushPendingResyncs();
 
     const currentTime = now();
@@ -298,7 +327,14 @@ export function createRuntimeIndexReaper(options: {
         // announces a state rebuilt from a member map that still holds the dead
         // seat (#242 review).
         if (removal.durable) {
-          memberRemovals.push(removal.durable.catch(() => undefined));
+          // The REAL outcome goes into the confirmation set — swallowing it
+          // here turned a refused `REMOVE_MEMBER_LUA` into a confirmed write,
+          // so the sweep published and then dropped the room's only resync
+          // record while the stale member binding was still in Redis and its
+          // token retention had never been armed (#242 review). Marked handled
+          // separately so a rejection before `Promise.all` reads it stays quiet.
+          void removal.durable.catch(() => undefined);
+          memberRemovals.push(removal.durable);
         }
       }
       if (session.roomCode) {
@@ -361,7 +397,16 @@ export function createRuntimeIndexReaper(options: {
     // announcement triggers may still be rebuilt from an index the cleanup has
     // not reached, and dropping the record on that publish leaves nothing to
     // announce the real state once the writes do land (#242 review).
-    await flushPendingResyncs({ keepRecords: !writesConfirmed });
+    if (writesConfirmed) {
+      for (const roomCode of roomsToResync) {
+        resyncAwaitingWrites.delete(roomCode);
+      }
+    } else {
+      for (const roomCode of roomsToResync) {
+        resyncAwaitingWrites.add(roomCode);
+      }
+    }
+    await flushPendingResyncs();
 
     const remainingSessions = await options.runtimeStore.listClusterSessions();
     const activeInstanceIds = new Set(

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -19,7 +19,17 @@ export type RuntimeIndexReaperStore = Pick<
   | "unregisterSession"
   | "purgeNodeStatus"
 > &
-  Partial<Pick<RuntimeStore, "flush">>;
+  Partial<Pick<RuntimeStore, "flush" | "confirmWrites">>;
+
+/**
+ * How many rooms may be waiting for a resync announcement at once.
+ *
+ * The records are the only retry trail there is, so they are kept until the
+ * publish succeeds — but a bus that is down for a long time must not turn that
+ * into unbounded growth. Overflow drops the OLDEST record: the newest ones name
+ * the rooms whose members most recently lost a seat.
+ */
+const MAX_PENDING_RESYNC_ROOMS = 512;
 
 export function createRuntimeIndexReaper(options: {
   enabled: boolean;
@@ -42,11 +52,69 @@ export function createRuntimeIndexReaper(options: {
   const now = options.now ?? Date.now;
   let timer: NodeJS.Timeout | null = null;
   let pendingSweep: Promise<number> | null = null;
+  /**
+   * Rooms still owed a resync announcement.
+   *
+   * The announcement is one-shot: a dead node's members left without anyone
+   * publishing their departure, and once this sweep has cleaned the indexes
+   * there is nothing left to rediscover them from — `listClusterSessions` no
+   * longer returns those sessions, so a later sweep finds no work and the room
+   * is stranded pointing at a member who will never come back (#242). The record
+   * therefore outlives the sweep that created it and is dropped only once the
+   * publish succeeds.
+   */
+  const roomsAwaitingResync = new Set<string>();
+
+  function rememberResync(roomCode: string): void {
+    if (
+      !roomsAwaitingResync.has(roomCode) &&
+      roomsAwaitingResync.size >= MAX_PENDING_RESYNC_ROOMS
+    ) {
+      const oldest = roomsAwaitingResync.values().next();
+      if (!oldest.done) {
+        roomsAwaitingResync.delete(oldest.value);
+        options.logEvent?.("runtime_index_resync_dropped", {
+          roomCode: oldest.value,
+          pendingRooms: roomsAwaitingResync.size,
+          result: "dropped",
+          reason: "pending_resync_overflow",
+        });
+      }
+    }
+    roomsAwaitingResync.add(roomCode);
+  }
+
+  /**
+   * Publish every outstanding announcement, keeping the ones that fail.
+   *
+   * Runs at the START of a sweep too, before the "no offline nodes" early
+   * return — otherwise a backlog accumulated during a bus outage would only
+   * ever be retried on a sweep that happened to find another dead node.
+   */
+  async function flushPendingResyncs(): Promise<void> {
+    for (const roomCode of Array.from(roomsAwaitingResync)) {
+      try {
+        await options.publishRoomStateUpdate?.(roomCode);
+        roomsAwaitingResync.delete(roomCode);
+      } catch (error) {
+        // Kept for the next sweep. The sweep's own work is done and must not be
+        // undone by a bus hiccup.
+        options.logEvent?.("runtime_index_resync_publish_failed", {
+          roomCode,
+          pendingRooms: roomsAwaitingResync.size,
+          result: "error",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
 
   async function sweep(): Promise<number> {
     if (!options.enabled) {
       return 0;
     }
+
+    await flushPendingResyncs();
 
     const currentTime = now();
     const nodeStatuses =
@@ -97,22 +165,30 @@ export function createRuntimeIndexReaper(options: {
     // Both cleanups are queued writes, so the announcement has to wait for them
     // to drain — otherwise the consumer rebuilds `room:state` from an index that
     // still lists the sessions this sweep just reaped.
-    await options.runtimeStore.flush?.();
+    //
+    // `confirmWrites` rather than `flush` where the store offers it: draining
+    // says only that the queue emptied, and this sweep is about to announce a
+    // state rebuilt from those very writes (#242). It does NOT gate the
+    // announcement — see the `markSessionLeftRoom` comment above for why
+    // announcing is still better than silence — but an unconfirmed sweep is
+    // worth saying out loud.
+    if (options.runtimeStore.confirmWrites) {
+      await options.runtimeStore.confirmWrites().catch((error: unknown) => {
+        options.logEvent?.("runtime_index_writes_unconfirmed", {
+          result: "error",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    } else {
+      await options.runtimeStore.flush?.();
+    }
 
     // After the whole sweep, so a room that lost several members to the same
     // dead node is announced once rather than once per seat.
     for (const roomCode of roomsToResync) {
-      try {
-        await options.publishRoomStateUpdate?.(roomCode);
-      } catch (error) {
-        // The sweep's own work is done and must not be undone by a bus hiccup.
-        options.logEvent?.("runtime_index_resync_publish_failed", {
-          roomCode,
-          result: "error",
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+      rememberResync(roomCode);
     }
+    await flushPendingResyncs();
 
     const remainingSessions = await options.runtimeStore.listClusterSessions();
     const activeInstanceIds = new Set(
@@ -141,14 +217,33 @@ export function createRuntimeIndexReaper(options: {
     return cleanedSessions;
   }
 
+  /**
+   * Skips the tick when the previous sweep is still running.
+   *
+   * Overlapping sweeps used to only waste work; now they share
+   * `roomsAwaitingResync`, so two of them would walk the same records and
+   * announce the same room twice. Worse, `stop()` awaits whichever sweep was
+   * scheduled LAST — so if the newer one finished first, shutdown tore Redis
+   * and the bus down while an older sweep was still writing.
+   */
   function scheduleSweep(): void {
-    pendingSweep = sweep().catch((error) => {
-      options.logEvent?.("runtime_index_reaper_failed", {
-        result: "error",
-        error: error instanceof Error ? error.message : String(error),
+    if (pendingSweep) {
+      return;
+    }
+    const running = sweep()
+      .catch((error: unknown) => {
+        options.logEvent?.("runtime_index_reaper_failed", {
+          result: "error",
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return 0;
+      })
+      .finally(() => {
+        if (pendingSweep === running) {
+          pendingSweep = null;
+        }
       });
-      return 0;
-    });
+    pendingSweep = running;
   }
 
   return {
@@ -171,6 +266,12 @@ export function createRuntimeIndexReaper(options: {
       }
       await pendingSweep;
       pendingSweep = null;
+      // Last chance for anything the final sweep could not announce. Nothing
+      // else will ever rediscover those rooms: their sessions are already out
+      // of the cluster index, and this record set is memory-only, so shutting
+      // down without trying loses the announcement for good (#242). One pass,
+      // not the retry loop — the shutdown step is on a clock.
+      await flushPendingResyncs();
     },
   };
 }

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -54,6 +54,34 @@ const SHUTDOWN_RESYNC_CONCURRENCY = 8;
  * step times out with the publish still running (#242 review).
  */
 const RESYNC_PUBLISH_TIMEOUT_MS = 2_000;
+/**
+ * Caps the sweep's `confirmWrites` wait.
+ *
+ * That call inherits the write queue's NORMAL retry budget — five attempts of
+ * up to `pendingOperationTimeoutMs` each, per session, serially — which one
+ * unreachable session is enough to stretch past the whole shutdown step. The
+ * sweep does not act on the answer (it announces either way), so waiting
+ * longer than this buys nothing (#242 review).
+ */
+const WRITE_CONFIRMATION_TIMEOUT_MS = 2_000;
+
+function withTimeout<T>(
+  work: Promise<T>,
+  timeoutMs: number,
+  onTimeout: () => Error,
+): Promise<T> {
+  let handle: ReturnType<typeof setTimeout> | null = null;
+  return Promise.race([
+    work,
+    new Promise<never>((_resolve, reject) => {
+      handle = setTimeout(() => reject(onTimeout()), Math.max(timeoutMs, 1));
+    }),
+  ]).finally(() => {
+    if (handle !== null) {
+      clearTimeout(handle);
+    }
+  });
+}
 
 export function createRuntimeIndexReaper(options: {
   enabled: boolean;
@@ -89,6 +117,16 @@ export function createRuntimeIndexReaper(options: {
    */
   const roomsAwaitingResync = new Set<string>();
   /**
+   * The publish a room already has out that has not answered yet.
+   *
+   * The per-publish cap races the bus call, it cannot abort it — so without
+   * this the next sweep starts ANOTHER publish for the same room every
+   * interval, and one hung bus accumulates Redis commands for as long as it
+   * stays hung (#242 review). Same reasoning as `pending-resync-queue`; the
+   * difference is only that here the retries are driven by the sweep timer.
+   */
+  const inFlightResyncByRoom = new Map<string, Promise<void>>();
+  /**
    * Set before `stop` awaits the sweep in flight, so that sweep's own serial
    * drain of the backlog gives way instead of running to completion. The
    * backlog is uncapped, so that drain is uncapped too — and `stop` waits for
@@ -118,10 +156,25 @@ export function createRuntimeIndexReaper(options: {
     roomCode: string,
     timeoutMs = RESYNC_PUBLISH_TIMEOUT_MS,
   ): Promise<void> {
+    if (inFlightResyncByRoom.has(roomCode)) {
+      // Still waiting on the previous call. Piling another on top is what the
+      // per-publish cap would otherwise turn every retry into.
+      return;
+    }
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
     try {
       const publish = options.publishRoomStateUpdate?.(roomCode);
       if (publish) {
+        const tracked = publish.then(
+          () => undefined,
+          () => undefined,
+        );
+        inFlightResyncByRoom.set(roomCode, tracked);
+        void tracked.finally(() => {
+          if (inFlightResyncByRoom.get(roomCode) === tracked) {
+            inFlightResyncByRoom.delete(roomCode);
+          }
+        });
         await Promise.race([
           publish,
           new Promise<never>((_resolve, reject) => {
@@ -210,6 +263,21 @@ export function createRuntimeIndexReaper(options: {
       },
     );
     await Promise.all(workers);
+    // A publish that timed out is still on its way to the bus, and the very
+    // next shutdown step closes that bus. Give the leftovers what remains of
+    // the budget rather than closing under them (#242 review).
+    const leftovers = Array.from(inFlightResyncByRoom.values());
+    if (leftovers.length > 0) {
+      await Promise.race([
+        Promise.allSettled(leftovers),
+        // Not `unref`'d, for the same reason as every other timer here: it is
+        // the only thing that ends this wait, and an idle loop must not drain
+        // past it.
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, Math.max(deadline - now(), 1));
+        }),
+      ]);
+    }
     if (roomsAwaitingResync.size > 0) {
       options.logEvent?.("runtime_index_resync_abandoned_at_shutdown", {
         pendingRooms: roomsAwaitingResync.size,
@@ -283,7 +351,14 @@ export function createRuntimeIndexReaper(options: {
     // announcing is still better than silence — but an unconfirmed sweep is
     // worth saying out loud.
     if (options.runtimeStore.confirmWrites) {
-      await options.runtimeStore.confirmWrites().catch((error: unknown) => {
+      await withTimeout(
+        options.runtimeStore.confirmWrites(),
+        WRITE_CONFIRMATION_TIMEOUT_MS,
+        () =>
+          new Error(
+            "Runtime index reaper gave up waiting for its writes to be confirmed.",
+          ),
+      ).catch((error: unknown) => {
         options.logEvent?.("runtime_index_writes_unconfirmed", {
           result: "error",
           error: error instanceof Error ? error.message : String(error),

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -38,6 +38,16 @@ export type RuntimeIndexReaperStore = Pick<
  */
 const PENDING_RESYNC_BACKLOG_WARN_THRESHOLD = 512;
 
+/**
+ * The shutdown pass's own budget, and how many publishes it runs at once.
+ *
+ * Comfortably inside `stop_runtime_index_reaper`'s step timeout (see
+ * `createSharedServerShutdownSteps`), which is what keeps an overrun from being
+ * recorded as a failed shutdown step.
+ */
+const SHUTDOWN_RESYNC_BUDGET_MS = 3_000;
+const SHUTDOWN_RESYNC_CONCURRENCY = 8;
+
 export function createRuntimeIndexReaper(options: {
   enabled: boolean;
   runtimeStore: RuntimeIndexReaperStore;
@@ -89,28 +99,74 @@ export function createRuntimeIndexReaper(options: {
     }
   }
 
+  async function publishPendingResync(roomCode: string): Promise<void> {
+    try {
+      await options.publishRoomStateUpdate?.(roomCode);
+      roomsAwaitingResync.delete(roomCode);
+    } catch (error) {
+      // Kept for the next sweep. The sweep's own work is done and must not be
+      // undone by a bus hiccup.
+      options.logEvent?.("runtime_index_resync_publish_failed", {
+        roomCode,
+        pendingRooms: roomsAwaitingResync.size,
+        result: "error",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   /**
    * Publish every outstanding announcement, keeping the ones that fail.
    *
    * Runs at the START of a sweep too, before the "no offline nodes" early
    * return — otherwise a backlog accumulated during a bus outage would only
    * ever be retried on a sweep that happened to find another dead node.
+   *
+   * Serial, because a sweep runs on its own timer and has all the time it
+   * needs. `stop` does NOT — see {@link flushPendingResyncsWithinBudget}.
    */
   async function flushPendingResyncs(): Promise<void> {
     for (const roomCode of Array.from(roomsAwaitingResync)) {
-      try {
-        await options.publishRoomStateUpdate?.(roomCode);
-        roomsAwaitingResync.delete(roomCode);
-      } catch (error) {
-        // Kept for the next sweep. The sweep's own work is done and must not be
-        // undone by a bus hiccup.
-        options.logEvent?.("runtime_index_resync_publish_failed", {
-          roomCode,
-          pendingRooms: roomsAwaitingResync.size,
-          result: "error",
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+      await publishPendingResync(roomCode);
+    }
+  }
+
+  /**
+   * The shutdown pass: bounded in both directions.
+   *
+   * The backlog has no cap — evicting an unpublished record is the loss this
+   * set exists to prevent — so a serial drain of it is unbounded too, and
+   * `stop_runtime_index_reaper` gets a few seconds. Overrunning it is not a
+   * harmless delay: the step is recorded as FAILED, shutdown carries on and
+   * closes the event bus, and publishes still in flight then return early
+   * against a closing bus, so their records get deleted as if they had
+   * succeeded (#242 review). Bounded concurrency plus a deadline keeps the pass
+   * inside the budget; whatever it does not reach stays in the set, which is
+   * honest — the set is memory-only and about to go with the process.
+   */
+  async function flushPendingResyncsWithinBudget(): Promise<void> {
+    const deadline = now() + SHUTDOWN_RESYNC_BUDGET_MS;
+    const queued = Array.from(roomsAwaitingResync);
+    let next = 0;
+    const workers = Array.from(
+      { length: Math.min(SHUTDOWN_RESYNC_CONCURRENCY, queued.length) },
+      async () => {
+        while (next < queued.length && now() < deadline) {
+          const roomCode = queued[next];
+          next += 1;
+          if (roomCode !== undefined) {
+            await publishPendingResync(roomCode);
+          }
+        }
+      },
+    );
+    await Promise.all(workers);
+    if (roomsAwaitingResync.size > 0) {
+      options.logEvent?.("runtime_index_resync_abandoned_at_shutdown", {
+        pendingRooms: roomsAwaitingResync.size,
+        budgetMs: SHUTDOWN_RESYNC_BUDGET_MS,
+        result: "dropped",
+      });
     }
   }
 
@@ -274,9 +330,9 @@ export function createRuntimeIndexReaper(options: {
       // Last chance for anything the final sweep could not announce. Nothing
       // else will ever rediscover those rooms: their sessions are already out
       // of the cluster index, and this record set is memory-only, so shutting
-      // down without trying loses the announcement for good (#242). One pass,
-      // not the retry loop — the shutdown step is on a clock.
-      await flushPendingResyncs();
+      // down without trying loses the announcement for good (#242). Bounded,
+      // because the shutdown step is on a clock and the backlog is not.
+      await flushPendingResyncsWithinBudget();
     },
   };
 }

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -81,6 +81,14 @@ export function createRuntimeIndexReaper(options: {
    * publish succeeds.
    */
   const roomsAwaitingResync = new Set<string>();
+  /**
+   * Set before `stop` awaits the sweep in flight, so that sweep's own serial
+   * drain of the backlog gives way instead of running to completion. The
+   * backlog is uncapped, so that drain is uncapped too — and `stop` waits for
+   * it BEFORE its own bounded pass ever starts, which is how the step budget
+   * was still being blown (#242 review).
+   */
+  let stopping = false;
 
   function rememberResync(roomCode: string): void {
     const isNew = !roomsAwaitingResync.has(roomCode);
@@ -127,6 +135,10 @@ export function createRuntimeIndexReaper(options: {
    */
   async function flushPendingResyncs(): Promise<void> {
     for (const roomCode of Array.from(roomsAwaitingResync)) {
+      if (stopping) {
+        // `stop` is waiting on this sweep and has its own bounded pass to run.
+        return;
+      }
       await publishPendingResync(roomCode);
     }
   }
@@ -321,6 +333,7 @@ export function createRuntimeIndexReaper(options: {
       return sweep();
     },
     async stop() {
+      stopping = true;
       if (timer) {
         clearInterval(timer);
         timer = null;

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -65,6 +65,14 @@ const RESYNC_PUBLISH_TIMEOUT_MS = 2_000;
  * longer than this buys nothing (#242 review).
  */
 const WRITE_CONFIRMATION_TIMEOUT_MS = 2_000;
+/**
+ * Caps the sweep's own wait on one session's index write.
+ *
+ * The write keeps going — the store retries it on its own budget — but the
+ * sweep must not inherit that budget, or one unreachable session holds `stop()`
+ * past the whole shutdown step.
+ */
+const SESSION_INDEX_WRITE_TIMEOUT_MS = 2_000;
 
 export function createRuntimeIndexReaper(options: {
   enabled: boolean;
@@ -127,7 +135,7 @@ export function createRuntimeIndexReaper(options: {
    * landed in between, that sweep found no offline session to rebuild the
    * record from either (#242 review).
    */
-  const resyncAwaitingWrites = new Set<string>();
+  const resyncAwaitingWrites = new Map<string, Promise<void>>();
 
   function rememberResync(roomCode: string): void {
     const isNew = !roomsAwaitingResync.has(roomCode);
@@ -265,28 +273,62 @@ export function createRuntimeIndexReaper(options: {
     }
   }
 
+  /**
+   * Re-check the writes that earlier sweeps could not confirm.
+   *
+   * `confirmWrites` alone is not the whole answer: the flag is also set by a
+   * member removal, whose `durable` promise the store's confirmation never
+   * sees. Clearing on `confirmWrites` alone therefore dropped records while
+   * `REMOVE_MEMBER_LUA` was still pending — or had already failed (#242
+   * review).
+   */
+  async function reconfirmEarlierSweepWrites(): Promise<void> {
+    if (resyncAwaitingWrites.size === 0) {
+      return;
+    }
+    const entries = Array.from(resyncAwaitingWrites);
+    const settled = await pacer
+      .capAttempt(
+        Promise.allSettled([
+          options.runtimeStore.confirmWrites?.() ?? Promise.resolve(),
+          ...entries.map(([, removal]) => removal),
+        ]),
+        WRITE_CONFIRMATION_TIMEOUT_MS,
+        () =>
+          new Error(
+            "Runtime index reaper gave up re-confirming earlier sweeps' writes.",
+          ),
+      )
+      .catch(() => null);
+    if (settled === null) {
+      // Still unanswered: every record stays gated.
+      return;
+    }
+    const [storeWrites, ...removals] = settled;
+    if (storeWrites?.status === "rejected") {
+      return;
+    }
+    entries.forEach(([roomCode], index) => {
+      if (removals[index]?.status === "rejected") {
+        // The removal will never land, so holding the record cannot fix it —
+        // only the member token's retention will. The announcement it gated
+        // has gone out on every sweep since; what is still wrong is the stale
+        // binding, and that needs saying rather than an endless republish.
+        options.logEvent?.("runtime_index_member_removal_failed", {
+          roomCode,
+          result: "error",
+        });
+      }
+      resyncAwaitingWrites.delete(roomCode);
+    });
+  }
+
   async function sweep(): Promise<number> {
     if (!options.enabled) {
       return 0;
     }
 
-    // Writes owed by earlier sweeps: once the store confirms them, the records
-    // they were gating are safe to publish AND drop.
-    if (options.runtimeStore.confirmWrites && resyncAwaitingWrites.size > 0) {
-      await pacer
-        .capAttempt(
-          options.runtimeStore.confirmWrites(),
-          WRITE_CONFIRMATION_TIMEOUT_MS,
-          () =>
-            new Error(
-              "Runtime index reaper gave up re-confirming earlier sweeps' writes.",
-            ),
-        )
-        .then(() => {
-          resyncAwaitingWrites.clear();
-        })
-        .catch(() => undefined);
-    }
+    await reconfirmEarlierSweepWrites();
     await flushPendingResyncs();
 
     const currentTime = now();
@@ -306,6 +348,8 @@ export function createRuntimeIndexReaper(options: {
     const roomsToResync = new Set<string>();
     /** Durable results of this sweep's member removals; see the push below. */
     const memberRemovals: Array<Promise<void>> = [];
+    /** The same promises, kept per room so a retained record can re-check them. */
+    const removalsByRoom = new Map<string, Array<Promise<void>>>();
     for (const session of sessions) {
       if (!session.instanceId || !offlineInstanceIds.has(session.instanceId)) {
         continue;
@@ -335,6 +379,9 @@ export function createRuntimeIndexReaper(options: {
           // separately so a rejection before `Promise.all` reads it stays quiet.
           void removal.durable.catch(() => undefined);
           memberRemovals.push(removal.durable);
+          const forRoom = removalsByRoom.get(session.roomCode) ?? [];
+          forRoom.push(removal.durable);
+          removalsByRoom.set(session.roomCode, forRoom);
         }
       }
       if (session.roomCode) {
@@ -347,8 +394,25 @@ export function createRuntimeIndexReaper(options: {
         // review). In the rare case both writes fail, announcing is still no
         // worse than silence: the rebuilt state names the dead member, which is
         // exactly what every client already caches.
-        await options.runtimeStore
-          .markSessionLeftRoom(session.id, session.roomCode)
+        // Capped, and by the reaper's own stop signal. This is the sweep's
+        // only direct `await` on a store write, and the store's write queue
+        // runs its FULL normal retry budget — five attempts of up to the
+        // pending-operation timeout each, per session, serially. One
+        // unreachable session was therefore enough to hold `stop()` past its
+        // step budget, because `stop` waits for the sweep in flight before its
+        // own bounded pass ever starts (#242 review).
+        await pacer
+          .capAttempt(
+            options.runtimeStore.markSessionLeftRoom(
+              session.id,
+              session.roomCode,
+            ),
+            SESSION_INDEX_WRITE_TIMEOUT_MS,
+            () =>
+              new Error(
+                `Runtime index reaper gave up waiting for the index write of ${session.id}.`,
+              ),
+          )
           .catch(() => undefined);
         roomsToResync.add(session.roomCode);
       }
@@ -403,7 +467,13 @@ export function createRuntimeIndexReaper(options: {
       }
     } else {
       for (const roomCode of roomsToResync) {
-        resyncAwaitingWrites.add(roomCode);
+        // The room carries the removals it is waiting on, so the next sweep
+        // re-checks THOSE and not just the store's own write queue.
+        const removals = removalsByRoom.get(roomCode) ?? [];
+        resyncAwaitingWrites.set(
+          roomCode,
+          Promise.all(removals).then(() => undefined),
+        );
       }
     }
     await flushPendingResyncs();

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -1,6 +1,6 @@
 import { createRetryPacer } from "./retry-pacer.js";
 import { clampTimerIntervalMs } from "./timers.js";
-import type { LogEvent, Session } from "./types.js";
+import type { LogEvent } from "./types.js";
 import type { RuntimeStore } from "./runtime-store.js";
 
 /**
@@ -55,16 +55,6 @@ const SHUTDOWN_RESYNC_CONCURRENCY = 8;
  * step times out with the publish still running (#242 review).
  */
 const RESYNC_PUBLISH_TIMEOUT_MS = 2_000;
-/**
- * Caps the sweep's `confirmWrites` wait.
- *
- * That call inherits the write queue's NORMAL retry budget — five attempts of
- * up to `pendingOperationTimeoutMs` each, per session, serially — which one
- * unreachable session is enough to stretch past the whole shutdown step. The
- * sweep does not act on the answer (it announces either way), so waiting
- * longer than this buys nothing (#242 review).
- */
-const WRITE_CONFIRMATION_TIMEOUT_MS = 2_000;
 /**
  * Caps the sweep's own wait on one session's index write.
  *
@@ -124,34 +114,6 @@ export function createRuntimeIndexReaper(options: {
    * difference is only that here the retries are driven by the sweep timer.
    */
   const inFlightResyncByRoom = new Map<string, Promise<void>>();
-  /**
-   * Rooms whose CLEANUP writes were never confirmed.
-   *
-   * A record here may be announced but must not be dropped on that
-   * announcement: the state it triggers can still be rebuilt from an index the
-   * cleanup has not reached. `keepRecords` used to be applied only in the sweep
-   * that created the record, so the very next sweep's opening flush published
-   * and deleted it before anything had been re-confirmed — and if the cleanup
-   * landed in between, that sweep found no offline session to rebuild the
-   * record from either (#242 review).
-   */
-  const resyncAwaitingWrites = new Map<string, Promise<void>>();
-  /**
-   * Removals that were refused, keyed by room, with everything needed to issue
-   * them again.
-   *
-   * `unregisterSession` has already taken the session out of
-   * `listClusterSessions` by the time a removal is known to have failed, so no
-   * later sweep can rediscover it — the comment that claimed otherwise was
-   * simply wrong (#242 review). Without this the member binding stays in Redis
-   * with no retention clock armed, `hasRoomResidue` keeps the code reserved for
-   * good, and the resync record republishes every sweep without ever clearing.
-   */
-  const failedRemovals = new Map<
-    string,
-    { memberId: string; session: Session }
-  >();
-
   function rememberResync(roomCode: string): void {
     const isNew = !roomsAwaitingResync.has(roomCode);
     roomsAwaitingResync.add(roomCode);
@@ -172,7 +134,6 @@ export function createRuntimeIndexReaper(options: {
   async function publishPendingResync(
     roomCode: string,
     timeoutMs = RESYNC_PUBLISH_TIMEOUT_MS,
-    keepRecord = false,
   ): Promise<void> {
     if (inFlightResyncByRoom.has(roomCode)) {
       // Still waiting on the previous call. Piling another on top is what the
@@ -199,9 +160,7 @@ export function createRuntimeIndexReaper(options: {
             new Error(`Room state resync publish timed out for ${roomCode}.`),
         );
       }
-      if (!keepRecord && !resyncAwaitingWrites.has(roomCode)) {
-        roomsAwaitingResync.delete(roomCode);
-      }
+      roomsAwaitingResync.delete(roomCode);
     } catch (error) {
       // Kept for the next sweep. The sweep's own work is done and must not be
       // undone by a bus hiccup.
@@ -224,19 +183,13 @@ export function createRuntimeIndexReaper(options: {
    * Serial, because a sweep runs on its own timer and has all the time it
    * needs. `stop` does NOT — see {@link flushPendingResyncsWithinBudget}.
    */
-  async function flushPendingResyncs(
-    flushOptions: { keepRecords?: boolean } = {},
-  ): Promise<void> {
+  async function flushPendingResyncs(): Promise<void> {
     for (const roomCode of Array.from(roomsAwaitingResync)) {
       if (pacer.stopped()) {
         // `stop` is waiting on this sweep and has its own bounded pass to run.
         return;
       }
-      await publishPendingResync(
-        roomCode,
-        RESYNC_PUBLISH_TIMEOUT_MS,
-        flushOptions.keepRecords,
-      );
+      await publishPendingResync(roomCode);
     }
   }
 
@@ -288,78 +241,11 @@ export function createRuntimeIndexReaper(options: {
     }
   }
 
-  /**
-   * Re-check the writes an earlier sweep could not confirm.
-   *
-   * Deliberately does NOT call `confirmWrites` again. That API reports "since
-   * you last asked" and CLEARS what it reports, so a second call cannot
-   * re-answer for writes an earlier call already consumed — and while the
-   * earlier call was still running, the two raced: one took the failure, the
-   * other returned success and the record was dropped (#242 review). What can
-   * honestly be re-checked is what this sweep kept a handle on: the member
-   * removals.
-   */
-  async function reconfirmEarlierSweepWrites(): Promise<void> {
-    if (resyncAwaitingWrites.size === 0) {
-      return;
-    }
-    const entries = Array.from(resyncAwaitingWrites);
-    const settled = await pacer
-      .capAttempt(
-        Promise.allSettled(entries.map(([, confirmation]) => confirmation)),
-        WRITE_CONFIRMATION_TIMEOUT_MS,
-        () =>
-          new Error(
-            "Runtime index reaper gave up re-checking an earlier sweep's confirmation.",
-          ),
-      )
-      .catch(() => null);
-    if (settled === null) {
-      // Still unanswered: every record stays gated.
-      return;
-    }
-    entries.forEach(([roomCode], index) => {
-      if (settled[index]?.status === "rejected") {
-        options.logEvent?.("runtime_index_member_removal_failed", {
-          roomCode,
-          result: "error",
-        });
-        const pending = failedRemovals.get(roomCode);
-        if (!pending) {
-          // Nothing left to re-issue, so holding the latch would only
-          // republish for ever.
-          resyncAwaitingWrites.delete(roomCode);
-          return;
-        }
-        // Issue it again from the arguments we kept, and let the latch wait on
-        // THAT. The session it names is gone from the cluster index, so this is
-        // the only handle on the removal that still exists.
-        const retry = options.runtimeStore.removeMember(
-          roomCode,
-          pending.memberId,
-          pending.session,
-        );
-        const durable = retry.durable ?? Promise.resolve();
-        void durable.then(
-          () => {
-            failedRemovals.delete(roomCode);
-          },
-          () => undefined,
-        );
-        resyncAwaitingWrites.set(roomCode, durable);
-        return;
-      }
-      failedRemovals.delete(roomCode);
-      resyncAwaitingWrites.delete(roomCode);
-    });
-  }
-
   async function sweep(): Promise<number> {
     if (!options.enabled) {
       return 0;
     }
 
-    await reconfirmEarlierSweepWrites();
     await flushPendingResyncs();
 
     const currentTime = now();
@@ -408,20 +294,6 @@ export function createRuntimeIndexReaper(options: {
           // separately so a rejection before `Promise.all` reads it stays quiet.
           void removal.durable.catch(() => undefined);
           memberRemovals.push(removal.durable);
-          // Kept so a refusal can be re-issued: by the time we learn about it,
-          // `unregisterSession` has removed the only other handle on it.
-          const roomCode = session.roomCode;
-          const memberId = session.memberId;
-          failedRemovals.set(roomCode, { memberId, session });
-          void removal.durable.then(
-            () => {
-              const held = failedRemovals.get(roomCode);
-              if (held?.session === session) {
-                failedRemovals.delete(roomCode);
-              }
-            },
-            () => undefined,
-          );
         }
       }
       if (session.roomCode) {
@@ -471,12 +343,14 @@ export function createRuntimeIndexReaper(options: {
     // announcement — see the `markSessionLeftRoom` comment above for why
     // announcing is still better than silence — but an unconfirmed sweep is
     // worth saying out loud.
-    let writesConfirmed = true;
-    // Kept, not just awaited. When the wait below times out the underlying
-    // confirmation is still running, and a later sweep must re-check THIS
-    // promise rather than call the store again: `confirmWrites` reports "since
-    // you last asked" and clears what it reports, so a second call cannot
-    // re-answer for it and the two race over the same failure (#242 review).
+    // Waited for, not merely sampled. The 2s cap this used to carry was itself
+    // the first patch — put there for the shutdown budget — and everything
+    // above it (the latch map, the re-confirmation pass, the re-issued removal)
+    // existed to compensate for giving up early. A sweep is a background timer
+    // task with no deadline of its own, and the writes it waits on are already
+    // bounded by the store's retry budget, so it can simply wait. Shutdown is
+    // the only thing that cuts it short, and `stop`'s own bounded pass takes
+    // the records from there (#242).
     const confirmation = options.runtimeStore.confirmWrites
       ? Promise.all([
           options.runtimeStore.confirmWrites(),
@@ -484,40 +358,23 @@ export function createRuntimeIndexReaper(options: {
         ]).then(() => undefined)
       : (options.runtimeStore.flush?.() ?? Promise.resolve());
     void confirmation.catch(() => undefined);
-    await pacer
-      .capAttempt(confirmation, WRITE_CONFIRMATION_TIMEOUT_MS, () => {
-        return new Error(
-          "Runtime index reaper gave up waiting for its writes to be confirmed.",
-        );
-      })
-      .catch((error: unknown) => {
-        writesConfirmed = false;
+    await Promise.race([
+      confirmation.catch((error: unknown) => {
+        // Retries are exhausted, so no later announcement can clean the index
+        // either — only saying so is left. The record still goes out: silence
+        // leaves every client naming a member who is gone.
         options.logEvent?.("runtime_index_writes_unconfirmed", {
           result: "error",
           error: error instanceof Error ? error.message : String(error),
         });
-      });
+      }),
+      pacer.whenStopped(),
+    ]);
 
     // After the whole sweep, so a room that lost several members to the same
     // dead node is announced once rather than once per seat.
     for (const roomCode of roomsToResync) {
       rememberResync(roomCode);
-    }
-    // `keepRecords` when the writes were not confirmed: the state this
-    // announcement triggers may still be rebuilt from an index the cleanup has
-    // not reached, and dropping the record on that publish leaves nothing to
-    // announce the real state once the writes do land (#242 review).
-    if (writesConfirmed) {
-      for (const roomCode of roomsToResync) {
-        resyncAwaitingWrites.delete(roomCode);
-      }
-    } else {
-      for (const roomCode of roomsToResync) {
-        // The room carries THIS sweep's confirmation — the store's write queue
-        // and its member removals together — so the next sweep re-checks the
-        // very promise that has not answered yet.
-        resyncAwaitingWrites.set(roomCode, confirmation);
-      }
     }
     await flushPendingResyncs();
 

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -1,6 +1,6 @@
 import { createRetryPacer } from "./retry-pacer.js";
 import { clampTimerIntervalMs } from "./timers.js";
-import type { LogEvent } from "./types.js";
+import type { LogEvent, Session } from "./types.js";
 import type { RuntimeStore } from "./runtime-store.js";
 
 /**
@@ -136,6 +136,21 @@ export function createRuntimeIndexReaper(options: {
    * record from either (#242 review).
    */
   const resyncAwaitingWrites = new Map<string, Promise<void>>();
+  /**
+   * Removals that were refused, keyed by room, with everything needed to issue
+   * them again.
+   *
+   * `unregisterSession` has already taken the session out of
+   * `listClusterSessions` by the time a removal is known to have failed, so no
+   * later sweep can rediscover it — the comment that claimed otherwise was
+   * simply wrong (#242 review). Without this the member binding stays in Redis
+   * with no retention clock armed, `hasRoomResidue` keeps the code reserved for
+   * good, and the resync record republishes every sweep without ever clearing.
+   */
+  const failedRemovals = new Map<
+    string,
+    { memberId: string; session: Session }
+  >();
 
   function rememberResync(roomCode: string): void {
     const isNew = !roomsAwaitingResync.has(roomCode);
@@ -305,17 +320,36 @@ export function createRuntimeIndexReaper(options: {
     }
     entries.forEach(([roomCode], index) => {
       if (settled[index]?.status === "rejected") {
-        // Held: the member binding is still in Redis with no retention clock
-        // armed, so `hasRoomResidue` keeps the code reserved and a state built
-        // now would still name the dead seat. Releasing the latch here dropped
-        // the record while all of that was true (#242 review). The removal is
-        // re-issued below, on the next sweep that can see the room.
         options.logEvent?.("runtime_index_member_removal_failed", {
           roomCode,
           result: "error",
         });
+        const pending = failedRemovals.get(roomCode);
+        if (!pending) {
+          // Nothing left to re-issue, so holding the latch would only
+          // republish for ever.
+          resyncAwaitingWrites.delete(roomCode);
+          return;
+        }
+        // Issue it again from the arguments we kept, and let the latch wait on
+        // THAT. The session it names is gone from the cluster index, so this is
+        // the only handle on the removal that still exists.
+        const retry = options.runtimeStore.removeMember(
+          roomCode,
+          pending.memberId,
+          pending.session,
+        );
+        const durable = retry.durable ?? Promise.resolve();
+        void durable.then(
+          () => {
+            failedRemovals.delete(roomCode);
+          },
+          () => undefined,
+        );
+        resyncAwaitingWrites.set(roomCode, durable);
         return;
       }
+      failedRemovals.delete(roomCode);
       resyncAwaitingWrites.delete(roomCode);
     });
   }
@@ -374,6 +408,20 @@ export function createRuntimeIndexReaper(options: {
           // separately so a rejection before `Promise.all` reads it stays quiet.
           void removal.durable.catch(() => undefined);
           memberRemovals.push(removal.durable);
+          // Kept so a refusal can be re-issued: by the time we learn about it,
+          // `unregisterSession` has removed the only other handle on it.
+          const roomCode = session.roomCode;
+          const memberId = session.memberId;
+          failedRemovals.set(roomCode, { memberId, session });
+          void removal.durable.then(
+            () => {
+              const held = failedRemovals.get(roomCode);
+              if (held?.session === session) {
+                failedRemovals.delete(roomCode);
+              }
+            },
+            () => undefined,
+          );
         }
       }
       if (session.roomCode) {

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -47,6 +47,13 @@ const PENDING_RESYNC_BACKLOG_WARN_THRESHOLD = 512;
  */
 const SHUTDOWN_RESYNC_BUDGET_MS = 3_000;
 const SHUTDOWN_RESYNC_CONCURRENCY = 8;
+/**
+ * Caps ONE publish. A deadline that only decides whether to START the next
+ * record is no bound at all when the bus hangs rather than rejecting: the call
+ * already in flight pins the sweep drain and the shutdown pass alike, and the
+ * step times out with the publish still running (#242 review).
+ */
+const RESYNC_PUBLISH_TIMEOUT_MS = 2_000;
 
 export function createRuntimeIndexReaper(options: {
   enabled: boolean;
@@ -107,9 +114,30 @@ export function createRuntimeIndexReaper(options: {
     }
   }
 
-  async function publishPendingResync(roomCode: string): Promise<void> {
+  async function publishPendingResync(
+    roomCode: string,
+    timeoutMs = RESYNC_PUBLISH_TIMEOUT_MS,
+  ): Promise<void> {
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
     try {
-      await options.publishRoomStateUpdate?.(roomCode);
+      const publish = options.publishRoomStateUpdate?.(roomCode);
+      if (publish) {
+        await Promise.race([
+          publish,
+          new Promise<never>((_resolve, reject) => {
+            timeoutHandle = setTimeout(
+              () => {
+                reject(
+                  new Error(
+                    `Room state resync publish timed out for ${roomCode}.`,
+                  ),
+                );
+              },
+              Math.max(timeoutMs, 1),
+            );
+          }),
+        ]);
+      }
       roomsAwaitingResync.delete(roomCode);
     } catch (error) {
       // Kept for the next sweep. The sweep's own work is done and must not be
@@ -120,6 +148,10 @@ export function createRuntimeIndexReaper(options: {
         result: "error",
         error: error instanceof Error ? error.message : String(error),
       });
+    } finally {
+      if (timeoutHandle !== null) {
+        clearTimeout(timeoutHandle);
+      }
     }
   }
 
@@ -167,7 +199,12 @@ export function createRuntimeIndexReaper(options: {
           const roomCode = queued[next];
           next += 1;
           if (roomCode !== undefined) {
-            await publishPendingResync(roomCode);
+            // Capped by what is LEFT of the budget, not by the per-publish
+            // default: the last record must not be able to overrun it either.
+            await publishPendingResync(
+              roomCode,
+              Math.min(RESYNC_PUBLISH_TIMEOUT_MS, deadline - now()),
+            );
           }
         }
       },

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -274,13 +274,15 @@ export function createRuntimeIndexReaper(options: {
   }
 
   /**
-   * Re-check the writes that earlier sweeps could not confirm.
+   * Re-check the writes an earlier sweep could not confirm.
    *
-   * `confirmWrites` alone is not the whole answer: the flag is also set by a
-   * member removal, whose `durable` promise the store's confirmation never
-   * sees. Clearing on `confirmWrites` alone therefore dropped records while
-   * `REMOVE_MEMBER_LUA` was still pending — or had already failed (#242
-   * review).
+   * Deliberately does NOT call `confirmWrites` again. That API reports "since
+   * you last asked" and CLEARS what it reports, so a second call cannot
+   * re-answer for writes an earlier call already consumed — and while the
+   * earlier call was still running, the two raced: one took the failure, the
+   * other returned success and the record was dropped (#242 review). What can
+   * honestly be re-checked is what this sweep kept a handle on: the member
+   * removals.
    */
   async function reconfirmEarlierSweepWrites(): Promise<void> {
     if (resyncAwaitingWrites.size === 0) {
@@ -289,14 +291,11 @@ export function createRuntimeIndexReaper(options: {
     const entries = Array.from(resyncAwaitingWrites);
     const settled = await pacer
       .capAttempt(
-        Promise.allSettled([
-          options.runtimeStore.confirmWrites?.() ?? Promise.resolve(),
-          ...entries.map(([, removal]) => removal),
-        ]),
+        Promise.allSettled(entries.map(([, confirmation]) => confirmation)),
         WRITE_CONFIRMATION_TIMEOUT_MS,
         () =>
           new Error(
-            "Runtime index reaper gave up re-confirming earlier sweeps' writes.",
+            "Runtime index reaper gave up re-checking an earlier sweep's confirmation.",
           ),
       )
       .catch(() => null);
@@ -304,20 +303,18 @@ export function createRuntimeIndexReaper(options: {
       // Still unanswered: every record stays gated.
       return;
     }
-    const [storeWrites, ...removals] = settled;
-    if (storeWrites?.status === "rejected") {
-      return;
-    }
     entries.forEach(([roomCode], index) => {
-      if (removals[index]?.status === "rejected") {
-        // The removal will never land, so holding the record cannot fix it —
-        // only the member token's retention will. The announcement it gated
-        // has gone out on every sweep since; what is still wrong is the stale
-        // binding, and that needs saying rather than an endless republish.
+      if (settled[index]?.status === "rejected") {
+        // Held: the member binding is still in Redis with no retention clock
+        // armed, so `hasRoomResidue` keeps the code reserved and a state built
+        // now would still name the dead seat. Releasing the latch here dropped
+        // the record while all of that was true (#242 review). The removal is
+        // re-issued below, on the next sweep that can see the room.
         options.logEvent?.("runtime_index_member_removal_failed", {
           roomCode,
           result: "error",
         });
+        return;
       }
       resyncAwaitingWrites.delete(roomCode);
     });
@@ -348,8 +345,6 @@ export function createRuntimeIndexReaper(options: {
     const roomsToResync = new Set<string>();
     /** Durable results of this sweep's member removals; see the push below. */
     const memberRemovals: Array<Promise<void>> = [];
-    /** The same promises, kept per room so a retained record can re-check them. */
-    const removalsByRoom = new Map<string, Array<Promise<void>>>();
     for (const session of sessions) {
       if (!session.instanceId || !offlineInstanceIds.has(session.instanceId)) {
         continue;
@@ -379,9 +374,6 @@ export function createRuntimeIndexReaper(options: {
           // separately so a rejection before `Promise.all` reads it stays quiet.
           void removal.durable.catch(() => undefined);
           memberRemovals.push(removal.durable);
-          const forRoom = removalsByRoom.get(session.roomCode) ?? [];
-          forRoom.push(removal.durable);
-          removalsByRoom.set(session.roomCode, forRoom);
         }
       }
       if (session.roomCode) {
@@ -432,12 +424,18 @@ export function createRuntimeIndexReaper(options: {
     // announcing is still better than silence — but an unconfirmed sweep is
     // worth saying out loud.
     let writesConfirmed = true;
+    // Kept, not just awaited. When the wait below times out the underlying
+    // confirmation is still running, and a later sweep must re-check THIS
+    // promise rather than call the store again: `confirmWrites` reports "since
+    // you last asked" and clears what it reports, so a second call cannot
+    // re-answer for it and the two race over the same failure (#242 review).
     const confirmation = options.runtimeStore.confirmWrites
       ? Promise.all([
           options.runtimeStore.confirmWrites(),
           ...memberRemovals,
         ]).then(() => undefined)
       : (options.runtimeStore.flush?.() ?? Promise.resolve());
+    void confirmation.catch(() => undefined);
     await pacer
       .capAttempt(confirmation, WRITE_CONFIRMATION_TIMEOUT_MS, () => {
         return new Error(
@@ -467,13 +465,10 @@ export function createRuntimeIndexReaper(options: {
       }
     } else {
       for (const roomCode of roomsToResync) {
-        // The room carries the removals it is waiting on, so the next sweep
-        // re-checks THOSE and not just the store's own write queue.
-        const removals = removalsByRoom.get(roomCode) ?? [];
-        resyncAwaitingWrites.set(
-          roomCode,
-          Promise.all(removals).then(() => undefined),
-        );
+        // The room carries THIS sweep's confirmation — the store's write queue
+        // and its member removals together — so the next sweep re-checks the
+        // very promise that has not answered yet.
+        resyncAwaitingWrites.set(roomCode, confirmation);
       }
     }
     await flushPendingResyncs();

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -137,6 +137,7 @@ export function createRuntimeIndexReaper(options: {
   async function publishPendingResync(
     roomCode: string,
     timeoutMs = RESYNC_PUBLISH_TIMEOUT_MS,
+    keepRecord = false,
   ): Promise<void> {
     if (inFlightResyncByRoom.has(roomCode)) {
       // Still waiting on the previous call. Piling another on top is what the
@@ -163,7 +164,9 @@ export function createRuntimeIndexReaper(options: {
             new Error(`Room state resync publish timed out for ${roomCode}.`),
         );
       }
-      roomsAwaitingResync.delete(roomCode);
+      if (!keepRecord) {
+        roomsAwaitingResync.delete(roomCode);
+      }
     } catch (error) {
       // Kept for the next sweep. The sweep's own work is done and must not be
       // undone by a bus hiccup.
@@ -186,13 +189,19 @@ export function createRuntimeIndexReaper(options: {
    * Serial, because a sweep runs on its own timer and has all the time it
    * needs. `stop` does NOT — see {@link flushPendingResyncsWithinBudget}.
    */
-  async function flushPendingResyncs(): Promise<void> {
+  async function flushPendingResyncs(
+    flushOptions: { keepRecords?: boolean } = {},
+  ): Promise<void> {
     for (const roomCode of Array.from(roomsAwaitingResync)) {
       if (pacer.stopped()) {
         // `stop` is waiting on this sweep and has its own bounded pass to run.
         return;
       }
-      await publishPendingResync(roomCode);
+      await publishPendingResync(
+        roomCode,
+        RESYNC_PUBLISH_TIMEOUT_MS,
+        flushOptions.keepRecords,
+      );
     }
   }
 
@@ -266,16 +275,31 @@ export function createRuntimeIndexReaper(options: {
     const sessions = await options.runtimeStore.listClusterSessions();
     let cleanedSessions = 0;
     const roomsToResync = new Set<string>();
+    /** Durable results of this sweep's member removals; see the push below. */
+    const memberRemovals: Array<Promise<void>> = [];
     for (const session of sessions) {
       if (!session.instanceId || !offlineInstanceIds.has(session.instanceId)) {
         continue;
       }
 
       if (session.roomCode && session.memberId) {
-        await options.runtimeStore.removeMember(
+        // `session` is passed, so `REMOVE_MEMBER_LUA`'s binding guard is armed.
+        // Without it the script HDELs the memberId unconditionally — and this
+        // write can land late, after the member reconnected elsewhere with the
+        // token they were allowed to keep, deleting the NEW session's binding
+        // (#242 review).
+        const removal = options.runtimeStore.removeMember(
           session.roomCode,
           session.memberId,
+          session,
         );
+        // The removal's own durable write is NOT part of `confirmWrites`, which
+        // only ever sees the session write queue. Publishing before it lands
+        // announces a state rebuilt from a member map that still holds the dead
+        // seat (#242 review).
+        if (removal.durable) {
+          memberRemovals.push(removal.durable.catch(() => undefined));
+        }
       }
       if (session.roomCode) {
         // Swallowed, and NOT used to gate the announcement. One unwritable entry
@@ -307,32 +331,37 @@ export function createRuntimeIndexReaper(options: {
     // announcement — see the `markSessionLeftRoom` comment above for why
     // announcing is still better than silence — but an unconfirmed sweep is
     // worth saying out loud.
-    if (options.runtimeStore.confirmWrites) {
-      await pacer
-        .capAttempt(
+    let writesConfirmed = true;
+    const confirmation = options.runtimeStore.confirmWrites
+      ? Promise.all([
           options.runtimeStore.confirmWrites(),
-          WRITE_CONFIRMATION_TIMEOUT_MS,
-          () =>
-            new Error(
-              "Runtime index reaper gave up waiting for its writes to be confirmed.",
-            ),
-        )
-        .catch((error: unknown) => {
-          options.logEvent?.("runtime_index_writes_unconfirmed", {
-            result: "error",
-            error: error instanceof Error ? error.message : String(error),
-          });
+          ...memberRemovals,
+        ]).then(() => undefined)
+      : (options.runtimeStore.flush?.() ?? Promise.resolve());
+    await pacer
+      .capAttempt(confirmation, WRITE_CONFIRMATION_TIMEOUT_MS, () => {
+        return new Error(
+          "Runtime index reaper gave up waiting for its writes to be confirmed.",
+        );
+      })
+      .catch((error: unknown) => {
+        writesConfirmed = false;
+        options.logEvent?.("runtime_index_writes_unconfirmed", {
+          result: "error",
+          error: error instanceof Error ? error.message : String(error),
         });
-    } else {
-      await options.runtimeStore.flush?.();
-    }
+      });
 
     // After the whole sweep, so a room that lost several members to the same
     // dead node is announced once rather than once per seat.
     for (const roomCode of roomsToResync) {
       rememberResync(roomCode);
     }
-    await flushPendingResyncs();
+    // `keepRecords` when the writes were not confirmed: the state this
+    // announcement triggers may still be rebuilt from an index the cleanup has
+    // not reached, and dropping the record on that publish leaves nothing to
+    // announce the real state once the writes do land (#242 review).
+    await flushPendingResyncs({ keepRecords: !writesConfirmed });
 
     const remainingSessions = await options.runtimeStore.listClusterSessions();
     const activeInstanceIds = new Set(

--- a/server/src/runtime-index-reaper.ts
+++ b/server/src/runtime-index-reaper.ts
@@ -1,3 +1,4 @@
+import { createRetryPacer } from "./retry-pacer.js";
 import { clampTimerIntervalMs } from "./timers.js";
 import type { LogEvent } from "./types.js";
 import type { RuntimeStore } from "./runtime-store.js";
@@ -65,24 +66,6 @@ const RESYNC_PUBLISH_TIMEOUT_MS = 2_000;
  */
 const WRITE_CONFIRMATION_TIMEOUT_MS = 2_000;
 
-function withTimeout<T>(
-  work: Promise<T>,
-  timeoutMs: number,
-  onTimeout: () => Error,
-): Promise<T> {
-  let handle: ReturnType<typeof setTimeout> | null = null;
-  return Promise.race([
-    work,
-    new Promise<never>((_resolve, reject) => {
-      handle = setTimeout(() => reject(onTimeout()), Math.max(timeoutMs, 1));
-    }),
-  ]).finally(() => {
-    if (handle !== null) {
-      clearTimeout(handle);
-    }
-  });
-}
-
 export function createRuntimeIndexReaper(options: {
   enabled: boolean;
   runtimeStore: RuntimeIndexReaperStore;
@@ -102,6 +85,13 @@ export function createRuntimeIndexReaper(options: {
   publishRoomStateUpdate?: (roomCode: string) => Promise<void>;
 }) {
   const now = options.now ?? Date.now;
+  // The sweep timer drives the retries here, so the pacer's backoff is unused;
+  // what this file needs from it is the per-attempt cap that does NOT cancel
+  // the call, the record of calls that outlived one, and the stop switch.
+  const pacer = createRetryPacer({
+    initialDelayMs: RESYNC_PUBLISH_TIMEOUT_MS,
+    maxDelayMs: RESYNC_PUBLISH_TIMEOUT_MS,
+  });
   let timer: NodeJS.Timeout | null = null;
   let pendingSweep: Promise<number> | null = null;
   /**
@@ -126,14 +116,6 @@ export function createRuntimeIndexReaper(options: {
    * difference is only that here the retries are driven by the sweep timer.
    */
   const inFlightResyncByRoom = new Map<string, Promise<void>>();
-  /**
-   * Set before `stop` awaits the sweep in flight, so that sweep's own serial
-   * drain of the backlog gives way instead of running to completion. The
-   * backlog is uncapped, so that drain is uncapped too — and `stop` waits for
-   * it BEFORE its own bounded pass ever starts, which is how the step budget
-   * was still being blown (#242 review).
-   */
-  let stopping = false;
 
   function rememberResync(roomCode: string): void {
     const isNew = !roomsAwaitingResync.has(roomCode);
@@ -161,7 +143,6 @@ export function createRuntimeIndexReaper(options: {
       // per-publish cap would otherwise turn every retry into.
       return;
     }
-    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
     try {
       const publish = options.publishRoomStateUpdate?.(roomCode);
       if (publish) {
@@ -175,21 +156,12 @@ export function createRuntimeIndexReaper(options: {
             inFlightResyncByRoom.delete(roomCode);
           }
         });
-        await Promise.race([
+        await pacer.capAttempt(
           publish,
-          new Promise<never>((_resolve, reject) => {
-            timeoutHandle = setTimeout(
-              () => {
-                reject(
-                  new Error(
-                    `Room state resync publish timed out for ${roomCode}.`,
-                  ),
-                );
-              },
-              Math.max(timeoutMs, 1),
-            );
-          }),
-        ]);
+          timeoutMs,
+          () =>
+            new Error(`Room state resync publish timed out for ${roomCode}.`),
+        );
       }
       roomsAwaitingResync.delete(roomCode);
     } catch (error) {
@@ -201,10 +173,6 @@ export function createRuntimeIndexReaper(options: {
         result: "error",
         error: error instanceof Error ? error.message : String(error),
       });
-    } finally {
-      if (timeoutHandle !== null) {
-        clearTimeout(timeoutHandle);
-      }
     }
   }
 
@@ -220,7 +188,7 @@ export function createRuntimeIndexReaper(options: {
    */
   async function flushPendingResyncs(): Promise<void> {
     for (const roomCode of Array.from(roomsAwaitingResync)) {
-      if (stopping) {
+      if (pacer.stopped()) {
         // `stop` is waiting on this sweep and has its own bounded pass to run.
         return;
       }
@@ -266,18 +234,7 @@ export function createRuntimeIndexReaper(options: {
     // A publish that timed out is still on its way to the bus, and the very
     // next shutdown step closes that bus. Give the leftovers what remains of
     // the budget rather than closing under them (#242 review).
-    const leftovers = Array.from(inFlightResyncByRoom.values());
-    if (leftovers.length > 0) {
-      await Promise.race([
-        Promise.allSettled(leftovers),
-        // Not `unref`'d, for the same reason as every other timer here: it is
-        // the only thing that ends this wait, and an idle loop must not drain
-        // past it.
-        new Promise<void>((resolve) => {
-          setTimeout(resolve, Math.max(deadline - now(), 1));
-        }),
-      ]);
-    }
+    await pacer.settleTracked(deadline - now());
     if (roomsAwaitingResync.size > 0) {
       options.logEvent?.("runtime_index_resync_abandoned_at_shutdown", {
         pendingRooms: roomsAwaitingResync.size,
@@ -351,19 +308,21 @@ export function createRuntimeIndexReaper(options: {
     // announcing is still better than silence — but an unconfirmed sweep is
     // worth saying out loud.
     if (options.runtimeStore.confirmWrites) {
-      await withTimeout(
-        options.runtimeStore.confirmWrites(),
-        WRITE_CONFIRMATION_TIMEOUT_MS,
-        () =>
-          new Error(
-            "Runtime index reaper gave up waiting for its writes to be confirmed.",
-          ),
-      ).catch((error: unknown) => {
-        options.logEvent?.("runtime_index_writes_unconfirmed", {
-          result: "error",
-          error: error instanceof Error ? error.message : String(error),
+      await pacer
+        .capAttempt(
+          options.runtimeStore.confirmWrites(),
+          WRITE_CONFIRMATION_TIMEOUT_MS,
+          () =>
+            new Error(
+              "Runtime index reaper gave up waiting for its writes to be confirmed.",
+            ),
+        )
+        .catch((error: unknown) => {
+          options.logEvent?.("runtime_index_writes_unconfirmed", {
+            result: "error",
+            error: error instanceof Error ? error.message : String(error),
+          });
         });
-      });
     } else {
       await options.runtimeStore.flush?.();
     }
@@ -445,7 +404,7 @@ export function createRuntimeIndexReaper(options: {
       return sweep();
     },
     async stop() {
-      stopping = true;
+      pacer.stop();
       if (timer) {
         clearInterval(timer);
         timer = null;

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -19,8 +19,40 @@ type TimedEvent = {
 const COUNTER_WINDOW_MS = 60_000;
 
 export type RuntimeStore = {
-  registerSession: (session: Session) => void;
+  /**
+   * Record the full session snapshot. The returned promise, where the store has
+   * a durable step, settles once that write is confirmed and REJECTS when it is
+   * not.
+   *
+   * Nothing is obliged to await it — the join path deliberately does not, see
+   * `markSessionJoinedRoom` — but a silently swallowed outcome was how a lost
+   * registration used to leave a session hash that later writes only ever
+   * patched a single field into, which `loadSession` reads as "no such session"
+   * (#242).
+   */
+  registerSession: (session: Session) => void | Promise<void>;
+  /**
+   * The queue has EMPTIED. Says nothing about whether the writes in it landed:
+   * it waits on error-swallowed copies, so a failed write drains exactly like a
+   * successful one.
+   *
+   * Use it when the point is ordering — "my own writes are visible to the read I
+   * am about to do". When the point is durability, use
+   * {@link RuntimeStore.confirmWrites}; conflating the two is what let #235's
+   * fixes be built on unconfirmed data (#242).
+   */
   flush?: () => Promise<void>;
+  /**
+   * Every queued session write has been CONFIRMED; rejects with an
+   * `AggregateError` naming the ones that were not.
+   *
+   * Store-wide, not per session: it answers "is the shared view of this node's
+   * sessions complete", which is the question a sweep or a shutdown asks. A
+   * caller that only needs its OWN write confirmed should await that write —
+   * `registerSession`, `markSessionJoinedRoom` and `markSessionLeftRoom` all
+   * report their real outcome.
+   */
+  confirmWrites?: () => Promise<void>;
   purgeSessionsByInstance?: (instanceId: string) => Promise<number>;
   unregisterSession: (sessionId: string) => void;
   /**
@@ -29,6 +61,14 @@ export type RuntimeStore = {
    * bootstrap `room:state` is rebuilt from this index, so a write that has not
    * landed produces a state missing the member who just joined, and every
    * ownership decision taken from it is wrong (#235 review).
+   *
+   * It also re-writes the WHOLE session record, not just the room code. A store
+   * with a durable step cannot assume `registerSession` landed, and a join that
+   * patched only `roomCode` on top of a missing registration produced a session
+   * hash with no `id` — which reads back as no session at all, so the joiner was
+   * absent from every state built from the shared view (#242). Folding the two
+   * into one write means the join either seats the member completely or not at
+   * all, and a lost registration heals at the next join.
    */
   markSessionJoinedRoom: (sessionId: string, roomCode: string) => Promise<void>;
   /**

--- a/server/src/ws-session-handler.ts
+++ b/server/src/ws-session-handler.ts
@@ -249,7 +249,7 @@ export function createWsConnectionHandler(args: {
     };
 
     args.securityPolicy.incrementConnectionCount(session.remoteAddress);
-    args.runtimeStore.registerSession(session);
+    void args.runtimeStore.registerSession(session);
     args.wsHeartbeat?.track(socket, session);
     args.logEvent("ws_connection_accepted", {
       sessionId: session.id,

--- a/server/src/ws-session-handler.ts
+++ b/server/src/ws-session-handler.ts
@@ -66,7 +66,7 @@ export async function cleanupSessionAfterClose(options: {
   code: number;
   reason: Buffer;
   messageHandler: {
-    leaveRoom: (session: Session, reason?: LeaveRoomReason) => Promise<void>;
+    leaveRoom: (session: Session, reason?: LeaveRoomReason) => Promise<unknown>;
   };
   runtimeStore: Pick<RuntimeStore, "unregisterSession">;
   securityPolicy: {
@@ -216,7 +216,7 @@ export function createWsConnectionHandler(args: {
       session: Session,
       message: ClientMessage,
     ) => Promise<void>;
-    leaveRoom: (session: Session, reason?: LeaveRoomReason) => Promise<void>;
+    leaveRoom: (session: Session, reason?: LeaveRoomReason) => Promise<unknown>;
   };
   logEvent: LogEvent;
   pendingSessionCleanup: Set<Promise<void>>;

--- a/server/test/durable-write-queue.test.ts
+++ b/server/test/durable-write-queue.test.ts
@@ -326,3 +326,50 @@ test("durable write queue holds the key until an abandoned command really finish
     "rollback-ran",
   ]);
 });
+
+test("durable write queue waits for the abandoned command before it retries", async () => {
+  // A timed-out attempt races its command rather than aborting it. Starting the
+  // next attempt straight away left up to `maxAttempts` uncancellable commands
+  // out at once for a single write — and the internal retries never go back
+  // through the store's capacity check, so nothing saw them (#242 review).
+  let live = 0;
+  let peak = 0;
+  const releases: Array<() => void> = [];
+  const started: Array<Promise<void>> = [];
+  const queue = createDurableWriteQueue({
+    maxAttempts: 4,
+    sleep: () => Promise.resolve(),
+  });
+
+  const outcome = queue.enqueue({
+    key: "session-a",
+    operationName: "write",
+    run: async () => {
+      const command = new Promise<void>((resolve) => {
+        live += 1;
+        peak = Math.max(peak, live);
+        releases.push(() => {
+          live -= 1;
+          resolve();
+        });
+      });
+      started.push(command);
+      // Stands in for the raced attempt timeout: the attempt gives up while the
+      // command it started is still running.
+      throw new Error("attempt timed out");
+    },
+    settle: async () => {
+      await Promise.all(started);
+    },
+  });
+  outcome.catch(() => undefined);
+
+  // Let every retry that is going to happen happen.
+  for (let tick = 0; tick < 8; tick += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    releases.shift()?.();
+  }
+  await assert.rejects(outcome, /timed out/);
+
+  assert.equal(peak, 1, `one live command per write at a time, saw ${peak}`);
+});

--- a/server/test/durable-write-queue.test.ts
+++ b/server/test/durable-write-queue.test.ts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createDurableWriteQueue,
+  NonRetryableWriteError,
+  SupersededWriteError,
+} from "../src/durable-write-queue.js";
+
+/** Runs the backoff instantly and records what the queue asked to wait. */
+function createSleepRecorder(): {
+  delays: number[];
+  sleep: (delayMs: number) => Promise<void>;
+} {
+  const delays: number[] = [];
+  return {
+    delays,
+    sleep: (delayMs) => {
+      delays.push(delayMs);
+      return Promise.resolve();
+    },
+  };
+}
+
+test("durable write queue retries a failed write instead of dropping it", async () => {
+  const { delays, sleep } = createSleepRecorder();
+  const queue = createDurableWriteQueue({
+    sleep,
+    initialRetryDelayMs: 10,
+    maxRetryDelayMs: 40,
+  });
+  let attempts = 0;
+
+  await queue.enqueue({
+    key: "session-a",
+    operationName: "write",
+    run: async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        throw new Error("redis blip");
+      }
+    },
+  });
+
+  assert.equal(attempts, 3);
+  // Exponential, capped.
+  assert.deepEqual(delays, [10, 20]);
+});
+
+test("durable write queue reports the failure once the attempts run out", async () => {
+  const { sleep } = createSleepRecorder();
+  const queue = createDurableWriteQueue({ sleep, maxAttempts: 2 });
+  let attempts = 0;
+
+  await assert.rejects(
+    queue.enqueue({
+      key: "session-a",
+      operationName: "write",
+      run: async () => {
+        attempts += 1;
+        throw new Error("redis down");
+      },
+    }),
+    /redis down/,
+  );
+  assert.equal(attempts, 2);
+});
+
+test("durable write queue does not retry a write that can never apply", async () => {
+  const { sleep } = createSleepRecorder();
+  const queue = createDurableWriteQueue({ sleep, maxAttempts: 5 });
+  let attempts = 0;
+
+  await assert.rejects(
+    queue.enqueue({
+      key: "session-a",
+      operationName: "write",
+      run: async () => {
+        attempts += 1;
+        throw new NonRetryableWriteError("code recycled", "generation");
+      },
+    }),
+    /code recycled/,
+  );
+  assert.equal(attempts, 1);
+});
+
+test("durable write queue keeps writes for one key strictly ordered", async () => {
+  const queue = createDurableWriteQueue();
+  const order: string[] = [];
+  const release: Array<() => void> = [];
+
+  const first = queue.enqueue({
+    key: "session-a",
+    operationName: "first",
+    run: () =>
+      new Promise<void>((resolve) => {
+        order.push("first-start");
+        release.push(() => {
+          order.push("first-end");
+          resolve();
+        });
+      }),
+  });
+  const second = queue.enqueue({
+    key: "session-a",
+    operationName: "second",
+    run: async () => {
+      order.push("second-start");
+    },
+  });
+
+  // The second write must not have started while the first was running.
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.deepEqual(order, ["first-start"]);
+  release[0]?.();
+  await Promise.all([first, second]);
+  assert.deepEqual(order, ["first-start", "first-end", "second-start"]);
+});
+
+test("durable write queue abandons a retry once a newer write for the key arrives", async () => {
+  // A retry that outlives the write meant to replace it fights it rather than
+  // helping it — the newer write is the one describing the state the caller
+  // wants (#242).
+  let releaseSleep: (() => void) | null = null;
+  const queue = createDurableWriteQueue({
+    maxAttempts: 5,
+    sleep: () =>
+      new Promise<void>((resolve) => {
+        releaseSleep = resolve;
+      }),
+  });
+  let staleAttempts = 0;
+
+  const stale = queue.enqueue({
+    key: "session-a",
+    operationName: "stale",
+    run: async () => {
+      staleAttempts += 1;
+      throw new Error("redis blip");
+    },
+  });
+  stale.catch(() => undefined);
+  // Let the first attempt fail and park in the backoff.
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(staleAttempts, 1);
+
+  const fresh = queue.enqueue({
+    key: "session-a",
+    operationName: "fresh",
+    run: async () => undefined,
+  });
+  (releaseSleep as (() => void) | null)?.();
+
+  await assert.rejects(stale, SupersededWriteError);
+  await fresh;
+  assert.equal(staleAttempts, 1, "the superseded write must not try again");
+});
+
+test("durable write queue separates draining from confirming", async () => {
+  const queue = createDurableWriteQueue({
+    maxAttempts: 1,
+    sleep: () => Promise.resolve(),
+  });
+  const failed = queue.enqueue({
+    key: "session-a",
+    operationName: "write",
+    run: async () => {
+      throw new Error("redis down");
+    },
+  });
+  failed.catch(() => undefined);
+
+  // Draining says only that the queue emptied — the conflation #242 ends.
+  await queue.drain();
+  assert.equal(queue.size(), 0);
+  await assert.rejects(queue.confirm(), /not confirmed/);
+});
+
+test("durable write queue remembers a failure until it is confirmed away", async () => {
+  const queue = createDurableWriteQueue({
+    maxAttempts: 1,
+    sleep: () => Promise.resolve(),
+  });
+  queue
+    .enqueue({
+      key: "session-a",
+      operationName: "write",
+      run: async () => {
+        throw new Error("redis down");
+      },
+    })
+    .catch(() => undefined);
+  await queue.drain();
+
+  await assert.rejects(queue.confirm(), /not confirmed/);
+  // Reading clears it: the answer is "since you last asked".
+  await queue.confirm();
+});
+
+test("durable write queue does not count a superseded write as unconfirmed", async () => {
+  let releaseSleep: (() => void) | null = null;
+  const queue = createDurableWriteQueue({
+    maxAttempts: 5,
+    sleep: () =>
+      new Promise<void>((resolve) => {
+        releaseSleep = resolve;
+      }),
+  });
+
+  const stale = queue.enqueue({
+    key: "session-a",
+    operationName: "stale",
+    run: async () => {
+      throw new Error("redis blip");
+    },
+  });
+  stale.catch(() => undefined);
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  const fresh = queue.enqueue({
+    key: "session-a",
+    operationName: "fresh",
+    run: async () => undefined,
+  });
+  (releaseSleep as (() => void) | null)?.();
+  await assert.rejects(stale, SupersededWriteError);
+  await fresh;
+
+  // The newer write landed, so the key IS in the state the caller wanted.
+  await queue.confirm();
+});

--- a/server/test/durable-write-queue.test.ts
+++ b/server/test/durable-write-queue.test.ts
@@ -228,3 +228,47 @@ test("durable write queue does not count a superseded write as unconfirmed", asy
   // The newer write landed, so the key IS in the state the caller wanted.
   await queue.confirm();
 });
+
+test("durable write queue drops writes that have not started once it is winding down", async () => {
+  // A queue can hold several writes for one session, and they run one at a
+  // time. Letting each still open an attempt held the close step for a whole
+  // attempt timeout apiece, so the step overran and the process exited non-zero
+  // over writes nobody was waiting for (#242 review). What survives
+  // `stopRetrying` is bounded by ONE attempt: the one already running.
+  const started: string[] = [];
+  let releaseFirst: (() => void) | null = null;
+  const queue = createDurableWriteQueue({ sleep: () => Promise.resolve() });
+
+  const first = queue.enqueue({
+    key: "session-a",
+    operationName: "first",
+    run: () =>
+      new Promise<void>((resolve) => {
+        started.push("first");
+        releaseFirst = resolve;
+      }),
+  });
+  const queued = ["second", "third"].map((operationName) => {
+    const outcome = queue.enqueue({
+      key: "session-a",
+      operationName,
+      run: async () => {
+        started.push(operationName);
+      },
+    });
+    outcome.catch(() => undefined);
+    return outcome;
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.deepEqual(started, ["first"], "only the first write may be running");
+
+  queue.stopRetrying();
+  (releaseFirst as (() => void) | null)?.();
+
+  await first;
+  for (const outcome of queued) {
+    await assert.rejects(outcome, /shutting down/);
+  }
+  assert.deepEqual(started, ["first"]);
+});

--- a/server/test/durable-write-queue.test.ts
+++ b/server/test/durable-write-queue.test.ts
@@ -373,3 +373,52 @@ test("durable write queue waits for the abandoned command before it retries", as
 
   assert.equal(peak, 1, `one live command per write at a time, saw ${peak}`);
 });
+
+test("durable write queue answers queued writes as soon as it is told to stop", async () => {
+  // A write queued behind a key whose command never comes back was out of reach
+  // of the stop check: `close()` then sat on an outcome that could never settle
+  // and the shutdown step was guaranteed to overrun (#242 review).
+  // `maxAttempts: 1`, so the first write is ANSWERED while its command is still
+  // out; with retries it would be blocked on that same command by design.
+  const queue = createDurableWriteQueue({
+    maxAttempts: 1,
+    sleep: () => Promise.resolve(),
+  });
+  let releaseCommand: (() => void) | null = null;
+  const command = new Promise<void>((resolve) => {
+    releaseCommand = resolve;
+  });
+
+  const first = queue.enqueue({
+    key: "session-a",
+    operationName: "first",
+    run: async () => {
+      // Stands in for the raced attempt timeout: answered, command still out.
+      throw new Error("attempt timed out");
+    },
+    settle: () => command,
+  });
+  first.catch(() => undefined);
+  await assert.rejects(first, /timed out/);
+
+  let secondRan = false;
+  const second = queue.enqueue({
+    key: "session-a",
+    operationName: "second",
+    run: async () => {
+      secondRan = true;
+    },
+  });
+  second.catch(() => undefined);
+
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(secondRan, false, "it is queued behind the live command");
+
+  queue.stopRetrying();
+  // Answered immediately, without waiting for the command that will not answer.
+  await assert.rejects(second, /shutting down/);
+  assert.equal(secondRan, false, "and it must not run either");
+
+  (releaseCommand as (() => void) | null)?.();
+  await queue.drain();
+});

--- a/server/test/durable-write-queue.test.ts
+++ b/server/test/durable-write-queue.test.ts
@@ -272,3 +272,57 @@ test("durable write queue drops writes that have not started once it is winding 
   }
   assert.deepEqual(started, ["first"]);
 });
+
+test("durable write queue holds the key until an abandoned command really finishes", async () => {
+  // A timeout races a command, it cannot abort one. Releasing the key when the
+  // caller is answered lets the compensating write — queued on this same key —
+  // run FIRST, and the abandoned command then lands on top of its own rollback
+  // (#242 review).
+  const order: string[] = [];
+  let releaseAbandoned: (() => void) | null = null;
+  const queue = createDurableWriteQueue({
+    maxAttempts: 1,
+    sleep: () => Promise.resolve(),
+  });
+
+  const abandonedCommand = new Promise<void>((resolve) => {
+    releaseAbandoned = () => {
+      order.push("abandoned-command-landed");
+      resolve();
+    };
+  });
+
+  const gaveUp = queue.enqueue({
+    key: "session-a",
+    operationName: "join",
+    run: async () => {
+      // Stands in for the raced timeout: the attempt reports failure while the
+      // command it started keeps going.
+      throw new Error("attempt timed out");
+    },
+    settle: () => abandonedCommand,
+  });
+  await assert.rejects(gaveUp, /timed out/);
+  order.push("caller-answered");
+
+  // The rollback the caller now performs.
+  const rollback = queue.enqueue({
+    key: "session-a",
+    operationName: "leave",
+    run: async () => {
+      order.push("rollback-ran");
+    },
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.deepEqual(order, ["caller-answered"], "the rollback must wait");
+
+  (releaseAbandoned as (() => void) | null)?.();
+  await rollback;
+
+  assert.deepEqual(order, [
+    "caller-answered",
+    "abandoned-command-landed",
+    "rollback-ran",
+  ]);
+});

--- a/server/test/graceful-shutdown.test.ts
+++ b/server/test/graceful-shutdown.test.ts
@@ -121,10 +121,10 @@ test("SIGINT is handled as well", async () => {
   assert.deepEqual(harness.exitCodes, [0]);
 });
 
-test("a shutdown step failure exits with code 1", async () => {
+test("a shutdown step that threw exits with code 1", async () => {
   const harness = createHarness();
   install(harness, async () => [
-    { step: "close_room_store", result: "timeout", error: "…" },
+    { step: "close_room_store", result: "error", error: "…" },
   ]);
 
   harness.signalTarget.emit("SIGTERM");
@@ -132,10 +132,46 @@ test("a shutdown step failure exits with code 1", async () => {
 
   assert.deepEqual(harness.exitCodes, [1]);
   assert.ok(
-    harness.errors.some((line) => line.includes("close_room_store (timeout)")),
+    harness.errors.some((line) => line.includes("close_room_store (error)")),
     `Missing failed-step log: ${harness.errors.join(" | ")}`,
   );
   assert.ok(!harness.logs.some((line) => line.includes("shutdown complete")));
+});
+
+test("a shutdown step that only ran out of its budget still exits cleanly", async () => {
+  // The budget exists because the work these steps wait on is I/O this process
+  // cannot cancel. Giving up on it is the designed outcome, not a fault —
+  // exiting non-zero for it turned every "what if this particular call hangs?"
+  // into a correctness claim with no last answer (#242).
+  const harness = createHarness();
+  install(harness, async () => [
+    { step: "close_shared_runtime_store", result: "timeout", error: "…" },
+  ]);
+
+  harness.signalTarget.emit("SIGTERM");
+  await flush();
+
+  assert.deepEqual(harness.exitCodes, [0]);
+  // Still loud: only the exit code distinguishes the two.
+  assert.ok(
+    harness.errors.some((line) =>
+      line.includes("close_shared_runtime_store (timeout)"),
+    ),
+    `Missing degraded-step log: ${harness.errors.join(" | ")}`,
+  );
+});
+
+test("a shutdown that timed out AND threw still exits with code 1", async () => {
+  const harness = createHarness();
+  install(harness, async () => [
+    { step: "close_shared_runtime_store", result: "timeout", error: "…" },
+    { step: "close_room_store", result: "error", error: "…" },
+  ]);
+
+  harness.signalTarget.emit("SIGTERM");
+  await flush();
+
+  assert.deepEqual(harness.exitCodes, [1]);
 });
 
 test("close runs once even if more signals arrive during shutdown", async () => {

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -3061,10 +3061,13 @@ test("a join whose rollback succeeds leaves the connection alone", async () => {
 async function runAbortedJoin(options: {
   leaveResult?: { room: { code: string } | null; notifyRoom?: boolean };
   leaveThrows?: boolean;
+  leaveNeverSettles?: boolean;
   roomLeftHookFails?: boolean;
-}): Promise<{ closes: number[]; errors: string[] }> {
+  joinRollbackTimeoutMs?: number;
+}): Promise<{ closes: number[]; errors: string[]; events: string[] }> {
   const closes: number[] = [];
   const errors: string[] = [];
+  const events: string[] = [];
   const session = createSession("member-1");
   (
     session.socket as unknown as { close: (c: number, r: string) => void }
@@ -3085,6 +3088,11 @@ async function runAbortedJoin(options: {
         return { room: { code: "ROOM01" }, memberToken: "member-token-1" };
       },
       async leaveRoomForSession() {
+        if (options.leaveNeverSettles) {
+          // The rollback's own index write is queued behind a command that
+          // never answers: it neither resolves nor rejects.
+          await new Promise<void>(() => {});
+        }
         if (options.leaveThrows) {
           throw new Error("leave persistence failed");
         }
@@ -3106,13 +3114,16 @@ async function runAbortedJoin(options: {
         throw new Error("unreachable");
       },
     },
-    logEvent() {},
+    logEvent(event) {
+      events.push(event);
+    },
     send() {},
     sendError(_socket, code) {
       errors.push(code);
     },
     async publishRoomEvent() {},
     instanceId: "node-a",
+    joinRollbackTimeoutMs: options.joinRollbackTimeoutMs,
     async onRoomJoined() {
       throw new Error("runtime index unavailable");
     },
@@ -3132,7 +3143,7 @@ async function runAbortedJoin(options: {
     },
   });
   await handler.flushPendingPublishes();
-  return { closes, errors };
+  return { closes, errors, events };
 }
 
 test("an aborted join drops the socket when the leave call throws", async () => {
@@ -3163,4 +3174,18 @@ test("an aborted join whose rollback cleaned the index keeps the connection", as
   const { closes, errors } = await runAbortedJoin({});
   assert.deepEqual(errors, ["internal_error"]);
   assert.deepEqual(closes, [], "the client may retry on the same socket");
+});
+
+test("an aborted join answers the client when its rollback never settles", async () => {
+  // The rollback's index write queues behind the join write's command, and a
+  // command that never answers neither resolves nor rejects — so the error and
+  // the socket close were unreachable and the client sat on a join that had
+  // already failed (#242 review).
+  const { closes, errors, events } = await runAbortedJoin({
+    leaveNeverSettles: true,
+    joinRollbackTimeoutMs: 30,
+  });
+  assert.deepEqual(errors, ["internal_error"]);
+  assert.deepEqual(closes, [1011]);
+  assert.ok(events.includes("room_join_rollback_timeout"));
 });

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -1964,6 +1964,7 @@ function createSharedOwnerHandler(options: {
   publishedRooms?: string[];
   enterRoomFails?: boolean;
   roomLeftHookFails?: boolean;
+  roomJoinedHookFails?: boolean;
 }) {
   return createMessageHandler({
     config: CONFIG,
@@ -2057,6 +2058,10 @@ function createSharedOwnerHandler(options: {
     },
     onRoomJoined() {
       options.hookOrder?.push("room-joined-hook");
+      if (options.roomJoinedHookFails) {
+        // Stands in for the room-index write failing, which refuses the join.
+        throw new Error("runtime index unavailable");
+      }
     },
   });
 }
@@ -2873,4 +2878,76 @@ test("a create that fails after leaving still resyncs the old room when the inde
   await handler.flushPendingPublishes();
 
   assert.deepEqual(published, ["room_member_left", "room_state_updated"]);
+});
+
+test("a rolled-back room switch still resyncs the old room it cleanly left", async () => {
+  // The refused join is the NEW room's problem. The old room was cleanly left,
+  // so it is still owed its full state — and if the leaver held the share,
+  // silence there means every client keeps a `sharedByMemberId` naming them and
+  // the room stops advancing (#242 review).
+  const published: string[] = [];
+  const publishedRooms: string[] = [];
+  const session = createSession("member-1", {
+    roomCode: "OLDR04",
+    memberId: "member-1",
+    memberToken: "member-token-1",
+  });
+
+  const handler = createSharedOwnerHandler({
+    published,
+    publishedRooms,
+    joinedRoomCode: "NEWR04",
+    roomJoinedHookFails: true,
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "NEWR04",
+      joinToken: "join-token-1",
+      protocolVersion: 2,
+    },
+  });
+  await handler.flushPendingPublishes();
+
+  // The abort's own leave announces the NEW room; what matters here is that the
+  // OLD room got its full state as well as its delta.
+  const oldRoomEvents = published.filter(
+    (_type, index) => publishedRooms[index] === "OLDR04",
+  );
+  assert.deepEqual(oldRoomEvents, ["room_member_left", "room_state_updated"]);
+});
+
+test("a rolled-back room switch stays silent when the old room was not cleanly left", async () => {
+  const published: string[] = [];
+  const session = createSession("member-1", {
+    roomCode: "OLDR05",
+    memberId: "member-1",
+    memberToken: "member-token-1",
+  });
+
+  const publishedRooms: string[] = [];
+  const handler = createSharedOwnerHandler({
+    published,
+    publishedRooms,
+    joinedRoomCode: "NEWR05",
+    roomJoinedHookFails: true,
+    roomLeftHookFails: true,
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "NEWR05",
+      joinToken: "join-token-1",
+      protocolVersion: 2,
+    },
+  });
+  await handler.flushPendingPublishes();
+
+  // Neither hook landed, so nothing can vouch for the old room's index.
+  const oldRoomEvents = published.filter(
+    (_type, index) => publishedRooms[index] === "OLDR05",
+  );
+  assert.deepEqual(oldRoomEvents, ["room_member_left"]);
 });

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -2951,3 +2951,104 @@ test("a rolled-back room switch stays silent when the old room was not cleanly l
   );
   assert.deepEqual(oldRoomEvents, ["room_member_left"]);
 });
+
+test("a join whose rollback fails drops the socket instead of claiming it was aborted", async () => {
+  // `leaveCurrentRoom` RESTORES the member when its own persistence fails and
+  // the socket is still open. Telling the client the join failed while the
+  // server still holds it as a member leaves the two disagreeing, and that
+  // connection can go on driving playback from a seat the shared index never
+  // received (#242 review).
+  const errors: string[] = [];
+  const closes: Array<{ code: number; reason: string }> = [];
+  const events: string[] = [];
+  const session = createSession("member-1");
+  (
+    session.socket as unknown as { close: (c: number, r: string) => void }
+  ).close = (code, reason) => {
+    closes.push({ code, reason });
+  };
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession(currentSession) {
+        currentSession.roomCode = "ROOM01";
+        currentSession.memberId = "member-1";
+        currentSession.memberToken = "member-token-1";
+        return { room: { code: "ROOM01" }, memberToken: "member-token-1" };
+      },
+      async leaveRoomForSession() {
+        // The rollback cannot complete: the member stays seated.
+        throw new Error("leave persistence failed");
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent(event) {
+      events.push(event);
+    },
+    send() {},
+    sendError(_socket, code) {
+      errors.push(code);
+    },
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+    async onRoomJoined() {
+      throw new Error("runtime index unavailable");
+    },
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      protocolVersion: 2,
+    },
+  });
+
+  assert.deepEqual(errors, ["internal_error"]);
+  assert.ok(events.includes("room_join_rollback_failed"));
+  assert.deepEqual(closes, [{ code: 1011, reason: "join_rollback_failed" }]);
+});
+
+test("a join whose rollback succeeds leaves the connection alone", async () => {
+  const closes: number[] = [];
+  const session = createSession("member-1");
+  (
+    session.socket as unknown as { close: (c: number, r: string) => void }
+  ).close = (code) => {
+    closes.push(code);
+  };
+
+  const handler = createSharedOwnerHandler({
+    published: [],
+    roomJoinedHookFails: true,
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      protocolVersion: 2,
+    },
+  });
+  await handler.flushPendingPublishes();
+
+  // The seat came back, so the client may simply retry on the same socket.
+  assert.deepEqual(closes, []);
+});

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -2700,3 +2700,88 @@ test("shutdown drains the retrying shared-owner resync, not just the one-shot pu
   await handler.flushPendingPublishes();
   assert.deepEqual(published, ["room_member_left", "room_state_updated"]);
 });
+
+test("the final publish flush does not let a resync record open a second batch", async () => {
+  // `flush_pending_room_event_publishes` is sized for one retry budget. A
+  // request that arrived mid-batch earns a fresh one at runtime, which at
+  // shutdown is two budgets in a step sized for one (#242 review).
+  const published: string[] = [];
+  let releaseFirstResync: (() => void) | null = null;
+  const session = createSession("member-1", {
+    roomCode: "ROOM01",
+    memberId: "member-1",
+    memberToken: "member-token-1",
+  });
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession(currentSession) {
+        currentSession.roomCode = null;
+        return {
+          room: { code: "ROOM01" },
+          memberRemoved: true,
+          needsRoomStateResync: true,
+        };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent() {},
+    send() {},
+    sendError() {},
+    publishRoomEvent(message) {
+      published.push(message.type);
+      if (message.type === "room_state_updated" && !releaseFirstResync) {
+        return new Promise<void>((resolve) => {
+          releaseFirstResync = resolve;
+        });
+      }
+      return Promise.resolve();
+    },
+    instanceId: "node-a",
+    sharedOwnerResyncRetry: {
+      initialRetryDelayMs: 1,
+      sleep: () => Promise.resolve(),
+    },
+  });
+
+  // Two leaves: the second asks for a resync while the first one's publish is
+  // still in flight, which is what would earn the extra batch.
+  await handler.handleClientMessage(session, {
+    type: "room:leave",
+    payload: { memberToken: "member-token-1" },
+  });
+  session.roomCode = "ROOM01";
+  session.memberId = "member-1";
+  await handler.handleClientMessage(session, {
+    type: "room:leave",
+    payload: { memberToken: "member-token-1" },
+  });
+
+  const flushed = handler.flushPendingPublishes({ final: true });
+  (releaseFirstResync as (() => void) | null)?.();
+  await flushed;
+
+  assert.equal(
+    published.filter((type) => type === "room_state_updated").length,
+    1,
+    "the wind-down must not open a second resync batch",
+  );
+});

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -2785,3 +2785,92 @@ test("the final publish flush does not let a resync record open a second batch",
     "the wind-down must not open a second resync batch",
   );
 });
+
+test("a room switch withholds the old room's full state until the join write re-stamps the session", async () => {
+  // #235 published it unconditionally on the reasoning that "a switcher's
+  // session hash already names the NEW room". That hash is written by
+  // `onRoomLeft`'s own `registerSession`, so when the hook fails it can still
+  // name the OLD room, and the state hands the switcher back in — share and all
+  // (#242 review). Publishing after the JOIN hook makes it safe unconditionally:
+  // that write re-stamps the whole session record under the new room code.
+  const order: string[] = [];
+  const session = createSession("member-1", {
+    roomCode: "OLDR01",
+    memberId: "member-1",
+    memberToken: "member-token-1",
+  });
+
+  const handler = createSharedOwnerHandler({
+    published: [],
+    publishedRooms: [],
+    joinedRoomCode: "NEWR01",
+    hookOrder: order,
+    roomLeftHookFails: true,
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "NEWR01",
+      joinToken: "join-token-1",
+      protocolVersion: 2,
+    },
+  });
+  await handler.flushPendingPublishes();
+
+  // The leave hook ran and failed; the join hook then re-stamped the record.
+  assert.deepEqual(order, ["room-left-hook", "room-joined-hook"]);
+});
+
+test("a create that fails after leaving withholds the old room's state when the index is dirty", async () => {
+  // Nothing re-stamps this session: the create failed, so it is in no room and
+  // no later write carries the old code. A state built from an index the hook
+  // could not clear still lists the switcher (#242 review).
+  const published: string[] = [];
+  const publishedRooms: string[] = [];
+  const session = createSession("member-1", {
+    roomCode: "OLDR02",
+    memberId: "member-1",
+    memberToken: "member-token-1",
+  });
+
+  const handler = createSharedOwnerHandler({
+    published,
+    publishedRooms,
+    enterRoomFails: true,
+    roomLeftHookFails: true,
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:create",
+    payload: { displayName: "Alice" },
+  });
+  await handler.flushPendingPublishes();
+
+  // The delta still goes out — it reads no state, so a dirty index cannot
+  // corrupt it — but the full state does not.
+  assert.deepEqual(published, ["room_member_left"]);
+  assert.deepEqual(publishedRooms, ["OLDR02"]);
+});
+
+test("a create that fails after leaving still resyncs the old room when the index was cleared", async () => {
+  const published: string[] = [];
+  const session = createSession("member-1", {
+    roomCode: "OLDR03",
+    memberId: "member-1",
+    memberToken: "member-token-1",
+  });
+
+  const handler = createSharedOwnerHandler({
+    published,
+    enterRoomFails: true,
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:create",
+    payload: { displayName: "Alice" },
+  });
+  await handler.flushPendingPublishes();
+
+  assert.deepEqual(published, ["room_member_left", "room_state_updated"]);
+});

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -3052,3 +3052,115 @@ test("a join whose rollback succeeds leaves the connection alone", async () => {
   // The seat came back, so the client may simply retry on the same socket.
   assert.deepEqual(closes, []);
 });
+
+/**
+ * `abortJoin` must treat all three ways the rollback can fail to clean the room
+ * index the same. Only one of them throws; the other two resolve normally, and
+ * my first fix only covered the throwing one (#242 review).
+ */
+async function runAbortedJoin(options: {
+  leaveResult?: { room: { code: string } | null; notifyRoom?: boolean };
+  leaveThrows?: boolean;
+  roomLeftHookFails?: boolean;
+}): Promise<{ closes: number[]; errors: string[] }> {
+  const closes: number[] = [];
+  const errors: string[] = [];
+  const session = createSession("member-1");
+  (
+    session.socket as unknown as { close: (c: number, r: string) => void }
+  ).close = (code) => {
+    closes.push(code);
+  };
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession(currentSession) {
+        currentSession.roomCode = "ROOM01";
+        currentSession.memberId = "member-1";
+        currentSession.memberToken = "member-token-1";
+        return { room: { code: "ROOM01" }, memberToken: "member-token-1" };
+      },
+      async leaveRoomForSession() {
+        if (options.leaveThrows) {
+          throw new Error("leave persistence failed");
+        }
+        return {
+          memberRemoved: true,
+          ...(options.leaveResult ?? { room: { code: "ROOM01" } }),
+        };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent() {},
+    send() {},
+    sendError(_socket, code) {
+      errors.push(code);
+    },
+    async publishRoomEvent() {},
+    instanceId: "node-a",
+    async onRoomJoined() {
+      throw new Error("runtime index unavailable");
+    },
+    onRoomLeft() {
+      if (options.roomLeftHookFails) {
+        throw new Error("index cleanup failed");
+      }
+    },
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:join",
+    payload: {
+      roomCode: "ROOM01",
+      joinToken: "join-token-1",
+      protocolVersion: 2,
+    },
+  });
+  await handler.flushPendingPublishes();
+  return { closes, errors };
+}
+
+test("an aborted join drops the socket when the leave call throws", async () => {
+  const { closes, errors } = await runAbortedJoin({ leaveThrows: true });
+  assert.deepEqual(errors, ["internal_error"]);
+  assert.deepEqual(closes, [1011]);
+});
+
+test("an aborted join drops the socket when the room-left hook reports failure", async () => {
+  // Resolves normally — `runRoomLeftHook` swallows the error — so only the
+  // RETURNED verdict reveals that the index was never cleaned.
+  const { closes, errors } = await runAbortedJoin({ roomLeftHookFails: true });
+  assert.deepEqual(errors, ["internal_error"]);
+  assert.deepEqual(closes, [1011]);
+});
+
+test("an aborted join drops the socket when the leave never reaches the hook", async () => {
+  // `!room && !notifyRoom` returns before `runRoomLeftHook` runs at all, so
+  // `markSessionLeftRoom` never went out and the index still lists the session.
+  const { closes, errors } = await runAbortedJoin({
+    leaveResult: { room: null },
+  });
+  assert.deepEqual(errors, ["internal_error"]);
+  assert.deepEqual(closes, [1011]);
+});
+
+test("an aborted join whose rollback cleaned the index keeps the connection", async () => {
+  const { closes, errors } = await runAbortedJoin({});
+  assert.deepEqual(errors, ["internal_error"]);
+  assert.deepEqual(closes, [], "the client may retry on the same socket");
+});

--- a/server/test/message-handler.test.ts
+++ b/server/test/message-handler.test.ts
@@ -252,7 +252,13 @@ test("message handler keeps room:create successful when bootstrap state fails", 
   assert.ok(events.includes("room_created"));
 });
 
-test("message handler keeps room:create successful when room join hook fails", async () => {
+test("message handler aborts room:create when the room join hook fails", async () => {
+  // The hook puts the session into the room index, and everything the create
+  // sends next is read back off that index. Carrying on used to seat a member
+  // the room could not see: their bootstrap state was missing them, and a
+  // stored sharer reconnecting into that room got a stand-in owner with no full
+  // state to follow (#242).
+  const leaveReasons: (string | undefined)[] = [];
   const sent: string[] = [];
   const errors: string[] = [];
   const events: string[] = [];
@@ -274,7 +280,8 @@ test("message handler keeps room:create successful when room join hook fails", a
       async joinRoomForSession() {
         throw new Error("unreachable");
       },
-      async leaveRoomForSession() {
+      async leaveRoomForSession(_session, reason) {
+        leaveReasons.push(reason);
         return { room: null };
       },
       async shareVideoForSession() {
@@ -316,10 +323,14 @@ test("message handler keeps room:create successful when room join hook fails", a
     payload: { displayName: "Alice" },
   });
 
-  assert.deepEqual(sent, ["room:created", "room:state"]);
-  assert.deepEqual(errors, []);
+  assert.deepEqual(sent, []);
+  assert.deepEqual(errors, ["internal_error"]);
   assert.ok(events.includes("room_join_hook_failed"));
-  assert.ok(events.includes("room_created"));
+  assert.ok(events.includes("room_join_aborted"));
+  assert.equal(events.includes("room_created"), false);
+  // `"disconnect"`, so a reconnecting member keeps the identity the whole
+  // ownership rule depends on.
+  assert.deepEqual(leaveReasons, ["disconnect"]);
 });
 
 test("message handler skips room state publish when playback update is ignored", async () => {
@@ -1382,7 +1393,11 @@ test("message handler keeps room:join successful when bootstrap state fails", as
   assert.ok(events.includes("room_joined"));
 });
 
-test("message handler keeps room:join successful when room join hook fails", async () => {
+test("message handler aborts room:join when the room join hook fails", async () => {
+  // Mirror of the create path: a joiner the room index never received is
+  // missing from every state built off the shared view, so refusing the join —
+  // which the client simply retries — beats seating them (#242).
+  const leaveReasons: (string | undefined)[] = [];
   const sent: string[] = [];
   const errors: string[] = [];
   const events: string[] = [];
@@ -1404,7 +1419,8 @@ test("message handler keeps room:join successful when room join hook fails", asy
           memberToken: "member-token-2",
         };
       },
-      async leaveRoomForSession() {
+      async leaveRoomForSession(_session, reason) {
+        leaveReasons.push(reason);
         return { room: null };
       },
       async shareVideoForSession() {
@@ -1451,12 +1467,16 @@ test("message handler keeps room:join successful when room join hook fails", asy
       protocolVersion: 2,
     },
   });
+  await handler.flushPendingPublishes();
 
-  assert.deepEqual(sent, ["room:joined", "room:state"]);
-  assert.deepEqual(errors, []);
-  assert.deepEqual(published, ["room_member_joined"]);
+  assert.deepEqual(sent, []);
+  assert.deepEqual(errors, ["internal_error"]);
+  // Nothing is announced: the room never gained this member.
+  assert.deepEqual(published, []);
   assert.ok(events.includes("room_join_hook_failed"));
-  assert.ok(events.includes("room_joined"));
+  assert.ok(events.includes("room_join_aborted"));
+  assert.equal(events.includes("room_joined"), false);
+  assert.deepEqual(leaveReasons, ["disconnect"]);
 });
 
 test("message handler keeps room:join successful when member joined publish fails", async () => {
@@ -2542,4 +2562,141 @@ test("switching rooms tells the old room even when the index cleanup fails", asy
     "room_member_joined",
   ]);
   assert.deepEqual(publishedRooms, ["ROOM-OLD", "ROOM-OLD", "ROOM-NEW"]);
+});
+
+test("a shared-owner resync that the bus rejects is retried until it lands", async () => {
+  // The one broadcast nothing else repeats. It goes out precisely because the
+  // room stopped advancing, so no later `video:share` / `playback:update`
+  // corrects a dropped one, and an idle room never sends `sync:request` either
+  // — the user would have to reload the page (#242).
+  const published: string[] = [];
+  let resyncFailures = 2;
+  const session = createSession("member-1", {
+    roomCode: "ROOM01",
+    memberId: "member-1",
+    memberToken: "member-token-1",
+  });
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession(currentSession) {
+        currentSession.roomCode = null;
+        return {
+          room: { code: "ROOM01" },
+          memberRemoved: true,
+          needsRoomStateResync: true,
+        };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent() {},
+    send() {},
+    sendError() {},
+    async publishRoomEvent(message) {
+      if (message.type === "room_state_updated" && resyncFailures > 0) {
+        resyncFailures -= 1;
+        throw new Error("bus rejected");
+      }
+      published.push(message.type);
+    },
+    instanceId: "node-a",
+    sharedOwnerResyncRetry: {
+      initialRetryDelayMs: 1,
+      sleep: () => Promise.resolve(),
+    },
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:leave",
+    payload: { memberToken: "member-token-1" },
+  });
+  await handler.flushPendingPublishes();
+
+  assert.deepEqual(published, ["room_member_left", "room_state_updated"]);
+});
+
+test("shutdown drains the retrying shared-owner resync, not just the one-shot publishes", async () => {
+  // `flushPendingPublishes` runs before the bus is torn down. A resync record
+  // left behind is the broadcast nothing will ever re-send (#242).
+  const published: string[] = [];
+  let resyncFailures = 1;
+  const session = createSession("member-1", {
+    roomCode: "ROOM01",
+    memberId: "member-1",
+    memberToken: "member-token-1",
+  });
+
+  const handler = createMessageHandler({
+    config: CONFIG,
+    roomService: {
+      async createRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async joinRoomForSession() {
+        throw new Error("unreachable");
+      },
+      async leaveRoomForSession(currentSession) {
+        currentSession.roomCode = null;
+        return {
+          room: { code: "ROOM01" },
+          memberRemoved: true,
+          needsRoomStateResync: true,
+        };
+      },
+      async shareVideoForSession() {
+        throw new Error("unreachable");
+      },
+      async updatePlaybackForSession() {
+        throw new Error("unreachable");
+      },
+      async updateProfileForSession() {
+        throw new Error("unreachable");
+      },
+      async getRoomStateForSession() {
+        throw new Error("unreachable");
+      },
+    },
+    logEvent() {},
+    send() {},
+    sendError() {},
+    async publishRoomEvent(message) {
+      if (message.type === "room_state_updated" && resyncFailures > 0) {
+        resyncFailures -= 1;
+        throw new Error("bus rejected");
+      }
+      published.push(message.type);
+    },
+    instanceId: "node-a",
+    sharedOwnerResyncRetry: {
+      initialRetryDelayMs: 30,
+    },
+  });
+
+  await handler.handleClientMessage(session, {
+    type: "room:leave",
+    payload: { memberToken: "member-token-1" },
+  });
+  // The retry is still parked in its backoff at this point.
+  assert.deepEqual(published, ["room_member_left"]);
+
+  await handler.flushPendingPublishes();
+  assert.deepEqual(published, ["room_member_left", "room_state_updated"]);
 });

--- a/server/test/pending-resync-queue.test.ts
+++ b/server/test/pending-resync-queue.test.ts
@@ -272,3 +272,42 @@ test("pending resync queue bounds how long it waits for an abandoned call", asyn
 
   assert.equal(queue.size(), 0);
 });
+
+test("pending resync queue caps how many rooms it publishes at once", async () => {
+  // The backlog is uncapped on purpose, so without a concurrency limit a bus
+  // that recovers after a long outage turns every retained record into a
+  // simultaneous publish — an unbounded backlog becoming an unbounded burst,
+  // and one that bypasses `firePublishRoomEvent`'s own cap (#242 review).
+  let active = 0;
+  let peak = 0;
+  const releases: Array<() => void> = [];
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    maxConcurrentPublishes: 3,
+    publish: () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      return new Promise<void>((resolve) => {
+        releases.push(() => {
+          active -= 1;
+          resolve();
+        });
+      });
+    },
+  });
+
+  for (let index = 0; index < 20; index += 1) {
+    queue.request(`ROOM${index}`);
+  }
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.equal(queue.size(), 20, "every room keeps its record");
+  assert.equal(peak, 3, `at most 3 publishes at once, saw ${peak}`);
+
+  while (releases.length > 0) {
+    releases.shift()?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  await queue.drain();
+  assert.equal(peak, 3);
+});

--- a/server/test/pending-resync-queue.test.ts
+++ b/server/test/pending-resync-queue.test.ts
@@ -132,23 +132,30 @@ test("pending resync queue publishes again for a request made mid-flight", async
   assert.deepEqual(attempts, ["ROOM01", "ROOM01"]);
 });
 
-test("pending resync queue treats a hung publish as a failed attempt", async () => {
-  let attempts = 0;
+test("pending resync queue keeps at most one publish in flight per room", async () => {
+  // The attempt cap races the bus call; it cannot abort it. With an unbounded
+  // retry loop behind it, starting a fresh publish on every timeout piles up
+  // one in-flight Redis command per retry for as long as the bus stays hung,
+  // and every one of them then spills into `roomEventBus.close()` (#242 review).
+  let calls = 0;
   const queue = createPendingResyncQueue({
     sleep: instantSleep,
-    attemptTimeoutMs: 10,
+    attemptTimeoutMs: 5,
     publish: () => {
-      attempts += 1;
-      // The first call never settles: without a cap it would pin the record and
-      // the resync would never be re-sent.
-      return attempts === 1 ? new Promise<void>(() => {}) : Promise.resolve();
+      calls += 1;
+      // Never settles: the bus is hung rather than rejecting.
+      return new Promise<void>(() => {});
     },
   });
 
   queue.request("ROOM01");
-  await queue.drain();
+  // Long enough for many attempt windows to have elapsed.
+  await new Promise((resolve) => setTimeout(resolve, 80));
+  assert.equal(calls, 1, "the record must wait, not pile on");
 
-  assert.equal(attempts, 2);
+  queue.stopRetrying();
+  await queue.drain();
+  assert.equal(calls, 1);
 });
 
 test("pending resync queue never refuses a room, however long the backlog", async () => {

--- a/server/test/pending-resync-queue.test.ts
+++ b/server/test/pending-resync-queue.test.ts
@@ -220,3 +220,55 @@ test("pending resync queue stops on demand so shutdown is bounded", async () => 
   assert.equal(attempts, 1, "the in-flight attempt must be the last one");
   assert.equal(queue.size(), 0);
 });
+
+test("pending resync queue waits out its abandoned calls before the drain returns", async () => {
+  // "We stopped retrying" is not "the call came back", and the bus is closed
+  // straight after the drain (#242 review).
+  const order: string[] = [];
+  let releasePublish: (() => void) | null = null;
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    // Small, so the record itself stops promptly and the ONLY thing that can
+    // still hold the drain is the abandoned call.
+    attemptTimeoutMs: 5,
+    abandonedDrainTimeoutMs: 1_000,
+    publish: () =>
+      new Promise<void>((resolve) => {
+        releasePublish = () => {
+          order.push("publish-settled");
+          resolve();
+        };
+      }),
+  });
+
+  queue.request("ROOM01");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  queue.stopRetrying();
+
+  const drained = queue.drain().then(() => {
+    order.push("drain-returned");
+  });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  (releasePublish as (() => void) | null)?.();
+  await drained;
+
+  assert.deepEqual(order, ["publish-settled", "drain-returned"]);
+});
+
+test("pending resync queue bounds how long it waits for an abandoned call", async () => {
+  // Bounded, because an unbounded wait would only move the shutdown overrun
+  // from the bus close to this step.
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    attemptTimeoutMs: 5,
+    // Never answers at all.
+    publish: () => new Promise<void>(() => {}),
+  });
+
+  queue.request("ROOM01");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  queue.stopRetrying();
+  await queue.drain();
+
+  assert.equal(queue.size(), 0);
+});

--- a/server/test/pending-resync-queue.test.ts
+++ b/server/test/pending-resync-queue.test.ts
@@ -123,27 +123,36 @@ test("pending resync queue treats a hung publish as a failed attempt", async () 
   assert.equal(attempts, 2);
 });
 
-test("pending resync queue refuses new rooms past its cap", async () => {
-  const rejected: string[] = [];
+test("pending resync queue never refuses a room, however long the backlog", async () => {
+  // This notification fires precisely because a room stopped advancing, so a
+  // room turned away has nothing else coming to fix a `sharedByMemberId` naming
+  // a member who is gone. A backlog is reported, never shed (#242 review).
+  const backlogged: string[] = [];
+  const published: string[] = [];
   let releaseAll: (() => void) | null = null;
   const gate = new Promise<void>((resolve) => {
     releaseAll = resolve;
   });
   const queue = createPendingResyncQueue({
     sleep: instantSleep,
-    maxPendingRooms: 2,
-    publish: () => gate,
-    onRejected: ({ roomCode }) => rejected.push(roomCode),
+    backlogWarnThreshold: 2,
+    publish: async (roomCode) => {
+      await gate;
+      published.push(roomCode);
+    },
+    onBacklog: ({ roomCode }) => backlogged.push(roomCode),
   });
 
-  queue.request("ROOM01");
-  queue.request("ROOM02");
-  queue.request("ROOM03");
+  for (const roomCode of ["ROOM01", "ROOM02", "ROOM03", "ROOM04"]) {
+    queue.request(roomCode);
+  }
 
-  assert.equal(queue.size(), 2);
-  assert.deepEqual(rejected, ["ROOM03"]);
+  assert.equal(queue.size(), 4, "nothing may be turned away");
+  assert.deepEqual(backlogged, ["ROOM03", "ROOM04"], "past the threshold");
+
   (releaseAll as (() => void) | null)?.();
   await queue.drain();
+  assert.deepEqual(published.sort(), ["ROOM01", "ROOM02", "ROOM03", "ROOM04"]);
 });
 
 test("pending resync queue still serves a request made while a doomed batch retried", async () => {

--- a/server/test/pending-resync-queue.test.ts
+++ b/server/test/pending-resync-queue.test.ts
@@ -346,3 +346,49 @@ test("pending resync queue does not publish the backlog when it is stopping", as
   await queue.drain();
   assert.equal(published, 2);
 });
+
+test("pending resync queue hands a freed slot straight to the waiter", async () => {
+  // Decrementing first and waking afterwards left the slot unowned for a
+  // continuation. A `request` arriving in that gap took it while the woken
+  // waiter incremented anyway — two publishes at once with the cap set to one
+  // (#242 review).
+  let active = 0;
+  let peak = 0;
+  const releases: Array<() => void> = [];
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    maxConcurrentPublishes: 1,
+    publish: () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      return new Promise<void>((resolve) => {
+        releases.push(() => {
+          active -= 1;
+          resolve();
+        });
+      });
+    },
+  });
+
+  queue.request("ROOM01");
+  queue.request("ROOM02");
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(peak, 1);
+  assert.equal(releases.length, 1, "only one publish may be in flight");
+
+  // Free the slot, then let exactly ONE microtask run: enough for the release
+  // handler, not enough for the woken waiter to resume. That is the gap the
+  // arriving request used to slip into.
+  releases.shift()?.();
+  await null;
+  queue.request("ROOM03");
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.equal(peak, 1, `the cap must hold across a handover, saw ${peak}`);
+
+  queue.stopRetrying();
+  while (releases.length > 0) {
+    releases.shift()?.();
+  }
+  await queue.drain();
+});

--- a/server/test/pending-resync-queue.test.ts
+++ b/server/test/pending-resync-queue.test.ts
@@ -179,3 +179,36 @@ test("pending resync queue still serves a request made while a doomed batch retr
   assert.equal(attempts, 3);
   assert.equal(queue.size(), 0);
 });
+
+test("pending resync queue stops opening new batches once it is winding down", async () => {
+  // Each batch costs a full retry budget, and the drain is otherwise unbounded
+  // in how many a record may run — two of them exceed the shutdown step that
+  // waits for them, and an overrun step is a FAILED step, after which the bus
+  // is torn down anyway (#242 review).
+  const attempts: string[] = [];
+  let releaseFirst: (() => void) | null = null;
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    publish: (roomCode) => {
+      attempts.push(roomCode);
+      if (attempts.length === 1) {
+        return new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return Promise.resolve();
+    },
+  });
+
+  queue.request("ROOM01");
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  // Mid-batch: at runtime this earns a second batch (see the test above).
+  queue.request("ROOM01");
+
+  queue.stopAfterCurrentBatch();
+  (releaseFirst as (() => void) | null)?.();
+  await queue.drain();
+
+  assert.deepEqual(attempts, ["ROOM01"], "the second batch must not open");
+  assert.equal(queue.size(), 0);
+});

--- a/server/test/pending-resync-queue.test.ts
+++ b/server/test/pending-resync-queue.test.ts
@@ -311,3 +311,38 @@ test("pending resync queue caps how many rooms it publishes at once", async () =
   await queue.drain();
   assert.equal(peak, 3);
 });
+
+test("pending resync queue does not publish the backlog when it is stopping", async () => {
+  // The stop signal releases the slot waiters so shutdown is not parked behind
+  // a slot a hung bus will never give back — but releasing them used to GRANT
+  // the slot, so every waiter published and the whole uncapped backlog became
+  // one simultaneous burst at shutdown (#242 review).
+  let published = 0;
+  const releases: Array<() => void> = [];
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    maxConcurrentPublishes: 2,
+    publish: () => {
+      published += 1;
+      return new Promise<void>((resolve) => {
+        releases.push(resolve);
+      });
+    },
+  });
+
+  for (let index = 0; index < 25; index += 1) {
+    queue.request(`ROOM${index}`);
+  }
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(published, 2, "only the slot holders may be publishing");
+
+  queue.stopRetrying();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(published, 2, "the waiters must exit, not take a slot");
+
+  for (const release of releases) {
+    release();
+  }
+  await queue.drain();
+  assert.equal(published, 2);
+});

--- a/server/test/pending-resync-queue.test.ts
+++ b/server/test/pending-resync-queue.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createPendingResyncQueue } from "../src/pending-resync-queue.js";
+
+const instantSleep = (): Promise<void> => Promise.resolve();
+
+test("pending resync queue keeps retrying a publish until it lands", async () => {
+  // The share-ownership resync is the one broadcast nothing else repeats: the
+  // room stopped advancing, so no later `video:share` or `playback:update` will
+  // correct a dropped one (#242).
+  const attempts: string[] = [];
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    publish: async (roomCode) => {
+      attempts.push(roomCode);
+      if (attempts.length < 3) {
+        throw new Error("bus rejected");
+      }
+    },
+  });
+
+  queue.request("ROOM01");
+  await queue.drain();
+
+  assert.deepEqual(attempts, ["ROOM01", "ROOM01", "ROOM01"]);
+  assert.equal(queue.size(), 0);
+});
+
+test("pending resync queue gives up only after its whole budget", async () => {
+  const abandoned: Array<{ roomCode: string; attempts: number }> = [];
+  const failures: number[] = [];
+  let attempts = 0;
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    maxAttempts: 3,
+    publish: async () => {
+      attempts += 1;
+      throw new Error("bus down");
+    },
+    onAttemptFailed: ({ attempt }) => failures.push(attempt),
+    onAbandoned: (info) =>
+      abandoned.push({ roomCode: info.roomCode, attempts: info.attempts }),
+  });
+
+  queue.request("ROOM01");
+  await queue.drain();
+
+  assert.equal(attempts, 3);
+  assert.deepEqual(failures, [1, 2]);
+  assert.deepEqual(abandoned, [{ roomCode: "ROOM01", attempts: 3 }]);
+});
+
+test("pending resync queue collapses repeat requests for one room", async () => {
+  const attempts: string[] = [];
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    publish: async (roomCode) => {
+      attempts.push(roomCode);
+    },
+  });
+
+  queue.request("ROOM01");
+  queue.request("ROOM01");
+  queue.request("ROOM01");
+  await queue.drain();
+
+  // Two publishes, not three. The event carries no payload — the consumer
+  // rebuilds the room's CURRENT state — so one publish satisfies every request
+  // made before it started; the extra one covers the requests that arrived
+  // while the first was already in flight.
+  assert.deepEqual(attempts, ["ROOM01", "ROOM01"]);
+
+  // And once the queue is idle, a fresh request costs exactly one publish.
+  attempts.length = 0;
+  queue.request("ROOM01");
+  await queue.drain();
+  assert.deepEqual(attempts, ["ROOM01"]);
+});
+
+test("pending resync queue publishes again for a request made mid-flight", async () => {
+  // The in-flight attempt may be consumed before the change being announced is
+  // visible, so a request that arrives during it still owes another publish.
+  let releaseFirst: (() => void) | null = null;
+  const attempts: string[] = [];
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    publish: (roomCode) => {
+      attempts.push(roomCode);
+      if (attempts.length === 1) {
+        return new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      }
+      return Promise.resolve();
+    },
+  });
+
+  queue.request("ROOM01");
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  queue.request("ROOM01");
+  (releaseFirst as (() => void) | null)?.();
+  await queue.drain();
+
+  assert.deepEqual(attempts, ["ROOM01", "ROOM01"]);
+});
+
+test("pending resync queue treats a hung publish as a failed attempt", async () => {
+  let attempts = 0;
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    attemptTimeoutMs: 10,
+    publish: () => {
+      attempts += 1;
+      // The first call never settles: without a cap it would pin the record and
+      // the resync would never be re-sent.
+      return attempts === 1 ? new Promise<void>(() => {}) : Promise.resolve();
+    },
+  });
+
+  queue.request("ROOM01");
+  await queue.drain();
+
+  assert.equal(attempts, 2);
+});
+
+test("pending resync queue refuses new rooms past its cap", async () => {
+  const rejected: string[] = [];
+  let releaseAll: (() => void) | null = null;
+  const gate = new Promise<void>((resolve) => {
+    releaseAll = resolve;
+  });
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    maxPendingRooms: 2,
+    publish: () => gate,
+    onRejected: ({ roomCode }) => rejected.push(roomCode),
+  });
+
+  queue.request("ROOM01");
+  queue.request("ROOM02");
+  queue.request("ROOM03");
+
+  assert.equal(queue.size(), 2);
+  assert.deepEqual(rejected, ["ROOM03"]);
+  (releaseAll as (() => void) | null)?.();
+  await queue.drain();
+});
+
+test("pending resync queue still serves a request made while a doomed batch retried", async () => {
+  // The batch that gives up describes an EARLIER change; a request that arrived
+  // during its retries describes a later one and is owed a publish of its own.
+  // Dropping it with the exhausted batch is the same permanent loss this queue
+  // exists to prevent (#242).
+  const abandoned: string[] = [];
+  let attempts = 0;
+  let requestedAgain = false;
+  const queue = createPendingResyncQueue({
+    sleep: instantSleep,
+    maxAttempts: 2,
+    publish: async (roomCode) => {
+      attempts += 1;
+      if (attempts <= 2) {
+        if (!requestedAgain) {
+          requestedAgain = true;
+          // Arrives mid-batch, i.e. while the record is still outstanding.
+          queue.request(roomCode);
+        }
+        throw new Error("bus rejected");
+      }
+    },
+    onAbandoned: ({ roomCode }) => abandoned.push(roomCode),
+  });
+
+  queue.request("ROOM01");
+  await queue.drain();
+
+  assert.deepEqual(abandoned, ["ROOM01"], "the first batch ran out of budget");
+  // Attempt 3 is the fresh batch the mid-flight request earned.
+  assert.equal(attempts, 3);
+  assert.equal(queue.size(), 0);
+});

--- a/server/test/pending-resync-queue.test.ts
+++ b/server/test/pending-resync-queue.test.ts
@@ -26,28 +26,56 @@ test("pending resync queue keeps retrying a publish until it lands", async () =>
   assert.equal(queue.size(), 0);
 });
 
-test("pending resync queue gives up only after its whole budget", async () => {
-  const abandoned: Array<{ roomCode: string; attempts: number }> = [];
+test("pending resync queue never gives up on a record by itself", async () => {
+  // A per-record attempt budget is just a slower way to discard the
+  // notification: the room is idle by definition, so nothing follows the
+  // give-up and its clients keep a `sharedByMemberId` naming a member who left
+  // (#242 review). Only an explicit stop ends the retries.
   const failures: number[] = [];
   let attempts = 0;
   const queue = createPendingResyncQueue({
     sleep: instantSleep,
-    maxAttempts: 3,
     publish: async () => {
       attempts += 1;
-      throw new Error("bus down");
+      if (attempts < 25) {
+        throw new Error("bus down");
+      }
     },
     onAttemptFailed: ({ attempt }) => failures.push(attempt),
-    onAbandoned: (info) =>
-      abandoned.push({ roomCode: info.roomCode, attempts: info.attempts }),
   });
 
   queue.request("ROOM01");
   await queue.drain();
 
-  assert.equal(attempts, 3);
-  assert.deepEqual(failures, [1, 2]);
-  assert.deepEqual(abandoned, [{ roomCode: "ROOM01", attempts: 3 }]);
+  // Well past any budget a bounded queue would have had.
+  assert.equal(attempts, 25);
+  assert.equal(failures.length, 24);
+  assert.equal(queue.size(), 0);
+});
+
+test("pending resync queue keeps knocking at the backoff ceiling", async () => {
+  const delays: number[] = [];
+  let attempts = 0;
+  const queue = createPendingResyncQueue({
+    initialRetryDelayMs: 10,
+    maxRetryDelayMs: 40,
+    sleep: (delayMs) => {
+      delays.push(delayMs);
+      return Promise.resolve();
+    },
+    publish: async () => {
+      attempts += 1;
+      if (attempts < 6) {
+        throw new Error("bus down");
+      }
+    },
+  });
+
+  queue.request("ROOM01");
+  await queue.drain();
+
+  // Exponential, then flat — it settles into a pace rather than giving up.
+  assert.deepEqual(delays, [10, 20, 40, 40, 40]);
 });
 
 test("pending resync queue collapses repeat requests for one room", async () => {
@@ -155,69 +183,33 @@ test("pending resync queue never refuses a room, however long the backlog", asyn
   assert.deepEqual(published.sort(), ["ROOM01", "ROOM02", "ROOM03", "ROOM04"]);
 });
 
-test("pending resync queue still serves a request made while a doomed batch retried", async () => {
-  // The batch that gives up describes an EARLIER change; a request that arrived
-  // during its retries describes a later one and is owed a publish of its own.
-  // Dropping it with the exhausted batch is the same permanent loss this queue
-  // exists to prevent (#242).
-  const abandoned: string[] = [];
+test("pending resync queue stops on demand so shutdown is bounded", async () => {
+  // `drain` is unbounded by design — records retry until they land — so the
+  // shutdown step calls `stopRetrying` first, leaving at most ONE in-flight
+  // attempt to wait for (#242 review).
   let attempts = 0;
-  let requestedAgain = false;
-  const queue = createPendingResyncQueue({
-    sleep: instantSleep,
-    maxAttempts: 2,
-    publish: async (roomCode) => {
-      attempts += 1;
-      if (attempts <= 2) {
-        if (!requestedAgain) {
-          requestedAgain = true;
-          // Arrives mid-batch, i.e. while the record is still outstanding.
-          queue.request(roomCode);
-        }
-        throw new Error("bus rejected");
-      }
-    },
-    onAbandoned: ({ roomCode }) => abandoned.push(roomCode),
-  });
-
-  queue.request("ROOM01");
-  await queue.drain();
-
-  assert.deepEqual(abandoned, ["ROOM01"], "the first batch ran out of budget");
-  // Attempt 3 is the fresh batch the mid-flight request earned.
-  assert.equal(attempts, 3);
-  assert.equal(queue.size(), 0);
-});
-
-test("pending resync queue stops opening new batches once it is winding down", async () => {
-  // Each batch costs a full retry budget, and the drain is otherwise unbounded
-  // in how many a record may run — two of them exceed the shutdown step that
-  // waits for them, and an overrun step is a FAILED step, after which the bus
-  // is torn down anyway (#242 review).
-  const attempts: string[] = [];
   let releaseFirst: (() => void) | null = null;
   const queue = createPendingResyncQueue({
     sleep: instantSleep,
-    publish: (roomCode) => {
-      attempts.push(roomCode);
-      if (attempts.length === 1) {
-        return new Promise<void>((resolve) => {
-          releaseFirst = resolve;
+    publish: () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return new Promise<void>((_resolve, reject) => {
+          releaseFirst = () => reject(new Error("bus down"));
         });
       }
-      return Promise.resolve();
+      return Promise.reject(new Error("bus down"));
     },
   });
 
   queue.request("ROOM01");
   await new Promise((resolve) => setTimeout(resolve, 5));
-  // Mid-batch: at runtime this earns a second batch (see the test above).
-  queue.request("ROOM01");
+  assert.equal(attempts, 1);
 
-  queue.stopAfterCurrentBatch();
+  queue.stopRetrying();
   (releaseFirst as (() => void) | null)?.();
   await queue.drain();
 
-  assert.deepEqual(attempts, ["ROOM01"], "the second batch must not open");
+  assert.equal(attempts, 1, "the in-flight attempt must be the last one");
   assert.equal(queue.size(), 0);
 });

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -2258,3 +2258,52 @@ test("redis runtime store leaves a tombstone where a torn-down room's generation
     await store.close();
   }
 });
+
+test("redis runtime store waits for in-flight commands before closing the connection", async () => {
+  // `pendingOperations` holds the CALLERS' answers, and a write that timed out
+  // answered long before its command did. Quitting on that alone closes the
+  // connection under commands still in flight — the same "a timeout is not a
+  // cancel" gap `settle` closes for the session chain (#242 review).
+  const order: string[] = [];
+  let releaseCommand: (() => void) | null = null;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async quit() {
+      order.push("quit");
+      return "OK";
+    },
+    async hgetall() {
+      return { id: "session-closing", roomCode: "" };
+    },
+    async get() {
+      return "gen-1";
+    },
+    eval() {
+      return new Promise((resolve) => {
+        releaseCommand = () => {
+          order.push("command-landed");
+          resolve(1);
+        };
+      });
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:closing-drain:",
+    redisClient: fakeRedis,
+    pendingOperationTimeoutMs: 100,
+    writeRetry: { maxAttempts: 1 },
+  });
+
+  const joined = store.markSessionJoinedRoom("session-closing", "ROOMCL");
+  await assert.rejects(joined, /timed out/);
+  assert.deepEqual(order, [], "the command has not answered yet");
+
+  const closing = store.close();
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.deepEqual(order, [], "close must not quit under a live command");
+
+  (releaseCommand as (() => void) | null)?.();
+  await closing;
+  assert.deepEqual(order, ["command-landed", "quit"]);
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -2892,3 +2892,50 @@ test("redis runtime store does not let one session's removal supersede another's
     await store.close();
   }
 });
+
+test("redis runtime store counts an unanswered generation read against capacity", async () => {
+  // Tracking it only for draining let a join whose generation read timed out
+  // release its pending slot and start another read every timeout window, past
+  // the configured cap without limit (#242 review).
+  let releaseRead: (() => void) | null = null;
+  let reads = 0;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    get() {
+      reads += 1;
+      return new Promise<string | null>((resolve) => {
+        releaseRead = () => resolve("gen-1");
+      });
+    },
+    async hgetall() {
+      return {};
+    },
+    async eval() {
+      return 1;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:read-capacity:",
+    redisClient: fakeRedis,
+    maxPendingOperations: 1,
+    pendingOperationTimeoutMs: 20,
+    writeRetry: { maxAttempts: 1 },
+  });
+
+  try {
+    const first = store.markSessionJoinedRoom("session-r1", "ROOMR1");
+    await assert.rejects(first, /Timed out reading the generation/);
+    assert.equal(reads, 1);
+
+    // The read is still out there, so the slot it occupies is not free.
+    assert.throws(
+      () => store.markSessionJoinedRoom("session-r2", "ROOMR2"),
+      /backpressure/,
+    );
+    assert.equal(reads, 1, "and no second read was started");
+  } finally {
+    (releaseRead as (() => void) | null)?.();
+    await store.close();
+  }
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { Redis } from "ioredis";
-import { createRedisRuntimeStore } from "../src/redis-runtime-store.js";
+import {
+  createRedisRuntimeStore,
+  JOIN_ROOM_INDEX_LUA,
+} from "../src/redis-runtime-store.js";
+import { NonRetryableWriteError } from "../src/durable-write-queue.js";
 import type { AttachedSession, Session } from "../src/types.js";
 
 const REDIS_URL = process.env.REDIS_URL;
@@ -2455,4 +2459,202 @@ test("redis runtime store drains the generation read it started at enqueue", asy
   (releaseGet as (() => void) | null)?.();
   await closing;
   assert.deepEqual(order, ["generation-read-answered", "quit"]);
+});
+
+test("redis runtime store refuses a join pinned after the room was torn down", async () => {
+  // The Lua guard only ever covered a pin taken BEFORE the teardown: that pin
+  // stops matching once the key holds the tombstone. A pin taken AFTER it reads
+  // the tombstone and matches ITSELF, so the script applied and rebuilt the
+  // indexes of a room that no longer exists (#242 review).
+  let evalCalls = 0;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async hgetall() {
+      return { id: "session-late-pin", roomCode: "" };
+    },
+    async get() {
+      // The teardown already ran, so this is what the key holds.
+      return "deleted";
+    },
+    async eval() {
+      evalCalls += 1;
+      return 1;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:late-pin:",
+    redisClient: fakeRedis,
+    writeRetry: { maxAttempts: 4, initialRetryDelayMs: 1 },
+  });
+
+  try {
+    await assert.rejects(
+      store.markSessionJoinedRoom("session-late-pin", "ROOMLP"),
+      // The `reason`, not a message substring: the read-failure handler wraps
+      // the message, and a wrapped one still CONTAINS the original — so a
+      // regex would pass either way and never notice the relabelling.
+      (error: unknown) =>
+        error instanceof NonRetryableWriteError &&
+        error.reason === "room_deleted",
+    );
+    assert.equal(evalCalls, 0, "nothing may be written against a dead room");
+  } finally {
+    await store.close();
+  }
+});
+
+test("the join index script declines a stale generation and writes nothing", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  // The script IS the guard, and a fake client cannot run it — the store-level
+  // tests only ever assert what the store does with a script that already
+  // declined (#242 review).
+  const keyPrefix = createKeyPrefix();
+  const redis = new Redis(REDIS_URL);
+  const generationKey = `${keyPrefix}room:ROOMSG:generation`;
+  const sessionKey = `${keyPrefix}session:session-stale`;
+  const roomSessionsKey = `${keyPrefix}room:ROOMSG:sessions`;
+
+  const run = (expectedGeneration: string): Promise<unknown> =>
+    redis.eval(
+      JOIN_ROOM_INDEX_LUA,
+      5,
+      generationKey,
+      sessionKey,
+      `${keyPrefix}sessions`,
+      roomSessionsKey,
+      `${keyPrefix}rooms`,
+      expectedGeneration,
+      "session-stale",
+      "ROOMSG",
+      "id",
+      "session-stale",
+      "roomCode",
+      "ROOMSG",
+    );
+
+  try {
+    await redis.set(generationKey, "gen-2");
+
+    // A pin taken under the room's PREVIOUS generation.
+    assert.equal(Number(await run("gen-1")), 0);
+    assert.equal(await redis.exists(sessionKey), 0, "no session hash written");
+    assert.equal(await redis.scard(roomSessionsKey), 0, "no room index entry");
+
+    // The tombstone a teardown leaves is likewise not the live generation.
+    await redis.set(generationKey, "deleted");
+    assert.equal(Number(await run("gen-2")), 0);
+    assert.equal(await redis.exists(sessionKey), 0);
+
+    // And the matching pin does apply, so the guard is not simply refusing all.
+    assert.equal(Number(await run("deleted")), 1);
+    assert.equal(await redis.exists(sessionKey), 1);
+    assert.equal(await redis.scard(roomSessionsKey), 1);
+  } finally {
+    const keys = await redis.keys(`${keyPrefix}*`);
+    if (keys.length > 0) {
+      await redis.del(...keys);
+    }
+    await redis.quit();
+  }
+});
+
+test("redis runtime store keeps the full session record when a leave supersedes a lost registration", async () => {
+  // A leave supersedes the RETRY of a `registerSession` that failed. When it
+  // wrote only `roomCode`, everything else the registration carried — the new
+  // `displayName` above all — never landed, and `confirm()` still reported
+  // success because a superseded write is not counted as unconfirmed (#242
+  // review).
+  //
+  // Fake-driven on purpose: against real Redis the registration succeeds on its
+  // first attempt, so nothing is ever left for the leave to supersede and the
+  // test cannot tell the two implementations apart.
+  const hsetCalls: Array<Record<string, string> | string[]> = [];
+  let execCalls = 0;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    multi() {
+      const commands = {
+        sadd() {
+          return commands;
+        },
+        srem() {
+          return commands;
+        },
+        del() {
+          return commands;
+        },
+        hset(_key: string, ...args: unknown[]) {
+          hsetCalls.push(
+            args.length === 1
+              ? (args[0] as Record<string, string>)
+              : (args as string[]),
+          );
+          return commands;
+        },
+        hdel() {
+          return commands;
+        },
+        zadd() {
+          return commands;
+        },
+        zrem() {
+          return commands;
+        },
+        exec() {
+          execCalls += 1;
+          // The registration's write fails, so its retry is what the leave
+          // then supersedes.
+          return execCalls === 1
+            ? Promise.reject(new Error("registration write failed"))
+            : Promise.resolve(null);
+        },
+      };
+      return commands;
+    },
+    async hgetall() {
+      return { id: "session-subset", roomCode: "ROOMSB" };
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:subset:",
+    redisClient: fakeRedis,
+    // Long enough that the registration is still waiting to retry when the
+    // leave arrives and supersedes it.
+    writeRetry: { maxAttempts: 5, initialRetryDelayMs: 10_000 },
+  });
+
+  try {
+    const session = createSession("session-subset");
+    session.displayName = "Renamed";
+    session.memberId = "member-subset";
+    session.memberToken = "token-subset";
+    void store.registerSession(session);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(
+      hsetCalls.length,
+      1,
+      "the registration attempt ran and failed",
+    );
+
+    session.roomCode = null;
+    await store.markSessionLeftRoom(session.id, "ROOMSB");
+
+    const leaveWrite = hsetCalls.at(-1);
+    assert.ok(
+      leaveWrite && !Array.isArray(leaveWrite),
+      `the leave must write a full record, got ${JSON.stringify(leaveWrite)}`,
+    );
+    assert.equal(leaveWrite.roomCode, "", "the leave still blanks the room");
+    assert.equal(leaveWrite.displayName, "Renamed", "the rename must land");
+    assert.equal(leaveWrite.id, "session-subset", "the record stays readable");
+    assert.equal(leaveWrite.memberId, "member-subset");
+  } finally {
+    await store.close();
+  }
 });

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -551,10 +551,15 @@ test("redis runtime store rejects new pending operations after reaching the conf
 });
 
 test("redis runtime store retries a timed-out write instead of dropping it", async () => {
-  // The first attempt never settles: the timeout has to end THAT ATTEMPT and
+  // The first attempt outlives its cap: the timeout has to end THAT ATTEMPT and
   // hand the write back to the retry queue, rather than end the write (#242).
-  const hangingOperation = createDeferred<unknown>();
-  const fakeRedis = createFakeRedisClient([hangingOperation.promise]);
+  //
+  // The slow command then ANSWERS, which is what releases the retry — the queue
+  // deliberately does not open a second attempt while the first command is
+  // still out there, or one write could leave `maxAttempts` uncancellable
+  // commands behind at once (#242 review).
+  const slowOperation = createDeferred<unknown>();
+  const fakeRedis = createFakeRedisClient([slowOperation.promise]);
   const errors: string[] = [];
   const store = await createRedisRuntimeStore("redis://unused", {
     redisClient: fakeRedis,
@@ -564,6 +569,9 @@ test("redis runtime store retries a timed-out write instead of dropping it", asy
       errors.push(context.reason);
     },
   });
+  const answered = setTimeout(() => {
+    slowOperation.reject(new Error("slow redis command finally answered"));
+  }, 40);
 
   try {
     store.registerSession(createSession("timed-out"));
@@ -575,7 +583,8 @@ test("redis runtime store retries a timed-out write instead of dropping it", asy
     assert.ok(errors.includes("retry"));
     assert.equal(errors.includes("failed"), false);
   } finally {
-    hangingOperation.resolve(null);
+    clearTimeout(answered);
+    slowOperation.reject(new Error("cleanup"));
     await store.close();
   }
 });

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -2939,3 +2939,64 @@ test("redis runtime store counts an unanswered generation read against capacity"
     await store.close();
   }
 });
+
+test("redis runtime store flush waiters do not consume command capacity", async () => {
+  // Routing the barrier through the command tracker made every concurrent
+  // `flush` register as another unanswered command, so one slow write could be
+  // amplified by its waiters until unrelated writes hit backpressure (#242
+  // review).
+  let releaseCommand: (() => void) | null = null;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    multi() {
+      const commands = {
+        sadd: () => commands,
+        srem: () => commands,
+        del: () => commands,
+        hset: () => commands,
+        hdel: () => commands,
+        zadd: () => commands,
+        zrem: () => commands,
+        exec: () =>
+          new Promise((resolve) => {
+            releaseCommand = () => resolve(null);
+          }),
+      };
+      return commands;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:flush-capacity:",
+    redisClient: fakeRedis,
+    maxPendingOperations: 4,
+    pendingOperationTimeoutMs: 120,
+    writeRetry: { maxAttempts: 1 },
+  });
+
+  try {
+    store.registerSession(createSession("session-slow"));
+    // Past the attempt cap, so `flush` gets past its `pendingOperations` wait
+    // and reaches the key-release barrier — the part under test.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    // Ten callers waiting on the same drain. Only ONE Redis command exists.
+    const waiters = Array.from({ length: 10 }, () => {
+      const flushed = store.flush?.();
+      flushed?.catch(() => undefined);
+      return flushed;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // Capacity must reflect the one real command, not its ten waiters.
+    assert.doesNotThrow(() => {
+      store.registerSession(createSession("session-unrelated"));
+    }, "flush waiters must not consume command capacity");
+
+    (releaseCommand as (() => void) | null)?.();
+    await Promise.allSettled(waiters);
+  } finally {
+    (releaseCommand as (() => void) | null)?.();
+    await store.close();
+  }
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -2061,3 +2061,95 @@ test("redis runtime store refuses a join whose room generation cannot be read", 
     await store.close();
   }
 });
+
+test("redis runtime store keeps a session's rollback behind the command it abandoned", async () => {
+  // The attempt timeout races the Redis command; it does not abort it. If the
+  // session's key were released when the CALLER is answered, the rollback the
+  // handler performs would run first and the abandoned join would then land on
+  // top of it — leaving a member the client was told does not exist, and one
+  // that can win the share back (#242 review).
+  const order: string[] = [];
+  let releaseJoin: (() => void) | null = null;
+  let evalCalls = 0;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    multi() {
+      return {
+        sadd() {
+          return this;
+        },
+        srem() {
+          return this;
+        },
+        del() {
+          return this;
+        },
+        hset() {
+          return this;
+        },
+        hdel() {
+          return this;
+        },
+        zadd() {
+          return this;
+        },
+        zrem() {
+          return this;
+        },
+        exec() {
+          order.push("leave-write");
+          return Promise.resolve(null);
+        },
+      };
+    },
+    async hgetall() {
+      return { id: "session-late", roomCode: "" };
+    },
+    async get() {
+      return "gen-1";
+    },
+    eval() {
+      evalCalls += 1;
+      if (evalCalls > 1) {
+        // Later calls are the empty-room cleanup, not the join script.
+        return Promise.resolve(1);
+      }
+      // Never settles inside the attempt window; lands only when released.
+      return new Promise((resolve) => {
+        releaseJoin = () => {
+          order.push("join-write");
+          resolve(1);
+        };
+      });
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:late:",
+    redisClient: fakeRedis,
+    pendingOperationTimeoutMs: 20,
+    writeRetry: { maxAttempts: 1 },
+  });
+
+  try {
+    const joined = store.markSessionJoinedRoom("session-late", "ROOMLT");
+    await assert.rejects(joined, /timed out/);
+    order.push("caller-answered");
+
+    // The rollback the handler performs on a refused join.
+    const left = store.markSessionLeftRoom("session-late", "ROOMLT");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.deepEqual(
+      order,
+      ["caller-answered"],
+      "the rollback must not overtake the abandoned command",
+    );
+
+    (releaseJoin as (() => void) | null)?.();
+    await left;
+    assert.deepEqual(order, ["caller-answered", "join-write", "leave-write"]);
+  } finally {
+    (releaseJoin as (() => void) | null)?.();
+    await store.close();
+  }
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -2787,3 +2787,108 @@ test("redis runtime store flush waits for the session key to be released", async
     await store.close();
   }
 });
+
+test("redis runtime store flush reports a barrier it could not hold", async () => {
+  // Resolving on the bound would say the barrier held when it had not, and the
+  // caller goes straight on to read or broadcast from an index the write never
+  // reached — the very failure `flush` exists to prevent (#242 review).
+  let releaseCommand: (() => void) | null = null;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    multi() {
+      const commands = {
+        sadd: () => commands,
+        srem: () => commands,
+        del: () => commands,
+        hset: () => commands,
+        hdel: () => commands,
+        zadd: () => commands,
+        zrem: () => commands,
+        exec: () =>
+          new Promise((resolve) => {
+            releaseCommand = () => resolve(null);
+          }),
+      };
+      return commands;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:flush-reject:",
+    redisClient: fakeRedis,
+    pendingOperationTimeoutMs: 40,
+    writeRetry: { maxAttempts: 1 },
+  });
+
+  try {
+    store.registerSession(createSession("session-barrier-fail"));
+    // Past the attempt cap, so the caller has been answered while the command
+    // runs on and the key is still held.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    await assert.rejects(async () => {
+      await store.flush?.();
+    }, /flush timed out before the session keys were released/);
+  } finally {
+    (releaseCommand as (() => void) | null)?.();
+    await store.close();
+  }
+});
+
+test("redis runtime store does not let one session's removal supersede another's", async () => {
+  // `REMOVE_MEMBER_LUA` is guarded on `session.id`, so a removal for a
+  // DIFFERENT session succeeds by doing nothing. Sharing a queue key let it
+  // supersede a still-retrying removal for the session that actually holds the
+  // binding — which then stayed, with no retention clock armed (#242 review).
+  const evalSessions: string[] = [];
+  let attempts = 0;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async eval(
+      _script: string,
+      numKeys: number,
+      ...args: Array<string | number>
+    ) {
+      attempts += 1;
+      // ARGV[2] is the guarding session id: KEYS come first, then memberId.
+      evalSessions.push(String(args[numKeys + 1]));
+      // The holder's first attempt fails, so its retry is what a shared key
+      // would have let the other session's removal cancel.
+      if (attempts === 1) {
+        throw new Error("remove member write failed");
+      }
+      return 1;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:remove-key:",
+    redisClient: fakeRedis,
+    // Long enough that the holder is still waiting to retry when the other
+    // session's removal is queued.
+    writeRetry: { maxAttempts: 3, initialRetryDelayMs: 30 },
+  });
+
+  try {
+    const holder = createSession("session-holder");
+    const stale = createSession("session-stale");
+    const holderRemoval = store.removeMember("ROOMRK", "member-rk", holder);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const staleRemoval = store.removeMember("ROOMRK", "member-rk", stale);
+
+    await staleRemoval.durable;
+    await holderRemoval.durable;
+
+    assert.ok(
+      evalSessions.includes("session-holder"),
+      `the holder's removal must have been retried, saw ${evalSessions.join()}`,
+    );
+    assert.equal(
+      evalSessions.filter((id) => id === "session-holder").length,
+      2,
+      "the holder's retry ran",
+    );
+  } finally {
+    await store.close();
+  }
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -550,18 +550,16 @@ test("redis runtime store rejects new pending operations after reaching the conf
   }
 });
 
-test("redis runtime store removes timed out pending operations and recovers", async () => {
-  const firstOperation = createDeferred<unknown>();
-  const secondOperation = createDeferred<unknown>();
-  const fakeRedis = createFakeRedisClient([
-    firstOperation.promise,
-    secondOperation.promise,
-  ]);
+test("redis runtime store retries a timed-out write instead of dropping it", async () => {
+  // The first attempt never settles: the timeout has to end THAT ATTEMPT and
+  // hand the write back to the retry queue, rather than end the write (#242).
+  const hangingOperation = createDeferred<unknown>();
+  const fakeRedis = createFakeRedisClient([hangingOperation.promise]);
   const errors: string[] = [];
   const store = await createRedisRuntimeStore("redis://unused", {
     redisClient: fakeRedis,
-    maxPendingOperations: 1,
     pendingOperationTimeoutMs: 20,
+    writeRetry: { initialRetryDelayMs: 1 },
     onPendingOperationError(context) {
       errors.push(context.reason);
     },
@@ -569,25 +567,37 @@ test("redis runtime store removes timed out pending operations and recovers", as
 
   try {
     store.registerSession(createSession("timed-out"));
-    await new Promise((resolve) => setTimeout(resolve, 40));
-    await store.flush?.();
-
-    secondOperation.resolve(null);
-    store.registerSession(createSession("recovered"));
-    await store.flush?.();
+    // Resolves only because the second attempt got a fresh `multi()`, which the
+    // fake answers with a resolved exec.
+    await store.confirmWrites?.();
 
     assert.ok(errors.includes("timeout"));
+    assert.ok(errors.includes("retry"));
+    assert.equal(errors.includes("failed"), false);
   } finally {
+    hangingOperation.resolve(null);
     await store.close();
   }
 });
 
-test("redis runtime store counts a timed-out operation failure only once", async () => {
-  const pending = createDeferred<unknown>();
+test("redis runtime store counts one failure per write, not per attempt", async () => {
   const failureOperations: string[] = [];
+  const errors: string[] = [];
+  // Every attempt rejects, so the write is genuinely lost — and it must be
+  // reported exactly once however many times the queue tried.
+  const rejections = Array.from({ length: 8 }, () =>
+    Promise.reject(new Error("redis failure")),
+  );
+  for (const rejection of rejections) {
+    rejection.catch(() => undefined);
+  }
   const store = await createRedisRuntimeStore("redis://example.test:6379", {
-    redisClient: createFakeRedisClient([pending.promise]),
+    redisClient: createFakeRedisClient(rejections),
     pendingOperationTimeoutMs: 5,
+    writeRetry: { maxAttempts: 3, initialRetryDelayMs: 1 },
+    onPendingOperationError(context) {
+      errors.push(context.reason);
+    },
     metricsCollector: {
       observeRedisRuntimeStoreDuration() {},
       observeRedisRuntimeStoreFailure(operation) {
@@ -597,14 +607,36 @@ test("redis runtime store counts a timed-out operation failure only once", async
   });
 
   try {
-    const session = createSession("session-timeout");
-    store.registerSession(session);
-
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    pending.reject(new Error("late redis failure"));
-    await store.flush?.();
+    store.registerSession(createSession("session-timeout"));
+    await assert.rejects(async () => {
+      await store.confirmWrites?.();
+    });
 
     assert.deepEqual(failureOperations, ["register_session"]);
+    // Two retries scheduled between the three attempts.
+    assert.equal(errors.filter((reason) => reason === "retry").length, 2);
+    assert.equal(errors.filter((reason) => reason === "failed").length, 1);
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store confirms writes separately from draining them", async () => {
+  const rejection = Promise.reject(new Error("redis failure"));
+  rejection.catch(() => undefined);
+  const store = await createRedisRuntimeStore("redis://example.test:6379", {
+    redisClient: createFakeRedisClient([rejection]),
+    writeRetry: { maxAttempts: 1 },
+  });
+
+  try {
+    store.registerSession(createSession("session-unconfirmed"));
+    // `flush` only ever says the queue emptied — a failed write drains exactly
+    // like a successful one, which is the conflation #242 exists to end.
+    await store.flush?.();
+    await assert.rejects(async () => {
+      await store.confirmWrites?.();
+    }, /not confirmed/);
   } finally {
     await store.close();
   }
@@ -1552,8 +1584,41 @@ test("redis runtime store reports a failed room-index cleanup to the caller", as
   // cannot carry that answer — it waits on the error-swallowed copies
   // `trackOperation` keeps for backpressure accounting, so it reports only that
   // the queue drained.
+  //
+  // The caller only hears about it once the retries are spent, so every attempt
+  // has to fail here — a single rejection would now be absorbed (#242).
+  let execAttempts = 0;
   const fakeRedis = {
-    ...createFakeRedisClient([Promise.reject(new Error("index write failed"))]),
+    ...createFakeRedisClient([]),
+    multi() {
+      return {
+        sadd() {
+          return this;
+        },
+        srem() {
+          return this;
+        },
+        del() {
+          return this;
+        },
+        hset() {
+          return this;
+        },
+        hdel() {
+          return this;
+        },
+        zadd() {
+          return this;
+        },
+        zrem() {
+          return this;
+        },
+        exec() {
+          execAttempts += 1;
+          return Promise.reject(new Error("index write failed"));
+        },
+      };
+    },
     async hgetall() {
       return { id: "session-dirty", roomCode: "ROOMDT" };
     },
@@ -1565,6 +1630,7 @@ test("redis runtime store reports a failed room-index cleanup to the caller", as
   const store = await createRedisRuntimeStore("redis://unused", {
     keyPrefix: "bsp:test:dirty:",
     redisClient: fakeRedis,
+    writeRetry: { maxAttempts: 3, initialRetryDelayMs: 1 },
   });
 
   try {
@@ -1572,6 +1638,7 @@ test("redis runtime store reports a failed room-index cleanup to the caller", as
       store.markSessionLeftRoom("session-dirty", "ROOMDT"),
       /index write failed/,
     );
+    assert.equal(execAttempts, 3, "the write must have been retried first");
     // The asymmetry the fix rests on: draining the queue looks like success.
     await store.flush?.();
   } finally {
@@ -1616,19 +1683,22 @@ test("redis runtime store reports a failed join-index write to the caller", asyn
   // produces a state missing the member who just joined — and the ownership
   // decision taken from it is wrong in the one case it exists for, the stored
   // sharer reconnecting (#235 review). `flush` cannot report it.
+  let evalAttempts = 0;
   const fakeRedis = {
-    ...createFakeRedisClient([Promise.reject(new Error("join write failed"))]),
+    ...createFakeRedisClient([]),
     async hgetall() {
       return { id: "session-join", roomCode: "" };
     },
     async eval() {
-      return 1;
+      evalAttempts += 1;
+      throw new Error("join write failed");
     },
   };
 
   const store = await createRedisRuntimeStore("redis://unused", {
     keyPrefix: "bsp:test:join:",
     redisClient: fakeRedis,
+    writeRetry: { maxAttempts: 3, initialRetryDelayMs: 1 },
   });
 
   try {
@@ -1636,8 +1706,261 @@ test("redis runtime store reports a failed join-index write to the caller", asyn
       store.markSessionJoinedRoom("session-join", "ROOMJN"),
       /join write failed/,
     );
+    assert.equal(evalAttempts, 3, "the write must have been retried first");
     await store.flush?.();
   } finally {
     await store.close();
   }
+});
+
+test("redis runtime store pins the room generation a join retry must still match", async () => {
+  // Room codes are recycled. A retry that outlived the room instance it was
+  // meant for would seat this session in whichever room took the code over, so
+  // the generation is read ONCE — before the first attempt writes anything —
+  // and every attempt carries it (#242, #237). Reading it per attempt instead
+  // would let the retry re-pin itself onto the new occupant.
+  const generationReads: string[] = [];
+  const expectedGenerations: string[] = [];
+  let evalAttempts = 0;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async hgetall() {
+      return { id: "session-recycled", roomCode: "" };
+    },
+    async get(key: string) {
+      generationReads.push(key);
+      // The code changes hands right after the first read. A store that read
+      // the generation again on the retry would happily write into "gen-2".
+      return generationReads.length === 1 ? "gen-1" : "gen-2";
+    },
+    async eval(
+      _script: string,
+      numKeys: number,
+      ...args: Array<string | number>
+    ) {
+      evalAttempts += 1;
+      // The expected generation is the first ARGV, i.e. straight after the keys.
+      expectedGenerations.push(String(args[numKeys]));
+      if (evalAttempts === 1) {
+        throw new Error("transient redis failure");
+      }
+      return 1;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:recycled:",
+    redisClient: fakeRedis,
+    writeRetry: { maxAttempts: 4, initialRetryDelayMs: 1 },
+  });
+
+  try {
+    await store.markSessionJoinedRoom("session-recycled", "ROOMRC");
+    assert.equal(evalAttempts, 2);
+    assert.equal(generationReads.length, 1, "the generation is read once");
+    assert.deepEqual(expectedGenerations, ["gen-1", "gen-1"]);
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store stops retrying a join whose room code changed hands", async () => {
+  let evalAttempts = 0;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async hgetall() {
+      return { id: "session-moved", roomCode: "" };
+    },
+    async get() {
+      return "gen-1";
+    },
+    // The script declines: by the time it ran, the code carried another
+    // generation.
+    async eval() {
+      evalAttempts += 1;
+      return 0;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:moved:",
+    redisClient: fakeRedis,
+    writeRetry: { maxAttempts: 4, initialRetryDelayMs: 1 },
+  });
+
+  try {
+    await assert.rejects(
+      store.markSessionJoinedRoom("session-moved", "ROOMMV"),
+      /changed hands/,
+    );
+    // Declined, never retried: a generation only moves forward, so no later
+    // attempt could find its way back.
+    assert.equal(evalAttempts, 1);
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store re-writes the whole session record when a join seats it", async () => {
+  // `registerSession` is a separate queued write and can have failed. A join
+  // that patched only `roomCode` on top of that left a hash with no `id`, which
+  // `loadSession` reads as no session at all — so the joiner was missing from
+  // every state built off the shared view, and the stored sharer's reconnect
+  // handed the share to a stand-in (#242).
+  let evalArgs: Array<string | number> = [];
+  const fakeRedis = {
+    ...createFakeRedisClient([
+      Promise.reject(new Error("registration write failed")),
+    ]),
+    async hgetall() {
+      // The registration never landed, so Redis holds nothing for it.
+      return {};
+    },
+    async get() {
+      return "gen-1";
+    },
+    async eval(
+      _script: string,
+      _numKeys: number,
+      ...args: Array<string | number>
+    ) {
+      evalArgs = args;
+      return 1;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:heal:",
+    redisClient: fakeRedis,
+    writeRetry: { maxAttempts: 1 },
+  });
+
+  try {
+    const session = createSession("session-heal");
+    session.displayName = "Alice";
+    session.memberId = "member-heal";
+    session.memberToken = "token-heal";
+    void store.registerSession(session);
+    await store.markSessionJoinedRoom(session.id, "ROOMHL");
+
+    const fields = evalArgs.map(String);
+    for (const field of [
+      "id",
+      "instanceId",
+      "remoteAddress",
+      "origin",
+      "roomCode",
+      "memberId",
+      "displayName",
+      "memberToken",
+      "joinedAt",
+      "invalidMessageCount",
+    ]) {
+      assert.ok(
+        fields.includes(field),
+        `the join write must carry ${field}, not just the room code`,
+      );
+    }
+    assert.ok(fields.includes("session-heal"));
+    assert.ok(fields.includes("Alice"));
+    assert.ok(fields.includes("member-heal"));
+    // And it is still the write that puts the session into both indexes.
+    assert.ok(fields.includes("ROOMHL"));
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store never leaks an unhandled rejection from a dropped write", async () => {
+  // `queueSessionOperation` returns a NEW promise (the one that logs and
+  // re-throws), so the durable queue's own handled-marker does not cover it.
+  // `unregisterSession` drops that promise on the floor, which crashed the
+  // process on an unhandled rejection once every retry had failed (#242).
+  const rejections: unknown[] = [];
+  const onUnhandled = (reason: unknown): void => {
+    rejections.push(reason);
+  };
+  process.on("unhandledRejection", onUnhandled);
+
+  const rejection = Promise.reject(new Error("redis down"));
+  rejection.catch(() => undefined);
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:unhandled:",
+    redisClient: createFakeRedisClient([rejection]),
+    writeRetry: { maxAttempts: 1 },
+  });
+
+  try {
+    store.unregisterSession("session-dropped");
+    await store.flush?.();
+    // Unhandled rejections are reported a macrotask after the microtask queue
+    // drains, so give the process a tick to raise one.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.deepEqual(rejections, []);
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+    await store.close();
+  }
+});
+
+test("redis runtime store stops backing off once it is closing", async () => {
+  // The close step is on a clock. Spending the whole retry budget on writes a
+  // dead Redis was never going to accept would record the step as failed and
+  // exit the process non-zero (#242).
+  let attempts = 0;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    multi() {
+      return {
+        sadd() {
+          return this;
+        },
+        srem() {
+          return this;
+        },
+        del() {
+          return this;
+        },
+        hset() {
+          return this;
+        },
+        hdel() {
+          return this;
+        },
+        zadd() {
+          return this;
+        },
+        zrem() {
+          return this;
+        },
+        exec() {
+          attempts += 1;
+          return Promise.reject(new Error("redis down"));
+        },
+      };
+    },
+  };
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:closing:",
+    redisClient: fakeRedis,
+    // A backoff long enough that a close which waited it out would be obvious.
+    writeRetry: {
+      maxAttempts: 6,
+      initialRetryDelayMs: 10_000,
+      maxRetryDelayMs: 10_000,
+    },
+  });
+
+  store.registerSession(createSession("session-closing"));
+  // Let the first attempt fail and park in the backoff.
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(attempts, 1);
+
+  const closedAt = Date.now();
+  await store.close();
+  assert.ok(
+    Date.now() - closedAt < 5_000,
+    "close must not wait out the retry backoff",
+  );
+  assert.equal(attempts, 1, "no further attempt after the close began");
 });

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -2658,3 +2658,132 @@ test("redis runtime store keeps the full session record when a leave supersedes 
     await store.close();
   }
 });
+
+test("redis runtime store starts no session read when the generation pin is refused", async () => {
+  // Started in parallel, that read outlived an operation that rejected on the
+  // pin: in no tracking set, counted by no capacity check, and waited for by
+  // nobody at close (#242 review).
+  let sessionReads = 0;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async hgetall() {
+      sessionReads += 1;
+      return {};
+    },
+    async get() {
+      return "deleted";
+    },
+    async eval() {
+      return 1;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:no-parallel-read:",
+    redisClient: fakeRedis,
+    writeRetry: { maxAttempts: 1 },
+  });
+
+  try {
+    await assert.rejects(
+      store.markSessionJoinedRoom("session-noread", "ROOMNR"),
+      (error: unknown) =>
+        error instanceof NonRetryableWriteError &&
+        error.reason === "room_deleted",
+    );
+    assert.equal(sessionReads, 0, "the read must not have been started");
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store retries a member removal instead of giving up on one attempt", async () => {
+  // It used to get a single attempt, so a transient error made `durable` reject
+  // for good: the member binding stayed in Redis with no retention clock armed,
+  // and the reaper grew a latch to compensate for a failure a retry would have
+  // healed (#242 review).
+  let attempts = 0;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async eval() {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("remove member write failed");
+      }
+      return 1;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:remove-retry:",
+    redisClient: fakeRedis,
+    writeRetry: { maxAttempts: 3, initialRetryDelayMs: 1 },
+  });
+
+  try {
+    const removal = store.removeMember("ROOMRM", "member-rm");
+    assert.ok(removal.durable, "the removal reports a durable outcome");
+    await removal.durable;
+    assert.equal(attempts, 2, "the transient failure was retried");
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store flush waits for the session key to be released", async () => {
+  // `pendingOperations` holds the CALLERS' answers, and an attempt that timed
+  // out answered long before its command did — so `flush` returned while the
+  // key was still held and the next broadcast saw stale data (#242 review).
+  const order: string[] = [];
+  let releaseCommand: (() => void) | null = null;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    multi() {
+      const commands = {
+        sadd: () => commands,
+        srem: () => commands,
+        del: () => commands,
+        hset: () => commands,
+        hdel: () => commands,
+        zadd: () => commands,
+        zrem: () => commands,
+        exec: () =>
+          new Promise((resolve) => {
+            releaseCommand = () => {
+              order.push("command-landed");
+              resolve(null);
+            };
+          }),
+      };
+      return commands;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:flush-barrier:",
+    redisClient: fakeRedis,
+    pendingOperationTimeoutMs: 200,
+    writeRetry: { maxAttempts: 1 },
+  });
+
+  try {
+    store.registerSession(createSession("session-barrier"));
+    // Past the attempt cap: the CALLER has been answered and the entry is out
+    // of `pendingOperations`, while the command is still running. That is the
+    // exact window `flush` used to slip through.
+    await new Promise((resolve) => setTimeout(resolve, 260));
+
+    const flushed = store.flush?.().then(() => {
+      order.push("flush-returned");
+    });
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    assert.deepEqual(order, [], "flush must not return under a live command");
+
+    (releaseCommand as (() => void) | null)?.();
+    await flushed;
+    assert.deepEqual(order, ["command-landed", "flush-returned"]);
+  } finally {
+    (releaseCommand as (() => void) | null)?.();
+    await store.close();
+  }
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -1964,3 +1964,100 @@ test("redis runtime store stops backing off once it is closing", async () => {
   );
   assert.equal(attempts, 1, "no further attempt after the close began");
 });
+
+test("redis runtime store pins the join generation before the queue gets to it", async () => {
+  // The operation body does not run until the session's chain drains, and that
+  // is unbounded — a prior write for the same session can hold it. Pinning in
+  // there reads whatever generation exists by THEN, including the new
+  // occupant's after a recycle, and the Lua check then waves the old join into
+  // a room it never joined (#242 review).
+  let currentGeneration = "gen-1";
+  let evalAttempts = 0;
+  const expectedGenerations: string[] = [];
+  const slowRegistration = createDeferred<unknown>();
+  const fakeRedis = {
+    ...createFakeRedisClient([slowRegistration.promise]),
+    async hgetall() {
+      return { id: "session-queued", roomCode: "" };
+    },
+    async get() {
+      return currentGeneration;
+    },
+    async eval(
+      _script: string,
+      numKeys: number,
+      ...args: Array<string | number>
+    ) {
+      evalAttempts += 1;
+      expectedGenerations.push(String(args[numKeys]));
+      // Stands in for the script's own check against the live generation.
+      return String(args[numKeys]) === currentGeneration ? 1 : 0;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:queued:",
+    redisClient: fakeRedis,
+    writeRetry: { maxAttempts: 4, initialRetryDelayMs: 1 },
+  });
+
+  try {
+    const session = createSession("session-queued");
+    // Occupies the session's chain: its first attempt is in flight, and
+    // supersession only abandons RETRIES, so the join queues behind it.
+    store.registerSession(session);
+    const joined = store.markSessionJoinedRoom(session.id, "ROOMQD");
+    joined.catch(() => undefined);
+
+    // The join is pinned by now, but its body has not run. The code changes
+    // hands while it waits.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(evalAttempts, 0, "the join body must still be queued");
+    currentGeneration = "gen-2";
+    slowRegistration.resolve(null);
+
+    await assert.rejects(joined, /changed hands/);
+    // Pinned at the call, so it still names the room the join was actually for.
+    assert.deepEqual(expectedGenerations, ["gen-1"]);
+    assert.equal(evalAttempts, 1);
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime store refuses a join whose room generation cannot be read", async () => {
+  // A second read is a second chance to pin the WRONG room instance, so an
+  // unreadable generation refuses the join rather than retrying the read. The
+  // client retries the join — the same trade this path makes for the index
+  // write itself (#242 review).
+  let evalAttempts = 0;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async hgetall() {
+      return { id: "session-blind", roomCode: "" };
+    },
+    async get() {
+      throw new Error("generation read failed");
+    },
+    async eval() {
+      evalAttempts += 1;
+      return 1;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:blind:",
+    redisClient: fakeRedis,
+    writeRetry: { maxAttempts: 4, initialRetryDelayMs: 1 },
+  });
+
+  try {
+    await assert.rejects(
+      store.markSessionJoinedRoom("session-blind", "ROOMBL"),
+      /Could not pin the generation/,
+    );
+    assert.equal(evalAttempts, 0, "nothing may be written unguarded");
+  } finally {
+    await store.close();
+  }
+});

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -2179,8 +2179,9 @@ test("redis runtime store declines a join pinned before the room was torn down",
     eval(script: string, numKeys: number, ...args: Array<string | number>) {
       // `HSET` is the join script's alone; the teardown only deletes and SREMs.
       if (!script.includes("HSET")) {
-        // The teardown script: it stamps the tombstone it was handed.
-        generation = String(args[args.length - 2]);
+        // The teardown script: it stamps the tombstone it was handed, which is
+        // the last ARGV now that the tombstone carries no TTL.
+        generation = String(args[args.length - 1]);
         return Promise.resolve(1);
       }
       // The join script. Held so the teardown can land between the pin and the
@@ -2306,4 +2307,143 @@ test("redis runtime store waits for in-flight commands before closing the connec
   (releaseCommand as (() => void) | null)?.();
   await closing;
   assert.deepEqual(order, ["command-landed", "quit"]);
+});
+
+test("redis runtime store leaves a generation tombstone that cannot expire", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  // A TTL would have to outlive every write still holding the old pin, and
+  // nothing bounds those — a session chain waits on a command that was never
+  // cancelled. A tombstone that lapsed first lets the join's `""` pin match an
+  // absent key all over again (#242 review).
+  const keyPrefix = createKeyPrefix();
+  const store = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const probe = new Redis(REDIS_URL);
+  const session = createSession("session-tombstone-ttl");
+
+  try {
+    store.registerSession(session);
+    await store.markSessionJoinedRoom(session.id, "ROOMTT");
+    await store.flush?.();
+    assert.equal(await store.deleteRoom("ROOMTT", null), true);
+
+    const key = `${keyPrefix}room:ROOMTT:generation`;
+    assert.equal(await probe.get(key), "deleted");
+    // -1 is redis for "no expiry"; anything positive is a lapsing tombstone.
+    assert.equal(await probe.pttl(key), -1);
+  } finally {
+    await probe.quit();
+    await store.close();
+  }
+});
+
+test("redis runtime store holds backpressure capacity until the command finishes", async () => {
+  // The retry budget rejects the outcome long before the commands stop running.
+  // Freeing the slot there let the next session's write take it and leave one
+  // more uncancellable command behind, so the configured cap stopped bounding
+  // anything (#242 review).
+  const releases: Array<() => void> = [];
+  let hangCommands = true;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async hgetall() {
+      return {};
+    },
+    async get() {
+      return "gen-1";
+    },
+    eval() {
+      if (!hangCommands) {
+        return Promise.resolve(1);
+      }
+      return new Promise((resolve) => {
+        releases.push(() => resolve(1));
+      });
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:capacity:",
+    redisClient: fakeRedis,
+    maxPendingOperations: 1,
+    pendingOperationTimeoutMs: 20,
+    writeRetry: { maxAttempts: 1 },
+  });
+
+  try {
+    const first = store.markSessionJoinedRoom("session-cap-a", "ROOMCA");
+    await assert.rejects(first, /timed out/);
+    // The caller has been answered, but the command is still out there — so the
+    // slot it occupies must not be handed to anybody else.
+    assert.throws(
+      () => store.markSessionJoinedRoom("session-cap-b", "ROOMCB"),
+      /backpressure/,
+    );
+
+    hangCommands = false;
+    for (const release of releases) {
+      release();
+    }
+    // A tick for the commands to answer: capacity is released by the command
+    // itself, and `flush` cannot stand in for that — its outcome settled back
+    // when the attempt timed out.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    // Once the commands answer, capacity comes back.
+    await store.markSessionJoinedRoom("session-cap-c", "ROOMCC");
+  } finally {
+    for (const release of releases) {
+      release();
+    }
+    await store.close();
+  }
+});
+
+test("redis runtime store drains the generation read it started at enqueue", async () => {
+  // That `GET` belongs to the write but is started before it — so it is in
+  // neither `settle`'s list nor anything else, and `close()` could `quit()`
+  // straight through it (#242 review).
+  const order: string[] = [];
+  let releaseGet: (() => void) | null = null;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async quit() {
+      order.push("quit");
+      return "OK";
+    },
+    async hgetall() {
+      return {};
+    },
+    get() {
+      return new Promise<string | null>((resolve) => {
+        releaseGet = () => {
+          order.push("generation-read-answered");
+          resolve("gen-1");
+        };
+      });
+    },
+    async eval() {
+      return 1;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:enqueue-read:",
+    redisClient: fakeRedis,
+    pendingOperationTimeoutMs: 30,
+    writeRetry: { maxAttempts: 1 },
+  });
+
+  const joined = store.markSessionJoinedRoom("session-read", "ROOMRD");
+  await assert.rejects(joined, /Timed out reading the generation/);
+
+  const closing = store.close();
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.deepEqual(order, [], "close must not quit under the pinned read");
+
+  (releaseGet as (() => void) | null)?.();
+  await closing;
+  assert.deepEqual(order, ["generation-read-answered", "quit"]);
 });

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -1689,6 +1689,9 @@ test("redis runtime store reports a failed join-index write to the caller", asyn
     async hgetall() {
       return { id: "session-join", roomCode: "" };
     },
+    async get() {
+      return "gen-1";
+    },
     async eval() {
       evalAttempts += 1;
       throw new Error("join write failed");
@@ -2150,6 +2153,43 @@ test("redis runtime store keeps a session's rollback behind the command it aband
     assert.deepEqual(order, ["caller-answered", "join-write", "leave-write"]);
   } finally {
     (releaseJoin as (() => void) | null)?.();
+    await store.close();
+  }
+});
+
+test("redis runtime store refuses a join against a room with no generation at all", async () => {
+  // A teardown leaves the generation key absent, exactly like a room that never
+  // had one. Pinning `""` would match both, so a delayed write would rebuild
+  // the indexes of a room whose persisted record is gone and strand its code
+  // (#242 review).
+  let evalAttempts = 0;
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async hgetall() {
+      return { id: "session-nogen", roomCode: "" };
+    },
+    async get() {
+      return null;
+    },
+    async eval() {
+      evalAttempts += 1;
+      return 1;
+    },
+  };
+
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:nogen:",
+    redisClient: fakeRedis,
+    writeRetry: { maxAttempts: 4, initialRetryDelayMs: 1 },
+  });
+
+  try {
+    await assert.rejects(
+      store.markSessionJoinedRoom("session-nogen", "ROOMNG"),
+      /no generation to pin/,
+    );
+    assert.equal(evalAttempts, 0, "nothing may be written unguarded");
+  } finally {
     await store.close();
   }
 });

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -2157,38 +2157,103 @@ test("redis runtime store keeps a session's rollback behind the command it aband
   }
 });
 
-test("redis runtime store refuses a join against a room with no generation at all", async () => {
-  // A teardown leaves the generation key absent, exactly like a room that never
-  // had one. Pinning `""` would match both, so a delayed write would rebuild
-  // the indexes of a room whose persisted record is gone and strand its code
-  // (#242 review).
-  let evalAttempts = 0;
+test("redis runtime store declines a join pinned before the room was torn down", async () => {
+  // Deleting the generation key made "torn down" indistinguishable from "never
+  // had a generation", so a join that pinned `""` against a legacy room matched
+  // just as well after the room was deleted — and rebuilt the indexes of a room
+  // whose persisted record was gone (#242 review). The teardown leaves a
+  // tombstone instead.
+  let generation: string | null = null;
+  let releaseJoinScript: (() => void) | null = null;
   const fakeRedis = {
     ...createFakeRedisClient([]),
     async hgetall() {
-      return { id: "session-nogen", roomCode: "" };
+      return { id: "session-tombstoned", roomCode: "" };
     },
     async get() {
-      return null;
+      return generation;
     },
-    async eval() {
-      evalAttempts += 1;
-      return 1;
+    async zrange() {
+      return [];
+    },
+    eval(script: string, numKeys: number, ...args: Array<string | number>) {
+      // `HSET` is the join script's alone; the teardown only deletes and SREMs.
+      if (!script.includes("HSET")) {
+        // The teardown script: it stamps the tombstone it was handed.
+        generation = String(args[args.length - 2]);
+        return Promise.resolve(1);
+      }
+      // The join script. Held so the teardown can land between the pin and the
+      // write — the very window the tombstone exists to close.
+      const expected = String(args[numKeys]);
+      return new Promise((resolve) => {
+        releaseJoinScript = () => {
+          resolve((generation ?? "") === expected ? 1 : 0);
+        };
+      });
     },
   };
 
   const store = await createRedisRuntimeStore("redis://unused", {
-    keyPrefix: "bsp:test:nogen:",
+    keyPrefix: "bsp:test:tombstone:",
     redisClient: fakeRedis,
-    writeRetry: { maxAttempts: 4, initialRetryDelayMs: 1 },
+    writeRetry: { maxAttempts: 1 },
   });
 
   try {
-    await assert.rejects(
-      store.markSessionJoinedRoom("session-nogen", "ROOMNG"),
-      /no generation to pin/,
-    );
-    assert.equal(evalAttempts, 0, "nothing may be written unguarded");
+    // The room never had a generation, so the join pins `""`.
+    const joined = store.markSessionJoinedRoom("session-tombstoned", "ROOMTS");
+    joined.catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.ok(releaseJoinScript, "the join must have pinned and be waiting");
+
+    // It is torn down, which stamps the tombstone rather than clearing the key.
+    assert.equal(await store.deleteRoom("ROOMTS", null), true);
+    assert.equal(generation, "deleted");
+
+    // The pinned write now lands. An absent key would have matched `""` all
+    // over again and rebuilt the room's indexes.
+    (releaseJoinScript as (() => void) | null)?.();
+    await assert.rejects(joined, /changed hands/);
+  } finally {
+    (releaseJoinScript as (() => void) | null)?.();
+    await store.close();
+  }
+});
+
+test("redis runtime store leaves a tombstone where a torn-down room's generation was", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  // Against the real script, because the tombstone IS the script: a fake that
+  // stands in for `DELETE_ROOM_LUA` cannot tell a `SET` from a `DEL` (#242
+  // review).
+  const keyPrefix = createKeyPrefix();
+  const store = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
+  const session = createSession("session-tombstone");
+
+  try {
+    store.registerSession(session);
+    await store.markSessionJoinedRoom(session.id, "ROOMTB");
+    session.memberId = "member-tombstone";
+    session.memberToken = "token-tombstone";
+    store.addMember("ROOMTB", session.memberId, session, session.memberToken);
+    await store.flush?.();
+
+    assert.equal(await store.getRoomGeneration("ROOMTB"), null);
+    assert.equal(await store.deleteRoom("ROOMTB", null), true);
+
+    // Deleting the key made "torn down" indistinguishable from "never had a
+    // generation", so a write pinned at `""` matched the room it was about to
+    // resurrect.
+    assert.equal(await store.getRoomGeneration("ROOMTB"), "deleted");
+    // Which is what the join script compares a pre-teardown pin against; the
+    // ordering half of that is pinned by the fake-driven test above.
+    // The tombstone must not keep the code reserved: it is deliberately absent
+    // from the residue check, so the code is free to be handed out again.
+    assert.equal(await store.hasRoomResidue("ROOMTB"), false);
   } finally {
     await store.close();
   }

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -1120,7 +1120,7 @@ test("runtime index reaper keeps the resync record when its writes were not conf
   // the cleanup has not reached; dropping the record there leaves nothing to
   // announce the real state once the writes land (#242 review).
   const published: string[] = [];
-  let confirmed = false;
+  let releaseConfirmation: (() => void) | null = null;
   let sweeps = 0;
   const deadSession = createSession("session-unconf", "offline-node");
   deadSession.roomCode = "ROOM50";
@@ -1155,8 +1155,12 @@ test("runtime index reaper keeps the resync record when its writes were not conf
     async markSessionLeftRoom() {},
     unregisterSession() {},
     async purgeNodeStatus() {},
+    // Called ONCE, by the sweep that creates the record; later sweeps re-check
+    // that same promise rather than asking the store again.
     confirmWrites: () =>
-      confirmed ? Promise.resolve() : new Promise<void>(() => {}),
+      new Promise<void>((resolve) => {
+        releaseConfirmation = resolve;
+      }),
     flush: async () => {},
   };
 
@@ -1176,9 +1180,9 @@ test("runtime index reaper keeps the resync record when its writes were not conf
     await reaper.sweep();
     assert.deepEqual(published, ["ROOM50"]);
 
-    // Sweep two, with the writes now confirmable: the retained record is
-    // announced again, this time on a state built from confirmed writes.
-    confirmed = true;
+    // Sweep two, once the confirmation the first sweep started answers: the
+    // retained record is announced again, on a state built from those writes.
+    (releaseConfirmation as (() => void) | null)?.();
     await reaper.sweep();
     assert.deepEqual(published, ["ROOM50", "ROOM50"]);
 
@@ -1255,6 +1259,13 @@ test("runtime index reaper treats a refused member removal as unconfirmed", asyn
     assert.deepEqual(published, ["ROOM51"]);
     await reaper.sweep();
     assert.deepEqual(published, ["ROOM51", "ROOM51"], "the record survived");
+
+    // And it stays held. The binding is still in Redis with no retention clock
+    // armed, so `hasRoomResidue` keeps the code reserved and a state built now
+    // would still name the dead seat — releasing the latch here dropped the
+    // record while all of that was true (#242 review).
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM51", "ROOM51", "ROOM51"]);
   } finally {
     await reaper.stop();
   }
@@ -1267,7 +1278,7 @@ test("runtime index reaper keeps an unconfirmed record across the next sweep's o
   // sweep found no offline session to rebuild the record from either (#242
   // review).
   const published: string[] = [];
-  let confirmable = false;
+  let releaseConfirmation: (() => void) | null = null;
   let sessionsVisible = true;
   const deadSession = createSession("session-crossflush", "offline-node");
   deadSession.roomCode = "ROOM52";
@@ -1301,8 +1312,12 @@ test("runtime index reaper keeps an unconfirmed record across the next sweep's o
     async markSessionLeftRoom() {},
     unregisterSession() {},
     async purgeNodeStatus() {},
+    // Slow, then it answers — the shape the retained promise exists for. It is
+    // called ONCE; later sweeps re-check this same promise.
     confirmWrites: () =>
-      confirmable ? Promise.resolve() : new Promise<void>(() => {}),
+      new Promise<void>((resolve) => {
+        releaseConfirmation = resolve;
+      }),
   };
 
   const reaper = createRuntimeIndexReaper({
@@ -1327,9 +1342,9 @@ test("runtime index reaper keeps an unconfirmed record across the next sweep's o
     await reaper.sweep();
     assert.deepEqual(published, ["ROOM52", "ROOM52"]);
 
-    // Once the writes confirm, the record is published on a state built from
-    // them and finally dropped.
-    confirmable = true;
+    // The confirmation the first sweep started finally answers; the record is
+    // published on a state built from it and only then dropped.
+    (releaseConfirmation as (() => void) | null)?.();
     await reaper.sweep();
     assert.deepEqual(published, ["ROOM52", "ROOM52", "ROOM52"]);
     await reaper.sweep();

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -1031,3 +1031,160 @@ test("runtime index reaper does not inherit the write queue's full retry budget"
     await reaper.stop();
   }
 });
+
+test("runtime index reaper waits for the member removal before it announces", async () => {
+  // `confirmWrites` only ever sees the session write queue; `removeMember`
+  // returns its own `durable` promise, and dropping it let the sweep announce a
+  // state rebuilt from a member map that still held the dead seat (#242 review).
+  const order: string[] = [];
+  let releaseRemoval: (() => void) | null = null;
+  const removalSessions: Array<string | undefined> = [];
+  const deadSession = createSession("session-durable", "offline-node");
+  deadSession.roomCode = "ROOM49";
+  deadSession.memberId = "member-durable";
+  let sweepDone = false;
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return sweepDone
+        ? []
+        : [
+            {
+              instanceId: "offline-node",
+              version: "test",
+              startedAt: 0,
+              lastHeartbeatAt: 0,
+              staleAt: 0,
+              expiresAt: 0,
+              connectionCount: 1,
+              activeRoomCount: 1,
+              activeMemberCount: 1,
+              health: "offline" as const,
+            },
+          ];
+    },
+    async listClusterSessions() {
+      return sweepDone ? [] : [deadSession];
+    },
+    removeMember(_code, _memberId, session) {
+      removalSessions.push(session?.id);
+      return {
+        room: null,
+        roomEmpty: false,
+        removed: true,
+        durable: new Promise<void>((resolve) => {
+          releaseRemoval = () => {
+            order.push("removal-landed");
+            resolve();
+          };
+        }),
+      };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    async confirmWrites() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: async () => {
+      order.push("announced");
+    },
+  });
+
+  try {
+    const swept = reaper.sweep();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.deepEqual(order, [], "nothing may be announced yet");
+
+    (releaseRemoval as (() => void) | null)?.();
+    await swept;
+    sweepDone = true;
+
+    assert.deepEqual(order, ["removal-landed", "announced"]);
+    // The session is passed, so `REMOVE_MEMBER_LUA`'s binding guard is armed —
+    // otherwise a late script deletes a reconnected session's binding.
+    assert.deepEqual(removalSessions, ["session-durable"]);
+  } finally {
+    (releaseRemoval as (() => void) | null)?.();
+    await reaper.stop();
+  }
+});
+
+test("runtime index reaper keeps the resync record when its writes were not confirmed", async () => {
+  // Announcing on unconfirmed writes may hand out a state rebuilt from an index
+  // the cleanup has not reached; dropping the record there leaves nothing to
+  // announce the real state once the writes land (#242 review).
+  const published: string[] = [];
+  let confirmed = false;
+  let sweeps = 0;
+  const deadSession = createSession("session-unconf", "offline-node");
+  deadSession.roomCode = "ROOM50";
+  deadSession.memberId = "member-unconf";
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return sweeps > 1
+        ? []
+        : [
+            {
+              instanceId: "offline-node",
+              version: "test",
+              startedAt: 0,
+              lastHeartbeatAt: 0,
+              staleAt: 0,
+              expiresAt: 0,
+              connectionCount: 1,
+              activeRoomCount: 1,
+              activeMemberCount: 1,
+              health: "offline" as const,
+            },
+          ];
+    },
+    async listClusterSessions() {
+      sweeps += 1;
+      return sweeps > 1 ? [] : [deadSession];
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    confirmWrites: () =>
+      confirmed ? Promise.resolve() : new Promise<void>(() => {}),
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: async (roomCode) => {
+      published.push(roomCode);
+    },
+  });
+
+  try {
+    // Sweep one: the confirmation never comes back, so the announcement goes
+    // out but the record must survive it.
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM50"]);
+
+    // Sweep two, with the writes now confirmable: the retained record is
+    // announced again, this time on a state built from confirmed writes.
+    confirmed = true;
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM50", "ROOM50"]);
+
+    // And now it is finally dropped.
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM50", "ROOM50"]);
+  } finally {
+    await reaper.stop();
+  }
+});

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -1338,3 +1338,157 @@ test("runtime index reaper keeps an unconfirmed record across the next sweep's o
     await reaper.stop();
   }
 });
+
+test("runtime index reaper re-confirms the member removal, not just the write queue", async () => {
+  // The flag is set by a member removal too, and `confirmWrites` never sees
+  // that promise — so clearing on `confirmWrites` alone dropped the record
+  // while `REMOVE_MEMBER_LUA` was still pending (#242 review).
+  const published: string[] = [];
+  let releaseRemoval: (() => void) | null = null;
+  let sweeps = 0;
+  const deadSession = createSession("session-reconfirm", "offline-node");
+  deadSession.roomCode = "ROOM53";
+  deadSession.memberId = "member-reconfirm";
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return sweeps > 1
+        ? []
+        : [
+            {
+              instanceId: "offline-node",
+              version: "test",
+              startedAt: 0,
+              lastHeartbeatAt: 0,
+              staleAt: 0,
+              expiresAt: 0,
+              connectionCount: 1,
+              activeRoomCount: 1,
+              activeMemberCount: 1,
+              health: "offline" as const,
+            },
+          ];
+    },
+    async listClusterSessions() {
+      sweeps += 1;
+      return sweeps > 1 ? [] : [deadSession];
+    },
+    removeMember() {
+      return {
+        room: null,
+        roomEmpty: false,
+        removed: true,
+        durable: new Promise<void>((resolve) => {
+          releaseRemoval = resolve;
+        }),
+      };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    // The store's OWN writes confirm immediately; only the removal is pending.
+    async confirmWrites() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: async (roomCode) => {
+      published.push(roomCode);
+    },
+  });
+
+  try {
+    // Sweep one: the removal never answers inside the budget, so the record is
+    // retained even though `confirmWrites` succeeded.
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM53"]);
+
+    // Sweep two: `confirmWrites` still succeeds, but the removal is STILL
+    // pending — the record must not be dropped on that alone.
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM53", "ROOM53"]);
+
+    // Once the removal lands, the record is published and finally dropped.
+    (releaseRemoval as (() => void) | null)?.();
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM53", "ROOM53", "ROOM53"]);
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM53", "ROOM53", "ROOM53"]);
+  } finally {
+    (releaseRemoval as (() => void) | null)?.();
+    await reaper.stop();
+  }
+});
+
+test("runtime index reaper does not inherit the store's retry budget on the index write", async () => {
+  // The sweep's only direct `await` on a store write ran on the write queue's
+  // FULL normal budget — attempts of up to the pending-operation timeout each,
+  // per session, serially. One unreachable session was enough to hold `stop()`
+  // past its whole step, because `stop` waits for the sweep in flight before
+  // its own bounded pass starts (#242 review).
+  let releaseWrite: (() => void) | null = null;
+  const deadSession = createSession("session-slowwrite", "offline-node");
+  deadSession.roomCode = "ROOM54";
+  deadSession.memberId = "member-slowwrite";
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return [
+        {
+          instanceId: "offline-node",
+          version: "test",
+          startedAt: 0,
+          lastHeartbeatAt: 0,
+          staleAt: 0,
+          expiresAt: 0,
+          connectionCount: 1,
+          activeRoomCount: 1,
+          activeMemberCount: 1,
+          health: "offline" as const,
+        },
+      ];
+    },
+    async listClusterSessions() {
+      return releaseWrite ? [] : [deadSession];
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    markSessionLeftRoom() {
+      // Stands in for a write burning the store's normal retry budget.
+      return new Promise<void>((resolve) => {
+        releaseWrite = resolve;
+      });
+    },
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    async confirmWrites() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: async () => {},
+  });
+
+  try {
+    const startedAt = Date.now();
+    // Completes because the sweep's wait is capped, not because the write
+    // answered — it never does.
+    await reaper.sweep();
+    const elapsed = Date.now() - startedAt;
+    assert.ok(
+      elapsed < 5_000,
+      `the sweep must not inherit the write's budget, took ${elapsed}ms`,
+    );
+    assert.ok(releaseWrite, "the write really was still outstanding");
+  } finally {
+    (releaseWrite as (() => void) | null)?.();
+    await reaper.stop();
+  }
+});

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -825,6 +825,7 @@ test("runtime index reaper caps a resync publish that never settles", async () =
   // at all when the bus hangs rather than rejecting: the call already in flight
   // pins the sweep drain and the shutdown pass alike (#242 review).
   const events: string[] = [];
+  let releasePublish: (() => void) | null = null;
   const deadSession = createSession("session-hung", "offline-node");
   deadSession.roomCode = "ROOM46";
   deadSession.memberId = "member-hung";
@@ -869,9 +870,12 @@ test("runtime index reaper caps a resync publish that never settles", async () =
     logEvent: (event) => {
       events.push(event);
     },
-    // Never settles. Without a per-publish cap the sweep — and every later
-    // shutdown pass — waits on it forever.
-    publishRoomStateUpdate: () => new Promise<void>(() => {}),
+    // Never settles until released. Without a per-publish cap the sweep — and
+    // every later shutdown pass — waits on it forever.
+    publishRoomStateUpdate: () =>
+      new Promise<void>((resolve) => {
+        releasePublish = resolve;
+      }),
   });
 
   try {
@@ -879,6 +883,151 @@ test("runtime index reaper caps a resync publish that never settles", async () =
     assert.ok(events.includes("runtime_index_resync_publish_failed"));
   } finally {
     sweepDone = true;
+    // The shutdown pass deliberately waits out its budget for a call still in
+    // flight; letting it answer keeps this test off that 3s path.
+    (releasePublish as (() => void) | null)?.();
+    await reaper.stop();
+  }
+});
+
+test("runtime index reaper does not start a second publish for a room still waiting", async () => {
+  // The per-publish cap races the bus call, it cannot abort it — so without
+  // tracking, every sweep starts ANOTHER publish for the same room and one hung
+  // bus accumulates Redis commands for as long as it stays hung (#242 review).
+  let publishCalls = 0;
+  let releasePublish: (() => void) | null = null;
+  let sweepsRun = 0;
+  const deadSession = createSession("session-stuck", "offline-node");
+  deadSession.roomCode = "ROOM47";
+  deadSession.memberId = "member-stuck";
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return sweepsRun > 0
+        ? []
+        : [
+            {
+              instanceId: "offline-node",
+              version: "test",
+              startedAt: 0,
+              lastHeartbeatAt: 0,
+              staleAt: 0,
+              expiresAt: 0,
+              connectionCount: 1,
+              activeRoomCount: 1,
+              activeMemberCount: 1,
+              health: "offline" as const,
+            },
+          ];
+    },
+    async listClusterSessions() {
+      return sweepsRun > 0 ? [] : [deadSession];
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    async flush() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: () => {
+      publishCalls += 1;
+      return new Promise<void>((resolve) => {
+        releasePublish = resolve;
+      });
+    },
+  });
+
+  try {
+    // Sweep one starts the publish; its cap fires and the record is retained.
+    await reaper.sweep();
+    sweepsRun = 1;
+    assert.equal(publishCalls, 1);
+
+    // Later sweeps retry the record — but the first call has still not come
+    // back, so they must not open another.
+    await reaper.sweep();
+    await reaper.sweep();
+    assert.equal(publishCalls, 1, "one in-flight publish per room, no more");
+  } finally {
+    (releasePublish as (() => void) | null)?.();
+    await reaper.stop();
+  }
+});
+
+test("runtime index reaper does not inherit the write queue's full retry budget", async () => {
+  // `confirmWrites` waits on the NORMAL retry budget — attempts of up to
+  // `pendingOperationTimeoutMs` each, per session, serially — and one
+  // unreachable session is enough to stretch that past the whole shutdown step.
+  // The sweep announces either way, so waiting longer buys nothing (#242 review).
+  const events: string[] = [];
+  const deadSession = createSession("session-slowconfirm", "offline-node");
+  deadSession.roomCode = "ROOM48";
+  deadSession.memberId = "member-slowconfirm";
+  let releaseConfirm: (() => void) | null = null;
+  const published: string[] = [];
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return [
+        {
+          instanceId: "offline-node",
+          version: "test",
+          startedAt: 0,
+          lastHeartbeatAt: 0,
+          staleAt: 0,
+          expiresAt: 0,
+          connectionCount: 1,
+          activeRoomCount: 1,
+          activeMemberCount: 1,
+          health: "offline" as const,
+        },
+      ];
+    },
+    async listClusterSessions() {
+      return published.length > 0 ? [] : [deadSession];
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    // Stands in for a session whose writes are still burning their retry
+    // budget against an unreachable Redis.
+    confirmWrites: () =>
+      new Promise<void>((resolve) => {
+        releaseConfirm = resolve;
+      }),
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    logEvent: (event) => {
+      events.push(event);
+    },
+    publishRoomStateUpdate: async (roomCode) => {
+      published.push(roomCode);
+    },
+  });
+
+  try {
+    // Completes because the wait is capped, not because the store answered.
+    assert.equal(await reaper.sweep(), 1);
+    assert.ok(events.includes("runtime_index_writes_unconfirmed"));
+    assert.deepEqual(published, ["ROOM48"], "the announcement is not gated");
+  } finally {
+    (releaseConfirm as (() => void) | null)?.();
     await reaper.stop();
   }
 });

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -962,11 +962,12 @@ test("runtime index reaper does not start a second publish for a room still wait
   }
 });
 
-test("runtime index reaper does not inherit the write queue's full retry budget", async () => {
-  // `confirmWrites` waits on the NORMAL retry budget — attempts of up to
-  // `pendingOperationTimeoutMs` each, per session, serially — and one
-  // unreachable session is enough to stretch that past the whole shutdown step.
-  // The sweep announces either way, so waiting longer buys nothing (#242 review).
+test("runtime index reaper waits out its own writes, and stop is what releases it", async () => {
+  // The 2s cap this used to carry was itself the first patch — put there for
+  // the shutdown budget — and the latch map, the re-confirmation pass and the
+  // re-issued removal all existed to compensate for giving up early. A sweep
+  // has no deadline of its own, so it simply waits; `stop()` is the only thing
+  // that cuts it short (#242).
   const events: string[] = [];
   const deadSession = createSession("session-slowconfirm", "offline-node");
   deadSession.roomCode = "ROOM48";
@@ -1000,8 +1001,6 @@ test("runtime index reaper does not inherit the write queue's full retry budget"
     async markSessionLeftRoom() {},
     unregisterSession() {},
     async purgeNodeStatus() {},
-    // Stands in for a session whose writes are still burning their retry
-    // budget against an unreachable Redis.
     confirmWrites: () =>
       new Promise<void>((resolve) => {
         releaseConfirm = resolve;
@@ -1022,14 +1021,76 @@ test("runtime index reaper does not inherit the write queue's full retry budget"
   });
 
   try {
-    // Completes because the wait is capped, not because the store answered.
-    assert.equal(await reaper.sweep(), 1);
-    assert.ok(events.includes("runtime_index_writes_unconfirmed"));
-    assert.deepEqual(published, ["ROOM48"], "the announcement is not gated");
+    let sweepDone = false;
+    const swept = reaper.sweep().then(() => {
+      sweepDone = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.equal(sweepDone, false, "the sweep waits for its own writes");
+    assert.deepEqual(published, [], "and announces nothing before they land");
+
+    (releaseConfirm as (() => void) | null)?.();
+    await swept;
+    assert.deepEqual(published, ["ROOM48"]);
   } finally {
     (releaseConfirm as (() => void) | null)?.();
     await reaper.stop();
   }
+});
+
+test("runtime index reaper stops waiting for its writes when it is told to stop", async () => {
+  const deadSession = createSession("session-stopwait", "offline-node");
+  deadSession.roomCode = "ROOM55";
+  deadSession.memberId = "member-stopwait";
+  let releaseConfirm: (() => void) | null = null;
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return [
+        {
+          instanceId: "offline-node",
+          version: "test",
+          startedAt: 0,
+          lastHeartbeatAt: 0,
+          staleAt: 0,
+          expiresAt: 0,
+          connectionCount: 1,
+          activeRoomCount: 1,
+          activeMemberCount: 1,
+          health: "offline" as const,
+        },
+      ];
+    },
+    async listClusterSessions() {
+      return [deadSession];
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    confirmWrites: () =>
+      new Promise<void>((resolve) => {
+        releaseConfirm = resolve;
+      }),
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: async () => {},
+  });
+
+  const swept = reaper.sweep();
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  // No timer releases this — only the stop signal.
+  await reaper.stop();
+  await swept;
+  (releaseConfirm as (() => void) | null)?.();
 });
 
 test("runtime index reaper waits for the member removal before it announces", async () => {
@@ -1109,346 +1170,6 @@ test("runtime index reaper waits for the member removal before it announces", as
     // The session is passed, so `REMOVE_MEMBER_LUA`'s binding guard is armed —
     // otherwise a late script deletes a reconnected session's binding.
     assert.deepEqual(removalSessions, ["session-durable"]);
-  } finally {
-    (releaseRemoval as (() => void) | null)?.();
-    await reaper.stop();
-  }
-});
-
-test("runtime index reaper keeps the resync record when its writes were not confirmed", async () => {
-  // Announcing on unconfirmed writes may hand out a state rebuilt from an index
-  // the cleanup has not reached; dropping the record there leaves nothing to
-  // announce the real state once the writes land (#242 review).
-  const published: string[] = [];
-  let releaseConfirmation: (() => void) | null = null;
-  let sweeps = 0;
-  const deadSession = createSession("session-unconf", "offline-node");
-  deadSession.roomCode = "ROOM50";
-  deadSession.memberId = "member-unconf";
-
-  const runtimeStore: RuntimeIndexReaperStore = {
-    async listNodeStatuses() {
-      return sweeps > 1
-        ? []
-        : [
-            {
-              instanceId: "offline-node",
-              version: "test",
-              startedAt: 0,
-              lastHeartbeatAt: 0,
-              staleAt: 0,
-              expiresAt: 0,
-              connectionCount: 1,
-              activeRoomCount: 1,
-              activeMemberCount: 1,
-              health: "offline" as const,
-            },
-          ];
-    },
-    async listClusterSessions() {
-      sweeps += 1;
-      return sweeps > 1 ? [] : [deadSession];
-    },
-    removeMember() {
-      return { room: null, roomEmpty: false, removed: true };
-    },
-    async markSessionLeftRoom() {},
-    unregisterSession() {},
-    async purgeNodeStatus() {},
-    // Called ONCE, by the sweep that creates the record; later sweeps re-check
-    // that same promise rather than asking the store again.
-    confirmWrites: () =>
-      new Promise<void>((resolve) => {
-        releaseConfirmation = resolve;
-      }),
-    flush: async () => {},
-  };
-
-  const reaper = createRuntimeIndexReaper({
-    enabled: true,
-    runtimeStore,
-    intervalMs: 50,
-    now: () => 1_000,
-    publishRoomStateUpdate: async (roomCode) => {
-      published.push(roomCode);
-    },
-  });
-
-  try {
-    // Sweep one: the confirmation never comes back, so the announcement goes
-    // out but the record must survive it.
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM50"]);
-
-    // Sweep two, once the confirmation the first sweep started answers: the
-    // retained record is announced again, on a state built from those writes.
-    (releaseConfirmation as (() => void) | null)?.();
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM50", "ROOM50"]);
-
-    // And now it is finally dropped.
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM50", "ROOM50"]);
-  } finally {
-    await reaper.stop();
-  }
-});
-
-test("runtime index reaper treats a refused member removal as unconfirmed", async () => {
-  // Swallowing `removal.durable` turned a refused `REMOVE_MEMBER_LUA` into a
-  // confirmed write, so the sweep published and then dropped the room's only
-  // resync record — while the stale member binding was still in Redis and its
-  // token retention had never been armed (#242 review).
-  const published: string[] = [];
-  const removalCalls: string[] = [];
-  const deadSession = createSession("session-refused", "offline-node");
-  deadSession.roomCode = "ROOM51";
-  deadSession.memberId = "member-refused";
-  let sweeps = 0;
-
-  const runtimeStore: RuntimeIndexReaperStore = {
-    async listNodeStatuses() {
-      return sweeps > 1
-        ? []
-        : [
-            {
-              instanceId: "offline-node",
-              version: "test",
-              startedAt: 0,
-              lastHeartbeatAt: 0,
-              staleAt: 0,
-              expiresAt: 0,
-              connectionCount: 1,
-              activeRoomCount: 1,
-              activeMemberCount: 1,
-              health: "offline" as const,
-            },
-          ];
-    },
-    async listClusterSessions() {
-      sweeps += 1;
-      return sweeps > 1 ? [] : [deadSession];
-    },
-    removeMember(code, memberId, session) {
-      removalCalls.push(`${code}:${memberId}:${session?.id ?? ""}`);
-      if (removalCalls.length >= 2) {
-        // Re-issued from the arguments the reaper kept: this one lands.
-        return {
-          room: null,
-          roomEmpty: false,
-          removed: true,
-          durable: Promise.resolve(),
-        };
-      }
-      const durable = Promise.reject(new Error("remove member refused"));
-      void durable.catch(() => undefined);
-      return { room: null, roomEmpty: false, removed: true, durable };
-    },
-    async markSessionLeftRoom() {},
-    unregisterSession() {},
-    async purgeNodeStatus() {},
-    async confirmWrites() {},
-  };
-
-  const reaper = createRuntimeIndexReaper({
-    enabled: true,
-    runtimeStore,
-    intervalMs: 50,
-    now: () => 1_000,
-    publishRoomStateUpdate: async (roomCode) => {
-      published.push(roomCode);
-    },
-  });
-
-  try {
-    await reaper.sweep();
-    // Announced — silence would be worse — but the record must NOT have been
-    // dropped on a removal that was refused.
-    assert.deepEqual(published, ["ROOM51"]);
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM51", "ROOM51"], "the record survived");
-
-    // The refusal is RE-ISSUED from the arguments the reaper kept — the session
-    // is already out of `listClusterSessions`, so nothing else could rediscover
-    // it. Only once that lands does the record clear.
-    assert.deepEqual(removalCalls, [
-      "ROOM51:member-refused:session-refused",
-      "ROOM51:member-refused:session-refused",
-    ]);
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM51", "ROOM51", "ROOM51"]);
-    await reaper.sweep();
-    assert.deepEqual(
-      published,
-      ["ROOM51", "ROOM51", "ROOM51"],
-      "the re-issued removal landed, so the record is finally dropped",
-    );
-  } finally {
-    await reaper.stop();
-  }
-});
-
-test("runtime index reaper keeps an unconfirmed record across the next sweep's opening flush", async () => {
-  // `keepRecords` used to be applied only in the sweep that created the record,
-  // so the very next sweep's OPENING flush published and deleted it before
-  // anything had been re-confirmed — and if the cleanup landed in between, that
-  // sweep found no offline session to rebuild the record from either (#242
-  // review).
-  const published: string[] = [];
-  let releaseConfirmation: (() => void) | null = null;
-  let sessionsVisible = true;
-  const deadSession = createSession("session-crossflush", "offline-node");
-  deadSession.roomCode = "ROOM52";
-  deadSession.memberId = "member-crossflush";
-
-  const runtimeStore: RuntimeIndexReaperStore = {
-    async listNodeStatuses() {
-      return sessionsVisible
-        ? [
-            {
-              instanceId: "offline-node",
-              version: "test",
-              startedAt: 0,
-              lastHeartbeatAt: 0,
-              staleAt: 0,
-              expiresAt: 0,
-              connectionCount: 1,
-              activeRoomCount: 1,
-              activeMemberCount: 1,
-              health: "offline" as const,
-            },
-          ]
-        : [];
-    },
-    async listClusterSessions() {
-      return sessionsVisible ? [deadSession] : [];
-    },
-    removeMember() {
-      return { room: null, roomEmpty: false, removed: true };
-    },
-    async markSessionLeftRoom() {},
-    unregisterSession() {},
-    async purgeNodeStatus() {},
-    // Slow, then it answers — the shape the retained promise exists for. It is
-    // called ONCE; later sweeps re-check this same promise.
-    confirmWrites: () =>
-      new Promise<void>((resolve) => {
-        releaseConfirmation = resolve;
-      }),
-  };
-
-  const reaper = createRuntimeIndexReaper({
-    enabled: true,
-    runtimeStore,
-    intervalMs: 50,
-    now: () => 1_000,
-    publishRoomStateUpdate: async (roomCode) => {
-      published.push(roomCode);
-    },
-  });
-
-  try {
-    // Sweep one: cleanup writes never confirm, so the record must survive.
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM52"]);
-
-    // The session is now gone from the cluster index — exactly the state in
-    // which nothing could rebuild the record — and the writes still do not
-    // confirm. The opening flush of sweep two must NOT drop it.
-    sessionsVisible = false;
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM52", "ROOM52"]);
-
-    // The confirmation the first sweep started finally answers; the record is
-    // published on a state built from it and only then dropped.
-    (releaseConfirmation as (() => void) | null)?.();
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM52", "ROOM52", "ROOM52"]);
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM52", "ROOM52", "ROOM52"]);
-  } finally {
-    await reaper.stop();
-  }
-});
-
-test("runtime index reaper re-confirms the member removal, not just the write queue", async () => {
-  // The flag is set by a member removal too, and `confirmWrites` never sees
-  // that promise — so clearing on `confirmWrites` alone dropped the record
-  // while `REMOVE_MEMBER_LUA` was still pending (#242 review).
-  const published: string[] = [];
-  let releaseRemoval: (() => void) | null = null;
-  let sweeps = 0;
-  const deadSession = createSession("session-reconfirm", "offline-node");
-  deadSession.roomCode = "ROOM53";
-  deadSession.memberId = "member-reconfirm";
-
-  const runtimeStore: RuntimeIndexReaperStore = {
-    async listNodeStatuses() {
-      return sweeps > 1
-        ? []
-        : [
-            {
-              instanceId: "offline-node",
-              version: "test",
-              startedAt: 0,
-              lastHeartbeatAt: 0,
-              staleAt: 0,
-              expiresAt: 0,
-              connectionCount: 1,
-              activeRoomCount: 1,
-              activeMemberCount: 1,
-              health: "offline" as const,
-            },
-          ];
-    },
-    async listClusterSessions() {
-      sweeps += 1;
-      return sweeps > 1 ? [] : [deadSession];
-    },
-    removeMember() {
-      return {
-        room: null,
-        roomEmpty: false,
-        removed: true,
-        durable: new Promise<void>((resolve) => {
-          releaseRemoval = resolve;
-        }),
-      };
-    },
-    async markSessionLeftRoom() {},
-    unregisterSession() {},
-    async purgeNodeStatus() {},
-    // The store's OWN writes confirm immediately; only the removal is pending.
-    async confirmWrites() {},
-  };
-
-  const reaper = createRuntimeIndexReaper({
-    enabled: true,
-    runtimeStore,
-    intervalMs: 50,
-    now: () => 1_000,
-    publishRoomStateUpdate: async (roomCode) => {
-      published.push(roomCode);
-    },
-  });
-
-  try {
-    // Sweep one: the removal never answers inside the budget, so the record is
-    // retained even though `confirmWrites` succeeded.
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM53"]);
-
-    // Sweep two: `confirmWrites` still succeeds, but the removal is STILL
-    // pending — the record must not be dropped on that alone.
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM53", "ROOM53"]);
-
-    // Once the removal lands, the record is published and finally dropped.
-    (releaseRemoval as (() => void) | null)?.();
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM53", "ROOM53", "ROOM53"]);
-    await reaper.sweep();
-    assert.deepEqual(published, ["ROOM53", "ROOM53", "ROOM53"]);
   } finally {
     (releaseRemoval as (() => void) | null)?.();
     await reaper.stop();

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -212,14 +212,19 @@ test("runtime index reaper tells the rooms it emptied to rebuild", async (t) => 
   }
 });
 
-test("runtime index reaper announces the room even when the index write fails", async () => {
-  // Gating the announcement on that write lost it for good: `unregisterSession`
-  // deletes the session hash and SREMs the same room-sessions key on its own, so
-  // the room ends up clean either way — while the session disappears from
-  // `listClusterSessions`, leaving the next pass nothing to retry (#235 review).
+test("runtime index reaper leaves the session alone when its index write fails", async () => {
+  // The announcement is one-shot, so spending it on a room whose index this
+  // sweep has not cleaned strands that room for good. #235 answered this by
+  // announcing anyway, on the grounds that `unregisterSession` deletes the
+  // session hash regardless and gating would leave the next pass nothing to
+  // retry. The session record IS the retry trail — so the sweep now stops
+  // short of destroying it, and the next sweep redoes the whole cleanup
+  // (#242 review).
   const published: string[] = [];
   let flushed = 0;
   const reaped: string[] = [];
+  const events: string[] = [];
+  let indexWriteFailures = 1;
   const deadSession = createSession("session-unwritable", "offline-node");
   deadSession.roomCode = "ROOM42";
   deadSession.memberId = "member-unwritable";
@@ -242,13 +247,18 @@ test("runtime index reaper announces the room even when the index write fails", 
       ];
     },
     async listClusterSessions() {
+      // The session is still in the cluster index precisely because the sweep
+      // did not unregister it.
       return reaped.length > 0 ? [] : [deadSession];
     },
     removeMember() {
       return { room: null, roomEmpty: false, removed: true };
     },
     async markSessionLeftRoom() {
-      throw new Error("index write failed");
+      if (indexWriteFailures > 0) {
+        indexWriteFailures -= 1;
+        throw new Error("index write failed");
+      }
     },
     unregisterSession(sessionId: string) {
       reaped.push(sessionId);
@@ -266,12 +276,21 @@ test("runtime index reaper announces the room even when the index write fails", 
     runtimeStore,
     intervalMs: 50,
     now: () => 1_000,
+    logEvent: (event) => {
+      events.push(event);
+    },
     publishRoomStateUpdate: async (roomCode) => {
       published.push(roomCode);
     },
   });
 
   try {
+    assert.equal(await reaper.sweep(), 0, "nothing was cleaned");
+    assert.deepEqual(reaped, [], "the retry trail must survive");
+    assert.deepEqual(published, [], "and the one-shot announcement with it");
+    assert.ok(events.includes("runtime_index_cleanup_unconfirmed"));
+
+    // Next sweep: the write lands, and only now is the session destroyed.
     assert.equal(await reaper.sweep(), 1);
     assert.deepEqual(reaped, ["session-unwritable"]);
     assert.deepEqual(published, ["ROOM42"]);
@@ -282,6 +301,174 @@ test("runtime index reaper announces the room even when the index write fails", 
   } finally {
     await reaper.stop();
   }
+});
+
+test("runtime index reaper retries a member removal that never landed", async () => {
+  // `removeMember`'s durable write can exhaust its retries. Unregistering the
+  // session anyway took the room code and member id with it, so nothing could
+  // ever re-issue the removal: the stale binding stayed in Redis with its token
+  // retention never armed, and `hasRoomResidue` kept the code reserved for good
+  // (#242 review).
+  const published: string[] = [];
+  const reaped: string[] = [];
+  const removals: Array<[string, string]> = [];
+  const leftRoom: string[] = [];
+  let removalFailures = 1;
+  const deadSession = createSession("session-stuckremoval", "offline-node");
+  deadSession.roomCode = "ROOM56";
+  deadSession.memberId = "member-stuckremoval";
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return [
+        {
+          instanceId: "offline-node",
+          version: "test",
+          startedAt: 0,
+          lastHeartbeatAt: 0,
+          staleAt: 0,
+          expiresAt: 0,
+          connectionCount: 1,
+          activeRoomCount: 1,
+          activeMemberCount: 1,
+          health: "offline" as const,
+        },
+      ];
+    },
+    async listClusterSessions() {
+      return reaped.length > 0 ? [] : [deadSession];
+    },
+    removeMember(code: string, memberId: string) {
+      removals.push([code, memberId]);
+      if (removalFailures > 0) {
+        removalFailures -= 1;
+        return {
+          room: null,
+          roomEmpty: false,
+          removed: true,
+          durable: Promise.reject(new Error("member removal exhausted")),
+        };
+      }
+      return {
+        room: null,
+        roomEmpty: false,
+        removed: true,
+        durable: Promise.resolve(),
+      };
+    },
+    async markSessionLeftRoom(sessionId: string) {
+      leftRoom.push(sessionId);
+    },
+    unregisterSession(sessionId: string) {
+      reaped.push(sessionId);
+    },
+    async purgeNodeStatus() {},
+    async confirmWrites() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: async (roomCode) => {
+      published.push(roomCode);
+    },
+  });
+
+  try {
+    assert.equal(await reaper.sweep(), 0);
+    assert.deepEqual(
+      leftRoom,
+      [],
+      "blanking the room code destroys what a retry needs",
+    );
+    assert.deepEqual(reaped, []);
+    assert.deepEqual(published, []);
+
+    assert.equal(await reaper.sweep(), 1);
+    assert.deepEqual(removals, [
+      ["ROOM56", "member-stuckremoval"],
+      ["ROOM56", "member-stuckremoval"],
+    ]);
+    assert.deepEqual(reaped, ["session-stuckremoval"]);
+    assert.deepEqual(published, ["ROOM56"]);
+  } finally {
+    await reaper.stop();
+  }
+});
+
+test("runtime index reaper does not announce a room it stopped halfway through", async () => {
+  // Stop resolves the wait immediately, and the sweep used to carry on to
+  // `roomsAwaitingResync` from there — where `stop()`'s own final pass
+  // broadcasts it at once. The cleanup writes then land AFTER the broadcast,
+  // and with the session unregistered nothing can rediscover the room: every
+  // other node keeps a state built from the dirty index for good (#242 review).
+  const published: string[] = [];
+  const reaped: string[] = [];
+  const deadSession = createSession("session-stopmid", "offline-node");
+  deadSession.roomCode = "ROOM57";
+  deadSession.memberId = "member-stopmid";
+  let releaseWrite: (() => void) | null = null;
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return [
+        {
+          instanceId: "offline-node",
+          version: "test",
+          startedAt: 0,
+          lastHeartbeatAt: 0,
+          staleAt: 0,
+          expiresAt: 0,
+          connectionCount: 1,
+          activeRoomCount: 1,
+          activeMemberCount: 1,
+          health: "offline" as const,
+        },
+      ];
+    },
+    async listClusterSessions() {
+      return [deadSession];
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    markSessionLeftRoom() {
+      // Outstanding when the stop signal arrives — the write is on its way,
+      // just not answered yet.
+      return new Promise<void>((resolve) => {
+        releaseWrite = resolve;
+      });
+    },
+    unregisterSession(sessionId: string) {
+      reaped.push(sessionId);
+    },
+    async purgeNodeStatus() {},
+    async confirmWrites() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: async (roomCode) => {
+      published.push(roomCode);
+    },
+  });
+
+  const swept = reaper.sweep();
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.ok(releaseWrite, "the index write really was outstanding");
+
+  // `stop` runs its own final publish pass; the room must not be in it.
+  await reaper.stop();
+  await swept;
+  (releaseWrite as (() => void) | null)?.();
+
+  assert.deepEqual(published, [], "no announcement off an uncleaned index");
+  assert.deepEqual(reaped, [], "and the session stays for the next instance");
 });
 
 test("runtime index reaper keeps a failed announcement until it is published", async () => {

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -1200,6 +1200,7 @@ test("runtime index reaper treats a refused member removal as unconfirmed", asyn
   // resync record — while the stale member binding was still in Redis and its
   // token retention had never been armed (#242 review).
   const published: string[] = [];
+  const removalCalls: string[] = [];
   const deadSession = createSession("session-refused", "offline-node");
   deadSession.roomCode = "ROOM51";
   deadSession.memberId = "member-refused";
@@ -1228,13 +1229,20 @@ test("runtime index reaper treats a refused member removal as unconfirmed", asyn
       sweeps += 1;
       return sweeps > 1 ? [] : [deadSession];
     },
-    removeMember() {
-      return {
-        room: null,
-        roomEmpty: false,
-        removed: true,
-        durable: Promise.reject(new Error("remove member refused")),
-      };
+    removeMember(code, memberId, session) {
+      removalCalls.push(`${code}:${memberId}:${session?.id ?? ""}`);
+      if (removalCalls.length >= 2) {
+        // Re-issued from the arguments the reaper kept: this one lands.
+        return {
+          room: null,
+          roomEmpty: false,
+          removed: true,
+          durable: Promise.resolve(),
+        };
+      }
+      const durable = Promise.reject(new Error("remove member refused"));
+      void durable.catch(() => undefined);
+      return { room: null, roomEmpty: false, removed: true, durable };
     },
     async markSessionLeftRoom() {},
     unregisterSession() {},
@@ -1260,12 +1268,21 @@ test("runtime index reaper treats a refused member removal as unconfirmed", asyn
     await reaper.sweep();
     assert.deepEqual(published, ["ROOM51", "ROOM51"], "the record survived");
 
-    // And it stays held. The binding is still in Redis with no retention clock
-    // armed, so `hasRoomResidue` keeps the code reserved and a state built now
-    // would still name the dead seat — releasing the latch here dropped the
-    // record while all of that was true (#242 review).
+    // The refusal is RE-ISSUED from the arguments the reaper kept — the session
+    // is already out of `listClusterSessions`, so nothing else could rediscover
+    // it. Only once that lands does the record clear.
+    assert.deepEqual(removalCalls, [
+      "ROOM51:member-refused:session-refused",
+      "ROOM51:member-refused:session-refused",
+    ]);
     await reaper.sweep();
     assert.deepEqual(published, ["ROOM51", "ROOM51", "ROOM51"]);
+    await reaper.sweep();
+    assert.deepEqual(
+      published,
+      ["ROOM51", "ROOM51", "ROOM51"],
+      "the re-issued removal landed, so the record is finally dropped",
+    );
   } finally {
     await reaper.stop();
   }

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -546,3 +546,86 @@ test("runtime index reaper does not start a sweep while one is still running", a
     await reaper.stop();
   }
 });
+
+test("runtime index reaper never evicts an announcement it has not published", async () => {
+  // A record is the only trail back to its room: the offline sessions are
+  // already out of the cluster index. Shedding load by discarding unpublished
+  // one-shot notifications reintroduces the exact loss the set exists to
+  // prevent (#242 review).
+  const published: string[] = [];
+  let busDown = true;
+  let sweepIndex = 0;
+  const roomCount = 600;
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return sweepIndex === 0
+        ? [
+            {
+              instanceId: "offline-node",
+              version: "test",
+              startedAt: 0,
+              lastHeartbeatAt: 0,
+              staleAt: 0,
+              expiresAt: 0,
+              connectionCount: roomCount,
+              activeRoomCount: roomCount,
+              activeMemberCount: roomCount,
+              health: "offline" as const,
+            },
+          ]
+        : [];
+    },
+    async listClusterSessions() {
+      if (sweepIndex > 0) {
+        return [];
+      }
+      return Array.from({ length: roomCount }, (_unused, index) => {
+        const session = createSession(`session-${index}`, "offline-node");
+        session.roomCode = `ROOM${index}`;
+        session.memberId = `member-${index}`;
+        return session;
+      });
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    async flush() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: async (roomCode) => {
+      if (busDown) {
+        throw new Error("bus down");
+      }
+      published.push(roomCode);
+    },
+  });
+
+  try {
+    assert.equal(await reaper.sweep(), roomCount);
+    // `.length`, not `deepEqual(published, [])`: under `assert/strict` that is
+    // an assertion signature and narrows `published` to `never[]` for the rest
+    // of the test, which `tsx --test` runs happily and `tsc` then rejects.
+    assert.equal(published.length, 0, "every publish failed");
+
+    // The bus recovers. Every room — including the ones a cap would have
+    // evicted — still gets its announcement, and the sessions are long gone
+    // from the cluster index by now.
+    sweepIndex = 1;
+    busDown = false;
+    assert.equal(await reaper.sweep(), 0);
+    assert.equal(published.length, roomCount);
+    assert.ok(published.includes("ROOM0"), "the oldest record survived");
+    assert.ok(published.includes(`ROOM${roomCount - 1}`));
+  } finally {
+    await reaper.stop();
+  }
+});

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -718,3 +718,104 @@ test("runtime index reaper bounds its shutdown announcement pass", async () => {
   );
   assert.ok(events.includes("runtime_index_resync_abandoned_at_shutdown"));
 });
+
+test("runtime index reaper cuts a sweep's serial backlog drain short at stop", async () => {
+  // `stop` waits for the sweep in flight BEFORE its own bounded pass runs, and
+  // that sweep's drain of an uncapped backlog is serial and uncapped too — so
+  // the step budget was still being blown by the wait itself (#242 review).
+  const events: string[] = [];
+  let currentTime = 1_000;
+  let busDown = true;
+  let sweepDone = false;
+  let sweepDrainPublishes = 0;
+  let releaseSweepDrain: (() => void) | null = null;
+  const roomCount = 100;
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return sweepDone
+        ? []
+        : [
+            {
+              instanceId: "offline-node",
+              version: "test",
+              startedAt: 0,
+              lastHeartbeatAt: 0,
+              staleAt: 0,
+              expiresAt: 0,
+              connectionCount: roomCount,
+              activeRoomCount: roomCount,
+              activeMemberCount: roomCount,
+              health: "offline" as const,
+            },
+          ];
+    },
+    async listClusterSessions() {
+      if (sweepDone) {
+        return [];
+      }
+      return Array.from({ length: roomCount }, (_unused, index) => {
+        const session = createSession(`session-${index}`, "offline-node");
+        session.roomCode = `ROOM${index}`;
+        session.memberId = `member-${index}`;
+        return session;
+      });
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    async flush() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => currentTime,
+    logEvent: (event) => {
+      events.push(event);
+    },
+    publishRoomStateUpdate: async () => {
+      if (busDown) {
+        throw new Error("bus down");
+      }
+      sweepDrainPublishes += 1;
+      // The bus recovered mid-sweep, so this sweep's SERIAL drain would happily
+      // walk the whole backlog. Hold the first one so `stop` can overlap it.
+      if (sweepDrainPublishes === 1) {
+        await new Promise<void>((resolve) => {
+          releaseSweepDrain = resolve;
+        });
+      }
+      currentTime += 100;
+    },
+  });
+
+  // Sweep one: the whole backlog fails to publish and is retained.
+  assert.equal(await reaper.sweep(), roomCount);
+  sweepDone = true;
+  busDown = false;
+
+  // Sweep two starts its serial drain of the retained backlog and parks.
+  reaper.start();
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  assert.equal(sweepDrainPublishes, 1, "the sweep drain is parked");
+
+  const stopStartedAt = currentTime;
+  const stopped = reaper.stop();
+  (releaseSweepDrain as (() => void) | null)?.();
+  await stopped;
+
+  // The whole of `stop` — the wait for the sweep INCLUDED — has to fit in the
+  // budget. Without the yield the sweep's serial drain walks all 100 rooms at
+  // 100ms each before the bounded pass ever starts.
+  const stopCostMs = currentTime - stopStartedAt;
+  assert.ok(
+    stopCostMs <= 3_100,
+    `stop must stay inside its budget, spent ${stopCostMs}ms`,
+  );
+  assert.ok(events.includes("runtime_index_resync_abandoned_at_shutdown"));
+});

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -629,3 +629,92 @@ test("runtime index reaper never evicts an announcement it has not published", a
     await reaper.stop();
   }
 });
+
+test("runtime index reaper bounds its shutdown announcement pass", async () => {
+  // The backlog has no cap, so a serial drain of it is unbounded too — and
+  // `stop_runtime_index_reaper` is on a clock. Overrunning it is not a harmless
+  // delay: the step is recorded as FAILED, shutdown closes the event bus
+  // anyway, and publishes still in flight then return early against a closing
+  // bus with their records deleted as if they had succeeded (#242 review).
+  const events: string[] = [];
+  let currentTime = 1_000;
+  let busDown = true;
+  let sweepDone = false;
+  let shutdownPublishes = 0;
+  const roomCount = 200;
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return sweepDone
+        ? []
+        : [
+            {
+              instanceId: "offline-node",
+              version: "test",
+              startedAt: 0,
+              lastHeartbeatAt: 0,
+              staleAt: 0,
+              expiresAt: 0,
+              connectionCount: roomCount,
+              activeRoomCount: roomCount,
+              activeMemberCount: roomCount,
+              health: "offline" as const,
+            },
+          ];
+    },
+    async listClusterSessions() {
+      if (sweepDone) {
+        return [];
+      }
+      return Array.from({ length: roomCount }, (_unused, index) => {
+        const session = createSession(`session-${index}`, "offline-node");
+        session.roomCode = `ROOM${index}`;
+        session.memberId = `member-${index}`;
+        return session;
+      });
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    async flush() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => currentTime,
+    logEvent: (event) => {
+      events.push(event);
+    },
+    publishRoomStateUpdate: async () => {
+      // Every publish fails during the sweep, so the whole backlog survives it.
+      if (busDown) {
+        throw new Error("bus down");
+      }
+      // The bus is back by shutdown, but each publish "costs" a second of the
+      // pass's budget — so a serial drain of 200 rooms could never fit.
+      shutdownPublishes += 1;
+      currentTime += 1_000;
+    },
+  });
+
+  assert.equal(await reaper.sweep(), roomCount);
+  sweepDone = true;
+  busDown = false;
+
+  await reaper.stop();
+
+  assert.ok(
+    shutdownPublishes > 0,
+    "the shutdown pass must actually try to publish",
+  );
+  assert.ok(
+    shutdownPublishes < roomCount,
+    `the shutdown pass must stop at its deadline, made ${shutdownPublishes} publishes`,
+  );
+  assert.ok(events.includes("runtime_index_resync_abandoned_at_shutdown"));
+});

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -1157,6 +1157,7 @@ test("runtime index reaper keeps the resync record when its writes were not conf
     async purgeNodeStatus() {},
     confirmWrites: () =>
       confirmed ? Promise.resolve() : new Promise<void>(() => {}),
+    flush: async () => {},
   };
 
   const reaper = createRuntimeIndexReaper({
@@ -1184,6 +1185,155 @@ test("runtime index reaper keeps the resync record when its writes were not conf
     // And now it is finally dropped.
     await reaper.sweep();
     assert.deepEqual(published, ["ROOM50", "ROOM50"]);
+  } finally {
+    await reaper.stop();
+  }
+});
+
+test("runtime index reaper treats a refused member removal as unconfirmed", async () => {
+  // Swallowing `removal.durable` turned a refused `REMOVE_MEMBER_LUA` into a
+  // confirmed write, so the sweep published and then dropped the room's only
+  // resync record — while the stale member binding was still in Redis and its
+  // token retention had never been armed (#242 review).
+  const published: string[] = [];
+  const deadSession = createSession("session-refused", "offline-node");
+  deadSession.roomCode = "ROOM51";
+  deadSession.memberId = "member-refused";
+  let sweeps = 0;
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return sweeps > 1
+        ? []
+        : [
+            {
+              instanceId: "offline-node",
+              version: "test",
+              startedAt: 0,
+              lastHeartbeatAt: 0,
+              staleAt: 0,
+              expiresAt: 0,
+              connectionCount: 1,
+              activeRoomCount: 1,
+              activeMemberCount: 1,
+              health: "offline" as const,
+            },
+          ];
+    },
+    async listClusterSessions() {
+      sweeps += 1;
+      return sweeps > 1 ? [] : [deadSession];
+    },
+    removeMember() {
+      return {
+        room: null,
+        roomEmpty: false,
+        removed: true,
+        durable: Promise.reject(new Error("remove member refused")),
+      };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    async confirmWrites() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: async (roomCode) => {
+      published.push(roomCode);
+    },
+  });
+
+  try {
+    await reaper.sweep();
+    // Announced — silence would be worse — but the record must NOT have been
+    // dropped on a removal that was refused.
+    assert.deepEqual(published, ["ROOM51"]);
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM51", "ROOM51"], "the record survived");
+  } finally {
+    await reaper.stop();
+  }
+});
+
+test("runtime index reaper keeps an unconfirmed record across the next sweep's opening flush", async () => {
+  // `keepRecords` used to be applied only in the sweep that created the record,
+  // so the very next sweep's OPENING flush published and deleted it before
+  // anything had been re-confirmed — and if the cleanup landed in between, that
+  // sweep found no offline session to rebuild the record from either (#242
+  // review).
+  const published: string[] = [];
+  let confirmable = false;
+  let sessionsVisible = true;
+  const deadSession = createSession("session-crossflush", "offline-node");
+  deadSession.roomCode = "ROOM52";
+  deadSession.memberId = "member-crossflush";
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return sessionsVisible
+        ? [
+            {
+              instanceId: "offline-node",
+              version: "test",
+              startedAt: 0,
+              lastHeartbeatAt: 0,
+              staleAt: 0,
+              expiresAt: 0,
+              connectionCount: 1,
+              activeRoomCount: 1,
+              activeMemberCount: 1,
+              health: "offline" as const,
+            },
+          ]
+        : [];
+    },
+    async listClusterSessions() {
+      return sessionsVisible ? [deadSession] : [];
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    confirmWrites: () =>
+      confirmable ? Promise.resolve() : new Promise<void>(() => {}),
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: async (roomCode) => {
+      published.push(roomCode);
+    },
+  });
+
+  try {
+    // Sweep one: cleanup writes never confirm, so the record must survive.
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM52"]);
+
+    // The session is now gone from the cluster index — exactly the state in
+    // which nothing could rebuild the record — and the writes still do not
+    // confirm. The opening flush of sweep two must NOT drop it.
+    sessionsVisible = false;
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM52", "ROOM52"]);
+
+    // Once the writes confirm, the record is published on a state built from
+    // them and finally dropped.
+    confirmable = true;
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM52", "ROOM52", "ROOM52"]);
+    await reaper.sweep();
+    assert.deepEqual(published, ["ROOM52", "ROOM52", "ROOM52"]);
   } finally {
     await reaper.stop();
   }

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -1245,3 +1245,70 @@ test("runtime index reaper does not inherit the store's retry budget on the inde
     await reaper.stop();
   }
 });
+
+test("runtime index reaper leaves the rest of the offline sessions to the next instance", async () => {
+  // A per-write bound is not a bound on the loop: each remaining session still
+  // spent its own wait, and a handful of them outlasted the whole shutdown step
+  // (#242 review). Stopping is the only thing that cuts the sweep short — the
+  // sessions it did not reach are still in the cluster index for next time.
+  const touched: string[] = [];
+  const sessions = Array.from({ length: 6 }, (_unused, index) => {
+    const session = createSession(`session-bulk-${index}`, "offline-node");
+    session.roomCode = `ROOMB${index}`;
+    session.memberId = `member-bulk-${index}`;
+    return session;
+  });
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return [
+        {
+          instanceId: "offline-node",
+          version: "test",
+          startedAt: 0,
+          lastHeartbeatAt: 0,
+          staleAt: 0,
+          expiresAt: 0,
+          connectionCount: sessions.length,
+          activeRoomCount: sessions.length,
+          activeMemberCount: sessions.length,
+          health: "offline" as const,
+        },
+      ];
+    },
+    async listClusterSessions() {
+      return sessions;
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    markSessionLeftRoom(sessionId: string) {
+      touched.push(sessionId);
+      // Never answers: only the per-write bound or the stop signal ends it.
+      return new Promise<void>(() => {});
+    },
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    async confirmWrites() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: async () => {},
+  });
+
+  const swept = reaper.sweep();
+  // Long enough for the first session's write to be outstanding, far too short
+  // for all six to have taken their own bounded wait in turn.
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  await reaper.stop();
+  await swept;
+
+  assert.ok(
+    touched.length < sessions.length,
+    `the loop must give way at stop, touched ${touched.length}/${sessions.length}`,
+  );
+});

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -283,3 +283,266 @@ test("runtime index reaper announces the room even when the index write fails", 
     await reaper.stop();
   }
 });
+
+test("runtime index reaper keeps a failed announcement until it is published", async () => {
+  // The announcement is one-shot. Once this sweep has cleaned the indexes,
+  // `listClusterSessions` no longer returns those sessions, so a later sweep
+  // finds nothing to rediscover the room from — a swallowed publish failure
+  // stranded the room forever, with every survivor caching a dead member as
+  // `sharedByMemberId` (#242).
+  const published: string[] = [];
+  const events: string[] = [];
+  let publishFailures = 2;
+  const reaped: string[] = [];
+  const deadSession = createSession("session-stranded", "offline-node");
+  deadSession.roomCode = "ROOM43";
+  deadSession.memberId = "member-stranded";
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      // Only the FIRST sweep sees a dead node. Every later sweep takes the
+      // "nothing to do" early return — which the retry has to survive.
+      return reaped.length > 0
+        ? []
+        : [
+            {
+              instanceId: "offline-node",
+              version: "test",
+              startedAt: 0,
+              lastHeartbeatAt: 0,
+              staleAt: 0,
+              expiresAt: 0,
+              connectionCount: 1,
+              activeRoomCount: 1,
+              activeMemberCount: 1,
+              health: "offline" as const,
+            },
+          ];
+    },
+    async listClusterSessions() {
+      return reaped.length > 0 ? [] : [deadSession];
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession(sessionId: string) {
+      reaped.push(sessionId);
+    },
+    async purgeNodeStatus() {},
+    async flush() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    logEvent: (event) => {
+      events.push(event);
+    },
+    publishRoomStateUpdate: async (roomCode) => {
+      if (publishFailures > 0) {
+        publishFailures -= 1;
+        throw new Error("bus rejected");
+      }
+      published.push(roomCode);
+    },
+  });
+
+  try {
+    assert.equal(await reaper.sweep(), 1);
+    assert.deepEqual(published, [], "the first announcement failed");
+    assert.ok(events.includes("runtime_index_resync_publish_failed"));
+
+    // The session is gone from the cluster index by now, so the record kept in
+    // the reaper is the only trail left.
+    assert.equal(await reaper.sweep(), 0);
+    assert.deepEqual(published, []);
+
+    assert.equal(await reaper.sweep(), 0);
+    assert.deepEqual(published, ["ROOM43"]);
+
+    // Dropped only once it landed: a fourth sweep must not re-announce.
+    assert.equal(await reaper.sweep(), 0);
+    assert.deepEqual(published, ["ROOM43"]);
+  } finally {
+    await reaper.stop();
+  }
+});
+
+test("runtime index reaper reports writes it could not confirm before announcing", async () => {
+  // `flush` says only that the queue emptied; the sweep is about to announce a
+  // state rebuilt from those very writes, so it asks the question that can be
+  // answered wrong (#242). It does NOT gate the announcement — silence is worse
+  // than a state naming a member every client already caches.
+  const published: string[] = [];
+  const events: string[] = [];
+  const reaped: string[] = [];
+  const deadSession = createSession("session-unconfirmed", "offline-node");
+  deadSession.roomCode = "ROOM44";
+  deadSession.memberId = "member-unconfirmed";
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return [
+        {
+          instanceId: "offline-node",
+          version: "test",
+          startedAt: 0,
+          lastHeartbeatAt: 0,
+          staleAt: 0,
+          expiresAt: 0,
+          connectionCount: 1,
+          activeRoomCount: 1,
+          activeMemberCount: 1,
+          health: "offline" as const,
+        },
+      ];
+    },
+    async listClusterSessions() {
+      return reaped.length > 0 ? [] : [deadSession];
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession(sessionId: string) {
+      reaped.push(sessionId);
+    },
+    async purgeNodeStatus() {},
+    async confirmWrites() {
+      throw new AggregateError([new Error("redis down")], "not confirmed");
+    },
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    logEvent: (event) => {
+      events.push(event);
+    },
+    publishRoomStateUpdate: async (roomCode) => {
+      published.push(roomCode);
+    },
+  });
+
+  try {
+    assert.equal(await reaper.sweep(), 1);
+    assert.ok(events.includes("runtime_index_writes_unconfirmed"));
+    assert.deepEqual(published, ["ROOM44"]);
+  } finally {
+    await reaper.stop();
+  }
+});
+
+test("runtime index reaper takes one last shot at its announcements on stop", async () => {
+  // The record set is memory-only and the sessions are already out of the
+  // cluster index, so shutting down without trying loses the announcement for
+  // good — nothing will ever rediscover the room (#242).
+  const published: string[] = [];
+  let publishFailures = 1;
+  const reaped: string[] = [];
+  const deadSession = createSession("session-shutdown", "offline-node");
+  deadSession.roomCode = "ROOM45";
+  deadSession.memberId = "member-shutdown";
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return [
+        {
+          instanceId: "offline-node",
+          version: "test",
+          startedAt: 0,
+          lastHeartbeatAt: 0,
+          staleAt: 0,
+          expiresAt: 0,
+          connectionCount: 1,
+          activeRoomCount: 1,
+          activeMemberCount: 1,
+          health: "offline" as const,
+        },
+      ];
+    },
+    async listClusterSessions() {
+      return reaped.length > 0 ? [] : [deadSession];
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession(sessionId: string) {
+      reaped.push(sessionId);
+    },
+    async purgeNodeStatus() {},
+    async flush() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    publishRoomStateUpdate: async (roomCode) => {
+      if (publishFailures > 0) {
+        publishFailures -= 1;
+        throw new Error("bus rejected");
+      }
+      published.push(roomCode);
+    },
+  });
+
+  assert.equal(await reaper.sweep(), 1);
+  assert.deepEqual(published, []);
+
+  await reaper.stop();
+  assert.deepEqual(published, ["ROOM45"]);
+});
+
+test("runtime index reaper does not start a sweep while one is still running", async () => {
+  // The sweeps share `roomsAwaitingResync`, so two of them would walk the same
+  // records and announce the same room twice — and `stop()` awaits whichever
+  // was scheduled LAST, so a newer sweep finishing first let shutdown tear
+  // Redis down under an older one (#242).
+  let releaseSweep: (() => void) | null = null;
+  let sweepsStarted = 0;
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      sweepsStarted += 1;
+      await new Promise<void>((resolve) => {
+        releaseSweep = resolve;
+      });
+      return [];
+    },
+    async listClusterSessions() {
+      return [];
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    async flush() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    // Clamped up by `clampTimerIntervalMs`, but still far below the time the
+    // first sweep is held for.
+    intervalMs: 1,
+    now: () => 1_000,
+  });
+
+  try {
+    reaper.start();
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    assert.equal(sweepsStarted, 1, "ticks must not stack sweeps");
+  } finally {
+    (releaseSweep as (() => void) | null)?.();
+    await reaper.stop();
+  }
+});

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -819,3 +819,66 @@ test("runtime index reaper cuts a sweep's serial backlog drain short at stop", a
   );
   assert.ok(events.includes("runtime_index_resync_abandoned_at_shutdown"));
 });
+
+test("runtime index reaper caps a resync publish that never settles", async () => {
+  // A deadline that only decides whether to START the next record is no bound
+  // at all when the bus hangs rather than rejecting: the call already in flight
+  // pins the sweep drain and the shutdown pass alike (#242 review).
+  const events: string[] = [];
+  const deadSession = createSession("session-hung", "offline-node");
+  deadSession.roomCode = "ROOM46";
+  deadSession.memberId = "member-hung";
+  let sweepDone = false;
+
+  const runtimeStore: RuntimeIndexReaperStore = {
+    async listNodeStatuses() {
+      return sweepDone
+        ? []
+        : [
+            {
+              instanceId: "offline-node",
+              version: "test",
+              startedAt: 0,
+              lastHeartbeatAt: 0,
+              staleAt: 0,
+              expiresAt: 0,
+              connectionCount: 1,
+              activeRoomCount: 1,
+              activeMemberCount: 1,
+              health: "offline" as const,
+            },
+          ];
+    },
+    async listClusterSessions() {
+      return sweepDone ? [] : [deadSession];
+    },
+    removeMember() {
+      return { room: null, roomEmpty: false, removed: true };
+    },
+    async markSessionLeftRoom() {},
+    unregisterSession() {},
+    async purgeNodeStatus() {},
+    async flush() {},
+  };
+
+  const reaper = createRuntimeIndexReaper({
+    enabled: true,
+    runtimeStore,
+    intervalMs: 50,
+    now: () => 1_000,
+    logEvent: (event) => {
+      events.push(event);
+    },
+    // Never settles. Without a per-publish cap the sweep — and every later
+    // shutdown pass — waits on it forever.
+    publishRoomStateUpdate: () => new Promise<void>(() => {}),
+  });
+
+  try {
+    assert.equal(await reaper.sweep(), 1);
+    assert.ok(events.includes("runtime_index_resync_publish_failed"));
+  } finally {
+    sweepDone = true;
+    await reaper.stop();
+  }
+});


### PR DESCRIPTION
## Summary

runtime store 是写回式的：四个 session 写入同步更新本节点 map，把 Redis 写入排进队列。队列里的失败既不重试，`flush()` 也无从察觉——它等的是 `trackOperation` 保留的吞错副本，只表示"队列排空了"。于是每一处"写完再读回来做判断"都可能建立在从未落盘的数据上。#241 是逐点加固；这次改根因。

**两套新设施**

- `server/src/durable-write-queue.ts`：按 session 串行、带指数退避重试、`drain()` 与 `confirm()` 语义分离。同一 session 有更新写入排队时放弃旧写入的重试（`SupersededWriteError`，不计入未确认）；`close()` 调 `stopRetrying()` 取消在途退避而不是等它走完。
- `server/src/pending-resync-queue.ts`：一次性 `room_state_updated` 的至少一次投递，按房号去重，单次尝试有超时上限。

**issue 里四条实例**

1. **加入索引写失败仍继续（app.ts / message-handler.ts）** — `runRoomJoinedHook` 现在报告成败，失败则经 `leaveRoom(session, "disconnect")` 回滚并回 `internal_error`。用 `"disconnect"` 是为了让重连成员保住归属规则依赖的身份。app.ts 里手写的"重试一次"删掉了，重试归队列。
2. **`registerSession` 静默吞错** — `markSessionJoinedRoom` 改为改写**整条**会话记录（原来只 patch `roomCode`，叠在丢失的注册上会留下没有 `id` 的哈希，`loadSession` 当作不存在）。丢失的注册由下一次加入自愈；`registerSession` 也返回真实结果。
3. **reaper 发布失败无重试** — 失败的房间留在 reaper 自己的记录集里，每次 sweep **开头**（在"无离线节点"提前返回之前）重试，发布成功才移除；`stop()` 再补一次，因为记录只在内存里。
4. **归属重发无重试** — 走 `pending-resync-queue`，`request()` 立即返回（不让 leave/join 处理器阻塞在总线上），`flushPendingPublishes()` 一并排空。

**房号回收约束（#237）**

重试重新打开了这个窗口。只有加入写入会把 session **加进**房间，所以只有它需要防护：在第一次尝试**之前**读一次 generation 并钉住，之后每次尝试都带着它进 Lua 脚本原子比较——不匹配是 `NonRetryableWriteError`（generation 只会前进，后续尝试不可能再回到那个房间）。`markSessionLeftRoom` / `unregisterSession` 不需要：它们只碰以 session id 命名的键，而 session id 从不复用。

## 取舍

- 重试预算是**有界**的，不是"成功前永不丢弃"。无界队列在房号回收和内存两方面都不安全，而且每个预算都要塞进排空它的关机步骤（close 步 5s，`flush_pending_room_event_publishes` 30s）——超时会被记成失败步骤、进程非零退出。相关算术写进了 `AGENTS.md` 和常量注释。
- `confirmWrites()` 是 store 级、读取即清空（"自上次询问以来"）。只关心自己那一笔的调用方应该 await 那笔写入本身，四个写入都报告真实结果。

## Test plan

- [x] 新增 `durable-write-queue.test.ts`（8 例）、`pending-resync-queue.test.ts`（7 例）
- [x] 新增/改写 store、message-handler、reaper 回归用例；每条都用回退探针验证过判别力（回退对应修复后必失败）
- [x] `format:check` / `lint` / `typecheck` / `build` / `test` / `audit` 全绿
- [x] 本地 codex 复审一轮，报出 4 条正确性问题（resync 放弃批次吞掉在途请求、`unregisterSession` 丢弃拒绝 promise 致 unhandledRejection、`stop()` 不排空待发布记录、sweep 可重叠）已全部修复并补测试
- [ ] Redis 集成用例本地跳过（无 `REDIS_URL`），新的 `JOIN_ROOM_INDEX_LUA` 需 CI 的 `test:server:redis` 实跑验证

Fixes #242