### PR TITLE
fix: 共享者连播时撤销自己打下的加载暂停

### DIFF
--- a/extension/src/content/festival-bridge.ts
+++ b/extension/src/content/festival-bridge.ts
@@ -4,6 +4,7 @@ import {
   buildBvidCidShareUrl,
   buildFestivalShareUrl,
 } from "./page-video";
+import { normalizePageVisitUrl } from "./video-identity";
 
 export interface FestivalSnapshot {
   videoId: string;
@@ -39,8 +40,9 @@ export interface FestivalBridgeController {
    * the player swaps videos, so this is the only reliable way for the navigation
    * watcher and auto-share self-check to observe the current video. Returns the
    * snapshot's resolved share URL (with `bvid`/`cid`) when the cached snapshot
-   * belongs to `pathname`, otherwise `null` (non-festival page, or no/stale
-   * matching snapshot — callers fall back to the address bar).
+   * belongs to the same pathname and full page URL visit, otherwise `null`
+   * (non-festival page, or no/stale matching snapshot — callers fall back to
+   * the address bar).
    *
    * When `maxAgeMs` is provided, a snapshot older than it is treated as stale and
    * `null` is returned: a cached video the user may already have left must not be
@@ -50,6 +52,7 @@ export interface FestivalBridgeController {
    */
   resolveVideoUrlForPage: (
     pathname: string,
+    pageUrl: string,
     maxAgeMs?: number,
   ) => string | null;
   refreshSnapshot: (args: {
@@ -62,6 +65,8 @@ export interface FestivalBridgeController {
 export function createFestivalBridgeController(): FestivalBridgeController {
   let festivalBridgeReady = false;
   let festivalSnapshot: FestivalSnapshot | null = null;
+  let pageVisitGeneration = 0;
+  let freshRequestSequence = 0;
 
   async function readFestivalSnapshotFromPageContext(
     pathname: string,
@@ -149,12 +154,18 @@ export function createFestivalBridgeController(): FestivalBridgeController {
     return pathname.replace(/\/+$/, "");
   }
 
-  function canUseCachedFestivalSnapshot(pathname: string): boolean {
+  function canUseCachedFestivalSnapshot(
+    pathname: string,
+    pageUrl: string,
+  ): boolean {
     return (
       pathname.startsWith("/festival/") &&
       festivalSnapshot?.pathname?.startsWith("/festival/") === true &&
       normalizeCachedPagePathname(festivalSnapshot.pathname) ===
-        normalizeCachedPagePathname(pathname)
+        normalizeCachedPagePathname(pathname) &&
+      festivalSnapshot.pageUrl !== undefined &&
+      normalizePageVisitUrl(festivalSnapshot.pageUrl) ===
+        normalizePageVisitUrl(pageUrl)
     );
   }
 
@@ -182,6 +193,7 @@ export function createFestivalBridgeController(): FestivalBridgeController {
 
   return {
     clearSnapshot: () => {
+      pageVisitGeneration += 1;
       festivalSnapshot = null;
     },
     ensureBridgeInjected: () => {
@@ -190,6 +202,7 @@ export function createFestivalBridgeController(): FestivalBridgeController {
     getSnapshot: () => festivalSnapshot,
     resolveVideoUrlForPage: (
       pathname: string,
+      pageUrl: string,
       maxAgeMs?: number,
     ): string | null => {
       if (!pathname.startsWith("/festival/")) {
@@ -198,7 +211,10 @@ export function createFestivalBridgeController(): FestivalBridgeController {
       if (
         !festivalSnapshot?.pathname?.startsWith("/festival/") ||
         normalizeCachedPagePathname(festivalSnapshot.pathname) !==
-          normalizeCachedPagePathname(pathname)
+          normalizeCachedPagePathname(pathname) ||
+        festivalSnapshot.pageUrl === undefined ||
+        normalizePageVisitUrl(festivalSnapshot.pageUrl) !==
+          normalizePageVisitUrl(pageUrl)
       ) {
         return null;
       }
@@ -217,6 +233,7 @@ export function createFestivalBridgeController(): FestivalBridgeController {
     refreshSnapshot: async ({ pathname, pageUrl, maxAgeMs }) => {
       const isBangumiPage = pathname.startsWith("/bangumi/play/");
       if (!pathname.startsWith("/festival/") && !isBangumiPage) {
+        pageVisitGeneration += 1;
         festivalSnapshot = null;
         return null;
       }
@@ -224,7 +241,7 @@ export function createFestivalBridgeController(): FestivalBridgeController {
       if (
         !isBangumiPage &&
         festivalSnapshot &&
-        canUseCachedFestivalSnapshot(pathname) &&
+        canUseCachedFestivalSnapshot(pathname, pageUrl) &&
         performance.now() - festivalSnapshot.updatedAt < maxAgeMs
       ) {
         return {
@@ -234,10 +251,21 @@ export function createFestivalBridgeController(): FestivalBridgeController {
         };
       }
 
+      // Only an actual page-world read supersedes another read. A concurrent
+      // cache hit is observational and must not cancel a fresh read that was
+      // already in flight for this same page visit.
+      const requestVisitGeneration = pageVisitGeneration;
+      const requestSequence = (freshRequestSequence += 1);
       const nextSnapshot = await readFestivalSnapshotFromPageContext(
         pathname,
         pageUrl,
       );
+      if (
+        requestVisitGeneration !== pageVisitGeneration ||
+        requestSequence !== freshRequestSequence
+      ) {
+        return null;
+      }
       if (!nextSnapshot) {
         // Mirror the fast-path freshness gate above: when a fresh read fails, only
         // fall back to the cached snapshot while it is still within `maxAgeMs`.
@@ -246,7 +274,7 @@ export function createFestivalBridgeController(): FestivalBridgeController {
         // video the user has already left.
         return !isBangumiPage &&
           festivalSnapshot &&
-          canUseCachedFestivalSnapshot(pathname) &&
+          canUseCachedFestivalSnapshot(pathname, pageUrl) &&
           performance.now() - festivalSnapshot.updatedAt < maxAgeMs
           ? {
               videoId: festivalSnapshot.videoId,

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -8,7 +8,7 @@ import { createAutoShareNextController } from "./auto-share-next-controller";
 import { runtimeSendMessage } from "./content-messaging";
 import { createFestivalBridgeController } from "./festival-bridge";
 import { startUserGestureTracking } from "./gesture-tracker";
-import { getVideoElement, pauseVideo } from "./player-binding";
+import { getVideoElement, pauseVideo, playVideo } from "./player-binding";
 import { createContentStateStore } from "./content-store";
 import { createNavigationController } from "./navigation-controller";
 import { startNavigationSignalListener } from "./navigation-signal";
@@ -198,6 +198,7 @@ const navigationController = createNavigationController({
     playbackBindingController.attachPlaybackListeners(),
   getVideoElement,
   pauseVideo,
+  playVideo,
   hydrateRoomState: () => syncController.hydrateRoomState(),
   activatePauseHold,
   scheduleAutoShareNextVideo: (input) =>

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -79,6 +79,7 @@ const autoShareNextController = createAutoShareNextController({
   getCurrentPageUrl: () =>
     festivalBridge.resolveVideoUrlForPage(
       window.location.pathname,
+      window.location.href.split("#")[0],
       FESTIVAL_SNAPSHOT_TTL_MS,
     ) ?? window.location.href.split("#")[0],
   // Lets the self-check distinguish a trustworthy resolved current video from the
@@ -87,6 +88,7 @@ const autoShareNextController = createAutoShareNextController({
   getResolvedVideoUrl: () =>
     festivalBridge.resolveVideoUrlForPage(
       window.location.pathname,
+      window.location.href.split("#")[0],
       FESTIVAL_SNAPSHOT_TTL_MS,
     ),
   normalizeVideoPageUrl: (url) => normalizeSharedVideoUrl(url),
@@ -188,11 +190,17 @@ const navigationController = createNavigationController({
   getResolvedVideoUrl: () =>
     festivalBridge.resolveVideoUrlForPage(
       window.location.pathname,
+      window.location.href.split("#")[0],
       FESTIVAL_SNAPSHOT_TTL_MS,
     ),
   isSupportedVideoPage: (url) => Boolean(normalizeSharedVideoUrl(url)),
   clearFestivalSnapshot: () => {
     festivalBridge.clearSnapshot();
+    // The navigation controller sees every real route transition, including a
+    // quick leave-and-return with no playback event on the page in between.
+    // Give that visit boundary to the share controller so a festival address
+    // bar refuted on the previous visit cannot stay refuted on the next one.
+    shareController.observePageVisit(window.location.href.split("#")[0]);
   },
   attachPlaybackListeners: () =>
     playbackBindingController.attachPlaybackListeners(),

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -54,6 +54,8 @@ export function createNavigationController(args: {
   attachPlaybackListeners: () => void;
   getVideoElement: () => HTMLVideoElement | null;
   pauseVideo: (video: HTMLVideoElement) => void;
+  /** Resumes a video this controller's own arrival hold paused. */
+  playVideo: (video: HTMLVideoElement) => Promise<void>;
   hydrateRoomState: () => Promise<void>;
   activatePauseHold: (durationMs?: number) => void;
   scheduleAutoShareNextVideo?: (input: {
@@ -243,6 +245,17 @@ export function createNavigationController(args: {
     // autoplay off a share whose `activeSharedUrl` is still the unstable route.
     const previousResolvedSharedVideoUrl =
       args.runtimeState.resolvedSharedVideoUrl;
+    // The page the playback binding force-paused as a "load paused" arrival,
+    // captured before `resetUserGestureState` below clears it. The binding acts on
+    // the `play` event, which fires the instant the player swaps videos — long
+    // before this watcher (a 400ms poll, and on a festival page it cannot even
+    // look at the address bar) gets to classify the navigation. So by the time the
+    // sharer branch below decides "this is the room's own autoplay-next", the
+    // video it is about to auto-share has ALREADY been paused. Remembering which
+    // URL that hold was armed for is what lets the branch undo it, and only it:
+    // any other pause (the user's own, a buffer stall) leaves this pointing
+    // elsewhere or null.
+    const previousAutoplayHoldUrl = args.runtimeState.nonSharerAutoplayHoldUrl;
     lastObservedPageUrl = nextPageUrl;
     lastObservedNormalizedPageUrl = nextNormalizedPageUrl;
     args.clearFestivalSnapshot();
@@ -483,6 +496,37 @@ export function createNavigationController(args: {
 
       if (shouldTreatAsAutoplay && isLocalSharedSource) {
         args.runtimeState.explicitNonSharedPlaybackUrl = nextNormalizedPageUrl;
+        // Undo the binding's "load paused" hold on this very page. Authorizing the
+        // URL (above) only stops a FUTURE pause; the one that already happened
+        // must be reverted here, or the sharer auto-shares a paused video ~900ms
+        // later and the whole room stops on it — the tab is the room's source, so
+        // nobody is left playing.
+        //
+        // Gated on the hold naming this exact page, so it can only ever revert a
+        // pause this controller's own arrival caused. `shouldTreatAsAutoplay`
+        // already excludes a recent user gesture, so a manual pause cannot be
+        // standing here either — and a pause the user makes AFTER this point sets
+        // no hold and is untouched.
+        // The hold naming this page is the whole condition. Whether the element
+        // is still paused only decides if `play()` is worth calling: the intent
+        // and the hold are ours either way, so they are released regardless (a
+        // hold left standing would have the binding re-pause the very next
+        // `play`).
+        if (previousAutoplayHoldUrl === nextNormalizedPageUrl) {
+          args.runtimeState.intendedPlayState = "playing";
+          args.runtimeState.pauseHoldUntil = 0;
+          const heldVideo = args.getVideoElement();
+          if (heldVideo?.paused) {
+            args.debugLog(
+              `Resumed sharer autoplay-next after load-pause hold ${nextNormalizedPageUrl}`,
+            );
+            void args.playVideo(heldVideo).catch(() => {
+              args.debugLog(
+                `Could not resume sharer autoplay-next ${nextNormalizedPageUrl}; the room will follow the paused state`,
+              );
+            });
+          }
+        }
         // Advance FROM the room's confirmed shared video (`activeSharedUrl`), not
         // the page we navigated from. A multi-part / chained autoplay that outruns
         // room confirmation (A→B→C→D before any `room:state` returns) can't replay

--- a/extension/src/content/navigation-controller.ts
+++ b/extension/src/content/navigation-controller.ts
@@ -507,16 +507,21 @@ export function createNavigationController(args: {
         // already excludes a recent user gesture, so a manual pause cannot be
         // standing here either — and a pause the user makes AFTER this point sets
         // no hold and is untouched.
-        // The hold naming this page is the whole condition. Whether the element
-        // is still paused only decides if `play()` is worth calling: the intent
-        // and the hold are ours either way, so they are released regardless (a
-        // hold left standing would have the binding re-pause the very next
-        // `play`).
+        // The hold naming this page is the whole condition — deliberately NOT
+        // "and the element is currently paused". The binding arms the hold
+        // synchronously on `play` but performs the pause in a `setTimeout`, so
+        // whether it has landed by the time we get here is a race we lose about
+        // as often as we win: reading `paused` picks the wrong branch on the
+        // half where the pause is still queued, and the queued pause then stops
+        // a video we just declared playing. `play()` on an already-playing
+        // element is a no-op, so calling it unconditionally costs nothing and
+        // covers both halves; the queued pause is handled on its own side, by
+        // re-checking `explicitNonSharedPlaybackUrl` before it fires.
         if (previousAutoplayHoldUrl === nextNormalizedPageUrl) {
           args.runtimeState.intendedPlayState = "playing";
           args.runtimeState.pauseHoldUntil = 0;
           const heldVideo = args.getVideoElement();
-          if (heldVideo?.paused) {
+          if (heldVideo) {
             args.debugLog(
               `Resumed sharer autoplay-next after load-pause hold ${nextNormalizedPageUrl}`,
             );

--- a/extension/src/content/page-video.ts
+++ b/extension/src/content/page-video.ts
@@ -20,6 +20,25 @@ export interface PageVideoSource {
     url: string;
     title: string;
   } | null;
+  /**
+   * Whether the address bar has been PROVEN stale as an identity for this page,
+   * so the `parseBilibiliVideoRef(pageUrl)` fallback below must not be used.
+   *
+   * A festival page keeps whatever `?bvid=` it was opened with while the player
+   * runs through the whole playlist, so once a snapshot has resolved even once
+   * we know the address bar names some earlier video — very likely not the one
+   * playing. The fallback then does not degrade gracefully: it answers with a
+   * confident, *wrong* `/video/<frozen bvid>` identity, which reads as "some
+   * other, non-shared video" and gets the page force-paused (and remote room
+   * states discarded as "not this page"). Answering `null` — "not known yet" —
+   * routes those callers to their unresolved-identity paths, which is what the
+   * situation actually is.
+   *
+   * Left false until a snapshot has resolved: a festival page opened from a
+   * share link carries `?bvid=A&cid=...` for the video it is about to play, and
+   * until the bridge resolves that is the only identity available.
+   */
+  addressBarIdentityRefuted?: boolean;
 }
 
 export interface VideoPlaybackSnapshot {
@@ -45,6 +64,10 @@ export function resolvePageSharedVideo(
       url: source.festivalSnapshot.url,
       title: source.festivalSnapshot.title,
     };
+  }
+
+  if (source.addressBarIdentityRefuted) {
+    return null;
   }
 
   const fallbackVideoRef = parseBilibiliVideoRef(source.pageUrl);

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -116,6 +116,25 @@ export function createPlaybackBindingController(args: {
       sharerEndedFlushTimerId = null;
     }
   };
+  const queuePauseIfCurrent = (
+    video: HTMLVideoElement,
+    shouldStillPause: () => boolean,
+  ): void => {
+    const playbackContextGeneration =
+      args.runtimeState.playbackContextGeneration;
+    window.setTimeout(() => {
+      if (
+        playbackContextGeneration !==
+          args.runtimeState.playbackContextGeneration ||
+        getVideoElement() !== video ||
+        video.paused ||
+        !shouldStillPause()
+      ) {
+        return;
+      }
+      pauseVideo(video);
+    }, 0);
+  };
   const clearActivePauseClassification = () => {
     args.runtimeState.pauseStartedAt = 0;
     args.runtimeState.pauseClassifiedAsBuffer = false;
@@ -128,9 +147,23 @@ export function createPlaybackBindingController(args: {
    */
   const armBufferPauseUpgrade = (video: HTMLVideoElement) => {
     clearBufferUpgradeTimer();
+    const playbackContextGeneration =
+      args.runtimeState.playbackContextGeneration;
+    const classifiedPauseStartedAt = args.runtimeState.pauseStartedAt;
     pauseBufferUpgradeTimerId = scheduleUpgradeTimer(() => {
       pauseBufferUpgradeTimerId = null;
-      if (!video.paused) {
+      if (
+        playbackContextGeneration !==
+        args.runtimeState.playbackContextGeneration
+      ) {
+        return;
+      }
+      if (
+        getVideoElement() !== video ||
+        !video.paused ||
+        !args.runtimeState.pauseClassifiedAsBuffer ||
+        args.runtimeState.pauseStartedAt !== classifiedPauseStartedAt
+      ) {
         return;
       }
       args.runtimeState.pauseClassifiedAsBuffer = false;
@@ -759,6 +792,8 @@ export function createPlaybackBindingController(args: {
     args.debugLog(
       "Forced pause for non-shared video autoplay (in room, load paused)",
     );
+    const playbackContextGeneration =
+      args.runtimeState.playbackContextGeneration;
     window.setTimeout(() => {
       // Re-check the premise before acting on it. This hold is decided on the
       // `play` event, but the navigation controller — the only layer that can
@@ -773,6 +808,22 @@ export function createPlaybackBindingController(args: {
       ) {
         args.debugLog(
           `Dropped load-pause hold for ${normalizedCurrentUrl}; it was authorized before the pause landed`,
+        );
+        return;
+      }
+      // The navigation reset clears this marker before the queued callback can
+      // run. A reused <video> element may already be showing the room's shared
+      // video by then, so the captured element and URL are not enough to prove
+      // this callback still owns a pause. Only the hold that armed this exact
+      // callback may let it act; a cleared or replaced marker makes it stale.
+      if (
+        playbackContextGeneration !==
+          args.runtimeState.playbackContextGeneration ||
+        getVideoElement() !== video ||
+        args.runtimeState.nonSharerAutoplayHoldUrl !== normalizedCurrentUrl
+      ) {
+        args.debugLog(
+          `Dropped stale load-pause for ${normalizedCurrentUrl}; its hold no longer owns the current page`,
         );
         return;
       }
@@ -804,11 +855,20 @@ export function createPlaybackBindingController(args: {
     );
     args.runtimeState.intendedPlayState = "paused";
     args.runtimeState.lastForcedPauseAt = monotonicNow();
-    window.setTimeout(() => {
-      if (!video.paused) {
-        pauseVideo(video);
-      }
-    }, 0);
+    const roomCode = args.runtimeState.activeRoomCode;
+    queuePauseIfCurrent(video, () => {
+      const latestCurrentVideo = args.getSharedVideo();
+      return (
+        args.runtimeState.activeRoomCode === roomCode &&
+        !isKnownNonSharedVideo(latestCurrentVideo) &&
+        shouldForcePauseWhileWaitingForInitialRoomState({
+          activeRoomCode: args.runtimeState.activeRoomCode,
+          pendingRoomStateHydration:
+            args.runtimeState.pendingRoomStateHydration,
+          videoPaused: video.paused,
+        })
+      );
+    });
     return true;
   }
 
@@ -942,9 +1002,18 @@ export function createPlaybackBindingController(args: {
         args.runtimeState.explicitSeekOriginPlayState = null;
         args.runtimeState.lastExplicitPlaybackAction = null;
         args.runtimeState.lastForcedPauseAt = monotonicNow();
-        window.setTimeout(() => {
-          pauseVideo(video);
-        }, 0);
+        const blockedUrl = args.normalizeUrl(currentVideo?.url);
+        const gestureAtWhenBlocked = args.runtimeState.lastUserGestureAt;
+        queuePauseIfCurrent(video, () => {
+          const latestCurrentVideo = args.getSharedVideo();
+          return (
+            blockedUrl !== null &&
+            args.runtimeState.intendedPlayState !== "playing" &&
+            args.runtimeState.lastUserGestureAt === gestureAtWhenBlocked &&
+            isCurrentVideoShared(latestCurrentVideo) &&
+            args.normalizeUrl(latestCurrentVideo?.url) === blockedUrl
+          );
+        });
         return true;
       }
 
@@ -958,9 +1027,9 @@ export function createPlaybackBindingController(args: {
           `Re-paused non-sharer multi-part autoplay after shared video natural end`,
         );
         args.runtimeState.lastForcedPauseAt = monotonicNow();
-        window.setTimeout(() => {
-          pauseVideo(video);
-        }, 0);
+        queuePauseIfCurrent(video, () =>
+          shouldReapplyHoldAfterSharedVideoEnd(video, args.getSharedVideo()),
+        );
         return true;
       }
 
@@ -976,9 +1045,19 @@ export function createPlaybackBindingController(args: {
           `Forced pause hold reapplied after unexpected resume intended=${args.runtimeState.intendedPlayState}`,
         );
         args.runtimeState.lastForcedPauseAt = monotonicNow();
-        window.setTimeout(() => {
-          pauseVideo(video);
-        }, 0);
+        const remoteStopUrl = args.normalizeUrl(currentVideo.url);
+        const gestureAtWhenBlocked = args.runtimeState.lastUserGestureAt;
+        queuePauseIfCurrent(video, () => {
+          const latestCurrentVideo = args.getSharedVideo();
+          return (
+            remoteStopUrl !== null &&
+            args.runtimeState.intendedPlayState !== "playing" &&
+            args.runtimeState.lastUserGestureAt === gestureAtWhenBlocked &&
+            isCurrentVideoShared(latestCurrentVideo) &&
+            args.normalizeUrl(latestCurrentVideo?.url) === remoteStopUrl &&
+            args.hasRecentRemoteStopIntent(latestCurrentVideo?.url ?? "")
+          );
+        });
         return true;
       }
 
@@ -989,9 +1068,11 @@ export function createPlaybackBindingController(args: {
         args.runtimeState.explicitNonSharedPlaybackUrl = null;
         args.runtimeState.lastNonSharedGuardUrl = null;
         args.runtimeState.lastForcedPauseAt = monotonicNow();
-        window.setTimeout(() => {
-          pauseVideo(video);
-        }, 0);
+        queuePauseIfCurrent(video, () =>
+          shouldReapplyPauseHoldForUnconfirmedSharedVideo(
+            args.getSharedVideo(),
+          ),
+        );
         return true;
       }
 

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -760,6 +760,22 @@ export function createPlaybackBindingController(args: {
       "Forced pause for non-shared video autoplay (in room, load paused)",
     );
     window.setTimeout(() => {
+      // Re-check the premise before acting on it. This hold is decided on the
+      // `play` event, but the navigation controller — the only layer that can
+      // tell a sharer's own autoplay-next from an arrival at someone else's
+      // video — classifies on a 400ms poll and can land in between. When it
+      // does, it authorizes this URL and undoes the hold; an unconditional
+      // pause here would then re-stop the very video the room is about to be
+      // advanced to, with nothing left to revert it (the classification for
+      // this navigation has already run).
+      if (
+        args.runtimeState.explicitNonSharedPlaybackUrl === normalizedCurrentUrl
+      ) {
+        args.debugLog(
+          `Dropped load-pause hold for ${normalizedCurrentUrl}; it was authorized before the pause landed`,
+        );
+        return;
+      }
       pauseVideo(video);
     }, 0);
     return true;

--- a/extension/src/content/player-binding.ts
+++ b/extension/src/content/player-binding.ts
@@ -42,6 +42,17 @@ export function pauseVideo(video: HTMLVideoElement): void {
   video.pause();
 }
 
+/**
+ * Resume a video WE paused. The rejection is expected and swallowed by the
+ * caller's `onRejected`: `play()` returns a promise that rejects when the
+ * browser's autoplay policy refuses (no media engagement yet) or when a newer
+ * load/pause interrupts it, and an unhandled rejection would surface as a page
+ * error for something we can only report.
+ */
+export function playVideo(video: HTMLVideoElement): Promise<void> {
+  return Promise.resolve(video.play()).then(() => undefined);
+}
+
 export function getPlayState(
   video: HTMLVideoElement,
   intendedPlayState: PlaybackState["playState"],

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -101,6 +101,8 @@ export interface ContentRuntimeState {
   hydrationReady: boolean;
   hasReceivedInitialRoomState: boolean;
   pendingRoomStateHydration: boolean;
+  /** Invalidates delayed work that captured an older room/page playback context. */
+  playbackContextGeneration: number;
   intendedPlayState: PlaybackState["playState"];
   intendedPlaybackRate: number;
   lastLocalIntentAt: number;
@@ -326,6 +328,7 @@ export interface ContentRuntimeState {
  * into treating browser-initiated playback as a user action.
  */
 export function resetUserGestureState(state: ContentRuntimeState): void {
+  invalidatePlaybackContext(state);
   state.lastUserGestureAt = GESTURE_NEVER_AT;
   state.lastUserGestureInPlayerAt = GESTURE_NEVER_AT;
   state.lastRateControlGestureAt = GESTURE_NEVER_AT;
@@ -337,6 +340,13 @@ export function resetUserGestureState(state: ContentRuntimeState): void {
   state.suppressedLocalEndPauseUrl = null;
   state.suppressedLocalEndPauseUntil = 0;
   state.nonSharerAutoplayHoldUrl = null;
+  state.lastBufferSignalAt = 0;
+  state.pauseStartedAt = 0;
+  state.pauseClassifiedAsBuffer = false;
+}
+
+export function invalidatePlaybackContext(state: ContentRuntimeState): void {
+  state.playbackContextGeneration += 1;
 }
 
 export function createContentRuntimeState(): ContentRuntimeState {
@@ -351,6 +361,7 @@ export function createContentRuntimeState(): ContentRuntimeState {
     hydrationReady: false,
     hasReceivedInitialRoomState: false,
     pendingRoomStateHydration: true,
+    playbackContextGeneration: 0,
     intendedPlayState: "paused",
     intendedPlaybackRate: 1,
     lastLocalIntentAt: 0,

--- a/extension/src/content/share-controller.ts
+++ b/extension/src/content/share-controller.ts
@@ -5,6 +5,7 @@ import {
   resolvePageSharedVideo,
 } from "./page-video";
 import type { ContentRuntimeState } from "./runtime-state";
+import { isAddressBarOpaqueVideoUrl } from "./video-identity";
 
 export interface ShareController {
   getSharedVideo(): SharedVideo | null;
@@ -188,6 +189,31 @@ export function createShareController(args: {
     });
   }
 
+  /**
+   * The address-bar-opaque pathname whose in-player identity a snapshot has
+   * already resolved at least once. From that point on the address bar's frozen
+   * `?bvid=` is known to be stale for this page — see
+   * {@link PageVideoSource.addressBarIdentityRefuted}. Keyed by pathname so
+   * leaving the page (a different festival, or any other route) starts over.
+   */
+  let snapshotResolvedPathname: string | null = null;
+
+  function rememberSnapshotResolved(pathname: string, pageUrl: string): void {
+    if (isAddressBarOpaqueVideoUrl(pageUrl)) {
+      snapshotResolvedPathname = normalizeCachedPagePathname(pathname);
+    }
+  }
+
+  function hasRefutedAddressBarIdentity(
+    pathname: string,
+    pageUrl: string,
+  ): boolean {
+    return (
+      isAddressBarOpaqueVideoUrl(pageUrl) &&
+      snapshotResolvedPathname === normalizeCachedPagePathname(pathname)
+    );
+  }
+
   function getSharedVideo(): SharedVideo | null {
     const festivalSnapshot = args.getFestivalSnapshot();
     const pathname = window.location.pathname;
@@ -206,6 +232,9 @@ export function createShareController(args: {
             title: festivalSnapshot.title,
           }
         : null;
+    if (matchingFestivalSnapshot) {
+      rememberSnapshotResolved(pathname, pageUrl);
+    }
     return resolvePageSharedVideo({
       pageUrl,
       pathname,
@@ -214,20 +243,30 @@ export function createShareController(args: {
       currentPartTitle: currentPart.title,
       pageSnapshot: matchingFestivalSnapshot,
       festivalSnapshot: matchingFestivalSnapshot,
+      addressBarIdentityRefuted: hasRefutedAddressBarIdentity(
+        pathname,
+        pageUrl,
+      ),
     });
   }
 
   async function refreshFestivalSnapshot(
     maxAgeMs = args.festivalSnapshotTtlMs,
   ): Promise<SharedVideo | null> {
+    const pathname = window.location.pathname;
+    const pageUrl = window.location.href.split("#")[0];
     const nextSnapshot = await args.refreshFestivalBridge({
-      pathname: window.location.pathname,
-      pageUrl: window.location.href.split("#")[0],
+      pathname,
+      pageUrl,
       maxAgeMs,
     });
     if (!nextSnapshot) {
       return null;
     }
+    // Recorded here as well as in `getSharedVideo`: a refresh is the
+    // authoritative resolution, and it can happen while no caller is reading the
+    // cached snapshot — the address bar is stale from this moment on either way.
+    rememberSnapshotResolved(pathname, pageUrl);
     args.debugLog(
       `Page video snapshot detected id=${nextSnapshot.videoId} title=${nextSnapshot.title} url=${nextSnapshot.url}`,
     );

--- a/extension/src/content/share-controller.ts
+++ b/extension/src/content/share-controller.ts
@@ -5,10 +5,15 @@ import {
   resolvePageSharedVideo,
 } from "./page-video";
 import type { ContentRuntimeState } from "./runtime-state";
-import { isAddressBarOpaqueVideoUrl } from "./video-identity";
+import {
+  isAddressBarOpaqueVideoUrl,
+  normalizePageVisitUrl,
+} from "./video-identity";
 
 export interface ShareController {
   getSharedVideo(): SharedVideo | null;
+  /** Records a real page visit so address-bar identity evidence cannot leak across it. */
+  observePageVisit(pageUrl: string): void;
   getCurrentPlaybackVideo(): Promise<SharedVideo | null>;
   getCurrentSharePayload(): {
     video: SharedVideo;
@@ -94,6 +99,7 @@ export function createShareController(args: {
 
   function canUseMatchingCachedPageSnapshot(argsForMatch: {
     pathname: string;
+    pageUrl: string;
     snapshot: CachedPageSnapshot | null;
     currentPart: CurrentPartIdentity;
   }): boolean {
@@ -103,7 +109,10 @@ export function createShareController(args: {
     if (canUseCachedPageSnapshot(argsForMatch.pathname)) {
       return (
         argsForMatch.snapshot.pathname?.startsWith("/festival/") === true &&
-        hasMatchingCachedPagePathname(argsForMatch)
+        hasMatchingCachedPagePathname(argsForMatch) &&
+        argsForMatch.snapshot.pageUrl !== undefined &&
+        normalizePageVisitUrl(argsForMatch.snapshot.pageUrl) ===
+          normalizePageVisitUrl(argsForMatch.pageUrl)
       );
     }
     const snapshotEpId =
@@ -190,27 +199,41 @@ export function createShareController(args: {
   }
 
   /**
-   * The address-bar-opaque pathname whose in-player identity a snapshot has
+   * The address-bar-opaque page visit whose in-player identity a snapshot has
    * already resolved at least once. From that point on the address bar's frozen
-   * `?bvid=` is known to be stale for this page — see
-   * {@link PageVideoSource.addressBarIdentityRefuted}. Keyed by pathname so
-   * leaving the page (a different festival, or any other route) starts over.
+   * `?bvid=` is known to be stale — see
+   * {@link PageVideoSource.addressBarIdentityRefuted}.
+   *
+   * This is keyed by the full page URL, not only its pathname: after leaving a
+   * festival and opening the same route from another share link, the new
+   * `?bvid=&cid=` is the only correct identity until its first snapshot resolves.
+   * Observing any different page also clears the old visit, which covers leaving
+   * and returning through the same link.
    */
-  let snapshotResolvedPathname: string | null = null;
+  let snapshotResolvedPageUrl: string | null = null;
 
-  function rememberSnapshotResolved(pathname: string, pageUrl: string): void {
-    if (isAddressBarOpaqueVideoUrl(pageUrl)) {
-      snapshotResolvedPathname = normalizeCachedPagePathname(pathname);
+  function observePageVisit(pageUrl: string): void {
+    const pageVisitUrl = normalizePageVisitUrl(pageUrl);
+    if (
+      snapshotResolvedPageUrl !== null &&
+      snapshotResolvedPageUrl !== pageVisitUrl
+    ) {
+      snapshotResolvedPageUrl = null;
     }
   }
 
-  function hasRefutedAddressBarIdentity(
-    pathname: string,
-    pageUrl: string,
-  ): boolean {
+  function rememberSnapshotResolved(pageUrl: string): void {
+    observePageVisit(pageUrl);
+    if (isAddressBarOpaqueVideoUrl(pageUrl)) {
+      snapshotResolvedPageUrl = normalizePageVisitUrl(pageUrl);
+    }
+  }
+
+  function hasRefutedAddressBarIdentity(pageUrl: string): boolean {
+    observePageVisit(pageUrl);
     return (
       isAddressBarOpaqueVideoUrl(pageUrl) &&
-      snapshotResolvedPathname === normalizeCachedPagePathname(pathname)
+      snapshotResolvedPageUrl === normalizePageVisitUrl(pageUrl)
     );
   }
 
@@ -223,6 +246,7 @@ export function createShareController(args: {
       festivalSnapshot &&
       canUseMatchingCachedPageSnapshot({
         pathname,
+        pageUrl,
         snapshot: festivalSnapshot,
         currentPart,
       })
@@ -233,7 +257,7 @@ export function createShareController(args: {
           }
         : null;
     if (matchingFestivalSnapshot) {
-      rememberSnapshotResolved(pathname, pageUrl);
+      rememberSnapshotResolved(pageUrl);
     }
     return resolvePageSharedVideo({
       pageUrl,
@@ -243,10 +267,7 @@ export function createShareController(args: {
       currentPartTitle: currentPart.title,
       pageSnapshot: matchingFestivalSnapshot,
       festivalSnapshot: matchingFestivalSnapshot,
-      addressBarIdentityRefuted: hasRefutedAddressBarIdentity(
-        pathname,
-        pageUrl,
-      ),
+      addressBarIdentityRefuted: hasRefutedAddressBarIdentity(pageUrl),
     });
   }
 
@@ -255,18 +276,29 @@ export function createShareController(args: {
   ): Promise<SharedVideo | null> {
     const pathname = window.location.pathname;
     const pageUrl = window.location.href.split("#")[0];
+    observePageVisit(pageUrl);
     const nextSnapshot = await args.refreshFestivalBridge({
       pathname,
       pageUrl,
       maxAgeMs,
     });
+    const currentPageUrl = window.location.href.split("#")[0];
+    if (
+      normalizePageVisitUrl(currentPageUrl) !== normalizePageVisitUrl(pageUrl)
+    ) {
+      observePageVisit(currentPageUrl);
+      args.debugLog(
+        `Discarded page video snapshot for stale visit ${pageUrl}; current page is ${currentPageUrl}`,
+      );
+      return null;
+    }
     if (!nextSnapshot) {
       return null;
     }
     // Recorded here as well as in `getSharedVideo`: a refresh is the
     // authoritative resolution, and it can happen while no caller is reading the
     // cached snapshot — the address bar is stale from this moment on either way.
-    rememberSnapshotResolved(pathname, pageUrl);
+    rememberSnapshotResolved(pageUrl);
     args.debugLog(
       `Page video snapshot detected id=${nextSnapshot.videoId} title=${nextSnapshot.title} url=${nextSnapshot.url}`,
     );
@@ -325,6 +357,7 @@ export function createShareController(args: {
 
   return {
     getSharedVideo,
+    observePageVisit,
     getCurrentPlaybackVideo,
     getCurrentSharePayload,
     resolveCurrentSharePayload,

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -38,7 +38,10 @@ import {
 } from "./sync-guards";
 import { createSoftApplyController } from "./soft-apply-controller";
 import { createPendingLocalOverrideController } from "./pending-local-override";
-import { hasGestureBeenRecorded } from "./runtime-state";
+import {
+  hasGestureBeenRecorded,
+  invalidatePlaybackContext,
+} from "./runtime-state";
 import type {
   ContentRuntimeState,
   LocalPlaybackEventSource,
@@ -317,6 +320,7 @@ export function createSyncController(args: {
   });
 
   function resetPlaybackSyncState(reason: string): void {
+    invalidatePlaybackContext(args.runtimeState);
     softApply.cancelActiveSoftApply(args.getVideoElement(), `reset:${reason}`);
     args.lastAppliedVersionByActor.clear();
     clearRemoteFollowPlayingWindow();
@@ -331,6 +335,9 @@ export function createSyncController(args: {
     softApply.clearSoftApplyCooldown();
     args.runtimeState.lastLocalPlaybackVersion = null;
     args.runtimeState.intendedPlaybackRate = 1;
+    args.runtimeState.lastBufferSignalAt = 0;
+    args.runtimeState.pauseStartedAt = 0;
+    args.runtimeState.pauseClassifiedAsBuffer = false;
     roomConfirmedBroadcast = null;
     args.runtimeState.lastNonSharedGuardUrl = null;
     args.runtimeState.lastExplicitPlaybackAction = null;
@@ -865,7 +872,9 @@ export function createSyncController(args: {
     eventSource: LocalPlaybackEventSource = "manual",
     naturalEnd?: boolean,
   ): Promise<void> {
-    const now = monotonicNow();
+    const playbackContextGeneration =
+      args.runtimeState.playbackContextGeneration;
+    let now = monotonicNow();
     if (!args.runtimeState.hydrationReady) {
       args.debugLog("Skip broadcast before hydration ready");
       logBroadcastTrace(
@@ -919,6 +928,20 @@ export function createSyncController(args: {
     }
 
     const currentVideo = await args.getCurrentPlaybackVideo();
+    if (
+      playbackContextGeneration !==
+        args.runtimeState.playbackContextGeneration ||
+      args.getVideoElement() !== video
+    ) {
+      args.debugLog(
+        "Dropped stale playback broadcast after resolving the current video",
+      );
+      return;
+    }
+    // Resolving festival-page identity can cross an async page bridge. All
+    // gesture and suppression windows below must be measured from the instant
+    // that result is known to still belong to this playback context.
+    now = monotonicNow();
     if (!currentVideo) {
       logBroadcastTrace(
         "no-current-video",
@@ -1423,10 +1446,24 @@ export function createSyncController(args: {
       );
       args.runtimeState.intendedPlayState = "paused";
       args.runtimeState.lastForcedPauseAt = now;
+      const remoteStopRoomCode = args.runtimeState.activeRoomCode;
+      const remoteStopGestureAt = args.runtimeState.lastUserGestureAt;
       window.setTimeout(() => {
-        if (!video.paused) {
-          pauseVideo(video);
+        if (
+          playbackContextGeneration !==
+            args.runtimeState.playbackContextGeneration ||
+          args.getVideoElement() !== video ||
+          args.runtimeState.activeRoomCode !== remoteStopRoomCode ||
+          args.normalizeUrl(args.getSharedVideo()?.url) !==
+            normalizedCurrentVideoUrl ||
+          args.runtimeState.lastUserGestureAt !== remoteStopGestureAt ||
+          args.runtimeState.intendedPlayState !== "paused" ||
+          !hasRecentRemoteStopIntent(currentVideo.url) ||
+          video.paused
+        ) {
+          return;
         }
+        pauseVideo(video);
       }, 0);
       logBroadcastTrace(
         "remote-stop-hold",
@@ -1599,6 +1636,18 @@ export function createSyncController(args: {
     if (response === null) {
       args.debugLog(
         `Dropped playback update actor=${payload.actorId} playState=${payload.playState} url=${payload.url} delta=0.00 result=no-response seq=${payload.seq} source=${eventSource} intent=${payload.syncIntent ?? "none"} rate=${payload.playbackRate.toFixed(2)}`,
+      );
+      return;
+    }
+    const currentLocalVersion = args.runtimeState.lastLocalPlaybackVersion;
+    if (
+      playbackContextGeneration !==
+        args.runtimeState.playbackContextGeneration ||
+      args.getVideoElement() !== video ||
+      (currentLocalVersion !== null && currentLocalVersion.seq > payload.seq)
+    ) {
+      args.debugLog(
+        `Ignored stale playback update acknowledgement seq=${payload.seq}`,
       );
       return;
     }

--- a/extension/src/content/video-identity.ts
+++ b/extension/src/content/video-identity.ts
@@ -32,6 +32,26 @@ export function isAddressBarOpaqueVideoUrl(url: string | null): boolean {
   }
 }
 
+/**
+ * Stable key for one address-bar page visit. Hash changes and trailing-slash
+ * variants do not create a new visit; a different query does. That distinction
+ * matters on festival pages: in-player autoplay never changes location.href,
+ * while opening another share link on the same pathname supplies a new bvid/cid
+ * that is authoritative until the bridge resolves its first snapshot.
+ */
+export function normalizePageVisitUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = "";
+    if (parsed.pathname !== "/") {
+      parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+    }
+    return parsed.toString();
+  } catch {
+    return url.split("#")[0]?.replace(/\/+$/, "") ?? url;
+  }
+}
+
 export function isUnstableSharedVideoUrl(url: string | null): boolean {
   if (!url) {
     return false;

--- a/extension/test/festival-bridge.test.ts
+++ b/extension/test/festival-bridge.test.ts
@@ -10,7 +10,14 @@ interface PageBridgeDetail {
   title?: string;
 }
 
-function installBridgeDomStub(details: Array<PageBridgeDetail | null>): {
+interface DeferredPageBridgeDetail {
+  deferred: PageBridgeDetail;
+}
+
+function installBridgeDomStub(
+  details: Array<PageBridgeDetail | DeferredPageBridgeDetail | null>,
+): {
+  flushDeferred: () => void;
   restore: () => void;
 } {
   const originalWindow = globalThis.window;
@@ -19,6 +26,7 @@ function installBridgeDomStub(details: Array<PageBridgeDetail | null>): {
   let listener: EventListener | null = null;
   const pendingTimeouts = new Map<number, boolean>();
   let timeoutSeq = 0;
+  let deferredResponse: (() => void) | null = null;
 
   const windowStub = {
     setTimeout(callback: () => void) {
@@ -43,18 +51,26 @@ function installBridgeDomStub(details: Array<PageBridgeDetail | null>): {
       }
     },
     postMessage(message: { requestId?: string }) {
-      const detail = details.shift();
-      if (!detail || !listener) {
+      const response = details.shift();
+      if (!response || !listener) {
         return;
       }
-      listener({
-        source: windowStub,
-        data: {
-          type: "bili-syncplay:festival-video",
-          requestId: message.requestId,
-          detail,
-        },
-      } as MessageEvent);
+      const detail = "deferred" in response ? response.deferred : response;
+      const dispatch = () => {
+        listener?.({
+          source: windowStub,
+          data: {
+            type: "bili-syncplay:festival-video",
+            requestId: message.requestId,
+            detail,
+          },
+        } as MessageEvent);
+      };
+      if ("deferred" in response) {
+        deferredResponse = dispatch;
+        return;
+      }
+      dispatch();
     },
   };
 
@@ -88,6 +104,14 @@ function installBridgeDomStub(details: Array<PageBridgeDetail | null>): {
   });
 
   return {
+    flushDeferred() {
+      if (!deferredResponse) {
+        throw new Error("No deferred page-bridge response is pending");
+      }
+      const dispatch = deferredResponse;
+      deferredResponse = null;
+      dispatch();
+    },
     restore() {
       Object.assign(globalThis, {
         window: originalWindow,
@@ -205,7 +229,13 @@ test("festival bridge resolves the cached video url for the matching festival pa
 
   try {
     // No snapshot yet.
-    assert.equal(controller.resolveVideoUrlForPage("/festival/demo"), null);
+    assert.equal(
+      controller.resolveVideoUrlForPage(
+        "/festival/demo",
+        "https://www.bilibili.com/festival/demo",
+      ),
+      null,
+    );
 
     await controller.refreshSnapshot({
       pathname: "/festival/demo",
@@ -215,19 +245,43 @@ test("festival bridge resolves the cached video url for the matching festival pa
 
     // Same page (incl. trailing-slash variant) resolves to the snapshot url.
     assert.equal(
-      controller.resolveVideoUrlForPage("/festival/demo"),
+      controller.resolveVideoUrlForPage(
+        "/festival/demo",
+        "https://www.bilibili.com/festival/demo",
+      ),
       "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123",
     );
     assert.equal(
-      controller.resolveVideoUrlForPage("/festival/demo/"),
+      controller.resolveVideoUrlForPage(
+        "/festival/demo/",
+        "https://www.bilibili.com/festival/demo/",
+      ),
       "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123",
     );
     // A different festival page or a non-festival page does not match.
-    assert.equal(controller.resolveVideoUrlForPage("/festival/other"), null);
-    assert.equal(controller.resolveVideoUrlForPage("/video/BVx"), null);
+    assert.equal(
+      controller.resolveVideoUrlForPage(
+        "/festival/other",
+        "https://www.bilibili.com/festival/other",
+      ),
+      null,
+    );
+    assert.equal(
+      controller.resolveVideoUrlForPage(
+        "/video/BVx",
+        "https://www.bilibili.com/video/BVx",
+      ),
+      null,
+    );
 
     controller.clearSnapshot();
-    assert.equal(controller.resolveVideoUrlForPage("/festival/demo"), null);
+    assert.equal(
+      controller.resolveVideoUrlForPage(
+        "/festival/demo",
+        "https://www.bilibili.com/festival/demo",
+      ),
+      null,
+    );
   } finally {
     dom.restore();
   }
@@ -254,13 +308,30 @@ test("festival bridge treats a stale cached snapshot as unresolved when a max ag
       "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123";
     // Within the freshness bound (and with no bound) the snapshot resolves.
     assert.equal(
-      controller.resolveVideoUrlForPage("/festival/demo", 60_000),
+      controller.resolveVideoUrlForPage(
+        "/festival/demo",
+        "https://www.bilibili.com/festival/demo",
+        60_000,
+      ),
       url,
     );
-    assert.equal(controller.resolveVideoUrlForPage("/festival/demo"), url);
+    assert.equal(
+      controller.resolveVideoUrlForPage(
+        "/festival/demo",
+        "https://www.bilibili.com/festival/demo",
+      ),
+      url,
+    );
     // Older than the bound: treated as stale so a possibly-left video is not
     // reported as the trustworthy current one.
-    assert.equal(controller.resolveVideoUrlForPage("/festival/demo", 0), null);
+    assert.equal(
+      controller.resolveVideoUrlForPage(
+        "/festival/demo",
+        "https://www.bilibili.com/festival/demo",
+        0,
+      ),
+      null,
+    );
   } finally {
     dom.restore();
   }
@@ -360,11 +431,96 @@ test("ages the cached snapshot on the monotonic clock", async () => {
     clock.clocks.monotonic += 100;
 
     assert.equal(
-      controller.resolveVideoUrlForPage("/festival/demo", 60_000),
+      controller.resolveVideoUrlForPage(
+        "/festival/demo",
+        "https://www.bilibili.com/festival/demo",
+        60_000,
+      ),
       "https://www.bilibili.com/festival/demo?bvid=BVfestival&cid=123",
     );
   } finally {
     clock.restore();
+    dom.restore();
+  }
+});
+
+test("festival bridge does not let a pre-clear refresh repopulate the snapshot", async () => {
+  const pageUrl = "https://www.bilibili.com/festival/demo";
+  const dom = installBridgeDomStub([
+    {
+      deferred: {
+        bvid: "BVstale",
+        cid: 123,
+        title: "Stale Visit",
+      },
+    },
+  ]);
+  const controller = createFestivalBridgeController();
+
+  try {
+    const pendingRefresh = controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl,
+      maxAgeMs: 0,
+    });
+    controller.clearSnapshot();
+    dom.flushDeferred();
+
+    assert.equal(await pendingRefresh, null);
+    assert.equal(controller.getSnapshot(), null);
+    assert.equal(
+      controller.resolveVideoUrlForPage("/festival/demo", pageUrl),
+      null,
+    );
+  } finally {
+    dom.restore();
+  }
+});
+
+test("festival bridge does not let a cache hit cancel an in-flight fresh read", async () => {
+  const pageUrl = "https://www.bilibili.com/festival/demo";
+  const dom = installBridgeDomStub([
+    {
+      bvid: "BVcached",
+      cid: 111,
+      title: "Cached Visit",
+    },
+    {
+      deferred: {
+        bvid: "BVfresh",
+        cid: 222,
+        title: "Fresh Visit",
+      },
+    },
+  ]);
+  const controller = createFestivalBridgeController();
+
+  try {
+    await controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl,
+      maxAgeMs: 0,
+    });
+    const pendingFreshRead = controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl,
+      maxAgeMs: 0,
+    });
+
+    const cachedRead = controller.refreshSnapshot({
+      pathname: "/festival/demo",
+      pageUrl,
+      maxAgeMs: 60_000,
+    });
+    dom.flushDeferred();
+    const [cachedSnapshot, freshSnapshot] = await Promise.all([
+      cachedRead,
+      pendingFreshRead,
+    ]);
+    assert.equal(cachedSnapshot?.videoId, "BVcached:111");
+    assert.equal(freshSnapshot?.videoId, "BVfresh:222");
+    assert.equal(controller.getSnapshot()?.videoId, "BVfresh:222");
+  } finally {
     dom.restore();
   }
 });

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -3211,3 +3211,75 @@ test("navigation controller leaves a paused autoplay-next alone when no load-pau
     windowHarness.restore();
   }
 });
+
+test("navigation controller resumes the sharer's autoplay-next before the binding's queued pause lands", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+
+  let resolved: string | null = null;
+  const video: MutablePausedVideoStub = {
+    paused: false,
+  } as MutablePausedVideoStub;
+  let playCalls = 0;
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    sharedVideoNaturalEndWindowMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => video,
+    playVideo: async () => {
+      playCalls += 1;
+      video.paused = false;
+    },
+    pauseVideo: () => {},
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1";
+    windowHarness.intervals[0]?.();
+
+    // The binding armed the hold on the `play` event but performs the pause in a
+    // `setTimeout`, which has NOT run yet — the element still reads as playing.
+    // Deciding by `video.paused` here loses the race: the queued pause lands
+    // right after and stops the video with nothing left to revert it.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    video.paused = false;
+    runtimeState.intendedPlayState = "paused";
+    runtimeState.pauseHoldUntil = 11_500;
+    runtimeState.nonSharerAutoplayHoldUrl =
+      "https://www.bilibili.com/video/BVb?cid=2";
+
+    windowHarness.intervals[0]?.();
+
+    assert.equal(playCalls, 1);
+    assert.equal(runtimeState.intendedPlayState, "playing");
+    assert.equal(runtimeState.pauseHoldUntil, 0);
+    // What makes the queued pause a no-op when it fires.
+    assert.equal(
+      runtimeState.explicitNonSharedPlaybackUrl,
+      "https://www.bilibili.com/video/BVb?cid=2",
+    );
+  } finally {
+    windowHarness.restore();
+  }
+});

--- a/extension/test/navigation-controller.test.ts
+++ b/extension/test/navigation-controller.test.ts
@@ -81,6 +81,7 @@ test("navigation controller ignores same-video url variants during in-room navig
       ({
         paused: false,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -131,6 +132,7 @@ test("navigation controller hydrates and suppresses autoplay when switching to a
       ({
         paused: false,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -187,6 +189,7 @@ test("navigation controller suppresses autoplay (load paused) when switching to 
       ({
         paused: false,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -254,6 +257,7 @@ test("navigation controller suppresses a non-shared SPA navigation immediately v
       ({
         paused: false,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -315,6 +319,7 @@ test("navigation controller schedules auto-share when a shared source autoplays 
       ({
         paused: false,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -390,6 +395,7 @@ test("navigation controller schedules auto-share when a bangumi season page auto
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -454,6 +460,7 @@ test("navigation controller holds a non-sharer when a bangumi season page autopl
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -526,6 +533,7 @@ test("navigation controller schedules auto-share for a season-page autoplay that
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -594,6 +602,7 @@ test("navigation controller does not auto-share a manual episode click whose nav
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -654,6 +663,7 @@ test("navigation controller does not auto-share a manual episode click that prec
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -716,6 +726,7 @@ test("navigation controller vetoes a pre-end manual click even when the navigati
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -781,6 +792,7 @@ test("navigation controller still auto-shares an autoplay whose only gesture lon
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -847,6 +859,7 @@ test("navigation controller does not auto-share a seek-to-end autoplay, the acce
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -906,6 +919,7 @@ test("navigation controller does not force-pause a non-sharer's manual episode c
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -966,6 +980,7 @@ test("navigation controller does not reuse one natural end for a second navigati
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -1044,6 +1059,7 @@ test("navigation controller ignores a natural-end marker for a video the room no
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -1106,6 +1122,7 @@ test("navigation controller does not treat an expired end marker as a season-pag
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -1164,6 +1181,7 @@ test("navigation controller does not auto-share a manual click even when its ges
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -1216,6 +1234,7 @@ test("navigation controller chains the next auto-share before the room confirms 
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -1303,6 +1322,7 @@ test("navigation controller does not auto-share a recent user-initiated navigati
       ({
         paused: false,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -1351,6 +1371,7 @@ test("navigation controller cancels a pending auto-share on a manual non-autopla
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -1413,6 +1434,7 @@ test("navigation controller suppresses autoplay and does not auto-share a manual
       ({
         paused: false,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -1479,6 +1501,7 @@ test("navigation controller does not auto-share an autoplay that started from a 
       ({
         paused: false,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -1542,6 +1565,7 @@ test("navigation controller pauses non-sharer autoplay to a different video", ()
       ({
         paused: false,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -1615,6 +1639,7 @@ test("navigation controller arms autoplay suppression for a non-shared video tha
       ({
         paused: true,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -1686,6 +1711,7 @@ test("navigation controller suppresses autoplay when navigating through an unsta
       ({
         paused: false,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -1742,6 +1768,7 @@ test("navigation controller keeps autoplay suppression armed when switching to a
       ({
         paused: true,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -1811,6 +1838,7 @@ test("navigation controller suppresses autoplay when shared url is an unstable s
       ({
         paused: false,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -1864,6 +1892,7 @@ test("navigation controller suppresses autoplay when shared url is not yet known
       ({
         paused: false,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -1921,6 +1950,7 @@ test("navigation controller anchors active shared url for post-navigation settle
       ({
         paused: true,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -1979,6 +2009,7 @@ test("navigation controller clears any anchor when user navigates back to the sh
       ({
         paused: true,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -2020,6 +2051,7 @@ test("navigation controller does not anchor when no shared video was active", ()
       ({
         paused: true,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -2070,6 +2102,7 @@ test("navigation controller clears stale gesture state on in-room navigation", (
       ({
         paused: true,
       }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {},
     hydrateRoomState: async () => {},
     activatePauseHold: () => {},
@@ -2094,6 +2127,14 @@ test("navigation controller clears stale gesture state on in-room navigation", (
 // only through the resolved page-bridge snapshot URL. The route itself
 // normalizes to an unstable id; a `?bvid=&cid=` snapshot URL normalizes to the
 // resolved `/video/...` page.
+/**
+ * `paused` 在 lib.dom 里是只读的,但连播用例需要模拟"播放器已被暂停/恢复"这个
+ * 状态变化,所以桩类型只把这一项放开为可写。
+ */
+type MutablePausedVideoStub = Omit<HTMLVideoElement, "paused"> & {
+  paused: boolean;
+};
+
 const FESTIVAL_ROUTE = "https://www.bilibili.com/festival/MyMuji";
 function normalizeFestivalPageUrl(url: string): string | null {
   if (url.includes("/festival/")) {
@@ -2139,6 +2180,7 @@ test("navigation controller schedules auto-share when a festival page autoplays 
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2214,6 +2256,7 @@ test("navigation controller schedules auto-share when the first festival resolut
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2278,6 +2321,7 @@ test("navigation controller pauses when the first festival resolution is a diffe
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2328,6 +2372,7 @@ test("navigation controller suppresses a first festival resolution while a joine
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2384,6 +2429,7 @@ test("navigation controller adopts a first festival resolution without pausing t
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2444,6 +2490,7 @@ test("navigation controller does not flip-flop when a festival snapshot is brief
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2509,6 +2556,7 @@ test("navigation controller adopts a first festival resolution when the room sha
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2569,6 +2617,7 @@ test("navigation controller defers, not cancels, when a festival address bar kee
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2647,6 +2696,7 @@ test("navigation controller auto-shares a same-page autoplay off a bare-route fe
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2727,6 +2777,7 @@ test("navigation controller anchors a bare-route festival share even when the ad
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2803,6 +2854,7 @@ test("navigation controller anchors a bare-route festival share when the resolve
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2881,6 +2933,7 @@ test("navigation controller does not auto-share a first festival resolution to a
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2935,6 +2988,7 @@ test("navigation controller does not pause a non-sharer on a first festival reso
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -2989,6 +3043,7 @@ test("navigation controller does not auto-share a gesture-driven first festival 
     clearFestivalSnapshot: () => {},
     attachPlaybackListeners: () => {},
     getVideoElement: () => ({ paused: false }) as HTMLVideoElement,
+    playVideo: async () => {},
     pauseVideo: () => {
       pauseCalls += 1;
     },
@@ -3012,6 +3067,146 @@ test("navigation controller does not auto-share a gesture-driven first festival 
     assert.deepEqual(autoShareRequests, []);
     assert.equal(pauseCalls, 1);
     assert.equal(runtimeState.intendedPlayState, "paused");
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller resumes the sharer's autoplay-next after the binding's load-pause hold", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+
+  let resolved: string | null = null;
+  const video: MutablePausedVideoStub = {
+    paused: false,
+  } as MutablePausedVideoStub;
+  let playCalls = 0;
+  const autoShareRequests: Array<{ nextNormalizedPageUrl: string }> = [];
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    sharedVideoNaturalEndWindowMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => video,
+    playVideo: async () => {
+      playCalls += 1;
+      video.paused = false;
+    },
+    pauseVideo: () => {},
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: (input) => {
+      autoShareRequests.push(input);
+    },
+    debugLog: () => {},
+    getMonotonicNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1";
+    windowHarness.intervals[0]?.();
+
+    // The player autoplays to B. The playback binding sees the `play` event
+    // first — this watcher only polls every 500ms and the festival address bar
+    // never changed — so by now B is already force-paused as a "load paused"
+    // non-shared arrival.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    video.paused = true;
+    runtimeState.intendedPlayState = "paused";
+    runtimeState.pauseHoldUntil = 11_500;
+    runtimeState.nonSharerAutoplayHoldUrl =
+      "https://www.bilibili.com/video/BVb?cid=2";
+
+    windowHarness.intervals[0]?.();
+
+    // Without the resume the sharer auto-shares a paused video and the whole
+    // room stops on it.
+    assert.equal(playCalls, 1);
+    assert.equal(video.paused, false);
+    assert.equal(runtimeState.intendedPlayState, "playing");
+    assert.equal(runtimeState.pauseHoldUntil, 0);
+    assert.deepEqual(
+      autoShareRequests.map((request) => request.nextNormalizedPageUrl),
+      ["https://www.bilibili.com/video/BVb?cid=2"],
+    );
+  } finally {
+    windowHarness.restore();
+  }
+});
+
+test("navigation controller leaves a paused autoplay-next alone when no load-pause hold names it", () => {
+  const windowHarness = installWindowStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVa?cid=1";
+  runtimeState.activeSharedByMemberId = "member-1";
+  runtimeState.localMemberId = "member-1";
+
+  let resolved: string | null = null;
+  const video: MutablePausedVideoStub = {
+    paused: false,
+  } as MutablePausedVideoStub;
+  let playCalls = 0;
+
+  const controller = createNavigationController({
+    runtimeState,
+    intervalMs: 500,
+    userGestureGraceMs: 300,
+    initialRoomStatePauseHoldMs: 1_500,
+    sharedVideoNaturalEndWindowMs: 1_500,
+    getCurrentPageUrl: () => FESTIVAL_ROUTE,
+    normalizeVideoPageUrl: normalizeFestivalPageUrl,
+    getResolvedVideoUrl: () => resolved,
+    isSupportedVideoPage: (url) =>
+      url.includes("/video/") || url.includes("/festival/"),
+    clearFestivalSnapshot: () => {},
+    attachPlaybackListeners: () => {},
+    getVideoElement: () => video,
+    playVideo: async () => {
+      playCalls += 1;
+      video.paused = false;
+    },
+    pauseVideo: () => {},
+    hydrateRoomState: async () => {},
+    activatePauseHold: () => {},
+    scheduleAutoShareNextVideo: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => 10_000,
+  });
+
+  try {
+    controller.start();
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVa&cid=1";
+    windowHarness.intervals[0]?.();
+
+    // B arrives paused, but nothing armed a load-pause hold for it — the pause
+    // came from somewhere this controller did not cause (a stall, or the user
+    // pressing pause during the countdown). Resuming it would override the
+    // player rather than undo our own interference.
+    resolved = "https://www.bilibili.com/festival/MyMuji?bvid=BVb&cid=2";
+    video.paused = true;
+    runtimeState.nonSharerAutoplayHoldUrl = null;
+
+    windowHarness.intervals[0]?.();
+
+    assert.equal(playCalls, 0);
+    assert.equal(video.paused, true);
   } finally {
     windowHarness.restore();
   }

--- a/extension/test/page-video.test.ts
+++ b/extension/test/page-video.test.ts
@@ -153,3 +153,40 @@ test("builds canonical episode and cid share URLs", () => {
     "https://www.bilibili.com/video/BV1abc?cid=22",
   );
 });
+
+test("refuses the frozen festival address bar once a snapshot has resolved before", () => {
+  // The festival player has moved on (the snapshot just got cleared for a
+  // re-resolve), but the address bar still carries the `?bvid=` the page was
+  // opened with. Answering with it would name a video that is not playing.
+  const video = resolvePageSharedVideo({
+    pageUrl: "https://www.bilibili.com/festival/MyMuji?bvid=BVfrozen",
+    pathname: "/festival/MyMuji",
+    documentTitle: "MyMuji_哔哩哔哩",
+    headingTitle: null,
+    currentPartTitle: null,
+    festivalSnapshot: null,
+    addressBarIdentityRefuted: true,
+  });
+
+  assert.equal(video, null);
+});
+
+test("still uses the festival address bar before any snapshot has resolved", () => {
+  // A festival page opened from a share link: the frozen `?bvid=` IS the video
+  // about to play, and until the bridge resolves it is the only identity there.
+  const video = resolvePageSharedVideo({
+    pageUrl: "https://www.bilibili.com/festival/MyMuji?bvid=BVshared&cid=99",
+    pathname: "/festival/MyMuji",
+    documentTitle: "MyMuji_哔哩哔哩",
+    headingTitle: null,
+    currentPartTitle: null,
+    festivalSnapshot: null,
+    addressBarIdentityRefuted: false,
+  });
+
+  assert.deepEqual(video, {
+    videoId: "BVshared:99",
+    url: "https://www.bilibili.com/video/BVshared?cid=99",
+    title: "MyMuji",
+  });
+});

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -4409,6 +4409,78 @@ test("playback binding controller re-pauses a remote-stopped video on a page you
   }
 });
 
+test("playback binding controller drops a queued pause from an older playback context", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  const sharedUrl = "https://www.bilibili.com/video/BVshared?p=1";
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.activeSharedUrl = sharedUrl;
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.intendedPlayState = "paused";
+  let pauseCalls = 0;
+  let queuedPause: (() => void) | null = null;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalPause = dom.video.pause;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => ({
+      videoId: "BVshared:p1",
+      url: sharedUrl,
+      title: "Shared Video",
+    }),
+    hasRecentRemoteStopIntent: () => true,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => 5_000,
+  });
+
+  try {
+    Object.assign(globalThis.window, {
+      setTimeout: (handler: () => void) => {
+        queuedPause = handler;
+        return 1;
+      },
+    });
+    dom.video.pause = () => {
+      pauseCalls += 1;
+      dom.video.paused = true;
+    };
+    dom.video.paused = false;
+
+    controller.attachPlaybackListeners();
+    dom.listeners.get("play")?.(new Event("play"));
+
+    assert.ok(queuedPause, "the remote-stop pause is queued");
+
+    // Only the playback context changes. The same element, shared URL, remote
+    // stop intent, gesture stamp, and intended state deliberately stay valid,
+    // so the helper's captured generation is the sole reason this old pause is
+    // dropped.
+    invalidatePlaybackContext(runtimeState);
+    queuedPause?.();
+
+    assert.equal(pauseCalls, 0);
+    assert.equal(dom.video.paused, false);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.video.pause = originalPause;
+    dom.restore();
+  }
+});
+
 test("playback binding controller drops a queued load-pause once the url gets authorized", async () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -4344,3 +4344,76 @@ test("playback binding controller re-pauses a remote-stopped video on a page you
     dom.restore();
   }
 });
+
+test("playback binding controller drops a queued load-pause once the url gets authorized", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.activeSharedUrl = "https://www.bilibili.com/video/BVshared?p=1";
+  runtimeState.pendingRoomStateHydration = false;
+  const nonSharedUrl = "https://www.bilibili.com/video/BVother?p=1";
+  let pauseCalls = 0;
+  let queuedPause: (() => void) | null = null;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalPause = dom.video.pause;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => ({
+      videoId: "BVother:p1",
+      url: nonSharedUrl,
+      title: "Other Video",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => 20_000,
+  });
+
+  try {
+    // Hold the pause instead of running it, so the navigation controller's
+    // classification can land in between — exactly the window it polls in.
+    Object.assign(globalThis.window, {
+      setTimeout: (handler: () => void) => {
+        queuedPause = handler;
+        return 1;
+      },
+    });
+    dom.video.pause = () => {
+      pauseCalls += 1;
+      dom.video.paused = true;
+    };
+    dom.video.paused = false;
+
+    controller.attachPlaybackListeners();
+    dom.listeners.get("play")?.(new Event("play"));
+    await Promise.resolve();
+
+    assert.equal(runtimeState.nonSharerAutoplayHoldUrl, nonSharedUrl);
+    assert.ok(queuedPause, "the pause is queued, not immediate");
+
+    // The navigation controller classified this as the sharer's own
+    // autoplay-next and authorized the url.
+    runtimeState.explicitNonSharedPlaybackUrl = nonSharedUrl;
+    queuedPause?.();
+
+    assert.equal(pauseCalls, 0);
+    assert.equal(dom.video.paused, false);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.video.pause = originalPause;
+    dom.restore();
+  }
+});

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { SharedVideo } from "@bili-syncplay/protocol";
-import { createContentRuntimeState } from "../src/content/runtime-state";
+import {
+  createContentRuntimeState,
+  invalidatePlaybackContext,
+} from "../src/content/runtime-state";
 import { installClockStubs } from "./clock-stubs";
 import { createPlaybackBindingController } from "../src/content/playback-binding-controller";
 import { createRoomStateController } from "../src/content/room-state-controller";
@@ -2933,6 +2936,67 @@ test("playback binding controller re-broadcasts paused after buffer-pause upgrad
   }
 });
 
+test("playback binding controller drops a buffer-pause upgrade from an older playback context", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 0;
+  let now = 5_000;
+  const broadcasts: string[] = [];
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const scheduledTimers: Array<{ cb: () => void; ms: number }> = [];
+  globalThis.window.setTimeout = ((callback: TimerHandler, ms?: number) => {
+    if (typeof callback === "function") {
+      scheduledTimers.push({ cb: callback as () => void, ms: ms ?? 0 });
+    }
+    return scheduledTimers.length;
+  }) as typeof globalThis.window.setTimeout;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async (_video, eventSource) => {
+      broadcasts.push(eventSource ?? "manual");
+    },
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("waiting")?.(new Event("waiting"));
+    now = 5_100;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+    await Promise.resolve();
+
+    const upgradeTimer = scheduledTimers.find((timer) => timer.ms === 1_500);
+    assert.notEqual(upgradeTimer, undefined);
+    broadcasts.length = 0;
+    invalidatePlaybackContext(runtimeState);
+    upgradeTimer?.cb();
+    await Promise.resolve();
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
+    assert.deepEqual(broadcasts, []);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.restore();
+  }
+});
+
 test("playback binding controller suppresses the natural-end pause for a non-sharer", async () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();
@@ -4407,6 +4471,85 @@ test("playback binding controller drops a queued load-pause once the url gets au
     // The navigation controller classified this as the sharer's own
     // autoplay-next and authorized the url.
     runtimeState.explicitNonSharedPlaybackUrl = nonSharedUrl;
+    queuedPause?.();
+
+    assert.equal(pauseCalls, 0);
+    assert.equal(dom.video.paused, false);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.video.pause = originalPause;
+    dom.restore();
+  }
+});
+
+test("playback binding controller drops a queued load-pause after navigation clears its hold", async () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  const sharedUrl = "https://www.bilibili.com/video/BVshared?p=1";
+  const nonSharedUrl = "https://www.bilibili.com/video/BVother?p=1";
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.activeSharedUrl = sharedUrl;
+  runtimeState.pendingRoomStateHydration = false;
+  let currentVideo = {
+    videoId: "BVother:p1",
+    url: nonSharedUrl,
+    title: "Other Video",
+  };
+  let pauseCalls = 0;
+  let queuedPause: (() => void) | null = null;
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalPause = dom.video.pause;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => currentVideo,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => 20_000,
+  });
+
+  try {
+    Object.assign(globalThis.window, {
+      setTimeout: (handler: () => void) => {
+        queuedPause = handler;
+        return 1;
+      },
+    });
+    dom.video.pause = () => {
+      pauseCalls += 1;
+      dom.video.paused = true;
+    };
+    dom.video.paused = false;
+
+    controller.attachPlaybackListeners();
+    dom.listeners.get("play")?.(new Event("play"));
+    await Promise.resolve();
+
+    assert.equal(runtimeState.nonSharerAutoplayHoldUrl, nonSharedUrl);
+    assert.ok(queuedPause, "the old page's pause is still queued");
+
+    // A navigation can run before a zero-delay timer that was queued by another
+    // due interval. The reset clears the old hold, while Bilibili reuses the same
+    // video element for the room's shared destination.
+    currentVideo = {
+      videoId: "BVshared:p1",
+      url: sharedUrl,
+      title: "Shared Video",
+    };
+    runtimeState.nonSharerAutoplayHoldUrl = null;
     queuedPause?.();
 
     assert.equal(pauseCalls, 0);

--- a/extension/test/share-controller.test.ts
+++ b/extension/test/share-controller.test.ts
@@ -621,12 +621,14 @@ test("stops falling back to the frozen festival address bar once a snapshot has 
     title: string;
     updatedAt: number;
     pathname?: string;
+    pageUrl?: string;
   } | null = {
     videoId: "BVplaying:2",
     url: "https://www.bilibili.com/video/BVplaying?cid=2",
     title: "Playing Video",
     updatedAt: 1_000,
     pathname: "/festival/MyMuji",
+    pageUrl: "https://www.bilibili.com/festival/MyMuji?bvid=BVfrozen",
   };
 
   const controller = createShareController({
@@ -679,6 +681,177 @@ test("still resolves the festival address bar before any snapshot has resolved",
       controller.getSharedVideo()?.url,
       "https://www.bilibili.com/video/BVshared?cid=99",
     );
+  } finally {
+    dom.restore();
+  }
+});
+
+test("uses the festival address bar again after leaving and returning to the page", () => {
+  const festivalUrl =
+    "https://www.bilibili.com/festival/MyMuji?bvid=BVentry&cid=1";
+  const dom = installDomStub({
+    href: festivalUrl,
+    pathname: "/festival/MyMuji",
+    title: "MyMuji_哔哩哔哩",
+  });
+  const runtimeState = createContentRuntimeState();
+  let snapshot: {
+    videoId: string;
+    url: string;
+    title: string;
+    updatedAt: number;
+    pathname?: string;
+    pageUrl?: string;
+  } | null = {
+    videoId: "BVplaying:2",
+    url: "https://www.bilibili.com/video/BVplaying?cid=2",
+    title: "Playing Video",
+    updatedAt: 1_000,
+    pathname: "/festival/MyMuji",
+    pageUrl: festivalUrl,
+  };
+
+  const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 1,
+    getFestivalSnapshot: () => snapshot,
+    refreshFestivalBridge: async () => null,
+    debugLog: () => {},
+  });
+
+  try {
+    assert.equal(
+      controller.getSharedVideo()?.url,
+      "https://www.bilibili.com/video/BVplaying?cid=2",
+    );
+    snapshot = null;
+    assert.equal(controller.getSharedVideo(), null);
+
+    // The navigation controller reports the departure immediately. This must
+    // reset the visit even when no video lookup occurs on the page in between.
+    controller.observePageVisit("https://www.bilibili.com/video/BVaway");
+    Object.assign(window.location, {
+      href: "https://www.bilibili.com/video/BVaway",
+      pathname: "/video/BVaway",
+    });
+
+    // Returning through the exact same share link is a new page visit: before
+    // its first snapshot, the entry bvid/cid is correct and must be usable.
+    Object.assign(window.location, {
+      href: festivalUrl,
+      pathname: "/festival/MyMuji",
+    });
+    assert.equal(
+      controller.getSharedVideo()?.url,
+      "https://www.bilibili.com/video/BVentry?cid=1",
+    );
+  } finally {
+    dom.restore();
+  }
+});
+
+test("uses a new festival share URL before that page visit resolves a snapshot", () => {
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/festival/MyMuji?bvid=BVold&cid=1",
+    pathname: "/festival/MyMuji",
+    title: "MyMuji_哔哩哔哩",
+  });
+  const runtimeState = createContentRuntimeState();
+  const snapshot: {
+    videoId: string;
+    url: string;
+    title: string;
+    updatedAt: number;
+    pathname?: string;
+    pageUrl?: string;
+  } = {
+    videoId: "BVplaying:2",
+    url: "https://www.bilibili.com/video/BVplaying?cid=2",
+    title: "Playing Video",
+    updatedAt: 1_000,
+    pathname: "/festival/MyMuji",
+    pageUrl: "https://www.bilibili.com/festival/MyMuji?bvid=BVold&cid=1",
+  };
+
+  const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 1,
+    getFestivalSnapshot: () => snapshot,
+    refreshFestivalBridge: async () => null,
+    debugLog: () => {},
+  });
+
+  try {
+    assert.equal(
+      controller.getSharedVideo()?.url,
+      "https://www.bilibili.com/video/BVplaying?cid=2",
+    );
+    // Festival autoplay never changes location.href, so a different query on
+    // the same pathname denotes a new share-link visit, not another video in the
+    // old visit. Its entry identity is valid until the new snapshot resolves.
+    Object.assign(window.location, {
+      href: "https://www.bilibili.com/festival/MyMuji?bvid=BVnew&cid=3",
+    });
+    assert.equal(
+      controller.getSharedVideo()?.url,
+      "https://www.bilibili.com/video/BVnew?cid=3",
+    );
+  } finally {
+    dom.restore();
+  }
+});
+
+test("discards a festival snapshot refresh that resolves after the page visit changes", async () => {
+  const festivalUrl =
+    "https://www.bilibili.com/festival/MyMuji?bvid=BVold&cid=1";
+  const dom = installDomStub({
+    href: festivalUrl,
+    pathname: "/festival/MyMuji",
+    title: "MyMuji_哔哩哔哩",
+  });
+  const runtimeState = createContentRuntimeState();
+  let resolveBridge!: (value: {
+    videoId: string;
+    url: string;
+    title: string;
+  }) => void;
+  const bridgeResult = new Promise<{
+    videoId: string;
+    url: string;
+    title: string;
+  }>((resolve) => {
+    resolveBridge = resolve;
+  });
+
+  const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 1,
+    getFestivalSnapshot: () => null,
+    refreshFestivalBridge: async () => bridgeResult,
+    debugLog: () => {},
+  });
+
+  try {
+    const pendingRefresh = controller.refreshFestivalSnapshot(0);
+    const awayUrl = "https://www.bilibili.com/video/BVaway";
+    controller.observePageVisit(awayUrl);
+    Object.assign(window.location, {
+      href: awayUrl,
+      pathname: "/video/BVaway",
+    });
+    resolveBridge({
+      videoId: "BVold:1",
+      url: "https://www.bilibili.com/video/BVold?cid=1",
+      title: "Old Visit",
+    });
+
+    assert.equal(await pendingRefresh, null);
   } finally {
     dom.restore();
   }

--- a/extension/test/share-controller.test.ts
+++ b/extension/test/share-controller.test.ts
@@ -603,3 +603,83 @@ test("share controller falls back to the element rate with no catch-up running",
     dom.restore();
   }
 });
+
+test("stops falling back to the frozen festival address bar once a snapshot has resolved", () => {
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/festival/MyMuji?bvid=BVfrozen",
+    pathname: "/festival/MyMuji",
+    title: "MyMuji_哔哩哔哩",
+  });
+  const runtimeState = createContentRuntimeState();
+  // The festival snapshot resolves the video actually playing, then goes away —
+  // the navigation controller clears it on every autoplay-next so the bridge
+  // re-resolves. During that window the address bar still names the video the
+  // page was OPENED with, which is not what is playing.
+  let snapshot: {
+    videoId: string;
+    url: string;
+    title: string;
+    updatedAt: number;
+    pathname?: string;
+  } | null = {
+    videoId: "BVplaying:2",
+    url: "https://www.bilibili.com/video/BVplaying?cid=2",
+    title: "Playing Video",
+    updatedAt: 1_000,
+    pathname: "/festival/MyMuji",
+  };
+
+  const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 1,
+    getFestivalSnapshot: () => snapshot,
+    refreshFestivalBridge: async () => null,
+    debugLog: () => {},
+  });
+
+  try {
+    assert.equal(
+      controller.getSharedVideo()?.url,
+      "https://www.bilibili.com/video/BVplaying?cid=2",
+    );
+
+    snapshot = null;
+
+    // Answering `null` ("not known yet") is what routes callers to their
+    // unresolved-identity paths. Answering `/video/BVfrozen` instead reads as a
+    // different, non-shared video and gets the page force-paused.
+    assert.equal(controller.getSharedVideo(), null);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("still resolves the festival address bar before any snapshot has resolved", () => {
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/festival/MyMuji?bvid=BVshared&cid=99",
+    pathname: "/festival/MyMuji",
+    title: "MyMuji_哔哩哔哩",
+  });
+  const runtimeState = createContentRuntimeState();
+
+  const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
+    runtimeState,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 1,
+    getFestivalSnapshot: () => null,
+    refreshFestivalBridge: async () => null,
+    debugLog: () => {},
+  });
+
+  try {
+    assert.equal(
+      controller.getSharedVideo()?.url,
+      "https://www.bilibili.com/video/BVshared?cid=99",
+    );
+  } finally {
+    dom.restore();
+  }
+});

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -47,6 +47,11 @@ function createControllerHarness() {
   let currentPlaybackVideo: SharedVideo | null = null;
   let sharedVideo: SharedVideo | null = null;
   let videoElement: HTMLVideoElement | null = null;
+  let nextSequence = 1;
+  let currentPlaybackVideoOverride: (() => Promise<SharedVideo | null>) | null =
+    null;
+  let sendPlaybackUpdateOverride:
+    ((payload: PlaybackState) => Promise<{ ok: boolean } | null>) | null = null;
 
   const controller = createSyncController({
     runtimeState,
@@ -64,7 +69,7 @@ function createControllerHarness() {
     bufferPauseUpgradeMs: 1_500,
     remotePauseDebounceMs: 0,
     duplicateBroadcastWindowMs: 1_000,
-    nextSeq: () => 1,
+    nextSeq: () => nextSequence++,
     markBroadcastAt: () => {},
     getMonotonicNow: () => now,
     debugLog: (message) => {
@@ -73,11 +78,17 @@ function createControllerHarness() {
     shouldLogHeartbeat: () => true,
     sendPlaybackUpdate: async (payload) => {
       runtimeMessages.push({ type: "content:playback-update", payload });
+      if (sendPlaybackUpdateOverride) {
+        return await sendPlaybackUpdateOverride(payload);
+      }
       return null;
     },
     requestRoomStateHydration: async () => null,
     getVideoElement: () => videoElement,
-    getCurrentPlaybackVideo: async () => currentPlaybackVideo,
+    getCurrentPlaybackVideo: async () =>
+      currentPlaybackVideoOverride
+        ? await currentPlaybackVideoOverride()
+        : currentPlaybackVideo,
     getSharedVideo: () => sharedVideo,
     normalizeUrl: (url) => url?.trim() ?? null,
     notifyRoomStateToasts: () => {},
@@ -94,6 +105,17 @@ function createControllerHarness() {
     },
     setCurrentPlaybackVideo(video: SharedVideo | null) {
       currentPlaybackVideo = video;
+    },
+    setCurrentPlaybackVideoOverride(
+      override: (() => Promise<SharedVideo | null>) | null,
+    ) {
+      currentPlaybackVideoOverride = override;
+    },
+    setSendPlaybackUpdateOverride(
+      override:
+        ((payload: PlaybackState) => Promise<{ ok: boolean } | null>) | null,
+    ) {
+      sendPlaybackUpdateOverride = override;
     },
     setSharedVideo(video: SharedVideo | null) {
       sharedVideo = video;
@@ -176,6 +198,166 @@ test("sync controller skips playback broadcast before hydration becomes ready", 
     harness.debugLogs.includes("Skip broadcast before hydration ready"),
     true,
   );
+});
+
+test("sync controller drops a broadcast whose video resolution outlives its playback context", async () => {
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({ paused: false, currentTime: 12 });
+  let resolveCurrentVideo!: (video: SharedVideo | null) => void;
+  const pendingCurrentVideo = new Promise<SharedVideo | null>((resolve) => {
+    resolveCurrentVideo = resolve;
+  });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.setSharedVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setCurrentPlaybackVideoOverride(() => pendingCurrentVideo);
+
+  const pendingBroadcast = harness.controller.broadcastPlayback(video, "play");
+  harness.controller.resetPlaybackSyncState("shared url changed");
+  resolveCurrentVideo(sharedVideo);
+  await pendingBroadcast;
+
+  assert.equal(harness.runtimeMessages.length, 0);
+  assert.equal(
+    harness.debugLogs.includes(
+      "Dropped stale playback broadcast after resolving the current video",
+    ),
+    true,
+  );
+});
+
+test("sync controller broadcasts an authoritative bangumi episode over a season fallback", async () => {
+  const harness = createControllerHarness();
+  const seasonFallback = {
+    videoId: "ss357",
+    url: "https://www.bilibili.com/bangumi/play/ss357",
+    title: "Season",
+  };
+  const resolvedEpisode = {
+    videoId: "ep508404",
+    url: "https://www.bilibili.com/bangumi/play/ep508404",
+    title: "Episode 46",
+  };
+  const video = createVideo({ paused: false, currentTime: 12 });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.setSharedVideo(seasonFallback);
+  harness.setCurrentPlaybackVideo(resolvedEpisode);
+  harness.setVideoElement(video);
+
+  await harness.controller.broadcastPlayback(video, "play");
+
+  assert.equal(harness.runtimeMessages.length, 1);
+  assert.equal(
+    (harness.runtimeMessages[0] as { payload: PlaybackState }).payload.url,
+    resolvedEpisode.url,
+  );
+});
+
+test("sync controller keeps a newer local version when acknowledgements arrive out of order", async () => {
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({ paused: false, currentTime: 12 });
+  const acknowledgements = new Map<
+    number,
+    (response: { ok: boolean }) => void
+  >();
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setSendPlaybackUpdateOverride(
+    (payload) =>
+      new Promise((resolve) => {
+        acknowledgements.set(payload.seq, resolve);
+      }),
+  );
+
+  const firstBroadcast = harness.controller.broadcastPlayback(video, "play");
+  await Promise.resolve();
+  video.currentTime = 13;
+  const secondBroadcast = harness.controller.broadcastPlayback(video, "play");
+  await Promise.resolve();
+
+  assert.equal(acknowledgements.has(1), true);
+  assert.equal(acknowledgements.has(2), true);
+  acknowledgements.get(2)?.({ ok: true });
+  await secondBroadcast;
+  assert.equal(harness.runtimeState.lastLocalPlaybackVersion?.seq, 2);
+
+  acknowledgements.get(1)?.({ ok: true });
+  await firstBroadcast;
+  assert.equal(harness.runtimeState.lastLocalPlaybackVersion?.seq, 2);
+  assert.equal(
+    harness.debugLogs.includes(
+      "Ignored stale playback update acknowledgement seq=1",
+    ),
+    true,
+  );
+});
+
+test("sync controller invalidates a queued remote-stop pause on playback reset", async () => {
+  const windowHarness = installWindowStub();
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  let pauseCalls = 0;
+  const video = createVideo({
+    paused: false,
+    currentTime: 12,
+    pause() {
+      pauseCalls += 1;
+    },
+  });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.activeRoomCode = "ROOM01";
+  harness.runtimeState.activeSharedUrl = sharedVideo.url;
+  harness.runtimeState.intendedPlayState = "paused";
+  harness.runtimeState.pauseHoldUntil = 11_000;
+  harness.runtimeState.pauseStartedAt = 9_900;
+  harness.runtimeState.pauseClassifiedAsBuffer = true;
+  harness.setNow(10_000);
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+
+  try {
+    await harness.controller.broadcastPlayback(video, "play");
+    assert.equal(windowHarness.scheduled.length, 1);
+
+    const previousGeneration = harness.runtimeState.playbackContextGeneration;
+    harness.controller.resetPlaybackSyncState("shared url changed");
+    windowHarness.scheduled[0]?.();
+
+    assert.equal(
+      harness.runtimeState.playbackContextGeneration,
+      previousGeneration + 1,
+    );
+    assert.equal(harness.runtimeState.pauseStartedAt, 0);
+    assert.equal(harness.runtimeState.pauseClassifiedAsBuffer, false);
+    assert.equal(pauseCalls, 0);
+  } finally {
+    windowHarness.restore();
+  }
 });
 
 test("sync controller accepts empty room hydration and clears active shared url", async () => {


### PR DESCRIPTION
> base 是 #252，待其合并后本 PR 自动改指 `main`。本 PR 只含 `8f4b56c` 一个提交。

## 问题

festival 连播时新视频**能**自动共享，但共享出去的播放态是 `paused`，房间整体停住——共享端自己就是源头，没有人还在播。1.3.2 / 1.3.3 都有。

## 根因：两层之间的竞态

| 层 | 时机 | 知道"这是共享者连播"吗 |
| --- | --- | --- |
| 播放绑定 `enforceNonSharedLoadPause` | `play` 事件，同步 | ❌ 只看到"不是当前共享视频" |
| 导航控制器分类 | 400ms 轮询；festival 页地址栏不变，还要等页面桥解析快照 | ✅ |

所以强制暂停**永远**排在分类前面（用户日志，1.3.3 共享端）：

```
Broadcast trace source=play  playState=playing t=0.01
Forced pause for non-shared video autoplay (in room, load paused)
Auto-share scheduled ... delayMs=900
Nav decision ...: scheduled auto-share [autoplay=true localSharer=true]
<- room:state seq=43 playState=paused t=0.05      ← 房间拿到的是暂停
```

共享者分支原本只写 `explicitNonSharedPlaybackUrl = 新URL`（`navigation-controller.ts:498`），那只能阻止**将来**的暂停，撤销不了**已经发生**的那一次；900ms 后 auto-share 带着 `paused` 出去。

## 改动

在共享者分支撤销这次暂停，判据只有一项：reset 之前捕获的 `nonSharerAutoplayHoldUrl` 是否正是这个新页面。

- 该标记只由"到达时的加载暂停"武装，所以撤销的必然是本控制器自己造成的暂停；缓冲停顿、用户手动暂停都不会让它指向这里。
- `shouldTreatAsAutoplay` 已排除最近用户手势，用户的暂停也不可能停在这个位置。
- 命中后复位 `intendedPlayState` / `pauseHoldUntil`（hold 留着会让绑定在下一个 `play` 上重新暂停）；元素仍处暂停时才真正调 `play()`。

决策留在看得见信息的那一层（导航控制器），没有把"是否共享者连播"复制进绑定层。代价是新视频会有一次极短的 暂停→恢复 抖动，换掉的是整个房间停住。

## 验证

`format:check` / `lint` / `typecheck` / `build` / `test`（646 pass）/ `audit` 全绿。

两条回归，逐项回退各自必失败（已实测）：

| 回退 | 失败用例 |
| --- | --- |
| 整块恢复逻辑删除 / 条件恒假 | `resumes the sharer's autoplay-next after the binding's load-pause hold` |
| 去掉 URL 门槛（无条件恢复） | `leaves a paused autoplay-next alone when no load-pause hold names it` |

测试桩用 `Omit<HTMLVideoElement, "paused"> & { paused: boolean }` 放开只读属性，没有 `as unknown as`。

## 未在本地验证

真实浏览器里的 festival 连播（`play()` 是否被自动播放策略拒绝）需要在装了扩展的环境实测——本机无法验证。被拒时会打 `Could not resume sharer autoplay-next ...`，行为退回当前的"房间跟随暂停"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)