### PR TITLE
fix(server): 防止对账吞掉孤儿房间清理债务

### DIFF
--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -147,6 +147,14 @@ Expected response:
 PONG
 ```
 
+Redis 6.0 or newer is supported. Connectivity alone is not enough when Redis
+ACLs are enabled: the room node and global-admin identities need read/write
+access to the room body/index keys and to both orphan-cleanup handoff keys. For
+the default namespace, include `bsp:rooms-by-expiry` and
+`bsp:room-index-orphans*` in addition to `bsp:room:*`. A missing handoff ACL can
+make bootstrap reconciliation, room listing, or expiry sweeps fail even on a
+single-node deployment.
+
 Expected startup log:
 
 ```text
@@ -475,6 +483,19 @@ If you know only `server/` changed and `packages/protocol` is unchanged, you can
 npm run build -w @bili-syncplay/server
 ```
 
+Before the first restart of a build that uses the room orphan-cleanup handoff:
+
+1. Grant both service identities read/write ACL access to
+   `bsp:room-index-orphans` and `bsp:room-index-orphans-queue` (replace `bsp`
+   with `REDIS_NAMESPACE`).
+2. Include both keys in the same Redis backup. The hash stores outstanding
+   tokened cleanup claims; the sorted set is their bounded rotating delivery
+   index.
+3. Monitor `HLEN bsp:room-index-orphans`. Once the queue is initialized,
+   `ZCARD bsp:room-index-orphans-queue` is normally that value plus one reserved
+   sequence member. Growth or persistent drift means cleanup, ACLs, or key
+   types need investigation.
+
 Single-node restart flow (the units created in step 3):
 
 ```bash
@@ -496,6 +517,24 @@ If you run multiple room nodes, prefer a rolling restart instead of restarting e
 2. verify `GET /readyz`, logs, and the global admin overview recover cleanly
 3. continue with the next room node
 4. restart `global-admin` last
+
+Exception: the first rollout of the orphan-cleanup handoff cannot mix old and
+new room-store holders. An old room node or global-admin can still prune an
+orphan without creating a claim. For that rollout, drain traffic and stop all
+old room nodes and global-admin before starting any new process. Later upgrades
+where both versions implement the handoff may use the rolling order above.
+
+If you must roll back to an older build, do not use one instantaneous
+`HLEN=0` as the drain barrier: shutdown stops the room reaper before the index
+reconciler, so a new claim can still appear while a process exits. Drain room
+traffic and stop every current room node and global-admin first. Only a zero
+observed after all processes exit is stable. If claims remain, start one current
+room node isolated from traffic, wait for successful reaper sweeps until the
+hash is zero, stop it cleanly, and check again after exit; repeat or abort if
+that post-stop check is nonzero. Preserve both handoff keys in backups; older
+builds ignore them, but deleting them loses pending runtime cleanup. A rollback
+to the legacy two-index room store also requires the rebuild procedure in the
+[multi-node deployment guide](./multi-node.md).
 
 ### Graceful shutdown
 

--- a/docs/operations/deployment.zh-CN.md
+++ b/docs/operations/deployment.zh-CN.md
@@ -147,6 +147,12 @@ redis-cli -u redis://127.0.0.1:6379 ping
 PONG
 ```
 
+项目支持 Redis 6.0 及以上版本。开启 Redis ACL 时，仅能连通还不够：Room Node 与
+Global Admin 使用的身份还要能读写房间 body/索引，以及两把孤儿清理交接键。默认命名空间
+下，除 `bsp:room:*` 外还要授权 `bsp:rooms-by-expiry` 与
+`bsp:room-index-orphans*`。即便是单节点部署，漏掉交接键 ACL 也会使启动对账、房间列表或
+过期回收失败。
+
 预期启动日志：
 
 ```text
@@ -475,6 +481,17 @@ npm run build
 npm run build -w @bili-syncplay/server
 ```
 
+首次重启使用房间孤儿清理交接机制的版本前：
+
+1. 给两个服务身份授予 `bsp:room-index-orphans` 与
+   `bsp:room-index-orphans-queue` 的读写 ACL（设置了 `REDIS_NAMESPACE` 时替换
+   `bsp`）。
+2. 在同一份 Redis 备份中同时包含两把键。哈希保存带 token 的未完成清理 claim，
+   sorted set 是其有界轮转投递索引。
+3. 监控 `HLEN bsp:room-index-orphans`。queue 初始化后，
+   `ZCARD bsp:room-index-orphans-queue` 通常应等于前者加一个保留序列成员；持续增长或
+   长期不一致说明清理、ACL 或键类型需要排查。
+
 单机部署重启方式（即第 3 步创建的两个单元）：
 
 ```bash
@@ -496,6 +513,19 @@ sudo systemctl restart bili-syncplay-global-admin
 2. 观察 `GET /readyz`、日志和全局管理面是否恢复正常
 3. 再继续重启下一个 Room Node
 4. 最后重启 `global-admin`
+
+例外：首次上线孤儿清理交接机制时，不能混跑新旧 room-store 持有者。旧版 Room Node 或
+Global Admin 仍可能剪掉孤儿却不创建 claim。因此本次必须先排空流量并停止全部旧版 Room
+Node 与 Global Admin，再启动任一新版本进程。以后两个版本都已实现交接机制时，才可使用
+上面的滚动顺序。
+
+如果必须回滚到旧版本，不要把某一次瞬时 `HLEN=0` 当成排空屏障：关服流程先停 Room
+Reaper、后停索引 Reconciler，进程退出途中仍可能出现新 claim。先排空房间流量并停止全部
+本版本 Room Node 与 Global Admin；只有所有进程退出后看到的零才稳定。若仍有 claim，启动
+一台不接流量的本版本 Room Node，等待成功 reaper sweep 直至哈希归零，再将它完整停止并于
+退出后复查；复查仍非零就重复或中止回滚。备份中要保留两把交接键；旧版本虽会忽略它们，
+删除却会丢失待完成的运行时清理。若回滚目标仍使用旧式双索引 room store，还必须按
+[多节点部署文档](./multi-node.zh-CN.md)执行重建流程。
 
 ### 优雅退出
 

--- a/docs/operations/multi-node-global-admin-migration.md
+++ b/docs/operations/multi-node-global-admin-migration.md
@@ -32,7 +32,7 @@ Recommended role split:
 
 Key families used by the rollout:
 
-- `bsp:room:*`, `bsp:rooms-by-expiry` (`bsp:room-index` and `bsp:room-expiry` are no longer written or read; see the rollback note in `multi-node.md`)
+- `bsp:room:*`, `bsp:rooms-by-expiry`, `bsp:room-index-orphans`, `bsp:room-index-orphans-queue` (`bsp:room-index` and `bsp:room-expiry` are no longer written or read; grant room nodes and global-admin read/write ACL access to both orphan handoff keys, and see the backup, monitoring, and rollback note in `multi-node.md`)
 - `bsp:runtime:*`
 - `bsp:admin:session:*`
 - `bsp:events`
@@ -44,10 +44,19 @@ Key families used by the rollout:
 Before rollout:
 
 1. Confirm Redis connectivity from every node.
-2. Confirm Redis persistence and eviction policy are compatible with your retention expectations.
-3. Confirm `INSTANCE_ID` values are unique.
+2. Confirm every room node and global-admin can read and write `bsp:room-index-orphans*`, backups include both keys, and monitoring tracks `HLEN bsp:room-index-orphans`.
+3. Confirm Redis persistence and eviction policy are compatible with your retention expectations.
+4. Confirm `INSTANCE_ID` values are unique.
 
 ## Rollout Order
+
+One-time compatibility note for the release that first introduces
+`room-index-orphans*`: do not use the phased/rolling order below while an older
+room node or global-admin still holds the room store. An old process can prune
+an orphan without creating a cleanup claim. Drain room traffic, stop every old
+room node and global-admin, then start the new processes and continue the
+phases. Later upgrades where both versions implement the handoff may roll
+normally.
 
 ### Phase 1: Shared Control Plane
 

--- a/docs/operations/multi-node-global-admin-migration.zh-CN.md
+++ b/docs/operations/multi-node-global-admin-migration.zh-CN.md
@@ -35,7 +35,7 @@
 
 当前会使用这些键族：
 
-- `bsp:room:*`、`bsp:rooms-by-expiry`(`bsp:room-index` 与 `bsp:room-expiry` 已不再写入或读取;回滚注意事项见 `multi-node.zh-CN.md`)
+- `bsp:room:*`、`bsp:rooms-by-expiry`、`bsp:room-index-orphans`、`bsp:room-index-orphans-queue`（`bsp:room-index` 与 `bsp:room-expiry` 已不再写入或读取；Room Node 与 Global Admin 都要有两把孤儿交接键的读写 ACL，备份、监控与回滚注意事项见 `multi-node.zh-CN.md`）
 - `bsp:runtime:*`
 - `bsp:admin:session:*`
 - `bsp:events`
@@ -47,10 +47,16 @@
 上线前至少确认：
 
 1. 每个节点都能连通 Redis。
-2. Redis 持久化与淘汰策略符合你的保留预期。
-3. 每个 `INSTANCE_ID` 唯一。
+2. 每个 Room Node 与 Global Admin 都能读写 `bsp:room-index-orphans*`，备份已覆盖两把键，且监控已跟踪 `HLEN bsp:room-index-orphans`。
+3. Redis 持久化与淘汰策略符合你的保留预期。
+4. 每个 `INSTANCE_ID` 唯一。
 
 ## 推荐上线顺序
+
+首次引入 `room-index-orphans*` 的版本有一项一次性兼容要求：只要仍有旧版 Room Node 或
+Global Admin 持有 room store，就不能使用下面的分阶段/滚动顺序。旧进程可能剪掉孤儿却不
+创建清理 claim。应先排空房间流量并停止全部旧版 Room Node 与 Global Admin，再启动新
+进程并继续以下阶段。以后两个版本都已实现交接机制时才可正常滚动。
 
 ### 阶段 1：共享控制面
 

--- a/docs/operations/multi-node.md
+++ b/docs/operations/multi-node.md
@@ -191,11 +191,12 @@ If the edge machine also carries `room-node-a`, `global-admin`, and `redis`, it 
 Redis key families used by the multi-node control plane:
 
 - `bsp:room:*`, `bsp:rooms-by-expiry`: persisted room base state. `bsp:rooms-by-expiry` holds every room scored by its expiry (`+inf` when the room does not expire) and is the single source for listing, counting and reaping.
+- `bsp:room-index-orphans`, `bsp:room-index-orphans-queue`: durable, tokened runtime-cleanup claims for room-index entries whose room body is already gone, plus their bounded rotating delivery index. Both room nodes and global-admin must have read/write ACL access to both keys. Back them up together. Monitor `HLEN bsp:room-index-orphans`; a value that only grows means room-node reaping or runtime teardown is not settling. Once initialized, the queue's `ZCARD` is normally the hash length plus one reserved sequence member; persistent drift identifies a partial write, wrong key type, or ACL problem.
 - `bsp:room-index`, `bsp:room-expiry`: no longer written or read. They are left in place untouched.
 
   **Rolling back** to a build that still reads them needs one step first: that build rebuilds `bsp:room-index` from room bodies on startup, but has no equivalent repair for `bsp:room-expiry`, so rooms whose expiry was set while this build was live would never be reaped. The order is: **stop every node on this build**, run `REDIS_URL=... node server/scripts/rebuild-legacy-room-expiry.mjs` (`DRY_RUN=1` to preview), then start the old build. The scan is a batched read rather than a snapshot, so a node still serving requests could change a room's expiry after the script read it. The script ships in the runtime image. Because every node must already be stopped, run it as a one-off container rather than `docker exec` — there is no running container left to exec into:
 
-  ````bash
+  ```bash
   docker run --rm --network <your-network> \
     -e REDIS_URL=redis://<redis-host>:6379 \
     -e REDIS_NAMESPACE=<your-namespace> \
@@ -205,9 +206,9 @@ Redis key families used by the multi-node control plane:
 
   It is idempotent and touches neither room bodies nor `bsp:rooms-by-expiry`.
 
-  Grant ACLs, backups and monitoring on `bsp:rooms-by-expiry`; a deployment that only allows the old two keys will fail room writes.
+  Before rolling out this build, grant every room node and global-admin read/write access to `bsp:rooms-by-expiry` and `bsp:room-index-orphans*`; otherwise bootstrap reconciliation, room listing repair, and expiry sweeps can fail. The **first rollout of the orphan handoff is not a normal rolling upgrade**: an old room-store holder can still prune a code without creating a claim. Drain traffic and stop every old room node and global-admin before starting any new one; later upgrades in which both versions already implement the handoff may roll normally.
 
-  ````
+  A pre-shutdown `HLEN=0` is also **not** a safe rollback barrier: shutdown stops the reaper before the reconciler. Drain traffic and stop every current room node and global-admin, then check the hash. Only a zero observed after all processes have exited is stable. If claims remain, start one current room node isolated from traffic, wait for successful reaper sweeps until the hash reaches zero, stop it cleanly, and check again after exit; repeat or abort the rollback if the post-stop check is nonzero. Then run the legacy rebuild above and start the old build. Older builds ignore both handoff keys; retain them in backups because deleting them discards any outstanding cleanup claim.
 
 - `bsp:runtime:*`: shared sessions, room members, blocked member tokens, and node heartbeats
 - `bsp:admin:session:*`: shared admin bearer sessions

--- a/docs/operations/multi-node.zh-CN.md
+++ b/docs/operations/multi-node.zh-CN.md
@@ -191,11 +191,12 @@ node server/dist/global-admin-index.js
 多节点控制面当前使用的 Redis 键族：
 
 - `bsp:room:*`、`bsp:rooms-by-expiry`：房间基础持久化。`bsp:rooms-by-expiry` 收录全部房间、分值为其过期时间(不过期的房间为 `+inf`),是列举、计数与回收的唯一来源。
+- `bsp:room-index-orphans`、`bsp:room-index-orphans-queue`：前者记录“索引仍在、room body 已不存在”的带 token 运行时清理 claim，后者是其有界轮转投递索引。Room Node 与 Global Admin 都必须拥有两把键的读写 ACL，备份也必须同时覆盖。监控 `HLEN bsp:room-index-orphans`；若只增不减，说明 Room Node 回收或运行时拆除未能完成。初始化后，queue 的 `ZCARD` 通常等于哈希长度加一个保留的序列成员；持续不一致说明出现了局部写入、错误键类型或 ACL 问题。
 - `bsp:room-index`、`bsp:room-expiry`：已不再写入也不再读取,原样保留。
 
   **回滚**到仍读取它们的版本前需要先做一步:旧版本会在启动时从房间体重建 `bsp:room-index`,却没有针对 `bsp:room-expiry` 的等价修复,因此在本版本期间被设为过期的房间将永远不会被回收。顺序是:**先停掉本版本的全部节点**,再执行 `REDIS_URL=... node server/scripts/rebuild-legacy-room-expiry.mjs`(加 `DRY_RUN=1` 可先预览),最后启动旧版本。该扫描是分批读取而非一致快照,仍在处理请求的节点可能在脚本读过之后修改房间的过期时间。脚本已随运行镜像发布。由于此时全部节点都已停止,**不能用 `docker exec`**(没有正在运行的容器可供进入),请以一次性容器执行:
 
-  ````bash
+  ```bash
   docker run --rm --network <你的网络> \
     -e REDIS_URL=redis://<redis 主机>:6379 \
     -e REDIS_NAMESPACE=<你的命名空间> \
@@ -205,9 +206,9 @@ node server/dist/global-admin-index.js
 
   脚本幂等,既不改动房间体,也不触碰 `bsp:rooms-by-expiry`。
 
-  Redis ACL、备份与监控请覆盖 `bsp:rooms-by-expiry`;仅放行旧两个键的部署会导致房间写入失败。
+  上线本版本前，必须给每个 Room Node 与 Global Admin 同时授予 `bsp:rooms-by-expiry` 和 `bsp:room-index-orphans*` 的读写权限；否则启动对账、房间列表修复与过期回收都可能失败。**首次上线孤儿交接机制时不能按普通滚动升级处理**：旧版 room-store 持有者仍可能剪掉 code 却不创建 claim。必须先排空流量并停止全部旧版 Room Node 与 Global Admin，再启动任一新版本；以后两个版本都已实现交接机制时才可正常滚动。
 
-  ````
+  关服前看到 `HLEN=0` 同样**不是**安全的回滚屏障：关服流程先停 reaper、后停 reconciler。应先排空流量并停止全部本版本 Room Node 与 Global Admin，再检查哈希；只有所有进程退出后观察到的零才稳定。若仍有 claim，启动一台不接流量的本版本 Room Node，等待成功 reaper sweep 直至哈希归零，再将它完整停止并于退出后复查；若复查仍非零就重复或中止回滚。随后执行上面的旧索引重建并启动旧版本。旧版本会忽略两把交接键；请保留其备份，删除会丢失尚未完成的清理 claim。
 
 - `bsp:runtime:*`：共享 session、房间成员、被踢 token 与节点心跳
 - `bsp:admin:session:*`：共享管理员 Bearer 会话

--- a/docs/reference/invariants.md
+++ b/docs/reference/invariants.md
@@ -341,6 +341,24 @@ decides something has to know which of the two questions it is asking (#242):
   fails, the socket is dropped: `leaveCurrentRoom` restores the member when its
   own persistence fails and the socket is open, so reporting the join refused
   while the server still holds the seat leaves the two disagreeing.
+- **Pruning an orphaned room-index member still owes runtime teardown.** Both
+  the periodic reconcile and room listing remove a member whose room body is
+  gone so enumeration and counts agree, but removal alone used to consume the
+  only code the room reaper could hand to `room-service` (#258). Every prune
+  therefore atomically adds a tokened claim to the shared
+  `room-index-orphans` hash and its `room-index-orphans-queue` delivery index.
+  Quarantining an unreadable body owes the same deferred claim before its index
+  member is removed: the bad body blocks delivery while it exists, then repair
+  clears the claim or deletion makes it deliverable.
+  Shared is essential: the standalone global-admin reconciles the index but
+  runs no room reaper. `deleteExpiredRooms` reads that handoff in bounded
+  rotating batches using Redis 6.0 commands, without consuming a claim,
+  re-checks that no room body took the code meanwhile, and reports the
+  survivors as `orphanedIndexCodes` plus their claim tokens. `room-service`
+  acknowledges a token only after its existing
+  generation-guarded runtime teardown settles. A process crash therefore leaves
+  the claim for another room node, while a late acknowledgement cannot erase a
+  newer claim created after the same room code was recycled.
 
 ## One-shot broadcasts need a retry trail; repeated ones do not
 

--- a/docs/reference/invariants.zh-CN.md
+++ b/docs/reference/invariants.zh-CN.md
@@ -244,6 +244,19 @@
   `leaveCurrentRoom` 在自身持久化失败且 socket 仍开着时会把成员恢复回来，
   所以在服务端仍占着席位的情况下告诉客户端加入被拒，会让两边就此各说各话。
 
+- **剪掉孤儿房间索引项，仍然欠一次运行时拆除。** 定时对账与房间列表都会移除
+  body 已不存在的索引成员，以保持枚举与计数一致；但只做移除，会把 room reaper
+  原本能交给 `room-service` 的唯一房间码一并消费掉（#258）。因此每一条剪枝路径都
+  必须原子地把带 token 的 claim 写进共享 `room-index-orphans` 哈希及其
+  `room-index-orphans-queue` 投递索引。隔离不可读 body 时，删除其索引成员前同样要留下延后
+  claim：坏 body 存在期间阻止投递，修复后清 claim，删除后才使其可投递。这里必须共享：
+  独立的 global-admin 会做索引对账，却不运行
+  room reaper。`deleteExpiredRooms` 只用 Redis 6.0 命令，以有界、轮转批次读取且不消费 claim，
+  再次确认期间没有新 room body 占用该 code，并把仍是孤儿的 code 及 claim token 上报。
+  `room-service` 只有在既有代守卫保护的运行时拆除确实完成后才确认该 token；
+  因此进程中途退出时，其他 room node 仍能接手，而同一 code 被回收再度成为孤儿后，迟到的
+  旧确认也删不掉新的 claim。
+
 ## 一次性广播需要重试轨迹，重复发送的则不需要
 
 几乎每一条 `room_state_updated` 都会被下一次 `video:share` / `playback:update` / `profile:update` 重发，

--- a/docs/runbook/multi-node-operations.md
+++ b/docs/runbook/multi-node-operations.md
@@ -59,6 +59,33 @@ Production should also set these explicitly and keep them aligned:
 - `ADMIN_SESSION_TTL_MS`
 - `ADMIN_ROLE`
 
+### Room-index orphan cleanup handoff
+
+Redis 6.0 or newer is supported. With ACLs enabled, every room node and
+global-admin must have read/write access to `bsp:rooms-by-expiry` and both
+`bsp:room-index-orphans` (tokened claims) and
+`bsp:room-index-orphans-queue` (their bounded rotating delivery index). Replace
+`bsp` with the configured `REDIS_NAMESPACE`. A broad existing `bsp:*` grant
+already covers them; narrower room-key grants must be extended before rollout.
+
+Back up the hash and sorted set together. Monitor the hash with
+`HLEN bsp:room-index-orphans`; sustained growth means room-node reaping or
+runtime teardown is not settling. Once initialized, the queue normally has one
+extra reserved sequence member, so persistent divergence between `ZCARD` and
+`HLEN + 1` points to an ACL, key-type, or partial-write problem.
+
+The first rollout of this handoff must not mix old and new room-store holders:
+drain traffic and stop every old room node and global-admin before starting the
+new build. For a rollback, an instantaneous pre-shutdown `HLEN=0` is not a
+stable barrier because shutdown stops the reaper before the reconciler. Stop
+every current process first and check after all have exited. If claims remain,
+start one current room node isolated from traffic, wait for successful reaper
+sweeps until the hash is empty, stop it cleanly, and check again after exit;
+repeat or abort if that post-stop check is nonzero. Do not delete either
+handoff key. If the target build uses the legacy room indexes, also follow the
+rebuild procedure in the
+[multi-node deployment guide](../operations/multi-node.md).
+
 ## Common Verification Commands
 
 ```bash
@@ -169,6 +196,12 @@ redis-cli -u "$REDIS_URL" ping
 curl -fsS http://10.0.0.11:8787/readyz
 curl -fsS http://10.0.0.11:8787/metrics | grep bili_syncplay_redis_operation_failures_total
 sudo journalctl -u bili-syncplay-room-node-a --since "15 min ago" | grep -E "redis|Redis|node_heartbeat_failed"
+
+# Default namespace; substitute your configured prefix
+redis-cli -u "$REDIS_URL" type bsp:room-index-orphans
+redis-cli -u "$REDIS_URL" type bsp:room-index-orphans-queue
+redis-cli -u "$REDIS_URL" hlen bsp:room-index-orphans
+redis-cli -u "$REDIS_URL" zcard bsp:room-index-orphans-queue
 ```
 
 Also check the global admin overview:
@@ -286,6 +319,7 @@ With `ADMIN_SESSION_STORE_PROVIDER=redis` and an unchanged `ADMIN_SESSION_SECRET
 | Abnormal drop in WebSocket connections                            | `bili_syncplay_connections`                                                            | Edge upstreams, room node `/readyz`, process logs                            | Restore the node or remove the unhealthy node from the LB                      |
 | Abnormal drop in active rooms                                     | `bili_syncplay_active_rooms`, `bili_syncplay_rooms_non_expired`                        | Redis connectivity, room expiry settings, restart history                    | Restore Redis; confirm `ROOM_STORE_PROVIDER` was not switched to memory        |
 | Expired rooms stop being reclaimed (reaper stalled)               | `bili_syncplay_room_reaper_sweeps_total`                                               | See [Is the room reaper still sweeping?](#is-the-room-reaper-still-sweeping) | Restore Redis; confirm `ROOM_CLEANUP_INTERVAL_MS` was not raised               |
+| Orphan-cleanup claim hash grows or diverges from its queue        | `HLEN bsp:room-index-orphans`, `ZCARD bsp:room-index-orphans-queue`                    | Room reaper outcomes, runtime teardown logs, ACLs, `TYPE` for both keys      | Restore the reaper/runtime store; repair ACL or wrong-type keys before restart |
 | Redis operation failures                                          | `bili_syncplay_redis_operation_failures_total`                                         | Redis process, network, ACLs, password, slow queries                         | Restore Redis first; downgrade to in-memory only if necessary                  |
 | Completed admin command result publish paths fail                 | `bili_syncplay_admin_command_result_publish_failures_total`                            | Admin command bus publisher saturation, Redis pub/sub, result publish logs   | Restore Redis; confirm close-room fan-out and command-bus capacity are healthy |
 | Elevated Redis runtime store latency                              | `bili_syncplay_redis_runtime_store_duration_seconds_bucket`                            | Redis CPU, memory, network RTT, command queueing                             | Scale Redis or reduce edge-layer traffic                                       |

--- a/docs/runbook/multi-node-operations.zh-CN.md
+++ b/docs/runbook/multi-node-operations.zh-CN.md
@@ -65,6 +65,26 @@ NODE_HEARTBEAT_ENABLED=true
 - `ADMIN_SESSION_TTL_MS`
 - `ADMIN_ROLE`
 
+### 房间索引孤儿清理交接
+
+项目支持 Redis 6.0 及以上版本。开启 ACL 时，每个 Room Node 与 Global Admin 都必须能
+读写 `bsp:rooms-by-expiry`，以及 `bsp:room-index-orphans`（带 token 的 claim）和
+`bsp:room-index-orphans-queue`（其有界轮转投递索引）。设置了
+`REDIS_NAMESPACE` 时请替换 `bsp`。已有的宽泛 `bsp:*` 授权会覆盖它们；较窄的房间键
+授权必须在上线前扩展。
+
+哈希与 sorted set 必须一起备份。用 `HLEN bsp:room-index-orphans` 监控哈希；持续增长表示
+Room Node 回收或运行时拆除没有完成。queue 初始化后通常多一个保留序列成员，因此 `ZCARD`
+与 `HLEN + 1` 长期不一致，说明 ACL、键类型或局部写入存在问题。
+
+首次上线这套交接机制时不能混跑新旧 room-store 持有者：必须先排空流量并停止全部旧版
+Room Node 与 Global Admin，再启动新版本。回滚时，关服前瞬时 `HLEN=0` 不是稳定屏障，
+因为关服流程先停 reaper、后停 reconciler。先停止全部本版本进程，并在它们都退出后复查。
+若仍有 claim，启动一台不接流量的本版本 Room Node，等待成功 reaper sweep 直至哈希为空，
+再将它完整停止并于退出后复查；复查仍非零就重复或中止回滚。不要删除任何一把交接键。
+若目标版本仍使用旧式房间索引，还要执行
+[多节点部署文档](../operations/multi-node.zh-CN.md)中的重建流程。
+
 ## 常用验证命令
 
 ```bash
@@ -177,6 +197,12 @@ redis-cli -u "$REDIS_URL" ping
 curl -fsS http://10.0.0.11:8787/readyz
 curl -fsS http://10.0.0.11:8787/metrics | grep bili_syncplay_redis_operation_failures_total
 sudo journalctl -u bili-syncplay-room-node-a --since "15 min ago" | grep -E "redis|Redis|node_heartbeat_failed"
+
+# 默认命名空间；如有配置请替换前缀
+redis-cli -u "$REDIS_URL" type bsp:room-index-orphans
+redis-cli -u "$REDIS_URL" type bsp:room-index-orphans-queue
+redis-cli -u "$REDIS_URL" hlen bsp:room-index-orphans
+redis-cli -u "$REDIS_URL" zcard bsp:room-index-orphans-queue
 ```
 
 同时检查 Global Admin 概览：
@@ -296,6 +322,7 @@ curl -fsS http://10.0.0.11:8788/readyz
 | WebSocket 连接数异常下降                       | `bili_syncplay_connections`                                                    | 入口层 upstream、Room Node `/readyz`、进程日志         | 恢复节点或从 LB 摘除异常节点                         |
 | 活跃房间数异常下降                             | `bili_syncplay_active_rooms`、`bili_syncplay_rooms_non_expired`                | Redis 连通性、房间过期配置、重启记录                   | 恢复 Redis，确认 `ROOM_STORE_PROVIDER` 未被改为内存  |
 | 过期房间不再被回收（reaper 停摆）              | `bili_syncplay_room_reaper_sweeps_total`                                       | 见 [reaper 还在扫吗？](#reaper-还在扫吗)               | 恢复 Redis；确认 `ROOM_CLEANUP_INTERVAL_MS` 未被调大 |
+| 孤儿清理 claim 哈希持续增长或与 queue 不一致   | `HLEN bsp:room-index-orphans`、`ZCARD bsp:room-index-orphans-queue`            | Room Reaper 结果、运行时拆除日志、ACL、两把键的 `TYPE` | 恢复 reaper/runtime store；重启前修正 ACL 或错误类型 |
 | Redis 操作失败                                 | `bili_syncplay_redis_operation_failures_total`                                 | Redis 进程、网络、ACL、密码、慢查询                    | 优先恢复 Redis；必要时执行应急降级                   |
 | 已完成的管理命令结果发布路径失败               | `bili_syncplay_admin_command_result_publish_failures_total`                    | 管理命令 publisher 饱和、Redis pub/sub、结果发布日志   | 恢复 Redis；确认关房扇出和命令总线容量健康           |
 | Redis runtime store 延迟升高                   | `bili_syncplay_redis_runtime_store_duration_seconds_bucket`                    | Redis CPU、内存、网络 RTT、命令排队                    | 扩容 Redis 或降低入口层流量                          |

--- a/server/src/redis-namespace.ts
+++ b/server/src/redis-namespace.ts
@@ -20,6 +20,15 @@ export function getRedisRoomStoreKeys(namespace?: string) {
     // the same source instead of reconciling separate indexes against each
     // other. It supersedes the room-index and room-expiry pair.
     roomsByExpiryKey: `${base}rooms-by-expiry`,
+    // A reconciler or listing can discover an index member whose room body is
+    // already gone, including in the standalone global-admin process that runs
+    // no room reaper. Keep the runtime-cleanup handoff shared so a room-serving
+    // process can still collect the residue (#258).
+    orphanedRoomCodesKey: `${base}room-index-orphans`,
+    // A bounded, rotating index over the claim hash. Its reserved sequence
+    // member supplies monotonic scores without requiring Redis newer than the
+    // 6.0 minimum documented for this project.
+    orphanedRoomQueueKey: `${base}room-index-orphans-queue`,
   };
 }
 

--- a/server/src/redis-room-store.ts
+++ b/server/src/redis-room-store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { ReplyError } from "ioredis";
 import type { RoomListQuery } from "./admin/types.js";
 import {
@@ -8,6 +9,7 @@ import { quitWithin, type RedisQuitOutcome } from "./redis-graceful-close.js";
 import { getRedisRoomStoreKeys } from "./redis-namespace.js";
 import {
   createPersistedRoom,
+  type OrphanedIndexClaim,
   type RoomStore,
   type RoomUpdateResult,
 } from "./room-store.js";
@@ -59,20 +61,79 @@ export type RedisRoomStoreClient = {
 // enumeration and reaping each read one key and nothing else. An earlier
 // design derived the same answers by subtracting one index from another, and
 // every scenario in which those two indexes could disagree turned into a
-// separate correctness hole.
+// separate correctness hole. `room-index-orphans` below is a cleanup-debt hash,
+// not a second room index: no room is enumerated or counted from it. Its field
+// is a room code and its value is a unique token for one orphan discovery.
+
+// The one atomic primitive for removing a room-index member that did not die
+// through the normal room deletion path. Every caller stages a tokened claim
+// before ZREM; a loser restores the claim it observed before trying. Keeping
+// this in one source block is the invariant — prune, quarantine, and reaper
+// candidate handling must not grow their own hand-written variants.
+const REMOVE_INDEX_WITH_ORPHAN_CLAIM_LUA = `
+local sequenceMember = "!sequence"
+
+local function rotateOrphanClaim(code)
+  local nextScore = redis.call(
+    "ZINCRBY", orphanedRoomsQueueKey, 1, sequenceMember
+  )
+  redis.call("ZADD", orphanedRoomsQueueKey, nextScore, code)
+end
+
+local function stageOrphanClaim(code, token)
+  redis.call("HSET", orphanedRoomsKey, code, token)
+  rotateOrphanClaim(code)
+end
+
+local function removeIndexWithOrphanClaim(code, token)
+  local previousToken = redis.call("HGET", orphanedRoomsKey, code)
+  local previousScore = redis.call("ZSCORE", orphanedRoomsQueueKey, code)
+  stageOrphanClaim(code, token)
+  if redis.call("ZREM", roomsKey, code) > 0 then
+    return 1
+  end
+
+  -- A concurrent remover already won. Preserve the token it may have handed
+  -- to a caller instead of replacing it with a token nobody owns.
+  if previousToken then
+    redis.call("HSET", orphanedRoomsKey, code, previousToken)
+  else
+    redis.call("HDEL", orphanedRoomsKey, code)
+  end
+  if previousScore then
+    redis.call("ZADD", orphanedRoomsQueueKey, previousScore, code)
+  else
+    redis.call("ZREM", orphanedRoomsQueueKey, code)
+  end
+  return 0
+end
+`;
 
 // Members whose room body is gone. Existence is re-checked inside the script
 // so a code that createRoom is reusing at this very moment cannot lose the
-// membership that create just wrote.
+// membership that create just wrote. Every removed code is added atomically to
+// a shared handoff hash so the next reaper sweep can still request its runtime
+// teardown. Shared matters because the standalone global-admin reconciles this
+// index but runs no room reaper of its own (#258).
 const PRUNE_ORPHANED_MEMBERS_LUA = `
 local roomsKey = KEYS[1]
+local orphanedRoomsKey = KEYS[2]
+local orphanedRoomsQueueKey = KEYS[3]
 local roomKeyPrefix = ARGV[1]
+local claimToken = ARGV[2]
 local removed = 0
 
-for index = 2, #ARGV do
+${REMOVE_INDEX_WITH_ORPHAN_CLAIM_LUA}
+
+for index = 3, #ARGV do
   local code = ARGV[index]
   if redis.call("EXISTS", roomKeyPrefix .. code) == 0 then
-    removed = removed + redis.call("ZREM", roomsKey, code)
+    -- Handoff first: a Lua runtime error does not roll earlier writes back. If
+    -- either handoff key is unavailable or has the wrong type, retaining the
+    -- index member lets a later pass retry instead of losing the only cleanup
+    -- trail. Restore the previous claim when another process already pruned
+    -- the member; it may still be working under that token.
+    removed = removed + removeIndexWithOrphanClaim(code, claimToken)
   end
 end
 
@@ -98,15 +159,24 @@ return 1
 // Drops the member of a body that exists but cannot be read. Enumeration
 // already skips such a room, so leaving it in the set made ZCARD count a row
 // listRooms would never return — the admin table reports a total larger than
-// the page it can render, and rooms_non_expired stays inflated. Guarded by the
-// bytes the caller read, so a body repaired in the meantime keeps its member.
+// the page it can render, and rooms_non_expired stays inflated. Before removal
+// it leaves a deferred cleanup claim: if an operator later deletes the bad
+// body, no index member would otherwise remain to name its runtime residue.
+// Guarded by the bytes the caller read, so a body repaired in the meantime
+// keeps its member.
 //
 // The body itself is deliberately left in place: it cannot be interpreted, so
 // deleting it would destroy data on a guess.
 const QUARANTINE_MEMBER_LUA = `
 local roomsKey = KEYS[1]
 local roomKey = KEYS[2]
+local orphanedRoomsKey = KEYS[3]
+local orphanedRoomsQueueKey = KEYS[4]
 local kind = redis.call("TYPE", roomKey)["ok"]
+local code = ARGV[2]
+local claimToken = ARGV[3]
+
+${REMOVE_INDEX_WITH_ORPHAN_CLAIM_LUA}
 
 if kind == "none" then
   -- No body at all; the orphan prune owns that case.
@@ -116,14 +186,14 @@ end
 if kind ~= "string" then
   -- GET would raise WRONGTYPE, so the caller could not have read bytes to
   -- compare. Such a key can never be enumerated, so its member has to go.
-  return redis.call("ZREM", roomsKey, ARGV[2])
+  return removeIndexWithOrphanClaim(code, claimToken)
 end
 
 if redis.call("GET", roomKey) ~= ARGV[1] then
   return 0
 end
 
-return redis.call("ZREM", roomsKey, ARGV[2])
+return removeIndexWithOrphanClaim(code, claimToken)
 `;
 
 // SET NX and the membership write must succeed or fail together, or a losing
@@ -239,11 +309,90 @@ return redis.call("DEL", KEYS[1])
 // a number in Lua and that is exactly how playback values got mangled before.
 const DELETE_EXPIRED_ROOMS_LUA = `
 local roomsKey = KEYS[1]
+local orphanedRoomsKey = KEYS[2]
+local orphanedRoomsQueueKey = KEYS[3]
 local roomKeyPrefix = ARGV[1]
 local now = tonumber(ARGV[2])
+local orphanLimit = tonumber(ARGV[3])
+local sweepClaimToken = ARGV[4]
 local candidates = redis.call("ZRANGEBYSCORE", roomsKey, "-inf", now)
 local deletedCodes = {}
-local orphanCodes = {}
+local orphanClaims = {}
+local orphanPositions = {}
+
+${REMOVE_INDEX_WITH_ORPHAN_CLAIM_LUA}
+
+local function roomBodyState(code)
+  local readable, rawRoom = pcall(function()
+    return redis.call("GET", roomKeyPrefix .. code)
+  end)
+  if not readable then
+    return "unusable"
+  end
+  if not rawRoom then
+    return "missing"
+  end
+
+  local ok, room = pcall(cjson.decode, rawRoom)
+  if not ok or type(room) ~= "table" then
+    return "unusable"
+  end
+  local expiresAt = room["expiresAt"]
+  if room["code"] ~= code
+    or type(room["version"]) ~= "number"
+    or type(room["createdAt"]) ~= "number"
+    or type(room["lastActiveAt"]) ~= "number"
+    or not (
+      expiresAt == cjson.null
+      or type(expiresAt) == "number"
+    ) then
+    return "unusable"
+  end
+  return "usable"
+end
+
+local function reportOrphan(code, token)
+  local position = orphanPositions[code]
+  if position then
+    orphanClaims[position + 1] = token
+  else
+    position = #orphanClaims + 1
+    orphanPositions[code] = position
+    orphanClaims[position] = code
+    orphanClaims[position + 1] = token
+  end
+end
+
+-- Reconcile/listing already removed these codes from the main index to keep
+-- counts accurate. Read, but do not consume, a bounded batch: only the caller
+-- can acknowledge a claim after runtime teardown has really settled. Rotating
+-- every delivered claim to the tail prevents one failing batch from starving
+-- newer debt, using commands available in the supported Redis 6.0 baseline.
+local stagedOrphanCodes = redis.call(
+  "ZRANGE", orphanedRoomsQueueKey, 0, orphanLimit - 1
+)
+for _, code in ipairs(stagedOrphanCodes) do
+  if code ~= sequenceMember then
+    local token = redis.call("HGET", orphanedRoomsKey, code)
+    if not token then
+      redis.call("ZREM", orphanedRoomsQueueKey, code)
+    else
+      local bodyState = roomBodyState(code)
+      if bodyState == "missing" then
+        reportOrphan(code, token)
+        rotateOrphanClaim(code)
+      elseif bodyState == "usable" then
+        redis.call("HDEL", orphanedRoomsKey, code)
+        redis.call("ZREM", orphanedRoomsQueueKey, code)
+      else
+        -- A wrong-type or malformed body is not proof that the room code was
+        -- reused. Keep the debt: if an operator later deletes that corrupt key,
+        -- this claim is the only remaining path to its runtime residue.
+        rotateOrphanClaim(code)
+      end
+    end
+  end
+end
 
 for _, code in ipairs(candidates) do
   local key = roomKeyPrefix .. code
@@ -255,7 +404,10 @@ for _, code in ipairs(candidates) do
   end)
 
   if not readable then
-    redis.call("ZREM", roomsKey, code)
+    -- The corrupt body is deliberately retained, but removing its index entry
+    -- still needs a durable trail in case an operator later deletes that body.
+    -- The staged path keeps this claim blocked while the bad key exists.
+    removeIndexWithOrphanClaim(code, sweepClaimToken)
   elseif not rawRoom then
     -- Index entry without a body: the room is already gone, so it still has to
     -- be reported — staying silent left its runtime state uncollected, and
@@ -264,8 +416,12 @@ for _, code in ipairs(candidates) do
     -- deletions though: no room died on this pass, and metering it as one would
     -- inflate reclamations with manual cleanups, older builds and corruption
     -- (#254 review).
-    redis.call("ZREM", roomsKey, code)
-    orphanCodes[#orphanCodes + 1] = code
+    -- Queue before removing the index member. The token replaces any older
+    -- claim for a previous incarnation, so a late acknowledgement of that
+    -- older claim cannot consume this new cleanup debt.
+    if removeIndexWithOrphanClaim(code, sweepClaimToken) > 0 then
+      reportOrphan(code, sweepClaimToken)
+    end
   else
     local ok, room = pcall(cjson.decode, rawRoom)
     -- cjson.decode("1") yields a truthy scalar; indexing it raises a Lua
@@ -284,7 +440,21 @@ for _, code in ipairs(candidates) do
   end
 end
 
-return { deletedCodes, orphanCodes }
+return { deletedCodes, orphanClaims }
+`;
+
+const ACKNOWLEDGE_ORPHANED_INDEX_CLAIMS_LUA = `
+local acknowledged = 0
+for index = 1, #ARGV, 2 do
+  local code = ARGV[index]
+  local token = ARGV[index + 1]
+  if redis.call("HGET", KEYS[1], code) == token then
+    redis.call("HDEL", KEYS[1], code)
+    redis.call("ZREM", KEYS[2], code)
+    acknowledged = acknowledged + 1
+  end
+end
+return acknowledged
 `;
 
 // Chunk the repair passes: a first run against a database that has never been
@@ -425,9 +595,12 @@ export async function createRedisRoomStore(
       boundedBy:
         "room-reaper's sweep cap and room-index-reconciler's, both via maintenance-pass; NOT the request path",
     }) as RedisRoomStoreClient);
-  const { roomKeyPrefix, roomsByExpiryKey } = getRedisRoomStoreKeys(
-    options.namespace,
-  );
+  const {
+    orphanedRoomCodesKey,
+    orphanedRoomQueueKey,
+    roomKeyPrefix,
+    roomsByExpiryKey,
+  } = getRedisRoomStoreKeys(options.namespace);
   const now = options.now ?? Date.now;
   const closeQuitTimeoutMs =
     options.closeQuitTimeoutMs ?? CLOSE_QUIT_TIMEOUT_MS;
@@ -534,13 +707,16 @@ export async function createRedisRoomStore(
         unreadable.map(async ({ code, raw }) =>
           redis.eval(
             QUARANTINE_MEMBER_LUA,
-            2,
+            4,
             roomsByExpiryKey,
             roomKey(code),
+            orphanedRoomCodesKey,
+            orphanedRoomQueueKey,
             // Empty when the read itself failed; the script's type check
             // decides that case without consulting these bytes.
             raw ?? "",
             code,
+            randomUUID(),
           ),
         ),
       );
@@ -567,9 +743,12 @@ export async function createRedisRoomStore(
 
       await redis.eval(
         PRUNE_ORPHANED_MEMBERS_LUA,
-        1,
+        3,
         roomsByExpiryKey,
+        orphanedRoomCodesKey,
+        orphanedRoomQueueKey,
         roomKeyPrefix,
+        randomUUID(),
         ...codes,
       );
     } while (cursor !== "0");
@@ -672,9 +851,12 @@ export async function createRedisRoomStore(
         try {
           await redis.eval(
             PRUNE_ORPHANED_MEMBERS_LUA,
-            1,
+            3,
             roomsByExpiryKey,
+            orphanedRoomCodesKey,
+            orphanedRoomQueueKey,
             roomKeyPrefix,
+            randomUUID(),
             ...orphanedCodes,
           );
         } catch {
@@ -692,11 +874,14 @@ export async function createRedisRoomStore(
             unreadable.map(async ({ code, raw }) =>
               redis.eval(
                 QUARANTINE_MEMBER_LUA,
-                2,
+                4,
                 roomsByExpiryKey,
                 roomKey(code),
+                orphanedRoomCodesKey,
+                orphanedRoomQueueKey,
                 raw as string,
                 code,
+                randomUUID(),
               ),
             ),
           );
@@ -829,19 +1014,44 @@ export async function createRedisRoomStore(
       // not survive the RESP conversion, only its array part does.
       const swept = await redis.eval(
         DELETE_EXPIRED_ROOMS_LUA,
-        1,
+        3,
         roomsByExpiryKey,
+        orphanedRoomCodesKey,
+        orphanedRoomQueueKey,
         roomKeyPrefix,
         String(currentTime),
+        REPAIR_CHUNK_SIZE,
+        randomUUID(),
       );
       const codesAt = (index: number): string[] => {
         const group = Array.isArray(swept) ? swept[index] : null;
         return Array.isArray(group) ? (group as string[]) : [];
       };
+      const orphanedClaimValues = codesAt(1);
+      const orphanedIndexClaims: OrphanedIndexClaim[] = [];
+      for (let index = 0; index + 1 < orphanedClaimValues.length; index += 2) {
+        orphanedIndexClaims.push({
+          code: orphanedClaimValues[index],
+          token: orphanedClaimValues[index + 1],
+        });
+      }
       return {
         deletedRoomCodes: codesAt(0),
-        orphanedIndexCodes: codesAt(1),
+        orphanedIndexCodes: orphanedIndexClaims.map(({ code }) => code),
+        orphanedIndexClaims,
       };
+    },
+    async acknowledgeOrphanedIndexClaims(claims) {
+      if (claims.length === 0) {
+        return;
+      }
+      await redis.eval(
+        ACKNOWLEDGE_ORPHANED_INDEX_CLAIMS_LUA,
+        2,
+        orphanedRoomCodesKey,
+        orphanedRoomQueueKey,
+        ...claims.flatMap(({ code, token }) => [code, token]),
+      );
     },
     async listRooms(
       query: Pick<

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -460,7 +460,8 @@ export function createRoomService(options: {
 
   async function collectRuntimeStateForDeletedRooms(
     codes: Iterable<string>,
-  ): Promise<void> {
+  ): Promise<Set<string>> {
+    const settledCodes = new Set<string>();
     for (const code of new Set(codes)) {
       // Defence in depth behind the allocation-time check: a teardown queued
       // for retry could otherwise fire after its code came back into use — the
@@ -495,6 +496,7 @@ export function createRoomService(options: {
       }
       if (currentRoom) {
         pendingRuntimeTeardowns.delete(code);
+        settledCodes.add(code);
         continue;
       }
       try {
@@ -503,6 +505,7 @@ export function createRoomService(options: {
         // delete itself conditional, which is what actually closes the race.
         await runtimeStore.deleteRoom(code, expectedGeneration);
         pendingRuntimeTeardowns.delete(code);
+        settledCodes.add(code);
       } catch (error) {
         pendingRuntimeTeardowns.add(code);
         logEvent("room_runtime_cleanup_failed", {
@@ -514,6 +517,7 @@ export function createRoomService(options: {
         });
       }
     }
+    return settledCodes;
   }
 
   async function resolveRoom(code: string): Promise<PersistedRoom | null> {
@@ -1927,11 +1931,37 @@ export function createRoomService(options: {
       // state that outlives it (member tokens survive a disconnect on purpose,
       // #234), and once the persisted room is gone nothing will ever name that
       // code again.
-      await collectRuntimeStateForDeletedRooms([
+      const settledCodes = await collectRuntimeStateForDeletedRooms([
         ...pendingRuntimeTeardowns,
         ...swept.deletedRoomCodes,
         ...swept.orphanedIndexCodes,
       ]);
+      const settledClaims = (swept.orphanedIndexClaims ?? []).filter(
+        ({ code }) => settledCodes.has(code),
+      );
+      if (
+        settledClaims.length > 0 &&
+        roomStore.acknowledgeOrphanedIndexClaims
+      ) {
+        try {
+          // The shared claim is the crash-recovery trail. Remove it only after
+          // the guarded runtime delete above has settled; a token comparison in
+          // the room store keeps this late acknowledgement from consuming a
+          // newer orphan occurrence under a recycled code (#258 review).
+          await roomStore.acknowledgeOrphanedIndexClaims(settledClaims);
+        } catch (error) {
+          // Runtime cleanup already landed. Rejecting now would overwrite that
+          // real result, while leaving the shared claim is safe and lets any
+          // later room-node sweep retry the idempotent teardown.
+          logEvent("room_persist_failed", {
+            provider: persistence.provider,
+            result: "error",
+            reason: "orphan_runtime_cleanup_ack_failed",
+            claimCount: settledClaims.length,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
       return {
         deletedRooms: swept.deletedRoomCodes.length,
         orphanedIndexEntries: swept.orphanedIndexCodes.length,

--- a/server/src/room-store-instrumentation.ts
+++ b/server/src/room-store-instrumentation.ts
@@ -62,10 +62,19 @@ export function instrumentRoomStore(
     isReady: measure("is_ready", () => roomStore.isReady()),
   };
 
-  // Both hooks must survive wrapping: losing close() would leak the Redis
-  // connection, and losing reconcileRoomIndex() would silently stop the index
-  // from ever converging again — a rolling upgrade's rooms would go unreaped
-  // with nothing failing.
+  if (typeof roomStore.acknowledgeOrphanedIndexClaims === "function") {
+    instrumented.acknowledgeOrphanedIndexClaims = measure(
+      "acknowledge_orphaned_index_claims",
+      roomStore.acknowledgeOrphanedIndexClaims.bind(roomStore),
+    );
+  }
+
+  // Both implementation hooks must survive wrapping: losing close() would
+  // leak the Redis connection, and losing reconcileRoomIndex() would silently
+  // stop the index from ever converging again — a rolling upgrade's rooms
+  // would go unreaped with nothing failing. The optional RoomStore operation
+  // above is deliberately part of `instrumented` instead: production room
+  // services call through this wrapper and must both retain and measure it.
   const hooks: Pick<MaintainableRoomStore, "close" | "reconcileRoomIndex"> = {};
   if (typeof roomStore.close === "function") {
     hooks.close = roomStore.close.bind(roomStore);

--- a/server/src/room-store.ts
+++ b/server/src/room-store.ts
@@ -28,6 +28,12 @@ export type RoomUpdateResult =
   | { ok: true; room: PersistedRoom }
   | { ok: false; reason: "not_found" | "version_conflict" };
 
+/** A durable handoff naming one discovery of an orphaned room-index entry. */
+export type OrphanedIndexClaim = {
+  code: string;
+  token: string;
+};
+
 /** What one expiry sweep removed, split by whether a room was actually there. */
 export type ExpiredRoomSweep = {
   /** Rooms whose body this pass deleted. */
@@ -37,6 +43,12 @@ export type ExpiredRoomSweep = {
    * still owe runtime teardown, but no room died here.
    */
   orphanedIndexCodes: string[];
+  /**
+   * Durable claims corresponding to {@link orphanedIndexCodes}. A Redis-backed
+   * store keeps each claim until the caller confirms that runtime teardown has
+   * settled, so another process can retry after a crash.
+   */
+  orphanedIndexClaims?: OrphanedIndexClaim[];
 };
 
 export type RoomStore = {
@@ -69,6 +81,14 @@ export type RoomStore = {
    * of step with room creations (#254 review).
    */
   deleteExpiredRooms: (now: number) => Promise<ExpiredRoomSweep>;
+  /**
+   * Acknowledge orphan claims only after their runtime teardown has settled.
+   * Tokens make a late acknowledgement harmless when the room code was reused
+   * and became orphaned again in the meantime.
+   */
+  acknowledgeOrphanedIndexClaims?: (
+    claims: readonly OrphanedIndexClaim[],
+  ) => Promise<void>;
   listRooms: (
     query: Pick<
       RoomListQuery,

--- a/server/test/redis-room-store.test.ts
+++ b/server/test/redis-room-store.test.ts
@@ -10,6 +10,53 @@ import {
 const REDIS_URL = process.env.REDIS_URL;
 
 type Store = Awaited<ReturnType<typeof createRedisRoomStore>>;
+type Sweep = Awaited<ReturnType<Store["deleteExpiredRooms"]>>;
+
+/**
+ * A setup barrier for tests that mutate the room index through a second Redis
+ * connection. The store starts its bootstrap reconcile in the background, so
+ * constructing drift before this resolves makes the fixture race that pass.
+ */
+async function settleRoomIndexBootstrap(store: Store): Promise<void> {
+  await store.reconcileRoomIndex();
+}
+
+async function acknowledgeOrphanClaims(
+  store: Store,
+  sweep: Sweep,
+): Promise<void> {
+  assert.ok(store.acknowledgeOrphanedIndexClaims);
+  assert.ok(sweep.orphanedIndexClaims);
+  await store.acknowledgeOrphanedIndexClaims(sweep.orphanedIndexClaims);
+}
+
+function orphanClaimKeys(namespace: string): {
+  hash: string;
+  queue: string;
+} {
+  return {
+    hash: `${namespace}:room-index-orphans`,
+    queue: `${namespace}:room-index-orphans-queue`,
+  };
+}
+
+async function seedOrphanClaims(
+  redis: Redis,
+  namespace: string,
+  claims: readonly { code: string; token: string }[],
+): Promise<void> {
+  const keys = orphanClaimKeys(namespace);
+  await redis.hset(
+    keys.hash,
+    ...claims.flatMap(({ code, token }) => [code, token]),
+  );
+  const pipeline = redis.pipeline();
+  claims.forEach(({ code }, index) => {
+    pipeline.zadd(keys.queue, index + 1, code);
+  });
+  pipeline.zadd(keys.queue, claims.length, "!sequence");
+  await pipeline.exec();
+}
 
 function uniqueNamespace(label: string): string {
   return `bsp-test-${label}-${Date.now().toString(36)}-${Math.random()
@@ -348,6 +395,7 @@ test("redis room listing prunes members whose room body is gone", async (t) => {
 
   const namespace = uniqueNamespace("orphan");
   const roomsKey = `${namespace}:rooms-by-expiry`;
+  const orphanKeys = orphanClaimKeys(namespace);
   const store = await createRedisRoomStore(REDIS_URL, { namespace });
   const redis = await connect();
 
@@ -367,9 +415,63 @@ test("redis room listing prunes members whose room body is gone", async (t) => {
       [room.code],
     );
     assert.equal(await redis.zscore(roomsKey, "GHOST1"), null);
+    // Removing the member keeps listing/counting accurate, but must not consume
+    // the runtime-cleanup debt that only the reaper's caller can settle.
+    const swept = await store.deleteExpiredRooms(0);
+    assert.deepEqual(swept.orphanedIndexCodes, ["GHOST1"]);
+    assert.deepEqual(swept.deletedRoomCodes, []);
+    assert.ok(await redis.hget(orphanKeys.hash, "GHOST1"));
+    assert.ok(await redis.zscore(orphanKeys.queue, "GHOST1"));
+    await acknowledgeOrphanClaims(store, swept);
+    assert.equal(await redis.hlen(orphanKeys.hash), 0);
+    assert.equal(await redis.zscore(orphanKeys.queue, "GHOST1"), null);
   } finally {
     await store.deleteRoom("LIVE01");
-    await redis.del(roomsKey);
+    await redis.del(roomsKey, orphanKeys.hash, orphanKeys.queue);
+    await redis.quit();
+    await store.close();
+  }
+});
+
+test("redis room orphan prune keeps the index member when its cleanup handoff fails", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = uniqueNamespace("orphanhandoff");
+  const roomsKey = `${namespace}:rooms-by-expiry`;
+  const orphanKeys = orphanClaimKeys(namespace);
+  const store = await createRedisRoomStore(REDIS_URL, { namespace });
+  const redis = await connect();
+
+  try {
+    await settleRoomIndexBootstrap(store);
+    await redis.zadd(roomsKey, "+inf", "GHOST2");
+    // HGET now raises WRONGTYPE. The handoff must be attempted before the
+    // member is removed so a later pass still has a retry trail.
+    await redis.set(orphanKeys.hash, "wrong type");
+
+    assert.deepEqual(await store.listRooms(LIST_ALL), []);
+    assert.equal(await redis.zscore(roomsKey, "GHOST2"), "inf");
+
+    // The rotating queue is equally required. Its WRONGTYPE failure must also
+    // retain the index member instead of stranding a hash-only claim.
+    await redis.del(orphanKeys.hash);
+    await redis.set(orphanKeys.queue, "wrong type");
+    assert.deepEqual(await store.listRooms(LIST_ALL), []);
+    assert.equal(await redis.zscore(roomsKey, "GHOST2"), "inf");
+
+    // Once both handoff keys are writable, the same listing retries the prune
+    // and the next reaper sweep receives the code.
+    await redis.del(orphanKeys.queue);
+    assert.deepEqual(await store.listRooms(LIST_ALL), []);
+    assert.equal(await redis.zscore(roomsKey, "GHOST2"), null);
+    const swept = await store.deleteExpiredRooms(0);
+    assert.deepEqual(swept.orphanedIndexCodes, ["GHOST2"]);
+    await acknowledgeOrphanClaims(store, swept);
+  } finally {
+    await redis.del(roomsKey, orphanKeys.hash, orphanKeys.queue);
     await redis.quit();
     await store.close();
   }
@@ -383,6 +485,7 @@ test("redis room reconcile sweeps orphans again when the reconciler drives it", 
 
   const namespace = uniqueNamespace("resweep");
   const roomsKey = `${namespace}:rooms-by-expiry`;
+  const orphanKeys = orphanClaimKeys(namespace);
   let clock = 1_000_000;
   const store = await createRedisRoomStore(REDIS_URL, {
     namespace,
@@ -410,8 +513,11 @@ test("redis room reconcile sweeps orphans again when the reconciler drives it", 
     await store.reconcileRoomIndex();
     assert.equal(await store.countRooms({ includeExpired: true }), 0);
     assert.equal(await redis.zcard(roomsKey), 0);
+    const swept = await store.deleteExpiredRooms(clock);
+    assert.deepEqual(swept.orphanedIndexCodes, ["LATEGH"]);
+    await acknowledgeOrphanClaims(store, swept);
   } finally {
-    await redis.del(roomsKey);
+    await redis.del(roomsKey, orphanKeys.hash, orphanKeys.queue);
     await redis.quit();
     await store.close();
   }
@@ -444,6 +550,200 @@ test("redis room store still reconciles once before answering the first read", a
     await redis.del(`${namespace}:room:OLDBLD`, roomsKey);
     await redis.quit();
     await store?.close();
+  }
+});
+
+test("redis room bootstrap reconcile preserves orphan codes for the next reaper sweep", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = uniqueNamespace("bootstraporphan");
+  const roomsKey = `${namespace}:rooms-by-expiry`;
+  const orphanKeys = orphanClaimKeys(namespace);
+  const redis = await connect();
+
+  let reconcilerStore: Store | null = null;
+  let reaperStore: Store | null = null;
+  try {
+    // A body removed by an older build before this process starts. The
+    // constructor's background reconcile wins the race in #258 and removes
+    // the member before the reaper can see it.
+    await redis.zadd(roomsKey, "+inf", "BOOTGH");
+    reconcilerStore = await createRedisRoomStore(REDIS_URL, { namespace });
+    await settleRoomIndexBootstrap(reconcilerStore);
+
+    assert.equal(await redis.zscore(roomsKey, "BOOTGH"), null);
+    // The standalone global-admin runs this reconcile but no reaper. Close that
+    // store and let a separate room-serving process claim the shared handoff.
+    await reconcilerStore.close();
+    reconcilerStore = null;
+    reaperStore = await createRedisRoomStore(REDIS_URL, { namespace });
+    const first = await reaperStore.deleteExpiredRooms(0);
+    assert.deepEqual(first.orphanedIndexCodes, ["BOOTGH"]);
+    // Simulate the room process exiting after it received the claim but before
+    // runtime teardown settled. The shared debt must survive for the next pass.
+    await reaperStore.close();
+    reaperStore = await createRedisRoomStore(REDIS_URL, { namespace });
+    const retried = await reaperStore.deleteExpiredRooms(0);
+    assert.deepEqual(retried.orphanedIndexCodes, ["BOOTGH"]);
+    assert.deepEqual(retried.orphanedIndexClaims, first.orphanedIndexClaims);
+    await acknowledgeOrphanClaims(reaperStore, retried);
+    assert.deepEqual(
+      (await reaperStore.deleteExpiredRooms(0)).orphanedIndexCodes,
+      [],
+    );
+  } finally {
+    await redis.del(roomsKey, orphanKeys.hash, orphanKeys.queue);
+    await redis.quit();
+    await reconcilerStore?.close();
+    await reaperStore?.close();
+  }
+});
+
+test("redis room reaper bounds the shared orphan handoff and skips a reused code", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = uniqueNamespace("orphanbatch");
+  const roomsKey = `${namespace}:rooms-by-expiry`;
+  const orphanKeys = orphanClaimKeys(namespace);
+  const store = await createRedisRoomStore(REDIS_URL, { namespace });
+  const redis = await connect();
+
+  try {
+    await settleRoomIndexBootstrap(store);
+    const orphanedCodes = Array.from(
+      { length: 501 },
+      (_, index) => `OR${index.toString().padStart(4, "0")}`,
+    );
+    await seedOrphanClaims(redis, namespace, [
+      ...orphanedCodes.map((code) => ({ code, token: `claim-${code}` })),
+      { code: "REUSED", token: "claim-reused" },
+    ]);
+    await store.createRoom({
+      code: "REUSED",
+      joinToken: "join-token-123456",
+      createdAt: 1,
+    });
+
+    const deliveredCodes: string[] = [];
+    for (let pass = 0; pass < 4; pass += 1) {
+      const swept = await store.deleteExpiredRooms(0);
+      assert.ok(swept.orphanedIndexCodes.length <= 500);
+      deliveredCodes.push(...swept.orphanedIndexCodes);
+      await acknowledgeOrphanClaims(store, swept);
+      if ((await redis.hlen(orphanKeys.hash)) === 0) {
+        break;
+      }
+    }
+    assert.deepEqual(deliveredCodes.sort(), orphanedCodes);
+    assert.equal(await redis.hlen(orphanKeys.hash), 0);
+    assert.equal(await redis.zcard(orphanKeys.queue), 1);
+    assert.ok(await store.getRoom("REUSED"));
+  } finally {
+    await store.deleteRoom("REUSED");
+    await redis.del(roomsKey, orphanKeys.hash, orphanKeys.queue);
+    await redis.quit();
+    await store.close();
+  }
+});
+
+test("redis room reaper keeps orphan claims behind corrupt room bodies", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = uniqueNamespace("orphanbadbody");
+  const orphanKeys = orphanClaimKeys(namespace);
+  const store = await createRedisRoomStore(REDIS_URL, { namespace });
+  const redis = await connect();
+
+  try {
+    await settleRoomIndexBootstrap(store);
+    await seedOrphanClaims(redis, namespace, [
+      { code: "BADTYP", token: "claim-wrong-type" },
+      { code: "BADJSN", token: "claim-invalid-json" },
+      { code: "REUSED", token: "claim-reused" },
+    ]);
+    await redis.hset(`${namespace}:room:BADTYP`, "field", "value");
+    await redis.set(`${namespace}:room:BADJSN`, "{not valid json");
+    await store.createRoom({
+      code: "REUSED",
+      joinToken: "join-token-123456",
+      createdAt: 1,
+    });
+
+    // Only a usable persisted room proves the code was recycled. Corruption
+    // must keep rotating the debt until the bad body is repaired or removed.
+    const blocked = await store.deleteExpiredRooms(0);
+    assert.deepEqual(blocked.orphanedIndexCodes, []);
+    assert.equal(
+      await redis.hget(orphanKeys.hash, "BADTYP"),
+      "claim-wrong-type",
+    );
+    assert.equal(
+      await redis.hget(orphanKeys.hash, "BADJSN"),
+      "claim-invalid-json",
+    );
+    assert.equal(await redis.hget(orphanKeys.hash, "REUSED"), null);
+
+    await redis.del(`${namespace}:room:BADTYP`, `${namespace}:room:BADJSN`);
+    const released = await store.deleteExpiredRooms(0);
+    assert.deepEqual(released.orphanedIndexCodes.sort(), ["BADJSN", "BADTYP"]);
+    await acknowledgeOrphanClaims(store, released);
+    assert.equal(await redis.hlen(orphanKeys.hash), 0);
+  } finally {
+    await store.deleteRoom("REUSED");
+    await redis.del(
+      `${namespace}:room:BADTYP`,
+      `${namespace}:room:BADJSN`,
+      orphanKeys.hash,
+      orphanKeys.queue,
+    );
+    await redis.quit();
+    await store.close();
+  }
+});
+
+test("redis room orphan acknowledgement cannot consume a newer claim", async (t) => {
+  if (!REDIS_URL) {
+    t.skip("REDIS_URL is not configured.");
+    return;
+  }
+
+  const namespace = uniqueNamespace("orphanack");
+  const orphanKeys = orphanClaimKeys(namespace);
+  const store = await createRedisRoomStore(REDIS_URL, { namespace });
+  const redis = await connect();
+
+  try {
+    await settleRoomIndexBootstrap(store);
+    await seedOrphanClaims(redis, namespace, [
+      { code: "RECYC1", token: "new-claim" },
+    ]);
+
+    // A previous process can finish late after the code was reused and became
+    // orphaned again. Its old token must not erase the new occurrence's debt.
+    await store.acknowledgeOrphanedIndexClaims?.([
+      { code: "RECYC1", token: "old-claim" },
+    ]);
+    assert.equal(await redis.hget(orphanKeys.hash, "RECYC1"), "new-claim");
+    assert.ok(await redis.zscore(orphanKeys.queue, "RECYC1"));
+
+    await store.acknowledgeOrphanedIndexClaims?.([
+      { code: "RECYC1", token: "new-claim" },
+    ]);
+    assert.equal(await redis.hget(orphanKeys.hash, "RECYC1"), null);
+    assert.equal(await redis.zscore(orphanKeys.queue, "RECYC1"), null);
+  } finally {
+    await redis.del(orphanKeys.hash, orphanKeys.queue);
+    await redis.quit();
+    await store.close();
   }
 });
 
@@ -1092,6 +1392,7 @@ test("redis room count and listing agree about an unreadable room body", async (
 
   const namespace = uniqueNamespace("quarantine");
   const roomsKey = `${namespace}:rooms-by-expiry`;
+  const orphanKeys = orphanClaimKeys(namespace);
   let clock = 1_000_000;
   const store = await createRedisRoomStore(REDIS_URL, {
     namespace,
@@ -1124,17 +1425,32 @@ test("redis room count and listing agree about an unreadable room body", async (
     );
     assert.equal(await store.countRooms({ includeExpired: true }), 1);
     assert.equal(await redis.zscore(roomsKey, "ROTTEN"), null);
+    assert.ok(await redis.hget(orphanKeys.hash, "ROTTEN"));
+    assert.ok(await redis.zscore(orphanKeys.queue, "ROTTEN"));
 
     // The body is kept: it cannot be interpreted, so deleting it would be a
-    // guess. It also must not creep back into the set on the next reconcile.
+    // guess. Its deferred claim must not run while that bad body still exists.
     assert.equal(await redis.exists(`${namespace}:room:ROTTEN`), 1);
+    assert.deepEqual(
+      (await store.deleteExpiredRooms(clock)).orphanedIndexCodes,
+      [],
+    );
     clock += 900_000;
     assert.equal(await store.countRooms({ includeExpired: true }), 1);
+
+    // Once an operator removes the corrupt body, the deferred claim becomes
+    // deliverable even though quarantine already removed the main index.
+    await redis.del(`${namespace}:room:ROTTEN`);
+    const released = await store.deleteExpiredRooms(clock);
+    assert.deepEqual(released.orphanedIndexCodes, ["ROTTEN"]);
+    await acknowledgeOrphanClaims(store, released);
   } finally {
     await redis.del(
       `${namespace}:room:STAYOK`,
       `${namespace}:room:ROTTEN`,
       roomsKey,
+      orphanKeys.hash,
+      orphanKeys.queue,
     );
     await redis.quit();
     await store.close();
@@ -1149,6 +1465,7 @@ test("redis room store isolates a room key of the wrong type", async (t) => {
 
   const namespace = uniqueNamespace("wrongtype");
   const roomsKey = `${namespace}:rooms-by-expiry`;
+  const orphanKeys = orphanClaimKeys(namespace);
   const store = await createRedisRoomStore(REDIS_URL, { namespace });
   const redis = await connect();
 
@@ -1190,21 +1507,28 @@ test("redis room store isolates a room key of the wrong type", async (t) => {
     ]);
     assert.equal(await store.countRooms({ includeExpired: true }), 2);
     assert.equal(await redis.zscore(roomsKey, doomed.code), null);
+    assert.ok(await redis.hget(orphanKeys.hash, doomed.code));
 
     // The genuinely expired room is still collected.
-    assert.equal(
-      (await store.deleteExpiredRooms(100)).deletedRoomCodes.length,
-      1,
-    );
+    const blocked = await store.deleteExpiredRooms(100);
+    assert.equal(blocked.deletedRoomCodes.length, 1);
+    assert.deepEqual(blocked.orphanedIndexCodes, []);
     assert.equal(await redis.exists(`${namespace}:room:EXPIRE`), 0);
     // The wrong-type key itself is left alone rather than destroyed.
     assert.equal(await redis.exists(`${namespace}:room:WRONGT`), 1);
+
+    await redis.del(`${namespace}:room:WRONGT`);
+    const released = await store.deleteExpiredRooms(100);
+    assert.deepEqual(released.orphanedIndexCodes, ["WRONGT"]);
+    await acknowledgeOrphanClaims(store, released);
   } finally {
     await redis.del(
       `${namespace}:room:OKROOM`,
       `${namespace}:room:WRONGT`,
       `${namespace}:room:EXPIRE`,
       roomsKey,
+      orphanKeys.hash,
+      orphanKeys.queue,
     );
     await redis.quit();
     await store.close();
@@ -1219,6 +1543,7 @@ test("redis room reaper survives a candidate whose key turns the wrong type", as
 
   const namespace = uniqueNamespace("reapwrong");
   const roomsKey = `${namespace}:rooms-by-expiry`;
+  const orphanKeys = orphanClaimKeys(namespace);
   const store = await createRedisRoomStore(REDIS_URL, { namespace });
   const redis = await connect();
 
@@ -1247,25 +1572,32 @@ test("redis room reaper survives a candidate whose key turns the wrong type", as
     // Settle the reconcile first, then corrupt the key inside the cooldown
     // window: the member is still a reaper candidate, so the Lua script is
     // what has to survive the WRONGTYPE — nothing quarantined it beforehand.
-    await store.countRooms({ includeExpired: true });
+    await settleRoomIndexBootstrap(store);
     await redis.del(`${namespace}:room:${doomed.code}`);
     await redis.hset(`${namespace}:room:${doomed.code}`, "field", "value");
     assert.notEqual(await redis.zscore(roomsKey, doomed.code), null);
 
     // Without the guard the script raises on the first candidate and the room
     // ordered after it is never collected.
-    assert.equal(
-      (await store.deleteExpiredRooms(100)).deletedRoomCodes.length,
-      1,
-    );
+    const blocked = await store.deleteExpiredRooms(100);
+    assert.equal(blocked.deletedRoomCodes.length, 1);
+    assert.deepEqual(blocked.orphanedIndexCodes, []);
     assert.equal(await redis.exists(`${namespace}:room:REAPME`), 0);
     assert.equal(await redis.zscore(roomsKey, doomed.code), null);
     assert.equal(await redis.exists(`${namespace}:room:BADKEY`), 1);
+    assert.ok(await redis.hget(orphanKeys.hash, doomed.code));
+
+    await redis.del(`${namespace}:room:BADKEY`);
+    const released = await store.deleteExpiredRooms(100);
+    assert.deepEqual(released.orphanedIndexCodes, ["BADKEY"]);
+    await acknowledgeOrphanClaims(store, released);
   } finally {
     await redis.del(
       `${namespace}:room:BADKEY`,
       `${namespace}:room:REAPME`,
       roomsKey,
+      orphanKeys.hash,
+      orphanKeys.queue,
     );
     await redis.quit();
     await store.close();
@@ -1280,10 +1612,12 @@ test("redis room store reports codes whose index entry outlived the room body", 
 
   const namespace = uniqueNamespace("nobody");
   const roomsKey = `${namespace}:rooms-by-expiry`;
+  const orphanKeys = orphanClaimKeys(namespace);
   const store = await createRedisRoomStore(REDIS_URL, { namespace });
   const redis = await connect();
 
   try {
+    await settleRoomIndexBootstrap(store);
     const room = await store.createRoom({
       code: "NOBODY",
       joinToken: "join-token-123456",
@@ -1308,8 +1642,9 @@ test("redis room store reports codes whose index entry outlived the room body", 
     assert.deepEqual(swept.orphanedIndexCodes, ["NOBODY"]);
     assert.deepEqual(swept.deletedRoomCodes, []);
     assert.equal(await redis.zscore(roomsKey, "NOBODY"), null);
+    await acknowledgeOrphanClaims(store, swept);
   } finally {
-    await redis.del(roomsKey);
+    await redis.del(roomsKey, orphanKeys.hash, orphanKeys.queue);
     await redis.quit();
     await store.close();
   }

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -5098,6 +5098,8 @@ test("room service tears down orphaned index codes without metering them as recl
   const baseRoomStore = createInMemoryRoomStore({ now: () => currentTime });
   const reclaimed: number[] = [];
   const tornDown: string[] = [];
+  const acknowledgedClaims: string[] = [];
+  const cleanupOrder: string[] = [];
   const runtime = createInMemoryRuntimeStore(() => currentTime);
   const roomStore = {
     ...baseRoomStore,
@@ -5108,7 +5110,12 @@ test("room service tears down orphaned index codes without metering them as recl
       return {
         deletedRoomCodes: ["REALRM"],
         orphanedIndexCodes: ["ORPHAN"],
+        orphanedIndexClaims: [{ code: "ORPHAN", token: "claim-1" }],
       };
+    },
+    async acknowledgeOrphanedIndexClaims(claims: readonly { code: string }[]) {
+      cleanupOrder.push("acknowledge");
+      acknowledgedClaims.push(...claims.map(({ code }) => code));
     },
   };
   const service = createRoomService({
@@ -5118,6 +5125,7 @@ test("room service tears down orphaned index codes without metering them as recl
     activeRooms: {
       ...runtime,
       deleteRoom: async (code: string, expectedGeneration?: string | null) => {
+        cleanupOrder.push(`teardown:${code}`);
         tornDown.push(code);
         return runtime.deleteRoom(code, expectedGeneration);
       },
@@ -5139,8 +5147,60 @@ test("room service tears down orphaned index codes without metering them as recl
   // The orphan owes runtime teardown exactly like a real deletion — its code
   // stays unallocatable until that state is gone (#237 review) …
   assert.deepEqual(tornDown.sort(), ["ORPHAN", "REALRM"]);
+  assert.deepEqual(acknowledgedClaims, ["ORPHAN"]);
+  assert.ok(
+    cleanupOrder.indexOf("teardown:ORPHAN") <
+      cleanupOrder.indexOf("acknowledge"),
+  );
   // … but no room died under it, so metering it would put this counter back
   // out of step with room creations (#254 review).
   assert.deepEqual(reclaimed, [1]);
   assert.deepEqual(swept, { deletedRooms: 1, orphanedIndexEntries: 1 });
+});
+
+test("room service keeps an orphan claim until runtime teardown succeeds", async () => {
+  const currentTime = 1_000;
+  const baseRoomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const claim = { code: "ORPHAN", token: "claim-1" };
+  const acknowledged: string[] = [];
+  const roomStore = {
+    ...baseRoomStore,
+    async deleteExpiredRooms() {
+      return {
+        deletedRoomCodes: [],
+        orphanedIndexCodes: [claim.code],
+        orphanedIndexClaims: [claim],
+      };
+    },
+    async acknowledgeOrphanedIndexClaims(claims: readonly (typeof claim)[]) {
+      acknowledged.push(...claims.map(({ token }) => token));
+    },
+  };
+  const runtime = createInMemoryRuntimeStore(() => currentTime);
+  let teardownFails = true;
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...runtime,
+      deleteRoom: async (code: string, expectedGeneration?: string | null) => {
+        if (teardownFails) {
+          throw new Error("redis unavailable");
+        }
+        return runtime.deleteRoom(code, expectedGeneration);
+      },
+    },
+    generateToken: () => "token-1234567890",
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    resolveActiveRoom: async (code) => runtime.getRoom(code),
+  });
+
+  await service.deleteExpiredRooms();
+  assert.deepEqual(acknowledged, []);
+
+  teardownFails = false;
+  await service.deleteExpiredRooms();
+  assert.deepEqual(acknowledged, [claim.token]);
 });

--- a/server/test/room-store-instrumentation.test.ts
+++ b/server/test/room-store-instrumentation.test.ts
@@ -158,6 +158,57 @@ test("instrumented room store reports a failed reconcile and rethrows", async ()
   );
 });
 
+test("instrumented room store preserves and measures orphan claim acknowledgement", async () => {
+  const recorder = createRecorder();
+  const acknowledged: Array<{ code: string; token: string }> = [];
+  const store = instrumentRoomStore(
+    {
+      ...createInMemoryRoomStore({ now: () => 0 }),
+      async acknowledgeOrphanedIndexClaims(claims) {
+        acknowledged.push(...claims);
+      },
+    },
+    recorder.collector,
+  );
+
+  const acknowledgeOrphanedIndexClaims = store.acknowledgeOrphanedIndexClaims;
+  assert.ok(acknowledgeOrphanedIndexClaims);
+  await acknowledgeOrphanedIndexClaims([{ code: "GHOST1", token: "claim-1" }]);
+
+  assert.deepEqual(acknowledged, [{ code: "GHOST1", token: "claim-1" }]);
+  assert.deepEqual(
+    recorder.durations.map((entry) => entry.operation),
+    ["acknowledge_orphaned_index_claims"],
+  );
+  assert.deepEqual(recorder.failures, []);
+});
+
+test("instrumented room store reports a failed orphan claim acknowledgement", async () => {
+  const recorder = createRecorder();
+  const store = instrumentRoomStore(
+    {
+      ...createInMemoryRoomStore({ now: () => 0 }),
+      async acknowledgeOrphanedIndexClaims() {
+        throw new Error("ack failed");
+      },
+    },
+    recorder.collector,
+  );
+
+  const acknowledgeOrphanedIndexClaims = store.acknowledgeOrphanedIndexClaims;
+  assert.ok(acknowledgeOrphanedIndexClaims);
+  await assert.rejects(
+    acknowledgeOrphanedIndexClaims([{ code: "GHOST1", token: "claim-1" }]),
+    /ack failed/,
+  );
+
+  assert.deepEqual(recorder.failures, ["acknowledge_orphaned_index_claims"]);
+  assert.deepEqual(
+    recorder.durations.map((entry) => entry.operation),
+    ["acknowledge_orphaned_index_claims"],
+  );
+});
+
 test("instrumented room store adds no reconcile hook when the underlying store has none", () => {
   const recorder = createRecorder();
   const store = instrumentRoomStore(


### PR DESCRIPTION
## Summary
- 为真 Redis 测试增加显式 bootstrap reconcile 屏障，消除构造期首趟对账与测试造数之间的时序赌博
- 将所有异常移除房间索引的路径收敛到一个 Lua 原语：先原子写入带 token 的共享清理 claim，再移除索引；room reaper 仅在 generation 守卫下的 runtime teardown 完成后确认 claim
- 使用 Redis 6.0 可用的 hash + rotating zset 实现有界、公平、崩溃可恢复的跨进程交接，并让生产 instrumentation 保留并度量确认方法
- 补齐 Redis ACL、备份、监控、首次停机式上线和稳定回滚屏障的中英文部署/运维文档

Fixes #258

## Compatibility and rollout
- 不改变客户端/服务端同步协议
- 保持 Redis 6.0 最低版本兼容
- 首次上线该 handoff 时，旧版 Room Node 或 Global Admin 仍可能无 claim 剪枝，因此必须排空流量并停止全部旧版 room-store 持有者后再启动新版；同时预先放行并备份 `bsp:room-index-orphans` 与 `bsp:room-index-orphans-queue`

## Test plan
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test && npm run audit`
- [x] Redis 7 真实例：`REDIS_URL=redis://127.0.0.1:6399 npm run --ignore-scripts test -w @bili-syncplay/server`（809/809）
- [x] Redis 6.0.20 真实例：`REDIS_URL=redis://127.0.0.1:6400 npx tsx --test server/test/redis-room-store.test.ts`（36/36）
- [x] 判别力探针：分别回退 bootstrap handoff、延迟确认/token 条件、instrumentation 转发、损坏 body quarantine claim 后，对应回归均按预期失败