### PR TITLE
chore(release): 1.3.3

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-exclude='../packages/**' test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.2"
+    "@bili-syncplay/protocol": "1.3.3"
   },
   "devDependencies": {
     "@types/chrome": "^0.2.2",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["alarms", "storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "workspaces": [
         "packages/*",
         "server",
@@ -28,9 +28,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.2"
+        "@bili-syncplay/protocol": "1.3.3"
       },
       "devDependencies": {
         "@types/chrome": "^0.2.2",
@@ -5650,10 +5650,10 @@
     },
     "packages/admin-ui": {
       "name": "@bili-syncplay/admin-ui",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
-        "@bili-syncplay/protocol": "1.3.2",
+        "@bili-syncplay/protocol": "1.3.3",
         "@tanstack/react-query": "^5.101.2",
         "antd": "^6.5.1",
         "dayjs": "^1.11.21",
@@ -5697,7 +5697,7 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "devDependencies": {
         "@types/node": "^24.0.0",
         "typescript": "^6.0.3"
@@ -5705,9 +5705,9 @@
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.2",
+        "@bili-syncplay/protocol": "1.3.3",
         "ioredis": "^5.10.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/admin-ui",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
-    "@bili-syncplay/protocol": "1.3.2",
+    "@bili-syncplay/protocol": "1.3.3",
     "@tanstack/react-query": "^5.101.2",
     "antd": "^6.5.1",
     "dayjs": "^1.11.21",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.2",
+    "@bili-syncplay/protocol": "1.3.3",
     "ioredis": "^5.10.0",
     "ws": "^8.21.0"
   },


### PR DESCRIPTION
## 发布内容

自 `v1.3.2` 起累积 21 个提交，其中 10 个 `fix:` + 1 个 `perf:`，无新特性，故走 patch。

扩展侧：经过时长改用单调钟（#231/#233）、`sync:request` 只在后台无缓存房间态时转发（#229/#230）、纠偏期间一律上报房间基准倍率（#238）、自然结束标记不再借用暂停保持时长（#244）。
服务端侧：共享归属按在线成员求解（#235/#241）、排队写入失败不再被静默丢弃（#242/#243）、断线不再吊销成员身份（#237）、优雅退出（#218/#219）、房间索引对账独立定时器（#228）。

## 变更范围

纯版本号：root / protocol / server / admin-ui / extension 的 `package.json`、`extension/public/manifest.json`、`package-lock.json`。无代码改动。

## 协议兼容性

`git diff v1.3.2..main -- packages/protocol/src` 为空，`PROTOCOL_VERSION` 与 `CURRENT_PROTOCOL_VERSION` 均未变。新旧扩展 ↔ 新旧服务端双向兼容，扩展发布与服务端镜像上线无先后约束。

## 验证

本地在本分支跑完整序列 `format:check && lint && typecheck && build && test && audit`，退出码 0：

- 脚本 7 / 协议 14 / admin 83（node:test）+ 服务端 536 + 扩展 642，fail 均为 0
- admin-ui vitest 70 passed
- audit gate passed
- 另跑真 Redis 集成测试 `REDIS_URL=redis://127.0.0.1:6399 npm run test:server:redis`：625 pass / 0 fail / **0 skipped**

## 合并后

打 `v1.3.3` 并推送，触发 `release.yml`（Chrome/Edge zip + Firefox zip/xpi + GitHub Release）与 `docker-release.yml`（GHCR + Docker Hub 镜像）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)