### PR TITLE
chore(deps): 提升 nanoid 至 3.3.18 以清掉 audit 门禁

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4598,9 +4598,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## 背景

`npm run audit`（CI `verify` 作业的同一道门）在本地与 CI 上均已变红，与任何代码改动无关 —— 新公告 [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)（high）：nanoid `<3.3.17` 在 size 为 0 时自定义生成器可能死循环。

依赖路径：`admin-ui → vite@8.1.4 → postcss@8.5.19 → nanoid`，属纯构建期依赖，不随扩展或服务端产物发布。

## 改动

只动 `package-lock.json`：`3.3.16 → 3.3.18`。postcss 声明的是 `nanoid: ^3.3.12`，3.3.18 落在同一 semver 范围内，vite / postcss 都不需要动，diff 三行。

没有加 `audit-allowlist.json` 条目 —— 公告确实适用于本仓库，只是它有修复版本，直接修好比挂豁免更合适。

## 验证

预提交序列逐项独立退出码（未用管道截断）：

| 步骤 | 退出码 |
|---|---|
| format:check | 0 |
| lint | 0 |
| typecheck | 0 |
| build | 0 |
| test | 0 |
| audit | 0（改动前为 1） |

拆成独立 PR 的原因：不把依赖升级混进正在准备的同步修复分支，两者可以各自评审。

🤖 Generated with [Claude Code](https://claude.com/claude-code)