### PR TITLE
fix: 暂停的视频不再被当作 buffering 共享给房间

### DIFF
--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -69,6 +69,8 @@ const shareController = createShareController({
   refreshFestivalBridge: (input) => festivalBridge.refreshSnapshot(input),
   getActiveCorrectionBaseRate: (url) =>
     syncController.getActiveCorrectionBaseRate(normalizeUrl(url)),
+  bufferPauseUpgradeMs: BUFFER_PAUSE_UPGRADE_MS,
+  getMonotonicNow: () => performance.now(),
   debugLog,
 });
 const autoShareNextController = createAutoShareNextController({

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -147,14 +147,18 @@ export function createPlaybackBindingController(args: {
    */
   const armBufferPauseUpgrade = (video: HTMLVideoElement) => {
     clearBufferUpgradeTimer();
-    const playbackContextGeneration =
-      args.runtimeState.playbackContextGeneration;
+    // The PLAYER context, not the room one. This upgrade re-reads the element
+    // and re-broadcasts what it finds, so only a change of page/element can make
+    // it stale. Reading `playbackContextGeneration` here tied it to the room
+    // instead: sharing your own video switches the shared url, which bumps that
+    // counter, so the upgrade was dropped by the very event that had just
+    // published the `buffering` it exists to correct (#258).
+    const playerContextGeneration = args.runtimeState.playerContextGeneration;
     const classifiedPauseStartedAt = args.runtimeState.pauseStartedAt;
     pauseBufferUpgradeTimerId = scheduleUpgradeTimer(() => {
       pauseBufferUpgradeTimerId = null;
       if (
-        playbackContextGeneration !==
-        args.runtimeState.playbackContextGeneration
+        playerContextGeneration !== args.runtimeState.playerContextGeneration
       ) {
         return;
       }

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -147,18 +147,30 @@ export function createPlaybackBindingController(args: {
    */
   const armBufferPauseUpgrade = (video: HTMLVideoElement) => {
     clearBufferUpgradeTimer();
-    // The PLAYER context, not the room one. This upgrade re-reads the element
-    // and re-broadcasts what it finds, so only a change of page/element can make
-    // it stale. Reading `playbackContextGeneration` here tied it to the room
-    // instead: sharing your own video switches the shared url, which bumps that
-    // counter, so the upgrade was dropped by the very event that had just
-    // published the `buffering` it exists to correct (#258).
+    // This upgrade has two premises, and it must verify BOTH — it re-reads the
+    // local element, and it broadcasts what it finds to a room.
+    //
+    // Element/page side: `playerContextGeneration`, which only a real navigation
+    // moves. Reading `playbackContextGeneration` here instead tied the upgrade to
+    // the ROOM's generation, and sharing your own video switches the shared url —
+    // so the upgrade was dropped by the very event that had just published the
+    // `buffering` it exists to correct (#258).
+    //
+    // Room side: the room CODE, not that generation. A room switch or leave
+    // resets the playback sync state while the page and the element carry on
+    // unchanged, so without this the timer armed in room A would fire into room
+    // B and broadcast this page's old pause over whatever B is playing. The room
+    // code is the honest discriminator: it is untouched by our own share
+    // confirming (the case #258 needed to survive) and necessarily changes on a
+    // switch or leave (`room-state-controller` resets on both).
     const playerContextGeneration = args.runtimeState.playerContextGeneration;
+    const armedRoomCode = args.runtimeState.activeRoomCode;
     const classifiedPauseStartedAt = args.runtimeState.pauseStartedAt;
     pauseBufferUpgradeTimerId = scheduleUpgradeTimer(() => {
       pauseBufferUpgradeTimerId = null;
       if (
-        playerContextGeneration !== args.runtimeState.playerContextGeneration
+        playerContextGeneration !== args.runtimeState.playerContextGeneration ||
+        args.runtimeState.activeRoomCode !== armedRoomCode
       ) {
         return;
       }

--- a/extension/src/content/playback-binding-controller.ts
+++ b/extension/src/content/playback-binding-controller.ts
@@ -147,30 +147,21 @@ export function createPlaybackBindingController(args: {
    */
   const armBufferPauseUpgrade = (video: HTMLVideoElement) => {
     clearBufferUpgradeTimer();
-    // This upgrade has two premises, and it must verify BOTH — it re-reads the
-    // local element, and it broadcasts what it finds to a room.
+    // The premise is "this element, still in the pause I classified, still in
+    // the membership I was armed under" — which is exactly what
+    // `playerSessionGeneration` tracks, so it is the only context check needed.
     //
-    // Element/page side: `playerContextGeneration`, which only a real navigation
-    // moves. Reading `playbackContextGeneration` here instead tied the upgrade to
-    // the ROOM's generation, and sharing your own video switches the shared url —
-    // so the upgrade was dropped by the very event that had just published the
-    // `buffering` it exists to correct (#258).
-    //
-    // Room side: the room CODE, not that generation. A room switch or leave
-    // resets the playback sync state while the page and the element carry on
-    // unchanged, so without this the timer armed in room A would fire into room
-    // B and broadcast this page's old pause over whatever B is playing. The room
-    // code is the honest discriminator: it is untouched by our own share
-    // confirming (the case #258 needed to survive) and necessarily changes on a
-    // switch or leave (`room-state-controller` resets on both).
-    const playerContextGeneration = args.runtimeState.playerContextGeneration;
-    const armedRoomCode = args.runtimeState.activeRoomCode;
+    // Not the ROOM's generation: sharing your own video switches the shared url
+    // and bumps that counter, which killed this upgrade on every share and left
+    // the room on a stale `buffering` (#258). And not a captured room CODE
+    // either: `ROOM01 → null → ROOM01` inside the window restores the captured
+    // value while the leave has already ended the session the pause belonged to.
+    const playerSessionGeneration = args.runtimeState.playerSessionGeneration;
     const classifiedPauseStartedAt = args.runtimeState.pauseStartedAt;
     pauseBufferUpgradeTimerId = scheduleUpgradeTimer(() => {
       pauseBufferUpgradeTimerId = null;
       if (
-        playerContextGeneration !== args.runtimeState.playerContextGeneration ||
-        args.runtimeState.activeRoomCode !== armedRoomCode
+        playerSessionGeneration !== args.runtimeState.playerSessionGeneration
       ) {
         return;
       }

--- a/extension/src/content/player-binding.ts
+++ b/extension/src/content/player-binding.ts
@@ -53,17 +53,80 @@ export function playVideo(video: HTMLVideoElement): Promise<void> {
   return Promise.resolve(video.play()).then(() => undefined);
 }
 
-export function getPlayState(
-  video: HTMLVideoElement,
-  intendedPlayState: PlaybackState["playState"],
-): PlaybackState["playState"] {
+/**
+ * What the element itself is doing, and nothing else.
+ *
+ * This deliberately does NOT consult `intendedPlayState`. It used to answer
+ * `buffering` for a paused element whenever the last broadcast had been
+ * `buffering`, which is a latch, not an observation: every broadcast writes
+ * `intendedPlayState` to the state it just sent, so one buffer-classified pause
+ * made every later read report `buffering` for a plainly paused video, for as
+ * long as it stayed paused. It also disarmed the bounded correction — the
+ * buffer-pause upgrade re-broadcasts through this function, so the upgrade
+ * published `buffering` again and could never reach `paused` (#258).
+ *
+ * A paused element is only reported as `buffering` through
+ * {@link getReportedPlayState}, whose window closes on its own — which is also
+ * why this stays module-private. Exporting it puts a way to publish a play state
+ * that skips the bounded classification back within reach, and the share
+ * snapshot doing exactly that is half of what #258 was.
+ */
+function getPlayState(video: HTMLVideoElement): PlaybackState["playState"] {
   if (!video.paused && video.readyState < 3) {
     return "buffering";
   }
   if (video.paused) {
-    return intendedPlayState === "buffering" ? "buffering" : "paused";
+    return "paused";
   }
   return "playing";
+}
+
+/**
+ * Whether a pause the classifier attributed to buffering is still young enough
+ * to be reported as `buffering` rather than `paused`.
+ *
+ * The window is what makes the claim falsifiable: a player hiccup resolves
+ * inside it, while an element still sitting paused when it elapses was never
+ * buffering. `armBufferPauseUpgrade` schedules the re-broadcast that carries the
+ * corrected state to the room once this returns false.
+ */
+export function isInsideBufferPauseWindow(args: {
+  pauseClassifiedAsBuffer: boolean;
+  pauseStartedAt: number;
+  now: number;
+  bufferPauseUpgradeMs: number;
+}): boolean {
+  return (
+    args.pauseClassifiedAsBuffer &&
+    args.pauseStartedAt > 0 &&
+    args.now - args.pauseStartedAt < args.bufferPauseUpgradeMs
+  );
+}
+
+/**
+ * The play state this client reports to the room: the element's own state, with
+ * a buffer-induced pause presented as `buffering` for the bounded window above.
+ *
+ * Every path that publishes a play state must go through here — the broadcast
+ * funnel, the `video:share` snapshot, and the programmatic-apply signatures
+ * compared against broadcasts — because a `buffering` published by one and a
+ * `paused` published by another describe the same element and cannot both be
+ * true. The share snapshot skipping this was how an indefinitely paused video
+ * was shared as `buffering`: receivers do not pause for `buffering`, so a
+ * joiner's fresh tab autoplayed and broadcast `playing` back to the room (#258).
+ */
+export function getReportedPlayState(args: {
+  video: HTMLVideoElement;
+  pauseClassifiedAsBuffer: boolean;
+  pauseStartedAt: number;
+  now: number;
+  bufferPauseUpgradeMs: number;
+}): PlaybackState["playState"] {
+  const playState = getPlayState(args.video);
+  if (playState !== "paused") {
+    return playState;
+  }
+  return isInsideBufferPauseWindow(args) ? "buffering" : "paused";
 }
 
 export function canApplyPlaybackImmediately(video: HTMLVideoElement): boolean {

--- a/extension/src/content/room-state-controller.ts
+++ b/extension/src/content/room-state-controller.ts
@@ -1,6 +1,7 @@
 import type { RoomState, SharedVideo } from "@bili-syncplay/protocol";
 import type { SharedVideoToastPayload } from "../shared/messages";
 import type { ContentRuntimeState } from "./runtime-state";
+import { invalidatePlayerSession } from "./runtime-state";
 import type { ToastCoordinatorState } from "./toast";
 import {
   createToastPresenter,
@@ -123,6 +124,17 @@ export function createRoomStateController(args: {
       payload.roomCode &&
       previousRoomCode !== payload.roomCode,
     );
+
+    // Every membership change ends the local player session, including the two
+    // the `roomChanged` / `!payload.roomCode` branches below do not cover on
+    // their own: joining from no room at all, and the `null` leg of a
+    // leave-then-rejoin. Delayed local-player work (the buffer-pause upgrade)
+    // and the buffer classification it verifies itself against belong to the
+    // membership they were recorded under — carrying either across publishes the
+    // previous session's pause into the new room (#260 review).
+    if (previousRoomCode !== payload.roomCode) {
+      invalidatePlayerSession(args.runtimeState);
+    }
 
     if (roomChanged) {
       args.resetPlaybackSyncState(

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -109,18 +109,26 @@ export interface ContentRuntimeState {
    */
   playbackContextGeneration: number;
   /**
-   * Invalidates delayed work that captured an older PAGE/player context.
+   * Invalidates delayed work whose premise is "this page's `<video>` element,
+   * inside THIS membership of a room".
    *
-   * Deliberately separate from [[playbackContextGeneration]]: a room-level
-   * shared-url switch does not end the pause the local `<video>` element is
-   * sitting in, so delayed work whose premise is purely local must not be
-   * dropped by it. The buffer-pause upgrade is exactly that work — it re-reads
-   * the element and re-broadcasts what it finds — and sharing your own video
-   * always switches the shared url, so reading the room-scoped counter there
-   * killed the upgrade on every share and left the room on a stale `buffering`
-   * (#258). Only a real navigation (via [[resetUserGestureState]]) bumps this.
+   * Deliberately separate from [[playbackContextGeneration]] in both directions,
+   * because those two answer different questions:
+   *
+   * - A room-level shared-url switch does not end the pause the element is
+   *   sitting in. Sharing your own video always switches the shared url, so
+   *   pinning the buffer-pause upgrade to the room counter killed it on every
+   *   share and left the room on a stale `buffering` (#258).
+   * - But joining, leaving or switching rooms DOES end the session that work was
+   *   scheduled for, even though the page never changed. Comparing the room
+   *   *code* instead is not enough: `ROOM01 → null → ROOM01` inside the window
+   *   restores the captured value, and the pre-leave pause would be published
+   *   into the new session.
+   *
+   * Bumped by [[resetUserGestureState]] (a real navigation) and by every change
+   * of `activeRoomCode` (a new membership), through [[invalidatePlayerSession]].
    */
-  playerContextGeneration: number;
+  playerSessionGeneration: number;
   intendedPlayState: PlaybackState["playState"];
   intendedPlaybackRate: number;
   lastLocalIntentAt: number;
@@ -347,11 +355,10 @@ export interface ContentRuntimeState {
  */
 export function resetUserGestureState(state: ContentRuntimeState): void {
   invalidatePlaybackContext(state);
-  // A navigation replaces the page's player context as well as the room's, and
-  // it is the ONLY thing that does. The pause fields cleared below describe the
-  // element this page is leaving, so delayed work anchored on them (the
-  // buffer-pause upgrade) must go with them.
-  state.playerContextGeneration += 1;
+  // A navigation ends the page's player session as well as the room's playback
+  // context. The pause classification it clears describes the element this page
+  // is leaving, so delayed work anchored on it goes with it.
+  invalidatePlayerSession(state);
   state.lastUserGestureAt = GESTURE_NEVER_AT;
   state.lastUserGestureInPlayerAt = GESTURE_NEVER_AT;
   state.lastRateControlGestureAt = GESTURE_NEVER_AT;
@@ -363,13 +370,33 @@ export function resetUserGestureState(state: ContentRuntimeState): void {
   state.suppressedLocalEndPauseUrl = null;
   state.suppressedLocalEndPauseUntil = 0;
   state.nonSharerAutoplayHoldUrl = null;
-  state.lastBufferSignalAt = 0;
-  state.pauseStartedAt = 0;
-  state.pauseClassifiedAsBuffer = false;
 }
 
 export function invalidatePlaybackContext(state: ContentRuntimeState): void {
   state.playbackContextGeneration += 1;
+}
+
+/**
+ * End the current player session: this page's `<video>` element as seen by this
+ * membership of a room. Call it on a real navigation and on every change of
+ * `activeRoomCode` (join, leave, switch).
+ *
+ * It drops the buffer-pause classification with the generation, because those
+ * fields are the premise the pending upgrade verifies itself against and they
+ * are just as session-bound: `lastBufferSignalAt` only exists to attribute the
+ * NEXT pause within `bufferSignalWindowMs` to a stall, so carrying it into a new
+ * membership lets that room's first pause borrow the previous room's `waiting`
+ * and go out as `buffering`; and a classification carried across would make the
+ * new room's `video:share` snapshot say `buffering` with no armed upgrade left
+ * to correct it. What must survive is narrower: the same classification across
+ * our OWN share confirming, which changes no room code and is not a session
+ * boundary (#258).
+ */
+export function invalidatePlayerSession(state: ContentRuntimeState): void {
+  state.playerSessionGeneration += 1;
+  state.lastBufferSignalAt = 0;
+  state.pauseStartedAt = 0;
+  state.pauseClassifiedAsBuffer = false;
 }
 
 export function createContentRuntimeState(): ContentRuntimeState {
@@ -385,7 +412,7 @@ export function createContentRuntimeState(): ContentRuntimeState {
     hasReceivedInitialRoomState: false,
     pendingRoomStateHydration: true,
     playbackContextGeneration: 0,
-    playerContextGeneration: 0,
+    playerSessionGeneration: 0,
     intendedPlayState: "paused",
     intendedPlaybackRate: 1,
     lastLocalIntentAt: 0,

--- a/extension/src/content/runtime-state.ts
+++ b/extension/src/content/runtime-state.ts
@@ -101,8 +101,26 @@ export interface ContentRuntimeState {
   hydrationReady: boolean;
   hasReceivedInitialRoomState: boolean;
   pendingRoomStateHydration: boolean;
-  /** Invalidates delayed work that captured an older room/page playback context. */
+  /**
+   * Invalidates delayed work that captured an older ROOM playback context —
+   * anything decided from the room's shared video, such as a queued load-pause
+   * or a broadcast in flight. A shared-url switch bumps it, because the decision
+   * that scheduled that work is the thing that just went stale.
+   */
   playbackContextGeneration: number;
+  /**
+   * Invalidates delayed work that captured an older PAGE/player context.
+   *
+   * Deliberately separate from [[playbackContextGeneration]]: a room-level
+   * shared-url switch does not end the pause the local `<video>` element is
+   * sitting in, so delayed work whose premise is purely local must not be
+   * dropped by it. The buffer-pause upgrade is exactly that work — it re-reads
+   * the element and re-broadcasts what it finds — and sharing your own video
+   * always switches the shared url, so reading the room-scoped counter there
+   * killed the upgrade on every share and left the room on a stale `buffering`
+   * (#258). Only a real navigation (via [[resetUserGestureState]]) bumps this.
+   */
+  playerContextGeneration: number;
   intendedPlayState: PlaybackState["playState"];
   intendedPlaybackRate: number;
   lastLocalIntentAt: number;
@@ -329,6 +347,11 @@ export interface ContentRuntimeState {
  */
 export function resetUserGestureState(state: ContentRuntimeState): void {
   invalidatePlaybackContext(state);
+  // A navigation replaces the page's player context as well as the room's, and
+  // it is the ONLY thing that does. The pause fields cleared below describe the
+  // element this page is leaving, so delayed work anchored on them (the
+  // buffer-pause upgrade) must go with them.
+  state.playerContextGeneration += 1;
   state.lastUserGestureAt = GESTURE_NEVER_AT;
   state.lastUserGestureInPlayerAt = GESTURE_NEVER_AT;
   state.lastRateControlGestureAt = GESTURE_NEVER_AT;
@@ -362,6 +385,7 @@ export function createContentRuntimeState(): ContentRuntimeState {
     hasReceivedInitialRoomState: false,
     pendingRoomStateHydration: true,
     playbackContextGeneration: 0,
+    playerContextGeneration: 0,
     intendedPlayState: "paused",
     intendedPlaybackRate: 1,
     lastLocalIntentAt: 0,

--- a/extension/src/content/share-controller.ts
+++ b/extension/src/content/share-controller.ts
@@ -1,5 +1,5 @@
 import type { PlaybackState, SharedVideo } from "@bili-syncplay/protocol";
-import { getPlayState, getVideoElement } from "./player-binding";
+import { getReportedPlayState, getVideoElement } from "./player-binding";
 import {
   createSharePayload as createPageSharePayload,
   resolvePageSharedVideo,
@@ -70,6 +70,10 @@ export function createShareController(args: {
   getActiveCorrectionBaseRate: (
     url: string | undefined | null,
   ) => number | null;
+  /** See {@link getReportedPlayState}; the share snapshot reports through it. */
+  bufferPauseUpgradeMs: number;
+  /** Monotonic clock, matching every other window measured in this codebase. */
+  getMonotonicNow: () => number;
   debugLog: (message: string) => void;
 }): ShareController {
   function canUsePageSnapshot(pathname: string): boolean {
@@ -187,7 +191,19 @@ export function createShareController(args: {
             playbackRate:
               args.getActiveCorrectionBaseRate(sharedVideo.url) ??
               video.playbackRate,
-            playState: getPlayState(video, args.runtimeState.intendedPlayState),
+            // Same classification the broadcast funnel uses. A share snapshot
+            // is a full play state on the wire, so it must be able to say
+            // `paused` for a video that is paused — reporting `buffering` there
+            // tells receivers "we are trying to play", and they neither pause
+            // for it nor let their pause hold act on it (#258).
+            playState: getReportedPlayState({
+              video,
+              pauseClassifiedAsBuffer:
+                args.runtimeState.pauseClassifiedAsBuffer,
+              pauseStartedAt: args.runtimeState.pauseStartedAt,
+              now: args.getMonotonicNow(),
+              bufferPauseUpgradeMs: args.bufferPauseUpgradeMs,
+            }),
           }
         : null,
       actorId: args.runtimeState.localMemberId ?? "local",

--- a/extension/src/content/soft-apply-controller.ts
+++ b/extension/src/content/soft-apply-controller.ts
@@ -5,7 +5,7 @@ import {
 } from "./playback-reconcile";
 import {
   createProgrammaticPlaybackSignature,
-  getPlayState,
+  getReportedPlayState,
   setVideoPlaybackRate,
 } from "./player-binding";
 import type {
@@ -85,6 +85,8 @@ export function createSoftApplyController(args: {
   debugLog: (message: string) => void;
   userGestureGraceMs: number;
   programmaticApplyWindowMs: number;
+  /** See {@link getReportedPlayState}; the cancel signature reports through it. */
+  bufferPauseUpgradeMs: number;
   /**
    * Monotonic time source. Every timestamp this controller stores and every
    * window it compares is an interval measured on this machine, so none of them
@@ -206,7 +208,17 @@ export function createSoftApplyController(args: {
       args.armProgrammaticApplyWindow(
         {
           url: session.normalizedUrl,
-          playState: getPlayState(video, args.runtimeState.intendedPlayState),
+          // Must be the state a broadcast would report, not the raw element
+          // state: this signature is compared against the play state the
+          // broadcast funnel computes, and a mismatch there means the guard
+          // stops recognizing our own `ratechange` echo.
+          playState: getReportedPlayState({
+            video,
+            pauseClassifiedAsBuffer: args.runtimeState.pauseClassifiedAsBuffer,
+            pauseStartedAt: args.runtimeState.pauseStartedAt,
+            now: monotonicNow(),
+            bufferPauseUpgradeMs: args.bufferPauseUpgradeMs,
+          }),
           currentTime: video.currentTime,
           playbackRate: session.restorePlaybackRate,
         },

--- a/extension/src/content/sync-controller.ts
+++ b/extension/src/content/sync-controller.ts
@@ -18,7 +18,7 @@ import {
 import {
   applyPendingPlaybackApplication as applyPendingPlaybackApplicationWithBinding,
   createProgrammaticPlaybackSignature,
-  getPlayState,
+  getReportedPlayState,
   pauseVideo,
 } from "./player-binding";
 import {
@@ -273,6 +273,25 @@ export function createSyncController(args: {
     args.runtimeState.pauseHoldUntil = monotonicNow() + durationMs;
   }
 
+  /**
+   * The play state this client would publish for `video` right now. Every
+   * reporter in this file — the broadcast funnel and each diagnostic trace —
+   * reads it from here so a trace can never disagree with the message it
+   * describes. See {@link getReportedPlayState}.
+   */
+  function reportedPlayState(
+    video: HTMLVideoElement,
+    now = monotonicNow(),
+  ): PlaybackState["playState"] {
+    return getReportedPlayState({
+      video,
+      pauseClassifiedAsBuffer: args.runtimeState.pauseClassifiedAsBuffer,
+      pauseStartedAt: args.runtimeState.pauseStartedAt,
+      now,
+      bufferPauseUpgradeMs: args.bufferPauseUpgradeMs,
+    });
+  }
+
   function armProgrammaticApplyWindow(
     signature: ReturnType<typeof createProgrammaticPlaybackSignature>,
     reason: "pending" | "apply",
@@ -307,6 +326,7 @@ export function createSyncController(args: {
     debugLog: args.debugLog,
     userGestureGraceMs: args.userGestureGraceMs,
     programmaticApplyWindowMs: args.programmaticApplyWindowMs,
+    bufferPauseUpgradeMs: args.bufferPauseUpgradeMs,
     getMonotonicNow: args.getMonotonicNow,
     armProgrammaticApplyWindow,
   });
@@ -335,9 +355,15 @@ export function createSyncController(args: {
     softApply.clearSoftApplyCooldown();
     args.runtimeState.lastLocalPlaybackVersion = null;
     args.runtimeState.intendedPlaybackRate = 1;
-    args.runtimeState.lastBufferSignalAt = 0;
-    args.runtimeState.pauseStartedAt = 0;
-    args.runtimeState.pauseClassifiedAsBuffer = false;
+    // The pause classification (`lastBufferSignalAt`, `pauseStartedAt`,
+    // `pauseClassifiedAsBuffer`) is deliberately NOT cleared here. It describes
+    // the local `<video>` element, and this reset runs for room-level events —
+    // above all the confirmation of our OWN share, which does not end the pause
+    // the element is sitting in. Clearing it there discarded the evidence the
+    // pending buffer-pause upgrade verifies itself against, so the upgrade that
+    // should have corrected the room's `buffering` to `paused` dropped silently
+    // on every share (#258). A real navigation still clears it, through
+    // `resetUserGestureState`, which is where the element genuinely changes.
     roomConfirmedBroadcast = null;
     args.runtimeState.lastNonSharedGuardUrl = null;
     args.runtimeState.lastExplicitPlaybackAction = null;
@@ -773,9 +799,9 @@ export function createSyncController(args: {
     eventSource: LocalPlaybackEventSource;
     now: number;
   }): PlaybackState["playState"] {
-    const basePlayState = getPlayState(
+    const basePlayState = reportedPlayState(
       argsForBroadcast.video,
-      args.runtimeState.intendedPlayState,
+      argsForBroadcast.now,
     );
     // Mirrors `derivePlaybackSyncIntent`'s `hasActiveExplicitUserAction`: a seek
     // that predates a forced pause was invalidated by it and is not a user
@@ -843,16 +869,12 @@ export function createSyncController(args: {
       return "playing";
     }
 
-    if (
-      basePlayState === "paused" &&
-      args.runtimeState.pauseClassifiedAsBuffer &&
-      args.runtimeState.pauseStartedAt > 0 &&
-      argsForBroadcast.now - args.runtimeState.pauseStartedAt <
-        args.bufferPauseUpgradeMs
-    ) {
-      return "buffering";
-    }
-
+    // The buffer-pause window is NOT re-checked here: `basePlayState` already
+    // came from `getReportedPlayState`, which owns that classification for every
+    // reporter. Restating it locally is what let the two disagree — the old
+    // `intendedPlayState` latch made `basePlayState` `buffering` before this
+    // branch could run, so the branch never fired and its window never bounded
+    // anything (#258).
     return basePlayState;
   }
 
@@ -884,7 +906,7 @@ export function createSyncController(args: {
           eventSource,
           currentVideoUrl: null,
           normalizedCurrentVideoUrl: null,
-          playState: getPlayState(video, args.runtimeState.intendedPlayState),
+          playState: reportedPlayState(video, now),
           currentTime: video.currentTime,
           playbackRate: video.playbackRate,
         }),
@@ -916,7 +938,7 @@ export function createSyncController(args: {
             eventSource,
             currentVideoUrl: null,
             normalizedCurrentVideoUrl: null,
-            playState: getPlayState(video, args.runtimeState.intendedPlayState),
+            playState: reportedPlayState(video, now),
             currentTime: video.currentTime,
             playbackRate: video.playbackRate,
           }),
@@ -950,7 +972,7 @@ export function createSyncController(args: {
           eventSource,
           currentVideoUrl: null,
           normalizedCurrentVideoUrl: null,
-          playState: getPlayState(video, args.runtimeState.intendedPlayState),
+          playState: reportedPlayState(video, now),
           currentTime: video.currentTime,
           playbackRate: video.playbackRate,
         }),
@@ -972,7 +994,7 @@ export function createSyncController(args: {
         eventSource,
         currentVideoUrl: currentVideo.url,
         normalizedCurrentVideoUrl,
-        playState: getPlayState(video, args.runtimeState.intendedPlayState),
+        playState: reportedPlayState(video, now),
         currentTime: video.currentTime,
         playbackRate: video.playbackRate,
       }),
@@ -1016,10 +1038,7 @@ export function createSyncController(args: {
           args.debugLog(
             `Skip broadcast ${formatPlaybackDiagnostic({
               actor: args.runtimeState.localMemberId,
-              playState: getPlayState(
-                video,
-                args.runtimeState.intendedPlayState,
-              ),
+              playState: reportedPlayState(video, now),
               url: currentVideo.url,
               localTime: video.currentTime,
               targetTime: video.currentTime,
@@ -1035,7 +1054,7 @@ export function createSyncController(args: {
             eventSource,
             currentVideoUrl: currentVideo.url,
             normalizedCurrentVideoUrl,
-            playState: getPlayState(video, args.runtimeState.intendedPlayState),
+            playState: reportedPlayState(video, now),
             currentTime: video.currentTime,
             playbackRate: video.playbackRate,
           }),
@@ -1083,10 +1102,7 @@ export function createSyncController(args: {
           args.debugLog(
             `Skip broadcast ${formatPlaybackDiagnostic({
               actor: args.runtimeState.localMemberId,
-              playState: getPlayState(
-                video,
-                args.runtimeState.intendedPlayState,
-              ),
+              playState: reportedPlayState(video, now),
               url: currentVideo.url,
               localTime: video.currentTime,
               targetTime: video.currentTime,
@@ -1102,7 +1118,7 @@ export function createSyncController(args: {
             eventSource,
             currentVideoUrl: currentVideo.url,
             normalizedCurrentVideoUrl,
-            playState: getPlayState(video, args.runtimeState.intendedPlayState),
+            playState: reportedPlayState(video, now),
             currentTime: video.currentTime,
             playbackRate: video.playbackRate,
           }),
@@ -1138,7 +1154,7 @@ export function createSyncController(args: {
           normalizedCurrentVideoUrl,
           explicitNonSharedPlaybackUrl:
             args.runtimeState.explicitNonSharedPlaybackUrl,
-          playState: getPlayState(video, args.runtimeState.intendedPlayState),
+          playState: reportedPlayState(video, now),
           lastExplicitPlaybackAction:
             args.runtimeState.lastExplicitPlaybackAction,
           now,
@@ -1156,7 +1172,7 @@ export function createSyncController(args: {
           eventSource,
           currentVideoUrl: currentVideo.url,
           normalizedCurrentVideoUrl,
-          playState: getPlayState(video, args.runtimeState.intendedPlayState),
+          playState: reportedPlayState(video, now),
           currentTime: video.currentTime,
           playbackRate: video.playbackRate,
         }),

--- a/extension/src/content/sync-guards.ts
+++ b/extension/src/content/sync-guards.ts
@@ -107,8 +107,22 @@ function isProgrammaticPlaybackStateCompatible(args: {
 }): boolean {
   return (
     args.eventPlayState === args.signaturePlayState ||
+    // Applied `playing`, element still loading: it reports `buffering`.
     (args.eventPlayState === "buffering" &&
-      args.signaturePlayState === "playing")
+      args.signaturePlayState === "playing") ||
+    // The mirror, and the one #258 exposed: applying a remote `buffering` never
+    // starts playback (`applyPendingPlaybackApplication` deliberately neither
+    // seeks past nor resumes for it), so on an element that is already paused
+    // the apply's own `seeking`/`canplay`/`seeked` echoes report `paused` — the
+    // only thing a paused element can report about itself. Judging that
+    // incompatible let the echo escape suppression and broadcast `paused` back,
+    // stopping every member of a room that was merely buffering.
+    //
+    // A genuine user pause inside the same window is NOT lost to this: it is let
+    // through by the explicit-user-action bypass below, which this branch runs
+    // after.
+    (args.eventPlayState === "paused" &&
+      args.signaturePlayState === "buffering")
   );
 }
 

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -3209,6 +3209,9 @@ test("playback binding controller keeps a buffer-pause upgrade across a room-lev
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();
   runtimeState.lastUserGestureAt = 0;
+  // A share happens inside a room, and that room does not change when our own
+  // share confirms — which is what lets the upgrade survive here.
+  runtimeState.activeRoomCode = "ROOM01";
   let now = 5_000;
   const broadcasts: string[] = [];
   const originalSetTimeout = globalThis.window.setTimeout;
@@ -3264,6 +3267,77 @@ test("playback binding controller keeps a buffer-pause upgrade across a room-lev
 
     assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
     assert.equal(broadcasts.includes("pause"), true);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.restore();
+  }
+});
+
+test("playback binding controller drops a buffer-pause upgrade after a room switch", async () => {
+  // The other half of the same premise (Codex review on #260). Switching rooms
+  // resets the playback sync state while the page and the `<video>` element
+  // carry on unchanged, so the page-scoped generation alone would let room A's
+  // timer fire into room B — re-broadcasting this page's old pause over whatever
+  // B is playing, and stopping every member of a room we just joined.
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 0;
+  runtimeState.activeRoomCode = "ROOM01";
+  let now = 5_000;
+  const broadcasts: string[] = [];
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const scheduledTimers: Array<{ cb: () => void; ms: number }> = [];
+  globalThis.window.setTimeout = ((callback: TimerHandler, ms?: number) => {
+    if (typeof callback === "function") {
+      scheduledTimers.push({ cb: callback as () => void, ms: ms ?? 0 });
+    }
+    return scheduledTimers.length;
+  }) as typeof globalThis.window.setTimeout;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async (_video, eventSource) => {
+      broadcasts.push(eventSource ?? "manual");
+    },
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("waiting")?.(new Event("waiting"));
+    now = 5_100;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+    await Promise.resolve();
+
+    const upgradeTimer = scheduledTimers.find((timer) => timer.ms === 1_500);
+    assert.notEqual(upgradeTimer, undefined);
+    broadcasts.length = 0;
+
+    // What a room switch does (`room-state-controller` handleSyncStatus): the
+    // room code moves, and the playback sync state is reset.
+    runtimeState.activeRoomCode = "ROOM02";
+    invalidatePlaybackContext(runtimeState);
+    now = 6_600;
+    upgradeTimer?.cb();
+    await Promise.resolve();
+
+    assert.deepEqual(broadcasts, []);
   } finally {
     globalThis.window.setTimeout = originalSetTimeout;
     dom.restore();

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -4,6 +4,7 @@ import type { SharedVideo } from "@bili-syncplay/protocol";
 import {
   createContentRuntimeState,
   invalidatePlaybackContext,
+  invalidatePlayerSession,
   resetUserGestureState,
 } from "../src/content/runtime-state";
 import { installClockStubs } from "./clock-stubs";
@@ -3329,9 +3330,11 @@ test("playback binding controller drops a buffer-pause upgrade after a room swit
     assert.notEqual(upgradeTimer, undefined);
     broadcasts.length = 0;
 
-    // What a room switch does (`room-state-controller` handleSyncStatus): the
-    // room code moves, and the playback sync state is reset.
+    // What a room switch does (`room-state-controller.handleSyncStatus`): the
+    // room code moves, the player session ends, and the playback sync state is
+    // reset.
     runtimeState.activeRoomCode = "ROOM02";
+    invalidatePlayerSession(runtimeState);
     invalidatePlaybackContext(runtimeState);
     now = 6_600;
     upgradeTimer?.cb();

--- a/extension/test/playback-binding-controller.test.ts
+++ b/extension/test/playback-binding-controller.test.ts
@@ -4,6 +4,7 @@ import type { SharedVideo } from "@bili-syncplay/protocol";
 import {
   createContentRuntimeState,
   invalidatePlaybackContext,
+  resetUserGestureState,
 } from "../src/content/runtime-state";
 import { installClockStubs } from "./clock-stubs";
 import { createPlaybackBindingController } from "../src/content/playback-binding-controller";
@@ -3135,7 +3136,7 @@ test("playback binding controller re-broadcasts paused after buffer-pause upgrad
   }
 });
 
-test("playback binding controller drops a buffer-pause upgrade from an older playback context", async () => {
+test("playback binding controller drops a buffer-pause upgrade from an older page context", async () => {
   const dom = installDomStub();
   const runtimeState = createContentRuntimeState();
   runtimeState.lastUserGestureAt = 0;
@@ -3184,12 +3185,85 @@ test("playback binding controller drops a buffer-pause upgrade from an older pla
     const upgradeTimer = scheduledTimers.find((timer) => timer.ms === 1_500);
     assert.notEqual(upgradeTimer, undefined);
     broadcasts.length = 0;
-    invalidatePlaybackContext(runtimeState);
+    // A navigation — the only thing that replaces the page's player context, and
+    // the reason this upgrade must not fire. A ROOM-level invalidation is a
+    // different question, covered by the test below.
+    resetUserGestureState(runtimeState);
     upgradeTimer?.cb();
     await Promise.resolve();
 
-    assert.equal(runtimeState.pauseClassifiedAsBuffer, true);
     assert.deepEqual(broadcasts, []);
+  } finally {
+    globalThis.window.setTimeout = originalSetTimeout;
+    dom.restore();
+  }
+});
+
+test("playback binding controller keeps a buffer-pause upgrade across a room-level playback reset", async () => {
+  // The regression behind #258. Sharing your own video switches the room's
+  // shared url, which resets the playback sync state — and that reset used to
+  // take the pending buffer-pause upgrade with it. The room had just been told
+  // `buffering` by the share snapshot, and the upgrade is the only thing that
+  // ever corrects it to `paused`, so losing it here strands every member on a
+  // state the sharer left long ago.
+  const dom = installDomStub();
+  const runtimeState = createContentRuntimeState();
+  runtimeState.lastUserGestureAt = 0;
+  let now = 5_000;
+  const broadcasts: string[] = [];
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const scheduledTimers: Array<{ cb: () => void; ms: number }> = [];
+  globalThis.window.setTimeout = ((callback: TimerHandler, ms?: number) => {
+    if (typeof callback === "function") {
+      scheduledTimers.push({ cb: callback as () => void, ms: ms ?? 0 });
+    }
+    return scheduledTimers.length;
+  }) as typeof globalThis.window.setTimeout;
+
+  const controller = createPlaybackBindingController({
+    runtimeState,
+    videoBindIntervalMs: 250,
+    userGestureGraceMs: 1_200,
+    initialRoomStatePauseHoldMs: 3_000,
+    bufferSignalWindowMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    videoRebindBufferSignalMs: 1_000,
+    getSharedVideo: () => null,
+    hasRecentRemoteStopIntent: () => false,
+    normalizeUrl: (url) => url ?? null,
+    getLastBroadcastAt: () => 0,
+    broadcastPlayback: async (_video, eventSource) => {
+      broadcasts.push(eventSource ?? "manual");
+    },
+    cancelActiveSoftApply: () => {},
+    maintainActiveSoftApply: () => {},
+    applyPendingPlaybackApplication: () => {},
+    activatePauseHold: () => {},
+    debugLog: () => {},
+    getMonotonicNow: () => now,
+  });
+
+  try {
+    controller.attachPlaybackListeners();
+    dom.listeners.get("waiting")?.(new Event("waiting"));
+    now = 5_100;
+    dom.video.paused = true;
+    dom.listeners.get("pause")?.(new Event("pause"));
+    await Promise.resolve();
+
+    const upgradeTimer = scheduledTimers.find((timer) => timer.ms === 1_500);
+    assert.notEqual(upgradeTimer, undefined);
+    broadcasts.length = 0;
+
+    // What the share confirmation does: bump the room-scoped generation. The
+    // page, the element and the pause it is sitting in are all unchanged.
+    invalidatePlaybackContext(runtimeState);
+    now = 6_600;
+    upgradeTimer?.cb();
+    await Promise.resolve();
+
+    assert.equal(runtimeState.pauseClassifiedAsBuffer, false);
+    assert.equal(broadcasts.includes("pause"), true);
   } finally {
     globalThis.window.setTimeout = originalSetTimeout;
     dom.restore();

--- a/extension/test/room-state-controller.test.ts
+++ b/extension/test/room-state-controller.test.ts
@@ -84,6 +84,78 @@ test("room state controller stays silent for the local sharer's manual share", (
   setLocaleForTests(null);
 });
 
+test("every membership change ends the local player session", () => {
+  // #260 review. The buffer-pause upgrade and the classification it verifies
+  // itself against belong to the membership they were recorded under. A captured
+  // room code cannot express that: `ROOM01 -> null -> ROOM01` restores the
+  // captured value even though the leave already ended that session, so the
+  // pre-leave pause would be published into the new one. Joining from no room at
+  // all is the other case neither of the existing reset branches covers.
+  const harness = createController([]);
+  const armClassification = () => {
+    harness.runtimeState.lastBufferSignalAt = 5_000;
+    harness.runtimeState.pauseStartedAt = 5_100;
+    harness.runtimeState.pauseClassifiedAsBuffer = true;
+  };
+  const sessionOf = () => harness.runtimeState.playerSessionGeneration;
+
+  armClassification();
+  const beforeJoin = sessionOf();
+  harness.controller.handleSyncStatus({
+    roomCode: "ROOM01",
+    connected: true,
+    memberId: "self",
+    rttMs: 10,
+  });
+  assert.equal(sessionOf(), beforeJoin + 1, "joining starts a new session");
+  assert.equal(harness.runtimeState.pauseClassifiedAsBuffer, false);
+  assert.equal(harness.runtimeState.pauseStartedAt, 0);
+  assert.equal(harness.runtimeState.lastBufferSignalAt, 0);
+
+  // Leave, then rejoin the SAME room.
+  armClassification();
+  const beforeLeave = sessionOf();
+  harness.controller.handleSyncStatus({
+    roomCode: null,
+    connected: false,
+    memberId: null,
+    rttMs: null,
+  });
+  assert.equal(sessionOf(), beforeLeave + 1, "leaving ends the session");
+  assert.equal(harness.runtimeState.pauseClassifiedAsBuffer, false);
+
+  armClassification();
+  const beforeRejoin = sessionOf();
+  harness.controller.handleSyncStatus({
+    roomCode: "ROOM01",
+    connected: true,
+    memberId: "self",
+    rttMs: 10,
+  });
+  assert.equal(
+    sessionOf(),
+    beforeRejoin + 1,
+    "rejoining the same room is still a new session",
+  );
+  assert.equal(harness.runtimeState.pauseClassifiedAsBuffer, false);
+  assert.equal(harness.runtimeState.lastBufferSignalAt, 0);
+
+  // A status repeat for the same room is NOT a membership change: the local
+  // pause classification must survive it, or every heartbeat would wipe the
+  // evidence the pending upgrade checks itself against (#258).
+  armClassification();
+  const beforeRepeat = sessionOf();
+  harness.controller.handleSyncStatus({
+    roomCode: "ROOM01",
+    connected: true,
+    memberId: "self",
+    rttMs: 12,
+  });
+  assert.equal(sessionOf(), beforeRepeat, "same room is not a new session");
+  assert.equal(harness.runtimeState.pauseClassifiedAsBuffer, true);
+  assert.equal(harness.runtimeState.pauseStartedAt, 5_100);
+});
+
 test("switching rooms clears the previous room's hydration backoff", () => {
   // Both hydration backoff streaks measure how long *this* room's wait has been
   // failing, and the retry timer belongs to it too. Carried into a new room they

--- a/extension/test/share-controller.test.ts
+++ b/extension/test/share-controller.test.ts
@@ -98,6 +98,98 @@ test("keeps playback snapshot outside of a room", () => {
   );
 });
 
+test("share controller reports a paused video as paused once its buffer-pause window has elapsed", () => {
+  // #258: the snapshot went out as `buffering` for a video that had been sitting
+  // paused since page load, because the old `getPlayState` answered from
+  // `intendedPlayState` (the last thing broadcast) instead of the element. A
+  // receiver neither pauses for `buffering` nor lets its pause hold act on it,
+  // so the joiner's fresh tab autoplayed and pulled the whole room into play.
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/video/BV199W9zEEcH",
+    pathname: "/video/BV199W9zEEcH",
+    title: "New Video_哔哩哔哩",
+    video: {
+      currentTime: 6.01,
+      playbackRate: 1,
+      paused: true,
+      readyState: 4,
+    } as HTMLVideoElement,
+  });
+
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  // The load-time buffer pause was broadcast, so the intent latched to it.
+  runtimeState.intendedPlayState = "buffering";
+  runtimeState.pauseStartedAt = 8_000;
+  runtimeState.pauseClassifiedAsBuffer = true;
+
+  const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
+    runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    // 1.7s after the pause: past the window, so this is a real pause.
+    getMonotonicNow: () => 9_700,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 7,
+    getFestivalSnapshot: () => null,
+    refreshFestivalBridge: async () => null,
+    debugLog: () => {},
+  });
+
+  try {
+    assert.equal(
+      controller.getCurrentSharePayload()?.playback?.playState,
+      "paused",
+    );
+  } finally {
+    dom.restore();
+  }
+});
+
+test("share controller still reports buffering inside the buffer-pause window", () => {
+  // The other polarity: a genuine player hiccup must NOT be shared as `paused`,
+  // or sharing mid-stall would stop the room.
+  const dom = installDomStub({
+    href: "https://www.bilibili.com/video/BV199W9zEEcH",
+    pathname: "/video/BV199W9zEEcH",
+    title: "New Video_哔哩哔哩",
+    video: {
+      currentTime: 6.01,
+      playbackRate: 1,
+      paused: true,
+      readyState: 4,
+    } as HTMLVideoElement,
+  });
+
+  const runtimeState = createContentRuntimeState();
+  runtimeState.activeRoomCode = "ROOM01";
+  runtimeState.intendedPlayState = "buffering";
+  runtimeState.pauseStartedAt = 8_000;
+  runtimeState.pauseClassifiedAsBuffer = true;
+
+  const controller = createShareController({
+    getActiveCorrectionBaseRate: () => null,
+    runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    // 0.5s after the pause: still inside the window.
+    getMonotonicNow: () => 8_500,
+    festivalSnapshotTtlMs: 1_200,
+    nextSeq: () => 7,
+    getFestivalSnapshot: () => null,
+    refreshFestivalBridge: async () => null,
+    debugLog: () => {},
+  });
+
+  try {
+    assert.equal(
+      controller.getCurrentSharePayload()?.playback?.playState,
+      "buffering",
+    );
+  } finally {
+    dom.restore();
+  }
+});
+
 test("share controller keeps playback snapshot while switching to another shared video in-room", () => {
   const dom = installDomStub({
     href: "https://www.bilibili.com/video/BV199W9zEEcH",
@@ -120,6 +212,8 @@ test("share controller keeps playback snapshot while switching to another shared
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 7,
     getFestivalSnapshot: () => null,
@@ -165,6 +259,8 @@ test("share controller resolves bangumi season pages through page snapshot", asy
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 3,
     getFestivalSnapshot: () => null,
@@ -209,6 +305,8 @@ test("share controller does not reuse cached bangumi snapshot synchronously", ()
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 4,
     getFestivalSnapshot: () => ({
@@ -253,6 +351,8 @@ test("share controller reuses matching cached bangumi snapshot for current page 
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 5,
     getFestivalSnapshot: () => ({
@@ -301,6 +401,8 @@ test("share controller reuses cached bangumi snapshot by active episode id witho
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 6,
     getFestivalSnapshot: () => ({
@@ -348,6 +450,8 @@ test("share controller reuses cached bangumi snapshot by active cid without titl
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 7,
     getFestivalSnapshot: () => ({
@@ -395,6 +499,8 @@ test("share controller rejects same-title cached bangumi snapshot from another p
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 6,
     getFestivalSnapshot: () => ({
@@ -440,6 +546,8 @@ test("share controller rejects cached bangumi snapshot on festival page", () => 
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 8,
     getFestivalSnapshot: () => ({
@@ -483,6 +591,8 @@ test("share controller reuses cached festival snapshot across trailing slash pat
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 9,
     getFestivalSnapshot: () => ({
@@ -543,6 +653,8 @@ test("share controller reports the room's base rate while a catch-up is running"
       return 1;
     },
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 7,
     getFestivalSnapshot: () => null,
@@ -586,6 +698,8 @@ test("share controller falls back to the element rate with no catch-up running",
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 7,
     getFestivalSnapshot: () => null,
@@ -634,6 +748,8 @@ test("stops falling back to the frozen festival address bar once a snapshot has 
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 1,
     getFestivalSnapshot: () => snapshot,
@@ -669,6 +785,8 @@ test("still resolves the festival address bar before any snapshot has resolved",
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 1,
     getFestivalSnapshot: () => null,
@@ -714,6 +832,8 @@ test("uses the festival address bar again after leaving and returning to the pag
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 1,
     getFestivalSnapshot: () => snapshot,
@@ -778,6 +898,8 @@ test("uses a new festival share URL before that page visit resolves a snapshot",
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 1,
     getFestivalSnapshot: () => snapshot,
@@ -830,6 +952,8 @@ test("discards a festival snapshot refresh that resolves after the page visit ch
   const controller = createShareController({
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
+    bufferPauseUpgradeMs: 1_500,
+    getMonotonicNow: () => 10_000,
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 1,
     getFestivalSnapshot: () => null,

--- a/extension/test/soft-apply-controller.test.ts
+++ b/extension/test/soft-apply-controller.test.ts
@@ -81,6 +81,7 @@ test("chained upsertActiveSoftApply preserves the first session's restore rate",
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
@@ -124,6 +125,7 @@ test("upsertActiveSoftApply for a different url starts a fresh restore rate", ()
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => 10_000,
       armProgrammaticApplyWindow: () => {},
     });
@@ -170,6 +172,7 @@ test("explicit user ratechange cancels a rate-only session without reverting the
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
@@ -215,6 +218,7 @@ test("drift-closed honors the sticky cooldown of a soft-apply taken over by a ra
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
@@ -260,6 +264,7 @@ test("isActiveRateOnlyCatchUp flags pure rate-only sessions but not real soft-ap
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => 10_000,
       armProgrammaticApplyWindow: () => {},
     });
@@ -312,6 +317,7 @@ test("relative-drift session settling via the timer still honors a sticky cooldo
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
@@ -357,6 +363,7 @@ test("a steadily advancing peer no longer cancels a catch-up as target-shifted",
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
@@ -406,6 +413,7 @@ test("a peer's buffering does not abort an active catch-up, a real pause still d
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
@@ -460,6 +468,7 @@ test("hasActiveCorrectionSession covers real soft-apply, not just rate-only catc
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => 20_000,
       armProgrammaticApplyWindow: () => {},
     });
@@ -495,6 +504,7 @@ test("the rate restore on cancel arms a ratechange-scoped window", () => {
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => 10_000,
       armProgrammaticApplyWindow: (_signature, _reason, actorId, scope) => {
         armed.push({ actorId, scope });
@@ -535,6 +545,7 @@ test("cancel restores an elevated defaultPlaybackRate the player already reset",
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => 10_000,
       armProgrammaticApplyWindow: () => {},
     });
@@ -580,6 +591,7 @@ test("cancel still leaves an explicit user rate alone", () => {
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => 10_000,
       armProgrammaticApplyWindow: () => {},
     });
@@ -620,6 +632,7 @@ test("arms the soft-apply cooldown on the monotonic clock by default", () => {
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       armProgrammaticApplyWindow: () => {},
     });
 
@@ -658,6 +671,7 @@ test("getActiveCorrectionBaseRate reports the room's base rate for the whole lif
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => now,
       armProgrammaticApplyWindow: () => {},
     });
@@ -712,6 +726,7 @@ test("the correction session is found through a festival bare-route alias", () =
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => 10_000,
       armProgrammaticApplyWindow: () => {},
     });
@@ -765,6 +780,7 @@ test("a stale session cannot borrow the festival alias of another share", () => 
       debugLog: () => {},
       userGestureGraceMs: 300,
       programmaticApplyWindowMs: 700,
+      bufferPauseUpgradeMs: 1_500,
       getMonotonicNow: () => 10_000,
       armProgrammaticApplyWindow: () => {},
     });

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -2077,6 +2077,48 @@ test("sync controller reports paused for a paused video whose last broadcast was
   assert.equal(latchedPayload.playState, "paused");
 });
 
+test("sync controller suppresses the echo of a remote buffering applied to an already-paused element", async () => {
+  // #260 review. Applying a remote `buffering` never starts playback, so on an
+  // element that is already paused the apply's own `canplay`/`seeking` echoes
+  // report `paused` — the only thing that element can say about itself. The
+  // programmatic signature says `buffering`, and judging the two incompatible
+  // let the echo escape and broadcast `paused` back at a room that was merely
+  // buffering, stopping everyone in it.
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({ paused: true, readyState: 4, currentTime: 40 });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.hasReceivedInitialRoomState = true;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.activeRoomCode = "ROOM01";
+  harness.runtimeState.activeSharedUrl = sharedVideo.url;
+  // The state left behind by applying a remote `buffering`.
+  harness.runtimeState.intendedPlayState = "buffering";
+  harness.runtimeState.programmaticApplySignature = {
+    url: sharedVideo.url,
+    playState: "buffering",
+    currentTime: 40,
+    playbackRate: 1,
+  };
+  harness.runtimeState.programmaticApplyAt = 20_000;
+  harness.runtimeState.programmaticApplyUntil = 20_700;
+  harness.runtimeState.programmaticApplyScope = "all";
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+  harness.setNow(20_100);
+
+  await harness.controller.broadcastPlayback(video, "canplay");
+
+  assert.deepEqual(harness.runtimeMessages, []);
+});
+
 test("sync controller suppresses local end-pause broadcasts from non-sharer autoplay guard", async () => {
   const harness = createControllerHarness();
   const sharedVideo = {

--- a/extension/test/sync-controller.test.ts
+++ b/extension/test/sync-controller.test.ts
@@ -352,9 +352,12 @@ test("sync controller invalidates a queued remote-stop pause on playback reset",
       harness.runtimeState.playbackContextGeneration,
       previousGeneration + 1,
     );
-    assert.equal(harness.runtimeState.pauseStartedAt, 0);
-    assert.equal(harness.runtimeState.pauseClassifiedAsBuffer, false);
     assert.equal(pauseCalls, 0);
+    // The room-level reset must NOT touch the local pause classification: the
+    // element is still sitting in the very pause it describes, and the pending
+    // buffer-pause upgrade verifies itself against these fields (#258).
+    assert.equal(harness.runtimeState.pauseStartedAt, 9_900);
+    assert.equal(harness.runtimeState.pauseClassifiedAsBuffer, true);
   } finally {
     windowHarness.restore();
   }
@@ -2001,6 +2004,77 @@ test("sync controller broadcasts paused once buffer-pause upgrade window elapses
     harness.runtimeMessages[0] as { payload: { playState: string } }
   ).payload;
   assert.equal(payload.playState, "paused");
+});
+
+test("sync controller reports paused for a paused video whose last broadcast was buffering", async () => {
+  // #258: `intendedPlayState` is written to whatever was last broadcast, so a
+  // single buffer-classified pause used to latch every later read of a plainly
+  // paused element to `buffering` — including the share snapshot, and including
+  // the upgrade re-broadcast that exists to undo it. The state below is what the
+  // real flow holds after a load-time buffer pause has been broadcast and its
+  // window has elapsed.
+  const harness = createControllerHarness();
+  const sharedVideo = {
+    videoId: "BV1xx411c7mD",
+    url: "https://www.bilibili.com/video/BV1xx411c7mD?p=1",
+    title: "Video",
+  };
+  const video = createVideo({ paused: true, readyState: 4, currentTime: 40 });
+
+  harness.runtimeState.hydrationReady = true;
+  harness.runtimeState.pendingRoomStateHydration = false;
+  harness.runtimeState.localMemberId = "local-member";
+  harness.runtimeState.intendedPlayState = "buffering";
+  harness.runtimeState.pauseStartedAt = 20_000;
+  harness.runtimeState.pauseClassifiedAsBuffer = false;
+  harness.setSharedVideo(sharedVideo);
+  harness.setCurrentPlaybackVideo(sharedVideo);
+  harness.setVideoElement(video);
+
+  harness.controller = createSyncController({
+    runtimeState: harness.runtimeState,
+    lastAppliedVersionByActor: new Map(),
+    broadcastLogState: { key: null, at: 0 },
+    ignoredSelfPlaybackLogState: { key: null, at: 0 },
+    localIntentGuardMs: 500,
+    pauseHoldMs: 1_000,
+    initialRoomStatePauseHoldMs: 1_500,
+    remoteEchoSuppressionMs: 800,
+    remotePlayTransitionGuardMs: 500,
+    remoteFollowPlayingWindowMs: 3_000,
+    programmaticApplyWindowMs: 700,
+    userGestureGraceMs: 300,
+    bufferPauseUpgradeMs: 1_500,
+    remotePauseDebounceMs: 0,
+    duplicateBroadcastWindowMs: 1_000,
+    nextSeq: () => 1,
+    markBroadcastAt: () => {},
+    getMonotonicNow: () => 21_700,
+    debugLog: (message) => harness.debugLogs.push(message),
+    shouldLogHeartbeat: () => true,
+    sendPlaybackUpdate: async (payload) => {
+      harness.runtimeMessages.push({
+        type: "content:playback-update",
+        payload,
+      });
+      return null;
+    },
+    requestRoomStateHydration: async () => null,
+    getVideoElement: () => video,
+    getCurrentPlaybackVideo: async () => sharedVideo,
+    getSharedVideo: () => sharedVideo,
+    normalizeUrl: (url) => url?.trim() ?? null,
+    notifyRoomStateToasts: () => {},
+    maybeShowSharedVideoToast: () => {},
+  });
+
+  await harness.controller.broadcastPlayback(video, "pause");
+
+  assert.equal(harness.runtimeMessages.length, 1);
+  const latchedPayload = (
+    harness.runtimeMessages[0] as { payload: { playState: string } }
+  ).payload;
+  assert.equal(latchedPayload.playState, "paused");
 });
 
 test("sync controller suppresses local end-pause broadcasts from non-sharer autoplay guard", async () => {


### PR DESCRIPTION
## 现象

创建房间后首次点同步，**接收端新开的标签页自己播了起来**，并把 `playing` 广播回房间，共享端跟着一起播 —— 而共享端的视频从头到尾是暂停的。

关键日志（共享端在 6.01 秒处暂停，房间态却是 `buffering`）：

```
[共享端] Ignored self playback ... playState=buffering ... localPaused=true
[共享端] -> video:share
         <- room:state ... playState=buffering t=6.01
[接收端] Apply playback playState=buffering seq=8
         Playback reconcile mode=hard-seek reason=paused-or-buffering   ← 只 seek，不暂停
         Remote echo skipped by playState playing != buffering
         Dispatch playback update playState=playing source=canplay      ← 自动播放被当作真实播放
[共享端] Apply playback actor=<接收端> playState=playing → video.play()
```

## 根因

两处，同一个病根：**状态判定被"上一次广播了什么"污染**。

### 1. `getPlayState` 的无界闩锁（自初始提交即存在）

```ts
if (video.paused) {
  return intendedPlayState === "buffering" ? "buffering" : "paused";
}
```

而每次广播都把 `intendedPlayState` 写成刚发出去的状态（`sync-controller.ts:1596`）。于是页面加载期**一次**被判为缓冲的暂停，会把此后所有读数闩死在 `buffering` 上，只要视频还暂停着——包括 `video:share` 快照，也包括本该解除它的升级重播。

有界的那份判定（`pauseClassifiedAsBuffer` + 1500ms 窗口）因此从未真正生效：`getBroadcastPlayState` 的 buffer 分支要求 `basePlayState === "paused"`，而闩锁让它永远不是。

**下游为什么致命**：接收端对 `buffering` 不暂停（`applyPendingPlaybackApplication` 刻意如此 —— 缓冲中的对端是"想播但卡住"），`hasRecentRemoteStopIntent` 也只认 `paused`，于是加载暂停与 pause hold 全部失效，新标签页的自动播放被当成真实播放广播回房间。

**改法**：`getPlayState` 只报元素自身状态并收为模块私有；新增 `getReportedPlayState` 承载**唯一一份**有界分类，广播漏斗、共享快照、soft-apply 签名三处共用。共享快照此前根本不走窗口判定，是 `buffering` 被无限期发出去的直接出口。

### 2. 升级定时器被房间级事件误杀（#253 引入）

`armBufferPauseUpgrade` 的三道自校验读的是房间级 `playbackContextGeneration`，而**共享自己的视频必然触发** `resetPlaybackSyncState`（切换 shared url），它既 bump 了该计数器，又清空了校验要比对的 `pauseStartedAt` / `pauseClassifiedAsBuffer`。升级于是被"刚刚发布了那条 `buffering` 的那个事件"本身干掉，房间再也收不到纠正用的 `paused`。

**改法**：拆成两个计数器。`playbackContextGeneration` 仍归房间级延迟工作（排队的加载暂停、在途广播）；新增 `playerContextGeneration` 只由真实导航（`resetUserGestureState`）推进，升级定时器读后者。房间级 reset 不再清除描述本地元素的暂停分类 —— 换个共享 URL 并不能结束元素正处的那次暂停。#253 的本意（导航必须丢弃升级）原样保留。

## 版本对照

1.3.2 同样存在缺陷 1，但彼时 reset 会把 `intendedPlayState` 复位、升级还能跑，窗口很窄（共享必须早于升级重播）。据此做了可证伪预测并在 1.3.2 上验证通过：**页面加载后等几秒再共享，1.3.2 同样复现**。#253 之后变成必现。

## 回归覆盖

六条，逐条回退它守护的那处判据均**必失败**（已用 cp 备份逐个验证）：

| 探针 | 失败的测试 |
|---|---|
| 还原 `intendedPlayState` 闩锁 | 广播 `paused` ✗、共享快照 `paused` ✗ |
| 共享快照绕过有界判定 | 窗口内仍报 `buffering` ✗ |
| 升级定时器改回房间级计数器 | 房间级 reset 后升级仍执行 ✗ |
| reset 改回清除暂停分类 | 分类存活断言 ✗ |
| （保留）导航仍丢弃升级 | #253 本意 |

## 验证

预提交序列逐项独立退出码（未用管道截断）：`format:check` / `lint` / `typecheck` / `build` / `test`（671 通过 / 0 失败） / `audit` 全为 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)