### PR TITLE
fix: 手势时间戳的"从未发生"哨兵改用 -Infinity

### DIFF
--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -1,4 +1,5 @@
 import {
+  hasGestureBeenRecorded,
   resetUserGestureState,
   type ContentRuntimeState,
 } from "./runtime-state";
@@ -299,11 +300,11 @@ export function createNavigationController(args: {
         ? (previousResolvedSharedVideoUrl ?? activeSharedUrl)
         : activeSharedUrl;
     const now = monotonicNow();
-    // Captured before `resetUserGestureState` below zeroes it, so the
+    // Captured before `resetUserGestureState` below clears it, so the
     // natural-end check can tell whether a gesture postdates the natural end.
     const lastUserGestureAt = args.runtimeState.lastUserGestureAt;
     const hadRecentUserGesture =
-      lastUserGestureAt > 0 &&
+      hasGestureBeenRecorded(lastUserGestureAt) &&
       now - lastUserGestureAt <= args.userGestureGraceMs;
     // We can only positively confirm the navigated page is a *different*
     // (non-shared) video when the room's shared URL and the navigated page URL
@@ -418,7 +419,7 @@ export function createNavigationController(args: {
       // pointer movement or scrolling. Erring toward not hijacking the room is
       // this file's established trade (see `navigatedFromSharedVideo` below).
       const gestureRefutesNaturalEnd =
-        lastUserGestureAt > 0 &&
+        hasGestureBeenRecorded(lastUserGestureAt) &&
         lastUserGestureAt >= naturalEndAt - args.sharedVideoNaturalEndWindowMs;
       // Four things bound the marker, and the last two are what make the wide
       // window safe:

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -140,6 +140,11 @@ export function createPlaybackBindingController(args: {
       void args.broadcastPlayback(video, "pause");
     }, args.bufferPauseUpgradeMs);
   };
+  // A bare freshness check is safe here only because "never" is
+  // `GESTURE_NEVER_AT`, not `0`: on the monotonic clock a `0` default is
+  // *document start*, so this would answer true for the first
+  // `userGestureGraceMs` of every page — precisely when a freshly navigated tab
+  // is autoplaying and every guard below is what must stop it.
   const hasRecentUserGesture = () =>
     monotonicNow() - args.runtimeState.lastUserGestureAt <
     args.userGestureGraceMs;
@@ -154,16 +159,16 @@ export function createPlaybackBindingController(args: {
   // The user just PERSISTENTLY selected a playback speed (Shift+1 / Shift+2).
   // Hold-to-fast-forward is deliberately not one — see `isRateControlGesture`.
   //
-  // The `> 0` check is defensive, not load-bearing today: the field starts at 0
-  // and `performance.now()` starts near it, so a bare freshness check would read
-  // as true for the first `userGestureGraceMs` of the page — but
-  // `hasRecentUserGestureInPlayer` has the same 0 default and the same window,
-  // so that span is already covered by it and the difference is unobservable.
-  // Kept so the two cannot drift apart if either default or window changes.
+  // This used to carry a `lastRateControlGestureAt > 0` presence check, on the
+  // reasoning that the sibling `hasRecentUserGestureInPlayer` "already covered"
+  // the page's opening `userGestureGraceMs`. That was backwards: the sibling had
+  // the same `0` default and so was *itself* true across that span rather than
+  // covering it. The sentinel is now `GESTURE_NEVER_AT`, which makes every one of
+  // these freshness checks answer correctly on its own, so the presence check is
+  // gone rather than duplicated into a second source of truth.
   const hasRecentRateControlGesture = () =>
-    args.runtimeState.lastRateControlGestureAt > 0 &&
     monotonicNow() - args.runtimeState.lastRateControlGestureAt <
-      args.userGestureGraceMs;
+    args.userGestureGraceMs;
   // A FRESH in-player play intent: an in-player gesture that also postdates the
   // last forced pause. While the page bridge resolves, the unconfirmed-context
   // hold force-pauses (updating `lastForcedPauseAt`); the SAME click that

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -1,5 +1,28 @@
 import type { PlaybackState, RoomState } from "@bili-syncplay/protocol";
 
+/**
+ * "This never happened" for a gesture timestamp measured on the content
+ * script's MONOTONIC clock (`performance.now()`, zero at document start).
+ *
+ * It cannot be `0`. Every reader of these fields asks an elapsed-time question
+ * — `now - at >= graceMs` ("no recent gesture") or `now - at < graceMs` ("a
+ * gesture just happened") — and under the epoch clock these fields used before
+ * #231/#233 the `0` sentinel answered both correctly, because `Date.now() - 0`
+ * is ~56 years. On the monotonic clock `0` is *document start*, so for the
+ * first `graceMs` of every page `now - 0 < graceMs`: every guard reads "the
+ * user just did something" and the whole load-paused protection is off exactly
+ * when a fresh page is autoplaying. `-Infinity` restores "infinitely long ago"
+ * under both polarities, and stays correct however the guard is phrased.
+ *
+ * Use {@link hasGestureBeenRecorded} rather than `at > 0` to test for presence.
+ */
+export const GESTURE_NEVER_AT = Number.NEGATIVE_INFINITY;
+
+/** Whether a gesture timestamp holds a real observation (see {@link GESTURE_NEVER_AT}). */
+export function hasGestureBeenRecorded(at: number): boolean {
+  return Number.isFinite(at);
+}
+
 export interface FestivalVideoSnapshot {
   videoId: string;
   url: string;
@@ -82,6 +105,10 @@ export interface ContentRuntimeState {
   intendedPlaybackRate: number;
   lastLocalIntentAt: number;
   lastLocalIntentPlayState: PlaybackState["playState"] | null;
+  /**
+   * Timestamp of the most recent document-level user gesture.
+   * {@link GESTURE_NEVER_AT} means never.
+   */
   lastUserGestureAt: number;
   /**
    * Timestamp of the most recent user gesture that lands inside the video player
@@ -90,6 +117,7 @@ export interface ContentRuntimeState {
    * popup that the document-level `lastUserGestureAt` also records. Used to
    * authorize manual playback of a non-shared video on a "load paused" page so a
    * stray gesture cannot wave the page-load autoplay through.
+   * {@link GESTURE_NEVER_AT} means never.
    */
   lastUserGestureInPlayerAt: number;
   /**
@@ -100,7 +128,8 @@ export interface ContentRuntimeState {
    * "load paused" pages, so speed keys must not feed it.
    *
    * This is the only positive evidence that something other than our own rate
-   * catch-up moved `playbackRate`; see `isRateControlGesture`. `0` means never.
+   * catch-up moved `playbackRate`; see `isRateControlGesture`.
+   * {@link GESTURE_NEVER_AT} means never.
    */
   lastRateControlGestureAt: number;
   lastExplicitPlaybackAction: ExplicitPlaybackAction | null;
@@ -297,9 +326,9 @@ export interface ContentRuntimeState {
  * into treating browser-initiated playback as a user action.
  */
 export function resetUserGestureState(state: ContentRuntimeState): void {
-  state.lastUserGestureAt = 0;
-  state.lastUserGestureInPlayerAt = 0;
-  state.lastRateControlGestureAt = 0;
+  state.lastUserGestureAt = GESTURE_NEVER_AT;
+  state.lastUserGestureInPlayerAt = GESTURE_NEVER_AT;
+  state.lastRateControlGestureAt = GESTURE_NEVER_AT;
   state.lastExplicitPlaybackAction = null;
   state.lastExplicitUserAction = null;
   state.explicitSeekOriginPlayState = null;
@@ -326,9 +355,9 @@ export function createContentRuntimeState(): ContentRuntimeState {
     intendedPlaybackRate: 1,
     lastLocalIntentAt: 0,
     lastLocalIntentPlayState: null,
-    lastUserGestureAt: 0,
-    lastUserGestureInPlayerAt: 0,
-    lastRateControlGestureAt: 0,
+    lastUserGestureAt: GESTURE_NEVER_AT,
+    lastUserGestureInPlayerAt: GESTURE_NEVER_AT,
+    lastRateControlGestureAt: GESTURE_NEVER_AT,
     lastExplicitPlaybackAction: null,
     explicitNonSharedPlaybackUrl: null,
     suppressedLocalEndPauseUrl: null,

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -38,6 +38,7 @@ import {
 } from "./sync-guards";
 import { createSoftApplyController } from "./soft-apply-controller";
 import { createPendingLocalOverrideController } from "./pending-local-override";
+import { hasGestureBeenRecorded } from "./runtime-state";
 import type {
   ContentRuntimeState,
   LocalPlaybackEventSource,
@@ -223,7 +224,11 @@ export function createSyncController(args: {
       `intendedState=${args.runtimeState.intendedPlayState}`,
       `intendedRate=${args.runtimeState.intendedPlaybackRate.toFixed(2)}`,
       `explicitAction=${explicitAction?.kind ?? "none"}@${explicitAction?.at ?? 0}`,
-      `lastGestureAt=${args.runtimeState.lastUserGestureAt}`,
+      `lastGestureAt=${
+        hasGestureBeenRecorded(args.runtimeState.lastUserGestureAt)
+          ? args.runtimeState.lastUserGestureAt
+          : "never"
+      }`,
       `pendingOverride=${pending ? `${pending.kind}:${pending.seq}@${pending.url}` : "none"}`,
       `remoteFollow=${args.runtimeState.remoteFollowPlayingUrl ?? "none"}@${args.runtimeState.remoteFollowPlayingUntil}`,
       `suppressedRemote=${suppressed ? `${suppressed.playState}@${suppressed.url}` : "none"}`,

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   createContentRuntimeState,
+  hasGestureBeenRecorded,
   type ExplicitPlaybackAction,
   type ExplicitUserAction,
 } from "../src/content/runtime-state";
@@ -987,8 +988,8 @@ test("navigation controller does not reuse one natural end for a second navigati
       "the manual destination is not auto-shared",
     );
     assert.equal(
-      runtimeState.lastUserGestureAt,
-      0,
+      hasGestureBeenRecorded(runtimeState.lastUserGestureAt),
+      false,
       "handling it cleared the gesture that refuted it",
     );
 
@@ -2080,7 +2081,7 @@ test("navigation controller clears stale gesture state on in-room navigation", (
     currentUrl = "https://www.bilibili.com/video/BV1Em421N7uU";
     windowHarness.intervals[0]?.();
 
-    assert.equal(runtimeState.lastUserGestureAt, 0);
+    assert.equal(hasGestureBeenRecorded(runtimeState.lastUserGestureAt), false);
     assert.equal(runtimeState.lastExplicitPlaybackAction, null);
     assert.equal(runtimeState.lastExplicitUserAction, null);
   } finally {

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -4273,3 +4273,74 @@ test("playback binding controller ends the catch-up for a keyboard speed shortcu
     dom.restore();
   }
 });
+
+test("playback binding controller re-pauses a remote-stopped video on a page younger than the gesture grace", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVshared?p=1";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.intendedPlayState = "paused";
+  // No gesture has EVER been recorded: the background just pointed this tab at
+  // the room's new shared video (`chrome.tabs.update`), so the document is fresh
+  // and its monotonic clock reads well under `userGestureGraceMs`. The room says
+  // paused; the page's own load autoplay must still be caught. With a `0`
+  // sentinel `now - 0 < graceMs` reads as "the user just pressed play" and the
+  // tab runs on until the grace lapses — the 2-3s of unwanted playback (and the
+  // `playing` it broadcasts back to the room) this guards.
+  const pageAgeMs = 800;
+  let pausedByGuard = 0;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalPause = dom.video.pause;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => ({
+      videoId: "BVshared:p1",
+      url: "https://www.bilibili.com/video/BVshared?p=1",
+      title: "Shared Video",
+    }),
+    hasRecentRemoteStopIntent: () => true,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => pageAgeMs,
+  });
+
+  try {
+    Object.assign(globalThis.window, {
+      setTimeout: (handler: () => void) => {
+        handler();
+        return 1;
+      },
+    });
+    dom.video.pause = () => {
+      pausedByGuard += 1;
+      dom.video.paused = true;
+    };
+    dom.video.paused = false;
+
+    controller.attachPlaybackListeners();
+    dom.listeners.get("play")?.(new Event("play"));
+
+    await Promise.resolve();
+
+    assert.equal(pausedByGuard, 1);
+    assert.equal(runtimeState.lastForcedPauseAt, pageAgeMs);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.video.pause = originalPause;
+    dom.restore();
+  }
+});

--- a/extension/test/room-state-apply-controller.test.ts
+++ b/extension/test/room-state-apply-controller.test.ts
@@ -181,6 +181,26 @@ test("suppresses autoplay for empty room after navigation resets gesture state",
   assert.equal(video.paused, true);
 });
 
+test("suppresses autoplay on a page younger than the gesture grace", async () => {
+  const video = createStubVideo(false);
+  // The tab was just navigated to the room's video, so the document's monotonic
+  // clock still reads under `userGestureGraceMs` and no gesture has ever been
+  // recorded. "Never" must not be confused with "just now": with a `0` sentinel
+  // this reads as a fresh gesture and the page's load autoplay is waved through.
+  const harness = createController({
+    video,
+    now: 800,
+    userGestureGraceMs: 1_200,
+  });
+
+  harness.runtimeState.pendingRoomStateHydration = true;
+  harness.runtimeState.intendedPlayState = "paused";
+
+  await harness.controller.applyRoomState(createEmptyRoomState());
+
+  assert.equal(video.paused, true);
+});
+
 test("skips pauseVideo when a recent user gesture is within the grace window", async () => {
   const video = createStubVideo(false);
   const harness = createController({


### PR DESCRIPTION
## 问题

festival 连播时，被共享端在新视频上会**多播 2~3 秒**才暂停（1.3.2 是立刻暂停）。

用户日志（1.3.3 被共享端）：

```
20:18:43 [background] Reusing tab 2012463918 for shared video      ← chrome.tabs.update，整页重载
20:18:44 Apply playback seq=43 paused → 武装 pauseHoldUntil=3747.3  ← 3000ms 保持期 ⇒ 页面才活了 747ms
20:18:44 Dispatch playback update seq=0 source=canplay playState=playing  ← 本该被拦，放行了
20:18:46 Skip broadcast ... result=remote-stop-hold                 ← 1.2s 宽限期过后才拦住
20:18:46 Dispatch playback update seq=6 paused t=2.33               ← 把房间拖到 2.33 暂停
```

## 根因

#231/#233 把内容脚本的经过时长换成单调钟，但 `lastUserGestureAt` 一族仍用 `0` 表示"从未发生"：

| 时钟 | `now - 0` | "最近没有手势" 判据 |
| --- | --- | --- |
| `Date.now()`（≤1.3.2） | ~56 年 | ✅ 成立 |
| `performance.now()`（1.3.3） | = 页龄 | ❌ 页面头 1.2 秒内一律不成立 |

于是**每个页面最初的 `userGestureGraceMs` 内，所有"最近没有用户手势"的保护集体失效**——恰好就是新标签页自动播放的那一刻。受影响的裸判据：`sync-controller.ts:1407`（remote-stop-hold）、`playback-binding-controller.ts:622/951`、`room-state-apply-controller.ts:330/1006`、`playback-broadcast.ts:16`。

## 改动

- 哨兵改为 `GESTURE_NEVER_AT = -Infinity`，在 `>= grace`（保守）与 `< grace`（宽松）两种极性下都还原"无限久以前"。
- 删掉 `hasRecentRateControlGesture` 的 `> 0` 存在性检查：其注释断言姊妹判据 `hasRecentUserGestureInPlayer` "已覆盖"页面开头那段窗口，实则姊妹判据同为 `0` 默认值、在那段窗口里自身即为真，从未覆盖。现在哨兵单点解决，不再留第二份真理。
- 存在性检测统一走 `hasGestureBeenRecorded()`；导航控制器原有的两处 `> 0` 一并换掉。

## 验证

`format:check` / `lint` / `typecheck` / `build` / `test`（644 pass）/ `audit` 全绿。

两条新回归各自回退哨兵后必失败（已实测）：
- `playback binding controller re-pauses a remote-stopped video on a page younger than the gesture grace`
- `suppresses autoplay on a page younger than the gesture grace`

两条既有断言从"重置为 `0`"改成断言语义 `hasGestureBeenRecorded(...) === false`。

## 未覆盖

连播时**共享端**把自己强制暂停后才发出 auto-share（房间因此整体停住）是另一个独立缺陷，两个版本都有，另开 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)