### PR TITLE
chore(deps): brace-expansion 升到 5.0.9，修复 GHSA-rgw5-rvv9-x895

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3198,9 +3198,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## 问题

`npm run audit` 在 **main 上就红**，与任何本地改动无关：

```
npm audit gate failed: 1 unallowlisted high+ vulnerability finding(s).
- npm:brace-expansion:1130734 [high] | DoS via unbounded intermediate arrays,
  bypassing the CVE-2026-14257 mitigation | range: >=4.0.0 <5.0.9
  https://github.com/advisories/GHSA-rgw5-rvv9-x895
```

新公告发布导致，正是 AGENTS.md 里说的"没有本地改动也会突然变红"的情形。它挡住了当前所有 PR 的预提交序列。

## 传递路径

```
bili-syncplay
└─┬ eslint@10.6.0            (devDependency)
  └─┬ minimatch@10.2.5
    └── brace-expansion@5.0.8 → 5.0.9
```

只有这一条，且全在开发依赖里，不进运行时产物。

## 改动

`npm update brace-expansion`，lockfile 只动了这一个条目（patch 版本）：

```diff
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
+      "version": "5.0.9",
```

**没有走 allowlist**：有可用修复版本时加豁免，只是把同一个洞留到过期日期那天。

## 验证

`format:check` / `lint` / `typecheck` / `build` / `test`（644 pass）/ `audit` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)