### PR TITLE
test: 真 Redis 测试的写后读回改由座位辅助层设屏障 (#247)

### DIFF
--- a/server/test/multi-node-runtime-repair.test.ts
+++ b/server/test/multi-node-runtime-repair.test.ts
@@ -11,6 +11,7 @@ import {
   createMultiNodeTestKit,
   requestJson,
 } from "./multi-node-test-kit.js";
+import { seatSession } from "./runtime-seat-helpers.js";
 
 function createGhostSession(roomCode: string): Session {
   return {
@@ -66,14 +67,15 @@ test("offline node sessions are reaped from the global room view after heartbeat
     const roomCode = (created.payload as { roomCode: string }).roomCode;
 
     const ghostSession = createGhostSession(roomCode);
-    runtimeStore.registerSession(ghostSession);
-    runtimeStore.markSessionJoinedRoom(ghostSession.id, roomCode);
-    runtimeStore.addMember(
+    // Seated through the helper so the shared index is readable when the admin
+    // route below reads it: the seat writes are write-behind, and the
+    // `heartbeatNode` await underneath is a coincidence of latency, not a
+    // barrier (#247).
+    await seatSession(runtimeStore, ghostSession, {
       roomCode,
-      ghostSession.memberId ?? "offline-member-1",
-      ghostSession,
-      ghostSession.memberToken ?? "offline-member-token",
-    );
+      memberId: "offline-member-1",
+      memberToken: "offline-member-token",
+    });
     await runtimeStore.heartbeatNode({
       instanceId: "node-crashed",
       version: "0.9.0-node-crashed-test",

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -307,8 +307,7 @@ test("redis runtime store keeps only the latest room membership after rapid room
     store.registerSession(session);
     store.markSessionJoinedRoom(session.id, "ROOMA1");
     store.markSessionJoinedRoom(session.id, "ROOMB1");
-    await store.flush?.();
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await settleRuntimeWrites(store);
 
     const roomA = await observer.listClusterSessionsByRoom("ROOMA1");
     const roomB = await observer.listClusterSessionsByRoom("ROOMB1");
@@ -347,22 +346,19 @@ test("redis runtime store can purge stale sessions for a restarted instance", as
   });
   const session = createSession("session-restart");
   session.instanceId = "room-node-a";
-  session.memberId = "member-restart";
-  session.memberToken = "token-restart";
 
   try {
-    store.registerSession(session);
-    store.markSessionJoinedRoom(session.id, "ROOMRS");
-    store.addMember("ROOMRS", session.memberId, session, session.memberToken);
-    await store.flush?.();
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await seatSession(store, session, {
+      roomCode: "ROOMRS",
+      memberId: "member-restart",
+      memberToken: "token-restart",
+    });
 
     assert.equal(
       (await observer.listClusterSessionsByRoom("ROOMRS")).length,
       1,
     );
     assert.equal(await store.purgeSessionsByInstance?.("room-node-a"), 1);
-    await new Promise((resolve) => setTimeout(resolve, 25));
 
     assert.deepEqual(await observer.listClusterSessionsByRoom("ROOMRS"), []);
     const room = await observer.getRoom("ROOMRS");
@@ -392,21 +388,18 @@ test("redis runtime store keeps the member token when only presence is dropped",
   const store = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
   const observer = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
   const session = createSession("session-presence");
-  session.memberId = "member-presence";
-  session.memberToken = "token-presence";
 
   try {
-    store.registerSession(session);
-    store.markSessionJoinedRoom(session.id, "ROOMPR");
-    store.addMember("ROOMPR", session.memberId, session, session.memberToken);
-    await store.flush?.();
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await seatSession(store, session, {
+      roomCode: "ROOMPR",
+      memberId: "member-presence",
+      memberToken: "token-presence",
+    });
 
     // A disconnect: presence goes, identity stays, so the reconnect can reclaim
     // the same memberId.
-    store.removeMember("ROOMPR", session.memberId, session);
-    await store.flush?.();
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    const removal = store.removeMember("ROOMPR", "member-presence", session);
+    await removal.durable;
 
     assert.equal(
       await observer.findMemberIdByToken("ROOMPR", "token-presence"),
@@ -414,9 +407,7 @@ test("redis runtime store keeps the member token when only presence is dropped",
     );
 
     // An explicit leave / kick: identity goes too.
-    store.revokeMemberToken("ROOMPR", session.memberId);
-    await store.flush?.();
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await store.revokeMemberToken("ROOMPR", "member-presence");
 
     assert.equal(
       await observer.findMemberIdByToken("ROOMPR", "token-presence"),
@@ -713,14 +704,13 @@ test("redis runtime store bounds how long a disconnected identity survives", asy
     memberTokenRetentionMs: 120,
   });
   const session = createSession("session-retention");
-  session.memberId = "member-retention";
-  session.memberToken = "token-retention";
 
   try {
-    store.registerSession(session);
-    store.markSessionJoinedRoom(session.id, "ROOMRT");
-    store.addMember("ROOMRT", session.memberId, session, session.memberToken);
-    await store.flush?.();
+    await seatSession(store, session, {
+      roomCode: "ROOMRT",
+      memberId: "member-retention",
+      memberToken: "token-retention",
+    });
 
     // Still connected: no clock at all, so someone who never leaves keeps their
     // identity however long the session lasts.
@@ -731,10 +721,10 @@ test("redis runtime store bounds how long a disconnected identity survives", asy
     );
 
     // The last session goes. Identity outlives the disconnect...
-    store.removeMember("ROOMRT", session.memberId, session);
+    const removal = store.removeMember("ROOMRT", "member-retention", session);
+    await removal.durable;
     store.unregisterSession(session.id);
-    await store.flush?.();
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await settleRuntimeWrites(store);
     assert.equal(
       await store.findMemberIdByToken("ROOMRT", "token-retention"),
       "member-retention",
@@ -781,7 +771,6 @@ test("redis runtime store lifts the retention clock when someone reconnects", as
     await removal.durable;
     store.unregisterSession(session.id);
     await settleRuntimeWrites(store);
-    await new Promise((resolve) => setTimeout(resolve, 25));
 
     // Reconnect inside the window: the clock must be lifted, not merely
     // restarted, or a room that keeps churning members would eventually drop
@@ -1123,19 +1112,16 @@ test("redis runtime store starts the retention clock for bindings cleared at sta
   });
   const session = createSession("session-crashed");
   session.instanceId = "crashed-node";
-  session.memberId = "member-crashed";
-  session.memberToken = "token-crashed";
 
   try {
-    store.registerSession(session);
-    store.markSessionJoinedRoom(session.id, "ROOMCR");
-    store.addMember("ROOMCR", session.memberId, session, session.memberToken);
-    await store.flush?.();
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await seatSession(store, session, {
+      roomCode: "ROOMCR",
+      memberId: "member-crashed",
+      memberToken: "token-crashed",
+    });
 
     // The process crashed and came back under the same instanceId.
     assert.equal(await store.purgeSessionsByInstance?.("crashed-node"), 1);
-    await new Promise((resolve) => setTimeout(resolve, 25));
 
     // The identity survives, so the client that is about to reconnect keeps it.
     assert.equal(
@@ -1565,10 +1551,8 @@ test("redis runtime store treats leftover session keys as residue on a room code
   try {
     assert.equal(await store.hasRoomResidue("ROOMRS"), false);
 
-    store.registerSession(session);
-    store.markSessionJoinedRoom(session.id, "ROOMRS");
-    await store.flush?.();
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await store.registerSession(session);
+    await store.markSessionJoinedRoom(session.id, "ROOMRS");
 
     // No members and no member tokens: the members/tokens view `getRoom` offers
     // reads as empty, which is what used to gate room code allocation.

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -143,6 +143,40 @@ function createFakeRedisClient(execPromises: Promise<unknown>[]) {
   };
 }
 
+test("runtime seat helper rejects when the add-member write is lost", async () => {
+  const addMemberFailure = Promise.reject(new Error("add-member write lost"));
+  addMemberFailure.catch(() => undefined);
+  const operationFailures: string[] = [];
+  const store = await createRedisRuntimeStore("redis://unused", {
+    redisClient: {
+      ...createFakeRedisClient([Promise.resolve(null), addMemberFailure]),
+      // `markSessionJoinedRoom` uses this script; one means its guarded index
+      // write landed, isolating the failure to `addMember` below.
+      async eval() {
+        return 1;
+      },
+    },
+    writeRetry: { maxAttempts: 1 },
+    onPendingOperationError(context) {
+      operationFailures.push(`${context.operationName}:${context.reason}`);
+    },
+  });
+
+  try {
+    await assert.rejects(
+      seatSession(store, createSession("session-add-failed"), {
+        roomCode: "ROOMAF",
+        memberId: "member-add-failed",
+        memberToken: "token-add-failed",
+      }),
+      /Runtime seat member-add-failed in ROOMAF was not persisted/,
+    );
+    assert.deepEqual(operationFailures, ["add_member:failed"]);
+  } finally {
+    await store.close();
+  }
+});
+
 test("redis runtime store shares room sessions and member token state across instances", async (t) => {
   if (!REDIS_URL) {
     t.skip("REDIS_URL is not configured.");
@@ -236,16 +270,14 @@ test("redis runtime store updates session display names when the session is re-r
   const session = createSession("session-display");
 
   try {
-    storeA.registerSession(session);
-    storeA.markSessionJoinedRoom(session.id, "ROOM02");
-    session.memberId = "member-display";
-    session.memberToken = "token-display";
-    storeA.addMember("ROOM02", session.memberId, session, session.memberToken);
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await seatSession(storeA, session, {
+      roomCode: "ROOM02",
+      memberId: "member-display",
+      memberToken: "token-display",
+    });
 
     session.displayName = "Alice";
-    storeA.registerSession(session);
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await storeA.registerSession(session);
 
     const room = await storeB.getRoom("ROOM02");
     assert.ok(room);
@@ -737,30 +769,29 @@ test("redis runtime store lifts the retention clock when someone reconnects", as
   // reading that cannot tell whether Redis still holds the token.
   const observer = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
   const session = createSession("session-relift");
-  session.memberId = "member-relift";
-  session.memberToken = "token-relift";
 
   try {
-    store.registerSession(session);
-    store.markSessionJoinedRoom(session.id, "ROOMRL");
-    store.addMember("ROOMRL", session.memberId, session, session.memberToken);
-    await store.flush?.();
+    await seatSession(store, session, {
+      roomCode: "ROOMRL",
+      memberId: "member-relift",
+      memberToken: "token-relift",
+    });
 
-    store.removeMember("ROOMRL", session.memberId, session);
+    const removal = store.removeMember("ROOMRL", "member-relift", session);
+    await removal.durable;
     store.unregisterSession(session.id);
-    await store.flush?.();
+    await settleRuntimeWrites(store);
     await new Promise((resolve) => setTimeout(resolve, 25));
 
     // Reconnect inside the window: the clock must be lifted, not merely
     // restarted, or a room that keeps churning members would eventually drop
     // identities while people are still in it.
     const reconnected = createSession("session-relift-2");
-    reconnected.memberId = "member-relift";
-    reconnected.memberToken = "token-relift";
-    store.registerSession(reconnected);
-    store.markSessionJoinedRoom(reconnected.id, "ROOMRL");
-    store.addMember("ROOMRL", "member-relift", reconnected, "token-relift");
-    await store.flush?.();
+    await seatSession(store, reconnected, {
+      roomCode: "ROOMRL",
+      memberId: "member-relift",
+      memberToken: "token-relift",
+    });
 
     await new Promise((resolve) => setTimeout(resolve, 250));
     assert.equal(
@@ -989,27 +1020,26 @@ test("redis runtime store releases a departed visitor from a room that never emp
     memberTokenRetentionMs: 120,
   });
   const host = createSession("session-host");
-  host.memberId = "member-host";
-  host.memberToken = "token-host";
   const visitor = createSession("session-visitor");
-  visitor.memberId = "member-visitor";
-  visitor.memberToken = "token-visitor";
 
   try {
     // The host never leaves, so the room is never empty and a room-scoped clock
     // would never start. A public room with a steady trickle of visitors then
     // accumulates one token per visitor, forever.
-    store.registerSession(host);
-    store.markSessionJoinedRoom(host.id, "ROOMBZ");
-    store.addMember("ROOMBZ", host.memberId, host, host.memberToken);
-    store.registerSession(visitor);
-    store.markSessionJoinedRoom(visitor.id, "ROOMBZ");
-    store.addMember("ROOMBZ", visitor.memberId, visitor, visitor.memberToken);
-    await store.flush?.();
+    await seatSession(store, host, {
+      roomCode: "ROOMBZ",
+      memberId: "member-host",
+      memberToken: "token-host",
+    });
+    await seatSession(store, visitor, {
+      roomCode: "ROOMBZ",
+      memberId: "member-visitor",
+      memberToken: "token-visitor",
+    });
 
-    store.removeMember("ROOMBZ", visitor.memberId, visitor);
-    store.markSessionLeftRoom(visitor.id, "ROOMBZ");
-    await store.flush?.();
+    const removal = store.removeMember("ROOMBZ", "member-visitor", visitor);
+    await removal.durable;
+    await store.markSessionLeftRoom(visitor.id, "ROOMBZ");
     await new Promise((resolve) => setTimeout(resolve, 250));
 
     assert.equal(
@@ -1235,12 +1265,13 @@ test("redis runtime store commits the block and the revoke of a kick together", 
     now: () => currentTime,
   });
   const session = createSession("session-evict");
-  session.memberId = "member-evict";
-  session.memberToken = "token-evict";
 
   try {
-    store.addMember("ROOMEV", session.memberId, session, session.memberToken);
-    await store.flush?.();
+    await seatSession(store, session, {
+      roomCode: "ROOMEV",
+      memberId: "member-evict",
+      memberToken: "token-evict",
+    });
 
     // One commit. As two independent writes, a block that landed could not be
     // rolled back when the revoke then failed: the admin saw the kick fail while
@@ -1379,12 +1410,13 @@ test("redis runtime store does not register a retention entry for a member with 
   const observer = await createRedisRuntimeStore(REDIS_URL, { keyPrefix });
   const redis = new Redis(REDIS_URL);
   const session = createSession("session-kicked");
-  session.memberId = "member-kicked";
-  session.memberToken = "token-kicked";
 
   try {
-    store.addMember("ROOMKX", session.memberId, session, session.memberToken);
-    await store.flush?.();
+    await seatSession(store, session, {
+      roomCode: "ROOMKX",
+      memberId: "member-kicked",
+      memberToken: "token-kicked",
+    });
 
     // The kick takes the token and its retention entry away...
     await store.evictMemberToken(
@@ -1396,9 +1428,8 @@ test("redis runtime store does not register a retention entry for a member with 
     await store.flush?.();
 
     // ...and the socket close arrives afterwards, as it always does.
-    store.removeMember("ROOMKX", session.memberId, session);
-    await store.flush?.();
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    const removal = store.removeMember("ROOMKX", "member-kicked", session);
+    await removal.durable;
 
     // Registering a retention entry here would leave one with no token behind
     // it, and the prune is lazy — nothing collects it once the room goes quiet.
@@ -1485,15 +1516,13 @@ test("redis runtime store does not register a retention entry during startup pur
   const redis = new Redis(REDIS_URL);
   const session = createSession("session-crash-kicked");
   session.instanceId = "crashed-node";
-  session.memberId = "member-crash-kicked";
-  session.memberToken = "token-crash-kicked";
 
   try {
-    store.registerSession(session);
-    store.markSessionJoinedRoom(session.id, "ROOMCK");
-    store.addMember("ROOMCK", session.memberId, session, session.memberToken);
-    await store.flush?.();
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await seatSession(store, session, {
+      roomCode: "ROOMCK",
+      memberId: "member-crash-kicked",
+      memberToken: "token-crash-kicked",
+    });
 
     // Kicked, then the process died before the socket close ran — so the member
     // binding is still there for the startup purge to find.
@@ -1506,7 +1535,6 @@ test("redis runtime store does not register a retention entry during startup pur
     await store.flush?.();
 
     assert.equal(await store.purgeSessionsByInstance?.("crashed-node"), 1);
-    await new Promise((resolve) => setTimeout(resolve, 25));
 
     // The identity is gone, so there is nothing to put on a clock. Registering
     // one anyway leaves an entry the lazy prune never reaches once the room goes

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../src/redis-runtime-store.js";
 import { NonRetryableWriteError } from "../src/durable-write-queue.js";
 import type { AttachedSession, Session } from "../src/types.js";
+import { seatSession, settleRuntimeWrites } from "./runtime-seat-helpers.js";
 
 const REDIS_URL = process.env.REDIS_URL;
 
@@ -162,14 +163,20 @@ test("redis runtime store shares room sessions and member token state across ins
   const sessionB = createSession("session-b");
 
   try {
-    storeA.registerSession(sessionA);
-    storeB.registerSession(sessionB);
-    storeA.markSessionJoinedRoom(sessionA.id, "ROOM01");
-    storeB.markSessionJoinedRoom(sessionB.id, "ROOM01");
-    storeA.addMember("ROOM01", "member-a", sessionA, "token-a");
-    storeB.addMember("ROOM01", "member-b", sessionB, "token-b");
-
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    // Both stores seat through the barrier rather than a sleep. The reads below
+    // are cross-instance, so what they need is the WRITER's queue drained — a
+    // fixed 25ms bought that on an idle machine and nothing at all on a loaded
+    // CI runner (#247).
+    await seatSession(storeA, sessionA, {
+      roomCode: "ROOM01",
+      memberId: "member-a",
+      memberToken: "token-a",
+    });
+    await seatSession(storeB, sessionB, {
+      roomCode: "ROOM01",
+      memberId: "member-b",
+      memberToken: "token-b",
+    });
 
     const room = await storeA.getRoom("ROOM01");
     assert.ok(room);
@@ -187,17 +194,22 @@ test("redis runtime store shares room sessions and member token state across ins
       "member-b",
     );
 
-    storeA.blockMemberToken("ROOM01", "token-a", currentTime + 500);
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    // `blockMemberToken` settles once the block is durable, so awaiting it is
+    // the barrier the sleep was standing in for.
+    await storeA.blockMemberToken("ROOM01", "token-a", currentTime + 500);
     assert.equal(await storeB.isMemberTokenBlocked("ROOM01", "token-a"), true);
 
     currentTime += 600;
     assert.equal(await storeB.isMemberTokenBlocked("ROOM01", "token-a"), false);
 
-    await storeA.removeMember("ROOM01", "member-a", sessionA);
-    storeA.markSessionLeftRoom(sessionA.id, "ROOM01");
+    // `removeMember` answers synchronously and hands its durable write back on
+    // the side; `markSessionLeftRoom` reports its own outcome. Both are waited
+    // for, then the queue behind `unregisterSession` is drained.
+    const removal = storeA.removeMember("ROOM01", "member-a", sessionA);
+    await removal.durable;
+    await storeA.markSessionLeftRoom(sessionA.id, "ROOM01");
     storeA.unregisterSession(sessionA.id);
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await settleRuntimeWrites(storeA);
 
     const roomAfterRemoval = await storeB.getRoom("ROOM01");
     assert.ok(roomAfterRemoval);

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -101,19 +101,8 @@ test("runtime index reaper clears sessions left behind by offline nodes", async 
     const cleanedSessions = await reaper.sweep();
     assert.equal(cleanedSessions, 1);
 
-    let remainingSessions = -1;
-    let remainingRooms = -1;
-    for (let attempt = 0; attempt < 20; attempt += 1) {
-      remainingSessions = (await runtimeStore.listClusterSessions()).length;
-      remainingRooms = await runtimeStore.countClusterActiveRooms();
-      if (remainingSessions === 0 && remainingRooms === 0) {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-
-    assert.equal(remainingSessions, 0);
-    assert.equal(remainingRooms, 0);
+    assert.equal((await runtimeStore.listClusterSessions()).length, 0);
+    assert.equal(await runtimeStore.countClusterActiveRooms(), 0);
     // The offline node's members are gone, but their identity is not: those
     // clients are alive and reconnecting to a surviving node, and they must
     // come back as the same members (#234). The token is what lets them.
@@ -124,18 +113,7 @@ test("runtime index reaper clears sessions left behind by offline nodes", async 
       "member-offline",
     );
 
-    let remainingStatuses: Awaited<
-      ReturnType<typeof runtimeStore.listNodeStatuses>
-    > = [];
-    for (let attempt = 0; attempt < 20; attempt += 1) {
-      await reaper.sweep();
-      remainingStatuses = await runtimeStore.listNodeStatuses(currentTime);
-      if (remainingStatuses.length === 0) {
-        break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-    assert.deepEqual(remainingStatuses, []);
+    assert.deepEqual(await runtimeStore.listNodeStatuses(currentTime), []);
   } finally {
     await reaper.stop();
     await runtimeStore.close();

--- a/server/test/runtime-index-reaper.test.ts
+++ b/server/test/runtime-index-reaper.test.ts
@@ -6,6 +6,7 @@ import {
   type RuntimeIndexReaperStore,
 } from "../src/runtime-index-reaper.js";
 import type { AttachedSession, Session } from "../src/types.js";
+import { seatSession } from "./runtime-seat-helpers.js";
 
 const REDIS_URL = process.env.REDIS_URL;
 
@@ -65,18 +66,11 @@ test("runtime index reaper clears sessions left behind by offline nodes", async 
   const session = createSession("session-offline", "offline-node");
 
   try {
-    runtimeStore.registerSession(session);
-    runtimeStore.markSessionJoinedRoom(session.id, "ROOM01");
-    session.roomCode = "ROOM01";
-    session.memberId = "member-offline";
-    session.memberToken = "token-offline";
-    runtimeStore.registerSession(session);
-    runtimeStore.addMember(
-      "ROOM01",
-      "member-offline",
-      session,
-      "token-offline",
-    );
+    await seatSession(runtimeStore, session, {
+      roomCode: "ROOM01",
+      memberId: "member-offline",
+      memberToken: "token-offline",
+    });
     await runtimeStore.heartbeatNode({
       instanceId: "offline-node",
       version: "test-version",
@@ -90,15 +84,11 @@ test("runtime index reaper clears sessions left behind by offline nodes", async 
       health: "ok",
     });
 
-    // The seat writes above are write-behind: they update this node's own maps
-    // synchronously and queue the shared write behind them. Reading the cluster
-    // index back without flushing races that queue — and the failure is silent
-    // and partial, because the queue drains in order: the session write lands
-    // (so `listClusterSessions` is right) while the room-index write is still
-    // pending (so `countClusterActiveRooms` reads 0). Flush is the ordering
-    // barrier for "my own writes must be visible to the read I am about to do".
-    await runtimeStore.flush?.();
-
+    // `seatSession` above carries the write-behind barrier: without it the read
+    // below races the queue, and the failure is silent and partial, because the
+    // queue drains in order — the session write lands (so `listClusterSessions`
+    // is right) while the room-index write is still pending (so
+    // `countClusterActiveRooms` reads 0).
     assert.equal((await runtimeStore.listClusterSessions()).length, 1);
     assert.equal(await runtimeStore.countClusterActiveRooms(), 1);
 
@@ -184,18 +174,11 @@ test("runtime index reaper tells the rooms it emptied to rebuild", async (t) => 
 
   try {
     for (const [index, session] of [first, second].entries()) {
-      runtimeStore.registerSession(session);
-      runtimeStore.markSessionJoinedRoom(session.id, "ROOM41");
-      session.roomCode = "ROOM41";
-      session.memberId = `member-dead-${index}`;
-      session.memberToken = `token-dead-${index}`;
-      runtimeStore.registerSession(session);
-      runtimeStore.addMember(
-        "ROOM41",
-        session.memberId,
-        session,
-        session.memberToken,
-      );
+      await seatSession(runtimeStore, session, {
+        roomCode: "ROOM41",
+        memberId: `member-dead-${index}`,
+        memberToken: `token-dead-${index}`,
+      });
     }
     await runtimeStore.heartbeatNode({
       instanceId: "offline-node",
@@ -210,11 +193,9 @@ test("runtime index reaper tells the rooms it emptied to rebuild", async (t) => 
       health: "ok",
     });
 
-    // Same write-behind barrier as the test above: the sweep reads the cluster
-    // index, so the seats must have actually landed in it or it finds nothing to
-    // clean and returns 0.
-    await runtimeStore.flush?.();
-
+    // Same write-behind barrier as the test above, carried by `seatSession`:
+    // the sweep reads the cluster index, so the seats must have actually landed
+    // in it or it finds nothing to clean and returns 0.
     currentTime += 200;
     assert.equal(await reaper.sweep(), 2);
 

--- a/server/test/runtime-seat-helpers.ts
+++ b/server/test/runtime-seat-helpers.ts
@@ -33,10 +33,9 @@ export type RuntimeSeat = {
  * Both halves, because they answer different questions (see
  * `docs/reference/invariants.md`): `flush` says the queue emptied — which is
  * what "my own writes are visible to the read I am about to do" needs — while
- * `confirmWrites` says they actually landed. `flush` waits on error-swallowed
- * copies, so without the second call a write that failed outright drains
- * exactly like one that succeeded, and the test reports the mismatched
- * assertion instead of the lost write that caused it.
+ * `confirmWrites` reports failures from the session write queue. `addMember`
+ * does not use that queue, so callers that depend on it must verify its shared
+ * result separately; {@link seatSession} does that before returning.
  */
 export async function settleRuntimeWrites(
   runtimeStore: SeatBarrierStore,
@@ -77,4 +76,31 @@ export async function seatSession(
   );
 
   await settleRuntimeWrites(runtimeStore);
+
+  // `addMember` returns only the local room and its Redis operation is tracked
+  // through an error-swallowed promise, outside the session write queue that
+  // `confirmWrites` reports. Read the seat back through Redis-authoritative
+  // paths so an add-member failure cannot turn a setup into a false green.
+  const persistedMemberId = await runtimeStore.findMemberIdByToken(
+    seat.roomCode,
+    seat.memberToken,
+  );
+  if (persistedMemberId !== seat.memberId) {
+    throw new Error(
+      `Runtime seat ${seat.memberId} in ${seat.roomCode} was not persisted: ` +
+        `member token resolved to ${persistedMemberId ?? "nothing"}.`,
+    );
+  }
+
+  // The token check above matters for the Redis store: once the shared token
+  // hash is non-empty, `getRoom` cannot fall back to this node's local mirror,
+  // so this verifies the shared member→session binding as well.
+  const persistedRoom = await runtimeStore.getRoom(seat.roomCode);
+  const persistedSessionId = persistedRoom?.members.get(seat.memberId)?.id;
+  if (persistedSessionId !== session.id) {
+    throw new Error(
+      `Runtime seat ${seat.memberId} in ${seat.roomCode} was not persisted: ` +
+        `member binding resolved to ${persistedSessionId ?? "nothing"}.`,
+    );
+  }
 }

--- a/server/test/runtime-seat-helpers.ts
+++ b/server/test/runtime-seat-helpers.ts
@@ -1,0 +1,80 @@
+import type { RuntimeStore } from "../src/runtime-store.js";
+import type { Session } from "../src/types.js";
+
+/**
+ * Test helpers for seating a session directly in a runtime store.
+ *
+ * The store is write-behind: `registerSession` / `markSessionJoinedRoom` /
+ * `addMember` update this node's own maps synchronously and queue the shared
+ * write behind them. A test that seats a session and then reads the cluster
+ * index back — directly, or through an admin HTTP route — is racing that queue,
+ * and it loses in a way that is silent and PARTIAL, because the queue drains in
+ * order: the session write lands while the room-index write is still pending
+ * (#247, and the CI failures in #244 that found it).
+ *
+ * These tests used to get away with it only because an unrelated
+ * `await heartbeatNode(...)` sat between the writes and the read and happened to
+ * cost enough round trips to drain the queue. That is incidental latency, not a
+ * barrier — a probe reading the shared index at seat time finds the session
+ * absent from it every run.
+ */
+
+type SeatBarrierStore = Pick<RuntimeStore, "flush" | "confirmWrites">;
+
+export type RuntimeSeat = {
+  roomCode: string;
+  memberId: string;
+  memberToken: string;
+};
+
+/**
+ * The ordering barrier a test owes any read of its own write-behind writes.
+ *
+ * Both halves, because they answer different questions (see
+ * `docs/reference/invariants.md`): `flush` says the queue emptied — which is
+ * what "my own writes are visible to the read I am about to do" needs — while
+ * `confirmWrites` says they actually landed. `flush` waits on error-swallowed
+ * copies, so without the second call a write that failed outright drains
+ * exactly like one that succeeded, and the test reports the mismatched
+ * assertion instead of the lost write that caused it.
+ */
+export async function settleRuntimeWrites(
+  runtimeStore: SeatBarrierStore,
+): Promise<void> {
+  await runtimeStore.flush?.();
+  await runtimeStore.confirmWrites?.();
+}
+
+/**
+ * Seat `session` as a member of a room and return once the shared index can be
+ * read back.
+ *
+ * The seat fields are written onto the session BEFORE it is registered, because
+ * `markSessionJoinedRoom` rebuilds the whole session hash from this node's live
+ * copy at the moment the queued write runs — so a session still carrying nulls
+ * is what gets persisted.
+ *
+ * `registerSession` and `markSessionJoinedRoom` report their real outcome, so
+ * they are awaited individually: a failure surfaces here, at the seat, rather
+ * than as an unhandled rejection or as a puzzling assertion further down.
+ */
+export async function seatSession(
+  runtimeStore: RuntimeStore,
+  session: Session,
+  seat: RuntimeSeat,
+): Promise<void> {
+  session.roomCode = seat.roomCode;
+  session.memberId = seat.memberId;
+  session.memberToken = seat.memberToken;
+
+  await runtimeStore.registerSession(session);
+  await runtimeStore.markSessionJoinedRoom(session.id, seat.roomCode);
+  runtimeStore.addMember(
+    seat.roomCode,
+    seat.memberId,
+    session,
+    seat.memberToken,
+  );
+
+  await settleRuntimeWrites(runtimeStore);
+}


### PR DESCRIPTION
## Summary

真 Redis 测试写完座位就读回集群索引，与 write-behind 队列赛跑（#247）。

- 新增 `server/test/runtime-seat-helpers.ts`，提供 `seatSession` / `settleRuntimeWrites`——写完即设屏障，从源头消除这一类，而不是再手写第四份 `flush`（AGENTS.md「机制写到第二份就抽出来」）。
- `multi-node-runtime-repair.test.ts`：issue 点名的未修文件，座位写入全文件零 flush，改走 `seatSession`。
- `runtime-index-reaper.test.ts`：#244 手写的两处 flush 收敛到辅助层。
- `redis-runtime-store.test.ts`（**姊妹路径普查发现**）：同一类竞态，只是用 25ms `setTimeout` 当屏障；相邻 display-name 用例与 relift、departed visitor、kick、startup purge 的准备/清理路径一并改用 `seatSession`、awaitable 写入或 `durable` 句柄。
- `runtime-lifecycle.test.ts`：**已确认无需修改**——它自己不做 write-behind 写入（唯一的写是 finally 里已 await 的 `deleteRoom`，且非队列写），跨节点读走的是 20 次重试轮询。

## 屏障为什么是两半

二者回答的问题不同（见 `docs/reference/invariants.md`）：`flush` 说队列空了，也就是「我自己的写对我即将做的读可见」；`confirmWrites` 说写真的落盘了。`flush` 会等那些吞掉错误的副本，所以少了第二半，一个彻底失败的写和一个成功的写排空得一模一样，测试报出来的是错位的断言而不是丢掉的那次写。

另外 `registerSession` / `markSessionJoinedRoom` 会上报真实结果，所以在辅助层里逐个 await：失败暴露在座位处，而不是变成 unhandled rejection 或下游一句莫名其妙的断言。座位字段在 `registerSession` 之前写到 session 上，因为 `markSessionJoinedRoom` 是在排队的写真正执行时、按本节点的活会话副本重建整条 session hash 的。

## 判别力证据

修复对象是测试本身，所以判别力靠探针，不靠「回退修复看它红」。在 `multi-node-runtime-repair.test.ts` 座位写入之后插入直读探针：

| 屏障 | `inSessionIndex`（座位写完那一刻） |
|---|---|
| 全部拿掉（修复前序列） | `false` ×3 |
| 仅 flush + confirmWrites | `true` ×3 |
| 仅逐个 await | `true` ×3 |
| 本 PR（两者都有） | `true` ×3 |

修复前 ghost 会话**根本不在共享会话索引里**——之所以平时能过，只是因为紧随其后的 `await heartbeatNode` 的往返恰好够队列排空。那是延迟的巧合，不是屏障。两半各自都能盖住会话索引，但覆盖的写不同：逐个 await 管 `registerSession`/`markSessionJoinedRoom`；`addMember` 没有可 await 的句柄，所以辅助层在排空后通过 `findMemberIdByToken` 与 `getRoom` 读回共享 token 和 member→session 绑定。失败注入证明：拿掉读回验证时新增用例以 `Missing expected rejection` 失败。

Fixes #247

## Test plan

- [x] `REDIS_URL=redis://127.0.0.1:6379 npm run test:server:redis` → `# tests 627 / # pass 627 / # fail 0 / # skipped 0`
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test && npm run audit` 全绿（`npm test` 无 REDIS_URL 时 627 中 89 跳过，故另跑上面那条）
- [x] 探针复现与还原（还原用 `cp` 备份，未用 `git checkout`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
