### PR TITLE
fix(server): 僵死 Redis 不再让心跳永久停摆且不报错

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,13 +117,14 @@ before changing the code it describes.
   the caller without cancelling the command. A shutdown step that ran out of its
   budget is DEGRADED, not failed. A join whose index write fails is aborted, not
   seated.
-- **A background pass that cannot time out cannot be observed** (#261): every
-  tick of `maintenance-pass` records exactly one outcome, a cap that does not
-  cancel the call means a pass never runs on top of another, and `stop` waits
-  for the real call but only inside its budget — reporting it when the budget
-  was not enough, since that overrun used to be visible as a failed shutdown
-  step. The cap belongs to the caller — the room store client still has no
-  `commandTimeout`.
+- **A background pass that cannot time out cannot be observed** (#261, #263):
+  every tick of `maintenance-pass` records exactly one outcome, a cap that does
+  not cancel the call means a pass never runs on top of another, and `stop`
+  waits for the real call but only inside its budget — reporting it when the
+  budget was not enough, since that overrun used to be visible as a failed
+  shutdown step. The cap is derived from what a late pass costs (the heartbeat's
+  from `NODE_HEARTBEAT_TTL_MS`), and belongs to the caller — neither Redis
+  client has a `commandTimeout`.
 - **One-shot broadcasts need a retry trail** (#242): most `room_state_updated`
   sends are repeated by the next update, but the share-ownership resync and the
   runtime index reaper's announcement are not — losing one loses the room until a

--- a/docs/reference/invariants.md
+++ b/docs/reference/invariants.md
@@ -316,16 +316,20 @@ one-shot, and both lose the room permanently when the bus rejects them (#242):
 
 ## A background pass that cannot time out cannot be observed
 
-`room-reaper` and `room-index-reconciler` both run one async pass against Redis
-per tick. Neither had a timeout anywhere on that path, and neither did the room
-store's client — `lazyConnect` and `maxRetriesPerRequest: 1` bound retries, not
-how long a command that Redis already accepted may take to answer. A half-open
-connection therefore left a pass pending forever, and the reaper stopped
-collecting expired rooms with **no** signal at all: both series of
-`bili_syncplay_room_reaper_sweeps_total` went flat, so an alert on the failure
-rate never fired, and only a manual restart recovered (#261). All three rules
-below live in `maintenance-pass.ts` — one driver, because the same defect
-appeared in both hand-written copies:
+`room-reaper`, `room-index-reconciler` and `node-heartbeat` each run one async
+pass against Redis per tick. None had a timeout anywhere on that path, and
+neither Redis client has one either — `lazyConnect` and `maxRetriesPerRequest:
+1` bound retries, not how long a command that Redis already accepted may take to
+answer. A half-open connection therefore left a pass pending forever, and the
+reaper stopped collecting expired rooms with **no** signal at all: both series
+of `bili_syncplay_room_reaper_sweeps_total` went flat, so an alert on the
+failure rate never fired, and only a manual restart recovered (#261). The
+heartbeat failed the same way and worse: `node_heartbeat_failed` was only ever
+reachable through the beat's `.catch`, so a beat that never settled logged
+nothing at all, while other nodes aged this one out of the cluster index and
+reaped its sessions — from a node still serving clients (#263). All the rules
+below live in `maintenance-pass.ts` — one driver, because the same defect turned
+up in every hand-written copy:
 
 - **Every tick records exactly one outcome.** That is what makes "the rate went
   flat" mean "the timer is gone" and nothing else. A pass that outlives its cap
@@ -359,8 +363,21 @@ appeared in both hand-written copies:
   outstanding. Bounding a wait and dropping its signal in the same change is how
   a fix for silence reintroduces it one step down.
 
-The cap belongs to the caller, not to the connection: the room store's client
-still has no `commandTimeout`, so the command itself stays out on the socket.
+- **The cap is derived from what a late pass costs, not picked for comfort.**
+  The reaper's is a flat 30s under a 60s default interval. The heartbeat's is
+  computed (`heartbeatTimeoutMs`): half an interval, and never more than a third
+  of `NODE_HEARTBEAT_TTL_MS` — because the consequence of a late beat is other
+  nodes calling this one stale at `staleAt` and reaping its sessions at
+  `expiresAt`. A cap that fired at the same time as the expiry would answer a
+  question nobody could still act on. Below the interval is the other half of
+  the rule: it is what makes the tick after a timeout a `stalled` rather than an
+  `overlapped`.
+
+The cap belongs to the caller, not to the connection: neither the room store's
+nor the runtime store's client has a `commandTimeout`, so the command itself
+stays out on the socket. `heartbeatNode` in particular is a direct `MULTI` —
+it does not go through the write queue, so the queue's own
+`pendingOperationTimeoutMs` never applied to it.
 Adding one there would bound the request path (`get_room` / `update_room`) too,
 which is a separate decision with its own retry semantics to weigh — deliberately
 not taken in #261.

--- a/docs/reference/invariants.zh-CN.md
+++ b/docs/reference/invariants.zh-CN.md
@@ -228,12 +228,15 @@
 
 ## 不能超时的后台轮次，也就无法被观测
 
-`room-reaper` 与 `room-index-reconciler` 每次触发都对 Redis 跑一轮异步任务。这条链路上原本没有任何超时，
-房间存储的客户端也没有——`lazyConnect` 与 `maxRetriesPerRequest: 1` 约束的是重试次数，
-而不是 Redis 已经收下的那条命令可以花多久回应。于是连接半开时一轮任务会永久挂起，
-reaper 不再回收过期房间，却**没有任何**信号：`bili_syncplay_room_reaper_sweeps_total`
-的两条序列一起静止，只看失败率的告警不会触发，恢复只能靠人工重启（#261）。
-下面三条规则统一放在 `maintenance-pass.ts` 里——一份驱动，因为同一个缺陷在两份手写副本里各出现了一次：
+`room-reaper`、`room-index-reconciler` 与 `node-heartbeat` 每次触发都对 Redis 跑一轮异步任务。
+这条链路上原本没有任何超时，两个 Redis 客户端也都没有——`lazyConnect` 与
+`maxRetriesPerRequest: 1` 约束的是重试次数，而不是 Redis 已经收下的那条命令可以花多久回应。
+于是连接半开时一轮任务会永久挂起，reaper 不再回收过期房间，却**没有任何**信号：
+`bili_syncplay_room_reaper_sweeps_total` 的两条序列一起静止，只看失败率的告警不会触发，
+恢复只能靠人工重启（#261）。心跳坏得一样、后果更重：`node_heartbeat_failed` 只能通过那一拍的
+`.catch` 抵达，所以一拍永远不 settle 就什么都不会记，与此同时其他节点把它从集群索引里判老、
+回收它的 session——而它还在服务客户端（#263）。
+下面这些规则统一放在 `maintenance-pass.ts` 里——一份驱动，因为同一个缺陷在每一份手写副本里都出现了：
 
 - **每一次触发都恰好记下一个结果。** 只有这样，"速率变平"才只能意味着"定时器没了"。
   超过上限的一轮记为 `error`，而不是沉默。如果上限只报告**第一次**僵死的触发，
@@ -256,7 +259,16 @@ reaper 不再回收过期房间，却**没有任何**信号：`bili_syncplay_roo
   欠调用方一条 `onSettleTimeout`，把仍未回应的调用数报出来。
   在同一次改动里既给等待加了界、又把它的信号丢掉，正是"治沉默的修复在下一步重新制造沉默"的做法。
 
-上限属于调用方，不属于连接：房间存储的客户端仍然没有 `commandTimeout`，命令本身照样挂在 socket 上。
+- **上限是由"这一轮迟到要付什么代价"推出来的，不是拍脑袋图省事定的。**
+  reaper 是固定 30s（默认间隔 60s）。心跳则是算出来的（`heartbeatTimeoutMs`）：半个间隔，
+  且不超过 `NODE_HEARTBEAT_TTL_MS` 的三分之一——因为一拍迟到的代价是别的节点在 `staleAt`
+  把它判老、在 `expiresAt` 回收它的 session。上限如果跟过期同时触发，那就是在回答一个
+  已经没人能据此行动的问题。"低于间隔"是这条规则的另一半：正是它让超时之后的那次触发
+  是 `stalled` 而不是 `overlapped`。
+
+上限属于调用方，不属于连接：房间存储与 runtime store 的客户端都仍然没有 `commandTimeout`，
+命令本身照样挂在 socket 上。尤其 `heartbeatNode` 是直连的 `MULTI`——它不走写回队列，
+所以队列自己的 `pendingOperationTimeoutMs` 从来就没管到它。
 在那里加超时会连带约束请求路径（`get_room` / `update_room`），那是另一个需要单独权衡重试语义的决定——
 #261 有意没有做。
 

--- a/docs/runbook/multi-node-operations.md
+++ b/docs/runbook/multi-node-operations.md
@@ -375,6 +375,35 @@ this series at all, so its absence there is expected rather than a stall.
   pass that collected something. Under steady traffic the lazy read path empties
   the backlog before each sweep, so a healthy reaper can stay silent for hours.
 
+### Why is a node missing or shown as expired?
+
+A node that stops beating drops out of the cluster index: the global admin shows
+it stale and then offline, and another node's runtime index reaper eventually
+reaps its sessions — while it may still be serving WebSocket clients. Read the
+node's OWN logs before believing the view from outside, because the two answer
+different questions: "others cannot see it" and "it knows why".
+
+- `node_heartbeat_sent` — beating. Absent for longer than
+  `NODE_HEARTBEAT_INTERVAL_MS` with nothing below, and the process itself is
+  gone.
+- `node_heartbeat_failed`, `reason=node_heartbeat_write_failed` — Redis
+  answered, with an error. Message on the same line.
+- `node_heartbeat_failed`, `reason=node_heartbeat_write_timeout` — Redis did not
+  answer within the beat's cap (half an interval, never more than a third of
+  `NODE_HEARTBEAT_TTL_MS`). A stalled connection or a blocked Redis. The cap is
+  deliberately well under the TTL, so this line lands **before** other nodes can
+  call this one stale — if you are looking at an expired node and its logs show
+  these, the stall started roughly one TTL before the expiry (#263).
+- `node_heartbeat_failed`, `reason=node_heartbeat_write_stalled` — the tick
+  found the previous beat's EXEC still unanswered past its cap and did not issue
+  another. Always follows a timeout; on its own it means the stall is ongoing.
+- `node_heartbeat_abandoned_at_shutdown` — the node was shutting down with a
+  beat still unanswered, so it stopped waiting. Expected on a node whose Redis
+  was already stalled; on its own it explains nothing else.
+
+As with the reaper, the cap only bounds how long the heartbeat waits, not the
+command: the runtime store's client sets no `commandTimeout` either.
+
 When troubleshooting, check these together first:
 
 ```bash

--- a/docs/runbook/multi-node-operations.zh-CN.md
+++ b/docs/runbook/multi-node-operations.zh-CN.md
@@ -374,6 +374,31 @@ sum(rate(bili_syncplay_room_reaper_sweeps_total{result="error"}[<窗口>])) by (
   东西时才记。持续访问下惰性读取路径会在每轮扫描前把积压删光，健康的 reaper
   也可以长期不记。
 
+### 某个节点不见了或显示已过期？
+
+停止心跳的节点会从集群索引里掉出去：Global Admin 先显示 stale 再显示 offline，
+另一个节点的 runtime index reaper 最终会回收它的 session——而它可能仍在服务
+WebSocket 客户端。先读**该节点自己的日志**再去信外部视图，因为两者回答的是不同的
+问题："别人看不见它"与"它知道为什么"。
+
+- `node_heartbeat_sent`——在跳。超过 `NODE_HEARTBEAT_INTERVAL_MS` 还没有，且下面
+  几条也没有，那就是进程本身没了。
+- `node_heartbeat_failed`，`reason=node_heartbeat_write_failed`——Redis 回了，回
+  的是错误。错误内容在同一行。
+- `node_heartbeat_failed`，`reason=node_heartbeat_write_timeout`——Redis 在这一拍
+  的上限内没有回应（半个间隔，且不超过 `NODE_HEARTBEAT_TTL_MS` 的三分之一）。连接
+  僵死或 Redis 被阻塞。这个上限有意远小于 TTL，所以这条日志会**先于**其他节点把它
+  判为 stale 落地——如果你正在看一个已过期的节点而它的日志里是这几条，那僵死大约
+  开始于过期时刻的一个 TTL 之前（#263）。
+- `node_heartbeat_failed`，`reason=node_heartbeat_write_stalled`——本次触发发现上
+  一拍的 EXEC 已超过上限仍未回应，于是没有再发一条。它总是跟在一次 timeout 之后；
+  单独看到它，说明僵死还在持续。
+- `node_heartbeat_abandoned_at_shutdown`——节点关闭时还有一拍没回应，于是不再等。
+  在 Redis 本来就僵死的节点上出现属于预期；它本身不额外说明任何问题。
+
+与 reaper 一样，这个上限只约束心跳等多久，并不约束命令本身：runtime store 的客户端
+同样没有设置 `commandTimeout`。
+
 排障时优先同时查看：
 
 ```bash

--- a/server/src/admin/event-visibility.ts
+++ b/server/src/admin/event-visibility.ts
@@ -1,7 +1,20 @@
+/**
+ * Infrastructure plumbing the admin event list hides unless asked for.
+ *
+ * A new event belongs here when its closest existing sibling is here: every
+ * `node_heartbeat_*` is (they say nothing about a room), and so is
+ * `server_shutdown_step_failed` — which is what the `*_abandoned_at_shutdown`
+ * lines replaced for the maintenance timers that now stop on their own budget
+ * (#261, #263). Room-lifecycle events stay visible, including
+ * `room_persist_failed` and `room_index_reconcile_failed`, so their `reason`
+ * variants are not listed here either.
+ */
 const HIDDEN_SYSTEM_EVENTS = new Set([
   "admin_audit_log_append_failed",
+  "node_heartbeat_abandoned_at_shutdown",
   "node_heartbeat_failed",
   "node_heartbeat_sent",
+  "node_heartbeat_skipped",
   "redis_runtime_store_operation_failed",
   "room_event_bus_error",
   "room_event_bus_invalid_message",
@@ -9,6 +22,8 @@ const HIDDEN_SYSTEM_EVENTS = new Set([
   "room_event_handler_failed",
   "room_event_publish_failed",
   "room_event_published",
+  "room_index_reconcile_abandoned_at_shutdown",
+  "room_reaper_sweep_abandoned_at_shutdown",
   "runtime_index_reaper_failed",
   "runtime_index_sessions_reaped",
   "server_shutdown_step_failed",

--- a/server/src/maintenance-pass.ts
+++ b/server/src/maintenance-pass.ts
@@ -4,21 +4,25 @@ import { clampTimerIntervalMs } from "./timers.js";
 /**
  * A background maintenance job on a timer, bounded in every direction.
  *
- * `room-reaper` and `room-index-reconciler` are the same shape: an interval
- * fires, one async pass runs against Redis, its outcome is logged, and a
- * shutdown step waits the pass out before the room store is closed. Both grew
- * that shape by hand, and both had the same hole — nothing on the path had a
- * timeout, so a stalled connection (TCP half-open, a blocked Redis) left the
- * pass pending forever. `maxRetriesPerRequest` does not help: it bounds
- * retries, not how long a command that was already accepted may take to answer.
+ * `room-reaper`, `room-index-reconciler` and `node-heartbeat` are the same
+ * shape: an interval fires, one async pass runs against Redis, its outcome is
+ * logged, and a shutdown step waits the pass out before that Redis connection
+ * is closed. All three grew that shape by hand, and all three had the same hole
+ * — nothing on the path had a timeout, so a stalled connection (TCP half-open,
+ * a blocked Redis) left the pass pending forever. `maxRetriesPerRequest` does
+ * not help: it bounds retries, not how long a command that was already accepted
+ * may take to answer.
  *
  * What that cost (#261): the reaper stopped collecting expired rooms and said
  * nothing — the `ok` and `error` series of
  * `bili_syncplay_room_reaper_sweeps_total` both went flat, so an alert on the
  * failure rate never fired, and recovery meant restarting the process by hand.
+ * And (#263): the heartbeat stopped beating just as quietly, while other nodes
+ * aged this one out of the cluster index and reaped the sessions of a process
+ * that was still serving clients.
  *
- * The three rules that fix it, in one place rather than two hand-written
- * copies (#242's lesson):
+ * The rules that fix it, in one place rather than three hand-written copies
+ * (#242's lesson):
  *
  * - **Every pass answers.** A pass that outlives {@link timeoutMs} is reported
  *   as `timed_out` — the call is NOT cancelled, because nothing can cancel an
@@ -67,6 +71,11 @@ export type MaintenancePassFailure = {
 
 export type MaintenancePass<T> = {
   /**
+   * Arm the timer. Idempotent, and only needed with `autoStart: false` — a
+   * caller that owns its own enable flag arms it after deciding.
+   */
+  start: () => void;
+  /**
    * Stop the timer and wait, bounded, for the call in flight.
    *
    * Resolves either once that call settles or once the settle budget runs out,
@@ -102,6 +111,17 @@ export function createMaintenancePass<Value, Reported>(options: {
   /** Caps ONE pass. Does not cancel it — nothing can. */
   timeoutMs: number;
   settleTimeoutMs?: number;
+  /** Leave the timer disarmed until `start()`. Defaults to arming on creation. */
+  autoStart?: boolean;
+  /**
+   * `unref` the timer, for a job the process need not stay alive for.
+   *
+   * Off by default: the reaper and the reconciler are the only thing keeping
+   * their own work scheduled, so an idle event loop draining past them would
+   * lose it silently. The heartbeat opts in — it only reports state, and a
+   * process with nothing else to do must still be able to exit.
+   */
+  unrefTimer?: boolean;
   run: () => Promise<Value>;
   /** Called only for a pass that answered inside its cap. */
   onSuccess: (value: Value) => Reported;
@@ -196,16 +216,34 @@ export function createMaintenancePass<Value, Reported>(options: {
     return options.onSuccess(value);
   }
 
-  const intervalId = setInterval(() => {
-    // The handlers own their own error reporting; swallowing here only stops a
-    // throwing one from surfacing as an unhandled rejection out of a timer,
-    // which would take the process down over a log line.
-    void runNow().catch(() => undefined);
-  }, clampTimerIntervalMs(options.intervalMs));
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+
+  function start(): void {
+    if (intervalId !== null) {
+      return;
+    }
+    intervalId = setInterval(() => {
+      // The handlers own their own error reporting; swallowing here only stops
+      // a throwing one from surfacing as an unhandled rejection out of a timer,
+      // which would take the process down over a log line.
+      void runNow().catch(() => undefined);
+    }, clampTimerIntervalMs(options.intervalMs));
+    if (options.unrefTimer) {
+      intervalId.unref?.();
+    }
+  }
+
+  if (options.autoStart !== false) {
+    start();
+  }
 
   return {
+    start,
     async stop() {
-      clearInterval(intervalId);
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
       // Waits on the underlying calls, not on `runNow`: a pass that already hit
       // its cap has answered its caller while its Redis command is still in the
       // air, and that command is exactly what the next shutdown step —

--- a/server/src/node-heartbeat.ts
+++ b/server/src/node-heartbeat.ts
@@ -187,6 +187,13 @@ export function createNodeHeartbeat(options: {
     },
     async stop() {
       await pass.stop();
+      // Reset only once the stop has settled, so `start()` can arm it again —
+      // `MaintenancePass.stop()` clears its own timer for exactly that reason,
+      // and the pre-driver implementation set `timer = null` here. A flag that
+      // never resets turns a stop/start cycle into a heartbeat that never beats
+      // again, and the node ages out of the cluster index with nothing said
+      // (#265 review).
+      started = false;
     },
   };
 }

--- a/server/src/node-heartbeat.ts
+++ b/server/src/node-heartbeat.ts
@@ -1,88 +1,192 @@
-import { clampTimerIntervalMs } from "./timers.js";
+import {
+  createMaintenancePass,
+  type MaintenancePassFailureReason,
+} from "./maintenance-pass.js";
 import type { LogEvent, ClusterNodeStatus } from "./types.js";
 import type { RuntimeStore } from "./runtime-store.js";
+
+/**
+ * Exactly what a beat touches, and no more.
+ *
+ * Narrow on purpose, same reason as `runtime-index-reaper`'s: a fake that has
+ * to satisfy the whole `RuntimeStore` gets cast past the checker instead, and
+ * the cast then swallows every later change to the contracts these tests exist
+ * to pin.
+ */
+export type NodeHeartbeatRuntimeStore = Pick<
+  RuntimeStore,
+  | "getStartedAt"
+  | "getConnectionCount"
+  | "getActiveRoomCount"
+  | "getActiveMemberCount"
+  | "heartbeatNode"
+>;
+
+export type NodeHeartbeat = {
+  start: () => void;
+  /**
+   * Beat once now, under the same cap and the same overlap rule as the timer.
+   *
+   * Does NOT reject on a failed write: like every other pass, the outcome is
+   * reported through `node_heartbeat_failed` — a heartbeat whose caller has to
+   * remember to catch is how this stayed silent for a whole class of failure
+   * (#263).
+   */
+  beat: () => Promise<void>;
+  stop: () => Promise<void>;
+};
+
+const HEARTBEAT_FAILURE_REASON: Record<
+  Exclude<MaintenancePassFailureReason, "overlapped">,
+  string
+> = {
+  run_failed: "node_heartbeat_write_failed",
+  timed_out: "node_heartbeat_write_timeout",
+  stalled: "node_heartbeat_write_stalled",
+};
+
+/**
+ * Caps ONE beat, derived from the two settings that decide what a late beat
+ * costs (#263).
+ *
+ * `heartbeatNode` is a direct `MULTI` on the shared runtime store — it does not
+ * go through the write queue, so nothing else on that path bounds it, and a
+ * half-open connection used to leave the beat pending forever: no
+ * `node_heartbeat_sent`, no `node_heartbeat_failed`, and the node quietly
+ * ageing out of the cluster index while it was still serving clients.
+ *
+ * Half an interval, and never more than a third of the TTL. Both halves matter:
+ *
+ * - **Below the interval**, so a beat that has not answered is reported before
+ *   the next one is due — which also means the tick after a timeout reports
+ *   `stalled` rather than `overlapped`, the ordering the runbook reads.
+ * - **Well below the TTL**, so the log line lands long before other nodes can
+ *   call this one stale (`staleAt`) or offline (`expiresAt`). A cap that fired
+ *   at the same time as the expiry would answer a question nobody could still
+ *   act on.
+ */
+export function heartbeatTimeoutMs(intervalMs: number, ttlMs: number): number {
+  return Math.max(1, Math.min(intervalMs / 2, ttlMs / 3));
+}
 
 export function createNodeHeartbeat(options: {
   enabled: boolean;
   instanceId: string;
   serviceVersion: string;
-  runtimeStore: RuntimeStore;
+  runtimeStore: NodeHeartbeatRuntimeStore;
   intervalMs: number;
   ttlMs: number;
   now?: () => number;
   logEvent?: LogEvent;
-}) {
+}): NodeHeartbeat {
   const now = options.now ?? Date.now;
   const staleAfterMs = Math.max(
     options.intervalMs,
     Math.min(options.ttlMs, options.intervalMs * 2),
   );
-  let timer: NodeJS.Timeout | null = null;
-  let pendingBeat: Promise<void> | null = null;
+  const timeoutMs = heartbeatTimeoutMs(options.intervalMs, options.ttlMs);
 
-  async function beat(): Promise<void> {
-    if (!options.enabled) {
-      return;
-    }
-
-    const currentTime = now();
-    const status: ClusterNodeStatus = {
-      instanceId: options.instanceId,
-      version: options.serviceVersion,
-      startedAt: options.runtimeStore.getStartedAt(),
-      lastHeartbeatAt: currentTime,
-      staleAt: currentTime + staleAfterMs,
-      expiresAt: currentTime + options.ttlMs,
-      connectionCount: options.runtimeStore.getConnectionCount(),
-      activeRoomCount: options.runtimeStore.getActiveRoomCount(),
-      activeMemberCount: options.runtimeStore.getActiveMemberCount(),
-      health: "ok",
-    };
-
-    await options.runtimeStore.heartbeatNode(status);
-    options.logEvent?.("node_heartbeat_sent", {
-      instanceId: status.instanceId,
-      version: status.version,
-      connectionCount: status.connectionCount,
-      activeRoomCount: status.activeRoomCount,
-      activeMemberCount: status.activeMemberCount,
-      ttlMs: options.ttlMs,
-      result: "ok",
-    });
-  }
-
-  function scheduleBeat(): void {
-    pendingBeat = beat().catch((error) => {
+  const pass = createMaintenancePass<ClusterNodeStatus, void>({
+    name: "node heartbeat",
+    intervalMs: options.intervalMs,
+    timeoutMs,
+    // The caller owns the enable flag, so the timer is armed from `start()`
+    // rather than from construction.
+    autoStart: false,
+    // A heartbeat is not work the process should stay alive for: it only
+    // reports state, and the shutdown path stops it explicitly. Same as before
+    // this moved onto the shared driver.
+    unrefTimer: true,
+    run: async () => {
+      const currentTime = now();
+      const status: ClusterNodeStatus = {
+        instanceId: options.instanceId,
+        version: options.serviceVersion,
+        startedAt: options.runtimeStore.getStartedAt(),
+        lastHeartbeatAt: currentTime,
+        staleAt: currentTime + staleAfterMs,
+        expiresAt: currentTime + options.ttlMs,
+        connectionCount: options.runtimeStore.getConnectionCount(),
+        activeRoomCount: options.runtimeStore.getActiveRoomCount(),
+        activeMemberCount: options.runtimeStore.getActiveMemberCount(),
+        health: "ok",
+      };
+      await options.runtimeStore.heartbeatNode(status);
+      return status;
+    },
+    onSuccess: (status) => {
+      options.logEvent?.("node_heartbeat_sent", {
+        instanceId: status.instanceId,
+        version: status.version,
+        connectionCount: status.connectionCount,
+        activeRoomCount: status.activeRoomCount,
+        activeMemberCount: status.activeMemberCount,
+        ttlMs: options.ttlMs,
+        result: "ok",
+      });
+    },
+    onFailure: ({ reason, error }) => {
+      if (reason === "overlapped") {
+        // Unreachable while the cap stays below the interval — kept because the
+        // driver's contract allows it and a silent fall-through would hide a
+        // future change to `heartbeatTimeoutMs`.
+        options.logEvent?.("node_heartbeat_skipped", {
+          instanceId: options.instanceId,
+          timeoutMs,
+          result: "ignored",
+        });
+        return;
+      }
       options.logEvent?.("node_heartbeat_failed", {
         instanceId: options.instanceId,
+        reason: HEARTBEAT_FAILURE_REASON[reason],
+        // Only where the cap produced the record; on a write that threw it
+        // would name a limit nothing came near.
+        ...(reason === "run_failed" ? {} : { timeoutMs }),
         result: "error",
         error: error instanceof Error ? error.message : String(error),
       });
-    });
-  }
+    },
+    onSettleTimeout: ({ pendingCalls, budgetMs }) => {
+      // Shutdown goes on to close the runtime store, so this says an EXEC is
+      // still on the connection `redis.quit()` will close. Until the cap
+      // existed the same situation showed up as a `stop_node_heartbeat` that
+      // timed out; a bounded stop has to say it in its own words.
+      options.logEvent?.("node_heartbeat_abandoned_at_shutdown", {
+        instanceId: options.instanceId,
+        pendingBeats: pendingCalls,
+        budgetMs,
+        result: "timeout",
+      });
+    },
+  });
+
+  let started = false;
 
   return {
     start() {
-      if (!options.enabled || timer) {
+      // Idempotent, and the flag is this function's own — `pass.start()` only
+      // guards the timer, so keying off it would let a second `start()` fire
+      // another immediate beat (and, while the first is in flight, report it as
+      // skipped). The old implementation returned early on `timer` existing;
+      // that guarantee has to survive the move to the shared driver.
+      if (!options.enabled || started) {
         return;
       }
-
-      scheduleBeat();
-      timer = setInterval(() => {
-        scheduleBeat();
-      }, clampTimerIntervalMs(options.intervalMs));
-      timer.unref?.();
+      started = true;
+      pass.start();
+      // Immediately, not one interval from now: the cluster index should carry
+      // this node from the moment it starts serving, not from the first tick.
+      void pass.runNow().catch(() => undefined);
     },
     async beat() {
-      await beat();
+      if (!options.enabled) {
+        return;
+      }
+      await pass.runNow();
     },
     async stop() {
-      if (timer) {
-        clearInterval(timer);
-        timer = null;
-      }
-      await pendingBeat;
-      pendingBeat = null;
+      await pass.stop();
     },
   };
 }

--- a/server/src/retry-pacer.ts
+++ b/server/src/retry-pacer.ts
@@ -27,6 +27,8 @@
  * and who decides to retry. Those differ per facility and belong to it.
  */
 
+import { clampTimerIntervalMs } from "./timers.js";
+
 export type RetryPacerOptions = {
   initialDelayMs: number;
   maxDelayMs: number;
@@ -94,7 +96,16 @@ export function createRetryPacer(options: RetryPacerOptions): RetryPacer {
           () => {
             onTimeout(resolve, reject);
           },
-          Math.max(timeoutMs, 1),
+          // Clamped at BOTH ends, and the upper one is the surprising half: a
+          // delay past the 32-bit limit does not mean "very late", it makes
+          // Node fire after ~1ms. Every cap here is derived from a caller's
+          // configuration — `heartbeatTimeoutMs` from `NODE_HEARTBEAT_TTL_MS`,
+          // for one — and those settings only have to be positive integers, so
+          // one absurd value would turn every capped call into an instant
+          // timeout instead of a slow one (#265 review). Same limit
+          // `clampTimerIntervalMs` exists for; this is the other place a delay
+          // reaches `setTimeout`.
+          clampTimerIntervalMs(Math.max(timeoutMs, 1)),
         );
       }),
     ]).finally(() => {

--- a/server/test/event-store.test.ts
+++ b/server/test/event-store.test.ts
@@ -352,6 +352,49 @@ test("in-memory event store hides system events by default and can include them 
   assert.equal(fullView.total, 3);
 });
 
+test("the maintenance timers' own events are hidden alongside their siblings", async () => {
+  const store = createEventStore();
+  // Every `node_heartbeat_*` is plumbing — it says nothing about a room — and
+  // the `*_abandoned_at_shutdown` lines are what a bounded `stop()` now emits
+  // in place of the `server_shutdown_step_failed` these used to cause (#261,
+  // #263). Leaving them visible puts shutdown-degraded noise in the operator's
+  // default event feed exactly when Redis is stalled and it is longest.
+  const hidden = [
+    "node_heartbeat_abandoned_at_shutdown",
+    "node_heartbeat_skipped",
+    "room_index_reconcile_abandoned_at_shutdown",
+    "room_reaper_sweep_abandoned_at_shutdown",
+  ];
+  for (const [index, event] of hidden.entries()) {
+    await store.append({
+      event,
+      timestamp: new Date(
+        Date.parse("2026-03-26T12:00:00.000Z") + index,
+      ).toISOString(),
+      data: { result: "timeout" },
+    });
+  }
+  // The room-lifecycle side of the rule: a failed sweep is still something an
+  // operator should see without asking for system events.
+  await store.append({
+    event: "room_persist_failed",
+    timestamp: "2026-03-26T12:00:10.000Z",
+    data: { reason: "room_reaper_sweep_timeout", result: "error" },
+  });
+
+  const defaultView = await store.query({ page: 1, pageSize: 10 });
+  assert.deepEqual(
+    defaultView.items.map((item) => item.event),
+    ["room_persist_failed"],
+  );
+  const fullView = await store.query({
+    includeSystem: true,
+    page: 1,
+    pageSize: 10,
+  });
+  assert.equal(fullView.total, hidden.length + 1);
+});
+
 test("countsByEventInWindow only indexes allowlisted events while totals count everything", async () => {
   const store = createEventStore();
   const base = Date.parse("2026-03-26T12:00:00.000Z");

--- a/server/test/maintenance-pass.test.ts
+++ b/server/test/maintenance-pass.test.ts
@@ -313,6 +313,50 @@ test("a run that throws synchronously is reported as a failed pass", async () =>
   }
 });
 
+test("unrefTimer decides whether the timer holds the event loop open", async () => {
+  const countRefdTimers = (): number =>
+    process.getActiveResourcesInfo().filter((kind) => kind === "Timeout")
+      .length;
+
+  function build(
+    unrefTimer: boolean,
+  ): ReturnType<typeof createMaintenancePass<void, string>> {
+    return createMaintenancePass<void, string>({
+      name: "test pass",
+      intervalMs: 60_000,
+      timeoutMs: 1_000,
+      settleTimeoutMs: 20,
+      unrefTimer,
+      run: async () => undefined,
+      onSuccess: () => "ok",
+      onFailure: (failure) => failure.reason,
+    });
+  }
+
+  // Sampled with no awaits in between, so the only handles that can appear are
+  // the ones each constructor arms — everything the test runner holds is
+  // identical across the three samples. `getActiveResourcesInfo` lists only
+  // resources keeping the loop alive, which is exactly the question here.
+  const before = countRefdTimers();
+  const holdsLoopOpen = build(false);
+  const withRef = countRefdTimers();
+  const releasesLoop = build(true);
+  const withUnref = countRefdTimers();
+
+  try {
+    // The default, and it must stay the default: the reaper's timer is the only
+    // thing keeping its work scheduled, so an idle loop draining past it would
+    // lose that work with nothing said.
+    assert.equal(withRef, before + 1);
+    // Opted out for the heartbeat, which only reports state — the process must
+    // still be able to exit when nothing else is running.
+    assert.equal(withUnref, withRef);
+  } finally {
+    await holdsLoopOpen.stop();
+    await releasesLoop.stop();
+  }
+});
+
 test("a timer tick does not take the process down when a handler throws", async () => {
   let ticks = 0;
   let sawTick!: () => void;

--- a/server/test/node-heartbeat.test.ts
+++ b/server/test/node-heartbeat.test.ts
@@ -1,9 +1,31 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createNodeHeartbeat } from "../src/node-heartbeat.js";
+import { setTimeout as delay } from "node:timers/promises";
+import {
+  createNodeHeartbeat,
+  heartbeatTimeoutMs,
+  type NodeHeartbeatRuntimeStore,
+} from "../src/node-heartbeat.js";
 import { createRedisRuntimeStore } from "../src/redis-runtime-store.js";
+import type { ClusterNodeStatus } from "../src/types.js";
 
 const REDIS_URL = process.env.REDIS_URL;
+
+/**
+ * Honest fixture: `NodeHeartbeatRuntimeStore` is the narrow slice a beat
+ * touches, so this satisfies it without a cast.
+ */
+function createStubRuntimeStore(
+  heartbeatNode: (status: ClusterNodeStatus) => Promise<void>,
+): NodeHeartbeatRuntimeStore {
+  return {
+    getStartedAt: () => 1,
+    getConnectionCount: () => 2,
+    getActiveRoomCount: () => 3,
+    getActiveMemberCount: () => 4,
+    heartbeatNode,
+  };
+}
 
 function createKeyPrefix(): string {
   return `bsp:test:heartbeat:${Date.now()}:${Math.random().toString(16).slice(2)}:`;
@@ -51,5 +73,337 @@ test("node heartbeat writes shared node status into redis runtime store", async 
   } finally {
     await heartbeat.stop();
     await sharedRuntimeStore.close();
+  }
+});
+
+test("a beat hung on Redis is reported instead of leaving both series silent", async () => {
+  const logged: Array<{ event: string; data: Record<string, unknown> }> = [];
+  let started = 0;
+  const heartbeat = createNodeHeartbeat({
+    enabled: true,
+    instanceId: "node-a",
+    serviceVersion: "test-version",
+    // A half-open connection: `heartbeatNode` is a direct MULTI on the shared
+    // store — it does not go through the write queue, so nothing on that path
+    // bounds it and no error ever comes back (#263).
+    runtimeStore: createStubRuntimeStore(() => {
+      started += 1;
+      return new Promise(() => undefined);
+    }),
+    // Interval 100ms, TTL 300ms, so the cap is 50ms: half an interval, a third
+    // of the TTL.
+    intervalMs: 100,
+    ttlMs: 300,
+    now: () => 10,
+    logEvent: (event, data) => {
+      logged.push({ event, data });
+    },
+  });
+
+  try {
+    // Before the cap this never returned. No `node_heartbeat_sent`, and — the
+    // part that made it invisible — no `node_heartbeat_failed` either: the
+    // `.catch` on the beat was never reached, so the node aged out of the
+    // cluster index while its own logs said nothing at all.
+    await heartbeat.beat();
+    // And a second beat must not put another EXEC on a connection that has
+    // answered neither.
+    await heartbeat.beat();
+  } finally {
+    await heartbeat.stop();
+  }
+
+  assert.equal(started, 1);
+  assert.deepEqual(
+    logged.map((entry) => entry.event),
+    [
+      "node_heartbeat_failed",
+      "node_heartbeat_failed",
+      // stop() returns on its budget rather than waiting the stall out, and
+      // says so: `close_runtime_store` is about to quit that connection.
+      "node_heartbeat_abandoned_at_shutdown",
+    ],
+  );
+  assert.deepEqual(
+    logged
+      .filter((entry) => entry.event === "node_heartbeat_failed")
+      .map((entry) => entry.data.reason),
+    ["node_heartbeat_write_timeout", "node_heartbeat_write_stalled"],
+  );
+  assert.equal(logged[0]?.data.timeoutMs, 50);
+  assert.equal(logged[2]?.data.pendingBeats, 1);
+});
+
+test("a beat that threw keeps its own reason and does not name the cap", async () => {
+  const logged: Array<Record<string, unknown>> = [];
+  const heartbeat = createNodeHeartbeat({
+    enabled: true,
+    instanceId: "node-a",
+    serviceVersion: "test-version",
+    runtimeStore: createStubRuntimeStore(() => {
+      throw new Error("redis is gone");
+    }),
+    intervalMs: 100,
+    ttlMs: 300,
+    now: () => 10,
+    logEvent: (_event, data) => {
+      logged.push(data);
+    },
+  });
+
+  try {
+    await heartbeat.beat();
+  } finally {
+    await heartbeat.stop();
+  }
+
+  assert.equal(logged[0]?.reason, "node_heartbeat_write_failed");
+  assert.equal(logged[0]?.error, "redis is gone");
+  assert.equal("timeoutMs" in (logged[0] ?? {}), false);
+});
+
+test("start() beats immediately, not one interval from now", async () => {
+  const beats: ClusterNodeStatus[] = [];
+  let announceFirst!: () => void;
+  const firstBeat = new Promise<void>((resolve) => {
+    announceFirst = resolve;
+  });
+  const heartbeat = createNodeHeartbeat({
+    enabled: true,
+    instanceId: "node-a",
+    serviceVersion: "test-version",
+    runtimeStore: createStubRuntimeStore(async (status) => {
+      beats.push(status);
+      announceFirst();
+    }),
+    // Far longer than this test will wait, so only the beat `start()` fires
+    // itself can satisfy it. With a short interval the timer would cover for a
+    // `start()` that had dropped the immediate beat, and the test would pass on
+    // a regression.
+    intervalMs: 60_000,
+    ttlMs: 180_000,
+    now: () => 10,
+  });
+
+  try {
+    heartbeat.start();
+    // The cluster index has to carry this node from the moment it starts
+    // serving; waiting a whole interval leaves other nodes free to treat a
+    // healthy new node as absent.
+    await firstBeat;
+    assert.equal(beats[0]?.instanceId, "node-a");
+    assert.equal(beats[0]?.connectionCount, 2);
+    // staleAt is two intervals out — one missed beat is not yet news — capped
+    // by the TTL and floored at a single interval; expiresAt is the full TTL.
+    // Both are stamped from the same instant the beat was built.
+    assert.equal(beats[0]?.staleAt, 120_010);
+    assert.equal(beats[0]?.expiresAt, 180_010);
+  } finally {
+    await heartbeat.stop();
+  }
+});
+
+test("stop() ends the timer", async () => {
+  let beats = 0;
+  let announceSecond!: () => void;
+  const twoBeats = new Promise<void>((resolve) => {
+    announceSecond = resolve;
+  });
+  const heartbeat = createNodeHeartbeat({
+    enabled: true,
+    instanceId: "node-a",
+    serviceVersion: "test-version",
+    runtimeStore: createStubRuntimeStore(async () => {
+      beats += 1;
+      if (beats === 2) {
+        announceSecond();
+      }
+    }),
+    intervalMs: 5,
+    ttlMs: 300,
+    now: () => 10,
+  });
+
+  // The beat timer is deliberately `unref`'d — a heartbeat is not work the
+  // process should stay alive for. In the server the HTTP listener holds the
+  // loop open; here nothing does, so without this the loop drains and the wait
+  // below never resolves.
+  const keepLoopAlive = setInterval(() => undefined, 1_000);
+
+  try {
+    heartbeat.start();
+    // Waits for the timer to have fired rather than asserting a count after a
+    // fixed window: Node does not replay ticks missed while the event loop was
+    // stalled, so a short window makes a correct implementation fail under
+    // load.
+    await twoBeats;
+    await heartbeat.stop();
+
+    const atStop = beats;
+    await delay(40);
+    // Or shutdown leaves a handle beating against a store that is being closed.
+    assert.equal(beats, atStop);
+  } finally {
+    clearInterval(keepLoopAlive);
+  }
+});
+
+test("stop() waits for the beat in flight", async () => {
+  let settled = false;
+  let announceStarted!: () => void;
+  let releaseBeat!: () => void;
+  const started = new Promise<void>((resolve) => {
+    announceStarted = resolve;
+  });
+  const blocked = new Promise<void>((resolve) => {
+    releaseBeat = resolve;
+  });
+
+  const heartbeat = createNodeHeartbeat({
+    enabled: true,
+    instanceId: "node-a",
+    serviceVersion: "test-version",
+    runtimeStore: createStubRuntimeStore(async () => {
+      announceStarted();
+      await blocked;
+      // Crossing a macrotask is what gives this test its teeth — see the
+      // matching note in maintenance-pass.test.ts.
+      await delay(0);
+      settled = true;
+    }),
+    // Long enough that the beat is still inside its cap when stop() runs.
+    intervalMs: 60_000,
+    ttlMs: 180_000,
+    now: () => 10,
+  });
+
+  heartbeat.start();
+  await started;
+  const stopped = heartbeat.stop();
+  // `close_runtime_store` follows this step; returning before the beat settles
+  // would leave its EXEC racing `redis.quit()`.
+  assert.equal(settled, false);
+  releaseBeat();
+  await stopped;
+  assert.equal(settled, true);
+});
+
+test("a disabled heartbeat neither beats nor arms a timer", async () => {
+  let beats = 0;
+  const heartbeat = createNodeHeartbeat({
+    enabled: false,
+    instanceId: "node-a",
+    serviceVersion: "test-version",
+    runtimeStore: createStubRuntimeStore(async () => {
+      beats += 1;
+    }),
+    intervalMs: 5,
+    ttlMs: 300,
+    now: () => 10,
+  });
+
+  heartbeat.start();
+  await heartbeat.beat();
+  await delay(30);
+  await heartbeat.stop();
+  assert.equal(beats, 0);
+});
+
+test("the beat cap lands before anything else can call this node late", () => {
+  // The two settings that decide what a late beat costs. `staleAt` is one
+  // interval out and `expiresAt` a full TTL, so a cap at or above either would
+  // report a timeout nobody could still act on.
+  assert.equal(heartbeatTimeoutMs(15_000, 45_000), 7_500);
+  // TTL-bound: a deployment that beats rarely relative to its TTL must not
+  // inherit a cap that outlives the expiry.
+  assert.equal(heartbeatTimeoutMs(60_000, 45_000), 15_000);
+  // Never above the interval, which is what makes the tick after a timeout a
+  // `stalled` rather than an `overlapped`. Equal only in the degenerate case
+  // where the 1ms floor is doing the work.
+  for (const [intervalMs = 0, ttlMs = 0] of [
+    [15_000, 45_000],
+    [60_000, 45_000],
+    [100, 300],
+  ]) {
+    assert.ok(heartbeatTimeoutMs(intervalMs, ttlMs) < intervalMs);
+  }
+  // The floor: a sub-millisecond cap would fire before the write left the
+  // process, turning every beat into a timeout.
+  assert.equal(heartbeatTimeoutMs(1, 1), 1);
+});
+
+test("start() is idempotent", async () => {
+  let beats = 0;
+  const logged: string[] = [];
+  let announceFirst!: () => void;
+  const firstBeat = new Promise<void>((resolve) => {
+    announceFirst = resolve;
+  });
+  const heartbeat = createNodeHeartbeat({
+    enabled: true,
+    instanceId: "node-a",
+    serviceVersion: "test-version",
+    runtimeStore: createStubRuntimeStore(async () => {
+      beats += 1;
+      announceFirst();
+    }),
+    // Long enough that the timer cannot account for any beat below.
+    intervalMs: 60_000,
+    ttlMs: 180_000,
+    now: () => 10,
+    logEvent: (event) => logged.push(event),
+  });
+
+  try {
+    heartbeat.start();
+    // Two calls while the first beat is still in flight. The overlap guard
+    // absorbs the beat itself, but it reports each one — a `start()` that is
+    // not idempotent turns an idle restart path into skipped-beat noise.
+    heartbeat.start();
+    heartbeat.start();
+    await firstBeat;
+    // And once the beat has ANSWERED the guard no longer absorbs anything: this
+    // is where a non-idempotent start() puts a second write on Redis. The old
+    // implementation returned early on an existing timer; guarding only the
+    // driver's timer would drop that guarantee, because `pass.start()` is
+    // idempotent while the immediate beat beside it is not.
+    await delay(0);
+    heartbeat.start();
+    await delay(0);
+
+    assert.equal(beats, 1);
+    assert.deepEqual(logged, ["node_heartbeat_sent"]);
+  } finally {
+    await heartbeat.stop();
+  }
+});
+
+test("the beat timer does not hold the process open", async () => {
+  const countRefdTimers = (): number =>
+    process.getActiveResourcesInfo().filter((kind) => kind === "Timeout")
+      .length;
+  const heartbeat = createNodeHeartbeat({
+    enabled: true,
+    instanceId: "node-a",
+    serviceVersion: "test-version",
+    runtimeStore: createStubRuntimeStore(async () => undefined),
+    intervalMs: 60_000,
+    ttlMs: 180_000,
+    now: () => 10,
+  });
+
+  // No awaits between the samples: `start()` arms the interval AND fires the
+  // immediate beat, so exactly one ref'd timer is expected — the cap on that
+  // beat, which clears as soon as it answers. A beat timer that had lost its
+  // `unref` would make this two, and would keep a process alive that has
+  // nothing else to do.
+  const before = countRefdTimers();
+  heartbeat.start();
+  const after = countRefdTimers();
+
+  try {
+    assert.equal(after, before + 1);
+  } finally {
+    await heartbeat.stop();
   }
 });

--- a/server/test/node-heartbeat.test.ts
+++ b/server/test/node-heartbeat.test.ts
@@ -407,3 +407,45 @@ test("the beat timer does not hold the process open", async () => {
     await heartbeat.stop();
   }
 });
+
+test("start() works again after stop()", async () => {
+  let beats = 0;
+  let announce!: () => void;
+  let beaten = new Promise<void>((resolve) => {
+    announce = resolve;
+  });
+  const heartbeat = createNodeHeartbeat({
+    enabled: true,
+    instanceId: "node-a",
+    serviceVersion: "test-version",
+    runtimeStore: createStubRuntimeStore(async () => {
+      beats += 1;
+      announce();
+    }),
+    // Long enough that only the beat `start()` fires itself can be counted.
+    intervalMs: 60_000,
+    ttlMs: 180_000,
+    now: () => 10,
+  });
+
+  heartbeat.start();
+  await beaten;
+  await heartbeat.stop();
+
+  beaten = new Promise<void>((resolve) => {
+    announce = resolve;
+  });
+  // A stopped heartbeat has to be startable again — `MaintenancePass.stop()`
+  // clears its own timer for that reason, and the pre-driver implementation
+  // reset its `timer` here. An idempotence flag that never resets would make
+  // this silently do nothing, and the node would age out of the cluster index
+  // with nothing in its log to say why.
+  heartbeat.start();
+  await beaten;
+
+  try {
+    assert.equal(beats, 2);
+  } finally {
+    await heartbeat.stop();
+  }
+});

--- a/server/test/retry-pacer.test.ts
+++ b/server/test/retry-pacer.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { createRetryPacer } from "../src/retry-pacer.js";
+import { MAX_TIMER_INTERVAL_MS } from "../src/timers.js";
+
+test("a cap past the 32-bit timer limit does not fire immediately", async () => {
+  const pacer = createRetryPacer({ initialDelayMs: 1, maxDelayMs: 1 });
+
+  // Node stores a timer delay as a signed 32-bit integer: anything larger is
+  // not "very late", it fires after ~1ms with a TimeoutOverflowWarning. Every
+  // cap on this pacer is derived from configuration that only has to be a
+  // positive integer — `heartbeatTimeoutMs` from `NODE_HEARTBEAT_TTL_MS`, for
+  // one — so one absurd setting would turn every capped call into an INSTANT
+  // timeout rather than a generous one, and a healthy Redis would look dead
+  // (#265 review).
+  //
+  // The work answers well after that ~1ms and well before any honest reading of
+  // the cap, so an unclamped delay rejects here and a clamped one resolves.
+  const answered = await pacer.capAttempt(
+    delay(30, "answered"),
+    MAX_TIMER_INTERVAL_MS + 1,
+    () => new Error("capped"),
+  );
+
+  assert.equal(answered, "answered");
+  pacer.stop();
+});
+
+test("a cap inside the limit still fires", async () => {
+  const pacer = createRetryPacer({ initialDelayMs: 1, maxDelayMs: 1 });
+
+  // The other half of the clamp: it must not have turned every cap into a
+  // no-op. Same call, an ordinary budget, work that takes far longer.
+  await assert.rejects(
+    pacer.capAttempt(delay(200, "answered"), 5, () => new Error("capped")),
+    /capped/,
+  );
+  pacer.stop();
+  // The call outlived its cap and is still pending — exactly the state
+  // `settleTracked` exists for. Bounded, so this test does not sit out the 200ms.
+  await pacer.settleTracked(10);
+});


### PR DESCRIPTION
## Summary

把 node heartbeat 迁到 #261/#262 引入的 `maintenance-pass`，补上它缺的那道上限。

`heartbeatNode` 是**直连**的 `MULTI`（`redis-runtime-store.ts:1741`），不走写回队列，所以
`trackOperation` 的 `pendingOperationTimeoutMs` 从来就没管到它——顺带一提，`trackOperation`
全文件只有 `add_member` 一处调用点，"runtime store 有超时"这个印象比实际覆盖面窄得多。
再加上客户端没有 `commandTimeout`，连接半开时一拍会永久挂起，而 `node_heartbeat_failed`
只能经由那一拍的 `.catch` 抵达：**既没有 sent 也没有 failed**，本节点日志一片空白，与此
同时别的节点把它判老、回收它的 session，而它还在服务 WebSocket 客户端。

迁移后拿到驱动的三条规则（每次触发恰好记一个结果 / 上限不取消调用因而不重叠 / `stop()`
有界等待并在预算耗尽时补一条 `node_heartbeat_abandoned_at_shutdown`），驱动新增两个选项
保留心跳原有语义：`autoStart`（心跳自己持有 enable 开关）与 `unrefTimer`（心跳不该把进程
托住）。

**上限由代价推导，不是拍脑袋定的**：`heartbeatTimeoutMs = min(间隔/2, TTL/3)`，默认
15s/45s 下是 7.5s。两半都必要——低于间隔，超时之后的那次触发才会是 `stalled` 而不是
`overlapped`；远低于 TTL，这条日志才会**先于**别的节点把本节点判为 stale 落地，否则就是在
回答一个没人能再据此行动的问题。

## 本地复审顺带修的三条

1. **`start()` 恢复幂等**。`pass.start()` 只护住定时器，紧随其后的立即一拍不受它保护——
   重复调用会多写一次 Redis，若首拍仍在飞还会记一条假的 `node_heartbeat_skipped`。旧实现
   靠 `if (timer) return` 保证过这一点，不能在迁移中丢掉。
2. **四个维护事件补进 `HIDDEN_SYSTEM_EVENTS`**：两个心跳事件，以及 **#262 漏掉的**两条
   `*_abandoned_at_shutdown`。判据是"看最近的同族事件"：所有 `node_heartbeat_*` 都是隐藏的，
   而 `*_abandoned_at_shutdown` 替代的正是本就隐藏的 `server_shutdown_step_failed`；
   `room_persist_failed` / `room_index_reconcile_failed` 是房间生命周期事件、保持可见，
   所以它们的 reason 变体不列入。
3. **`runtimeStore` 依赖收窄**为 `NodeHeartbeatRuntimeStore`（`Pick` 出一拍真正用到的五个
   方法），测试夹具因此不需要 `as unknown as RuntimeStore`。

## 不在范围内

runtime store 客户端的 `commandTimeout` —— 与 room store 那侧同一个决定，会连带约束该
客户端上的所有命令，仍待单独评估。上限属于调用方，命令本身照样挂在 socket 上，runbook 与
invariants 都写明了。event store 的无界 append 链是 #264。

## Test plan

- [x] `server/test/node-heartbeat.test.ts` 新增 9 条（原文件只有一条需要 Redis 的集成测试）
- [x] **判别力逐项验证**（`cp` 备份后打探针，非 `git checkout`）：
  - 回退整个 node-heartbeat 到 main → 新测试全数挂掉
  - 去掉 `start()` 的立即一拍 → "start() beats immediately" 失败（间隔设为 60s，否则定时器
    会替它兜底，测试就没有判别力了）
  - 去掉 `onSettleTimeout` 上报 → "a beat hung on Redis…" 失败
  - `unrefTimer` 在驱动侧失效 / 在心跳侧不传 → 两条 `getActiveResourcesInfo()` 测试各自失败
  - 去掉 `start()` 幂等 → "start() is idempotent" 失败（**第一版没有判别力**：三次同步调用会
    被不重叠守卫吸收，改成"等首拍答复之后再 start()"才抓得住）
  - 从 `HIDDEN_SYSTEM_EVENTS` 删掉四个事件 → 新的 event-store 测试失败
- [x] `format:check && lint && typecheck && build && test && audit` 全绿（test 退出码 0，1441 项 0 失败）
- [x] 本地 Redis 集成测试：`REDIS_URL=redis://127.0.0.1:6399 npm run test:server:redis` → 663/663，0 skip
- [x] 本地 codex 复审已跑，三条意见全部采纳并各自补了判别力测试

Fixes #263
