### PR TITLE
fix: 不让延迟 seeked 复活陈旧 seek

### DIFF
--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -308,11 +308,11 @@ export function createPlaybackBindingController(args: {
         at: monotonicNow(),
       };
       if (kind === "seek") {
-        // One gesture produces `seeking` AND `seeked`, and the `seeking`
-        // broadcast in between writes `intendedPlayState` back to `playing`.
-        // Re-snapshotting on `seeked` would therefore record the write-back
-        // rather than the origin, erasing a `buffering` start. Only the first
-        // event of a seek establishes the origin; the rest inherit it.
+        // A seek can surface more than one start signal, and the first one's
+        // broadcast writes `intendedPlayState` back to `playing`.
+        // Re-snapshotting on a later signal would therefore record the
+        // write-back rather than the origin, erasing a `buffering` start. Only
+        // the first event of a seek establishes the origin; the rest inherit it.
         // A forced pause invalidates the seek that preceded it, so the next
         // gesture starts a NEW seek even inside the grace window — inheriting
         // the old origin there would let a `buffering` start survive into a
@@ -1148,7 +1148,11 @@ export function createPlaybackBindingController(args: {
         if (hasRecentUserGesture()) {
           args.cancelActiveSoftApply(video, "seek");
         }
-        rememberExplicitUserAction("seek");
+        // `seeking` already established the seek intent. `seeked` is decoder
+        // driven and may arrive after an unrelated, newer user action; recording
+        // it again would borrow that action's fresh gesture and revive the stale
+        // seek with a new timestamp. A prompt `seeked` still inherits the
+        // existing seek record, while a delayed or superseded one stays stale.
         scheduleBroadcast(video, "seeked", 120);
       },
       onRateChange: () => {

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -308,11 +308,11 @@ export function createPlaybackBindingController(args: {
         at: monotonicNow(),
       };
       if (kind === "seek") {
-        // A seek can surface more than one start signal, and the first one's
-        // broadcast writes `intendedPlayState` back to `playing`.
-        // Re-snapshotting on a later signal would therefore record the
-        // write-back rather than the origin, erasing a `buffering` start. Only
-        // the first event of a seek establishes the origin; the rest inherit it.
+        // One gesture produces `seeking` and `seeked`, and the `seeking`
+        // broadcast can write `intendedPlayState` back to `playing`.
+        // Re-snapshotting on `seeked` would therefore record the write-back
+        // rather than the origin, erasing a `buffering` start. Only the first
+        // event of a seek establishes the origin; the rest inherit it.
         // A forced pause invalidates the seek that preceded it, so the next
         // gesture starts a NEW seek even inside the grace window — inheriting
         // the old origin there would let a `buffering` start survive into a
@@ -1148,11 +1148,17 @@ export function createPlaybackBindingController(args: {
         if (hasRecentUserGesture()) {
           args.cancelActiveSoftApply(video, "seek");
         }
-        // `seeking` already established the seek intent. `seeked` is decoder
-        // driven and may arrive after an unrelated, newer user action; recording
-        // it again would borrow that action's fresh gesture and revive the stale
-        // seek with a new timestamp. A prompt `seeked` still inherits the
-        // existing seek record, while a delayed or superseded one stays stale.
+        // Renew only the seek that is still current. Its completion extends the
+        // guard against browser autoplay after a paused scrub, while a `seeked`
+        // delayed by the decoder cannot overwrite a newer play/pause/rate
+        // action. A forced pause likewise invalidates the preceding seek.
+        const previousAction = args.runtimeState.lastExplicitUserAction;
+        if (
+          previousAction?.kind === "seek" &&
+          previousAction.at > args.runtimeState.lastForcedPauseAt
+        ) {
+          rememberExplicitUserAction("seek");
+        }
         scheduleBroadcast(video, "seeked", 120);
       },
       onRateChange: () => {

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -301,6 +301,67 @@ test("playback binding controller does not revive a superseded seek when seeked 
   }
 });
 
+test("playback binding controller does not renew a seek invalidated by a forced pause", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 1_000;
+  let now = 1_100;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("seeking")?.(new Event("seeking"));
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "seek",
+      at: 1_100,
+    });
+
+    // The forced pause invalidates the seek. A later gesture may make the old
+    // decoder completion look recordable, but must not turn it into new intent.
+    runtimeState.lastForcedPauseAt = 1_200;
+    runtimeState.lastUserGestureAt = 1_250;
+    now = 1_300;
+    dom.listeners.get("seeked")?.(new Event("seeked"));
+
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "seek",
+      at: 1_100,
+    });
+    assert.equal(
+      derivePlaybackSyncIntent({
+        eventSource: "seeked",
+        lastExplicitUserAction: runtimeState.lastExplicitUserAction,
+        lastForcedPauseAt: runtimeState.lastForcedPauseAt,
+        now,
+        userGestureGraceMs: 1_200,
+      }),
+      undefined,
+    );
+  } finally {
+    dom.restore();
+  }
+});
+
 test("playback binding controller keeps seek-triggered autoplay blocked through seeked", () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -4,6 +4,7 @@ import type { SharedVideo } from "@bili-syncplay/protocol";
 import { createContentRuntimeState } from "../src/content/runtime-state";
 import { installClockStubs } from "./clock-stubs";
 import { createPlaybackBindingController } from "../src/content/playback-binding-controller";
+import { derivePlaybackSyncIntent } from "../src/content/playback-broadcast";
 import { createRoomStateController } from "../src/content/room-state-controller";
 import { createToastCoordinatorState } from "../src/content/toast";
 
@@ -231,6 +232,70 @@ test("playback binding controller preserves explicit seek intent across immediat
       kind: "seek",
       at: 1_100,
     });
+  } finally {
+    dom.restore();
+  }
+});
+
+test("playback binding controller does not revive a superseded seek when seeked arrives late", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.intendedPlayState = "playing";
+  runtimeState.lastUserGestureAt = 1_000;
+  let now = 1_100;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("seeking")?.(new Event("seeking"));
+
+    // A later play press supersedes the seek while the decoder is still waiting
+    // to emit `seeked` for it.
+    runtimeState.lastUserGestureAt = 2_500;
+    now = 2_550;
+    dom.listeners.get("play")?.(new Event("play"));
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "play",
+      at: 2_550,
+    });
+
+    now = 2_600;
+    dom.listeners.get("seeked")?.(new Event("seeked"));
+
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "play",
+      at: 2_550,
+    });
+    assert.equal(
+      derivePlaybackSyncIntent({
+        eventSource: "seeked",
+        lastExplicitUserAction: runtimeState.lastExplicitUserAction,
+        lastForcedPauseAt: runtimeState.lastForcedPauseAt,
+        now,
+        userGestureGraceMs: 1_200,
+      }),
+      undefined,
+    );
   } finally {
     dom.restore();
   }

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -301,6 +301,79 @@ test("playback binding controller does not revive a superseded seek when seeked 
   }
 });
 
+test("playback binding controller keeps seek-triggered autoplay blocked through seeked", () => {
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  const url = "https://www.bilibili.com/video/BVshared?p=1";
+  runtimeState.activeRoomCode = "ROOM42";
+  runtimeState.activeSharedUrl = url;
+  runtimeState.pendingRoomStateHydration = false;
+  runtimeState.intendedPlayState = "paused";
+  runtimeState.lastUserGestureAt = 1_000;
+  dom.video.paused = true;
+  let now = 1_100;
+  let pauseCalls = 0;
+  dom.video.pause = () => {
+    pauseCalls += 1;
+    dom.video.paused = true;
+  };
+  Object.assign(globalThis.window, {
+    setTimeout(callback: () => void) {
+      callback();
+      return 1;
+    },
+  });
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => ({
+      videoId: "BVshared:p1",
+      url,
+      title: "Shared",
+    }),
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (value) => value ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async () => {},
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("seeking")?.(new Event("seeking"));
+
+    // The decoder finishes inside the gesture window, but the browser resumes
+    // after the original `seeking` record has aged out.
+    now = 2_100;
+    dom.listeners.get("seeked")?.(new Event("seeked"));
+    assert.deepEqual(runtimeState.lastExplicitUserAction, {
+      kind: "seek",
+      at: 2_100,
+    });
+    assert.equal(runtimeState.explicitSeekOriginPlayState, "paused");
+
+    now = 2_500;
+    dom.video.paused = false;
+    dom.listeners.get("play")?.(new Event("play"));
+
+    assert.equal(pauseCalls, 1);
+    assert.equal(runtimeState.lastExplicitUserAction, null);
+  } finally {
+    dom.restore();
+  }
+});
+
 test("playback binding controller does not mark programmatic ratechange as explicit user action", async () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();


### PR DESCRIPTION
## 修复内容

- 只让 `seeking` 建立显式 seek 意图；decoder 驱动的 `seeked` 不再刷新 `lastExplicitUserAction.at`。
- 即时 `seeked` 仍继承现有 seek 记录；被更新操作取代或延迟到达的 `seeked` 保持陈旧。
- 增加 `seek -> 后续 play -> 延迟 seeked` 回归测试，断言后续 play 不被覆盖，且不会派生 `explicit-seek`。
- 已 rebase 到包含依赖升级 #256 的最新 `main`；本 PR 不包含 audit allowlist、锁文件或依赖变更。

## fresh `at` 的消费者方向

- `derivePlaybackSyncIntent`：放宽。fresh seek 会标为 `explicit-seek`，接收端可无条件硬 seek。
- `getBroadcastPlayState`：放宽。fresh seek 会让 seeking/seeked 广播 `playing`（起点明确 paused 时除外）。
- programmatic apply guard：放宽。fresh 且匹配的显式操作会绕过程序化回声抑制。

因此，延迟 `seeked` 把 `at` 刷新到当前时刻，会同时把陈旧 seek 变成可分类、可广播、可绕过抑制的新鲜意图；修复保留真正较新的 play 记录。

## 验证

- rebase 后再次执行回归判别：临时恢复旧 `onSeeked -> rememberExplicitUserAction("seek")` 后，新测试失败，实际值为 `seek@2600`、期望为 `play@2550`；恢复修复后通过。
- `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test && npm run audit`
- 全仓结果：server 536 passed / 89 skipped，extension 645 passed，admin UI 70 passed；audit gate 无 allowlist 通过。
- 未改变 wire format 或协议语义，无需升级协议版本。

Fixes #246