### PR TITLE
chore(release): 1.3.4

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-exclude='../packages/**' test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.3"
+    "@bili-syncplay/protocol": "1.3.4"
   },
   "devDependencies": {
     "@types/chrome": "^0.2.2",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["alarms", "storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "workspaces": [
         "packages/*",
         "server",
@@ -28,9 +28,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.3"
+        "@bili-syncplay/protocol": "1.3.4"
       },
       "devDependencies": {
         "@types/chrome": "^0.2.2",
@@ -5650,10 +5650,10 @@
     },
     "packages/admin-ui": {
       "name": "@bili-syncplay/admin-ui",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
-        "@bili-syncplay/protocol": "1.3.3",
+        "@bili-syncplay/protocol": "1.3.4",
         "@tanstack/react-query": "^5.101.2",
         "antd": "^6.5.1",
         "dayjs": "^1.11.21",
@@ -5697,7 +5697,7 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "devDependencies": {
         "@types/node": "^24.0.0",
         "typescript": "^6.0.3"
@@ -5705,9 +5705,9 @@
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.3",
+        "@bili-syncplay/protocol": "1.3.4",
         "ioredis": "^5.10.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/admin-ui",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
-    "@bili-syncplay/protocol": "1.3.3",
+    "@bili-syncplay/protocol": "1.3.4",
     "@tanstack/react-query": "^5.101.2",
     "antd": "^6.5.1",
     "dayjs": "^1.11.21",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.3",
+    "@bili-syncplay/protocol": "1.3.4",
     "ioredis": "^5.10.0",
     "ws": "^8.21.0"
   },


### PR DESCRIPTION
## 发布内容

自 `v1.3.3` 起累积 5 个提交，其中 3 个 `fix:`，无新特性，故走 patch。

全部集中在扩展侧的播放绑定与手势判据：

- **#252** 手势时间戳的「从未发生」哨兵从 `0` 改为 `GESTURE_NEVER_AT`（`-Infinity`）。切到单调钟后 `now - 0` 等于页龄而非 56 年，导致每个页面最初的 `userGestureGraceMs` 内所有「最近没有用户手势」的保护集体失效——恰好是新标签页自动播放的那一刻。
- **#253** 共享者连播时撤销自己打下的加载暂停，房间不再停在新视频上；含 festival 快照空窗期不再回退到地址栏冻结的 bvid，以及延迟 pause 改为先复核前提（playback generation + 当前元素）。
- **#255** 不让延迟到达的 `seeked` 复活陈旧 seek：`onSeeked` 只在 `lastExplicitUserAction` 仍是该 seek、且它晚于 `lastForcedPauseAt` 时续期。

另有 **#250**（真 Redis 测试的写后读回改由座位辅助层设屏障，纯测试）与 **#256**（brace-expansion 升到 5.0.9，修复 GHSA-rgw5-rvv9-x895）。

## 变更范围

纯版本号：root / protocol / server / admin-ui / extension 的 `package.json`、`extension/public/manifest.json`、`package-lock.json`。无代码改动。

## 协议兼容性

`git diff v1.3.3..main -- packages/protocol/src` 为空，`PROTOCOL_VERSION` 与 `CURRENT_PROTOCOL_VERSION` 均未变。新旧扩展 ↔ 新旧服务端双向兼容，扩展发布与服务端镜像上线无先后约束。

## 验证

本地在本分支跑完整序列 `format:check && lint && typecheck && build && test && audit`，逐项退出码均为 0（未走管道，避免尾部命令吞掉退出码）：

- 脚本 7 / 协议 14 / admin 83（node:test）+ 服务端 538 + 扩展 667，fail 均为 0
- admin-ui vitest 15 文件 / 70 passed
- `npm audit gate passed: no unallowlisted high+ vulnerability findings.`

## 真 Redis 集成测试：1 个既有失败，与本次发布无关

`REDIS_URL=redis://127.0.0.1:6399 npm run test:server:redis` 得 627 tests / 626 pass / **1 fail** / 0 skipped。失败项：

```
not ok - redis room store reports codes whose index entry outlived the room body
  expected: [ 'NOBODY' ]   actual: []
```

**不是本批改动引入**，也不阻塞本次发布：

- `v1.3.3` tag 上以 worktree 复跑同一文件 **5/5 同样失败**；该测试自 #237 引入，`v1.3.3..main` 期间无提交触及 `redis-room-store.ts` 或该测试文件（#250 只改了 runtime-store 侧的三个测试与新 helper）。
- CI 的 `redis-integration` job 一直是绿的（redis:7-alpine），本地是 Redis 8.0.2 / arm64，时序落在竞态的另一侧。

**根因（已用探针证明）**：`createRedisRoomStore` 在第 538 行 `void reconcileRoomIndex().catch(...)` 后台启动首趟对账且不等待。测试直接 `redis.del(room:NOBODY)` 制造孤儿索引项，但没有屏障保证那趟对账已经结束——若它在删除之后才扫到，`reconcileFromRoomBodies` 会自己把这个孤儿项从索引摘掉，于是 reaper 的 `ZRANGEBYSCORE` 无候选，返回 `[]`。

探针：在删除 body 前插入 `await store.reconcileRoomIndex()`（该方法本就暴露在返回类型上）。

| 分支 | 结果 |
| --- | --- |
| 本分支，无探针 | 5 次中 4 次失败 |
| `v1.3.3`，无探针 | 5 次中 5 次失败 |
| 本分支，加探针 | 6 次中 0 次失败 |

探针已按备份文件还原（`cp`，未用 `git checkout`），本 PR 不含任何测试改动。

与 #247/#250 属同一类「写后读回与后台异步赛跑」，只是 #250 修的是 runtime store 一侧，room store 这处是同构漏网。另需评估的窄生产影响：若首趟对账抢先摘掉孤儿索引项，reaper 就不会报告该 code，其 runtime state 便不会被回收——正是 #237 想解决的问题的一个残余窗口（仅限进程启动后首趟对账期间）。将单开 issue 跟进，不在发布 PR 内顺手改。

## 合并后

打 `v1.3.4` 并推送，触发 `release.yml`（Chrome/Edge zip + Firefox zip/xpi + GitHub Release）与 `docker-release.yml`（GHCR + Docker Hub 镜像）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)