### PR TITLE
refactor(server): 移除未使用的房间覆盖写路径 (#277)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,10 +209,11 @@ before changing the code it describes.
   shut the dispatch gate before unsubscribe can wait, and drain accepted
   handlers plus late evictions inside one shared budget; report what remains
   instead of relying on a later store close to do it implicitly. Still
-  open on purpose: the seven durable writes, where #237's trade holds because
+  open on purpose: the six durable writes, where #237's trade holds because
   their effects — unlike a lock's or a dedup slot's — do not expire. The former
   standalone `blockMemberToken` had no production caller and was removed rather
-  than kept as another unbounded path beside atomic eviction.
+  than kept as another unbounded path beside atomic eviction; the room store's
+  unused unconditional `saveRoom` write was removed for the same reason.
   Three more the review round added: **a refusal cap must never be reachable by
   ordinary fan-out** (every read that maps over a deployment-sized collection
   goes through a waiting limiter sized under admission, placed at the fan-out

--- a/docs/reference/invariants.md
+++ b/docs/reference/invariants.md
@@ -823,11 +823,12 @@ do NOT compose, and that is the part that decides which connection gets which:
   stalled Redis is never answered — measured, after #269 and the first round of
   #277 both leaned on it in a comment. Any argument of the form "this path is at
   least bounded by the HTTP server" is false here.
-- **Still open, deliberately: seven durable writes.** Three runtime-store writes
-  through `trackAwaitedOperation` and four room-body writes stay uncapped,
+- **Still open, deliberately: six durable writes.** Three runtime-store writes
+  through `trackAwaitedOperation` and three room-body writes stay uncapped,
   because #237 settled that an answer which can be wrong is worse than a slow
   one and their effects do not expire on their own. The standalone
-  `blockMemberToken` path had no production caller, so #277 removed it. Atomic
+  `blockMemberToken` path and the room store's unconditional `saveRoom` write
+  had no production callers, so #277 removed them. Atomic
   `evictMemberToken` is different: the admin executor caps only its own wait and
   reports `status=error, confirmation=unconfirmed, code=block_unconfirmed`,
   while the original promise keeps the Redis write and both local-mirror
@@ -854,7 +855,7 @@ do NOT compose, and that is the part that decides which connection gets which:
   owns. The gate matters because the Redis bus may already have captured a
   handler behind a promise boundary; such a handler answers `stale_target`
   instead of creating fresh work after the drain snapshot.
-  The remaining seven differ from
+  The remaining six differ from
   `acquireRoomLock` and `tryClaimMessageSlot`, which ARE capped at the store:
   a `SET NX PX` that lands after its caller gave up releases itself at its TTL,
   so "may have landed" costs one lock interval rather than a permanent wrong

--- a/docs/reference/invariants.zh-CN.md
+++ b/docs/reference/invariants.zh-CN.md
@@ -576,10 +576,11 @@
 - **Node 的 `requestTimeout` 不是慢 handler 的兜底。** 它约束的是**接收**请求，不是产出响应，
   所以一个在等僵死 Redis 的 HTTP handler 永远不会被答复——这是实测结论，而 #269 和 #277 的
   第一轮都曾在注释里倚靠它。任何"这条路径至少还有 HTTP 服务器兜底"的论证在这里都不成立。
-- **仍然刻意留着的：七个持久写。** 运行时存储经 `trackAwaitedOperation` 的三个写和房间
-  存储的四个房间体写维持无上限，因为 #237 已经判过"一个可能是错的答复比一个慢的答复更
-  糟"，而它们的副作用不会自己过期。独立的 `blockMemberToken` 路径没有生产调用方，所以
-  #277 直接删除它。原子的 `evictMemberToken` 不同：管理命令执行器只限制自己的等待并返回
+- **仍然刻意留着的：六个持久写。** 运行时存储经 `trackAwaitedOperation` 的三个写和房间
+  存储的三个房间体写维持无上限，因为 #237 已经判过"一个可能是错的答复比一个慢的答复更
+  糟"，而它们的副作用不会自己过期。独立的 `blockMemberToken` 路径和房间存储中无条件写入的
+  `saveRoom` 都没有生产调用方，所以 #277 直接删除了它们。原子的 `evictMemberToken` 不同：
+  管理命令执行器只限制自己的等待并返回
   `status=error, confirmation=unconfirmed, code=block_unconfirmed`，原始 Promise 继续承载
   Redis 写入和两层本地镜像更新，再断开套接字以触发正常离房清理。最终的
   `admin_command_executed` 日志归真实
@@ -595,7 +596,7 @@
   `admin_command_consumer_close_unfinished`，分别报告仍未结束的 handler 与驱逐，而不是依赖
   更晚的 runtime-store 关闭去排空一份本来属于 consumer 的效果。分发闸门不可省：Redis 总线
   可能已经在 Promise 边界后捕获了 handler；这类 handler 在关服后应答 `stale_target`，不能在
-  drain 快照之后再创建新工作。剩下七个与在
+  drain 快照之后再创建新工作。剩下六个与在
   store 内**已经**加了上限的
   `acquireRoomLock`、`tryClaimMessageSlot` 不同：一条 `SET NX PX` 即使在调用方放弃之后
   才落地，也会在 TTL 到期时自行释放，"可能已经落地"的代价是一个锁周期，而不是一个永久

--- a/docs/runbook/multi-node-operations.md
+++ b/docs/runbook/multi-node-operations.md
@@ -748,11 +748,12 @@ on the background passes**, on purpose:
   `room_reaper_sweep_timeout` → `room_reaper_sweep_stalled`,
   `node_heartbeat_failed`.
 
-Seven persistent writes remain uncapped by design: the runtime store's three
+Six persistent writes remain uncapped by design: the runtime store's three
 writes through `trackAwaitedOperation` (revoke / generation / delete) and the
-room store's four room-body writes. Their effects do not expire, so #237's rule
+room store's three room-body writes. Their effects do not expire, so #237's rule
 still applies: an answer that may be wrong is worse than a slow one. The unused
-standalone `blockMemberToken` operation was removed in #277. The atomic
+standalone `blockMemberToken` operation and the unused unconditional room-store
+`saveRoom` write were removed in #277. The atomic
 `evictMemberToken` call now caps only the executor's wait: it returns
 `status=error, confirmation=unconfirmed, code=block_unconfirmed` at the
 deadline, while its original promise keeps the Redis write and local mirrors
@@ -818,7 +819,7 @@ incident:
   `status=error, confirmation=unconfirmed`; its complete kick effect remains
   outstanding. Retry is safe because the block deadline only moves later. What
   still stays **silent**
-  is the seven durable writes named above; a
+  is the six durable writes named above; a
   revoke, teardown write, or room-body write that never returns is what that
   looks like from outside.
 

--- a/docs/runbook/multi-node-operations.zh-CN.md
+++ b/docs/runbook/multi-node-operations.zh-CN.md
@@ -672,10 +672,11 @@ socket，并在重抛意外实现错误之前 settle 两端结果。房间事件
   僵住，靠的正是这份沉默。它们的信号还是调用方的那些：`room_reaper_sweep_timeout` →
   `room_reaper_sweep_stalled`、`node_heartbeat_failed`。
 
-仍有七个持久写按设计不设上限：运行时存储经 `trackAwaitedOperation` 的三个（吊销 /
-generation / 删房），以及房间存储的四个房间体写。它们的副作用不会自行过期，所以 #237 的
-规则仍适用：一个可能是错的答复比一个慢的答复更糟。独立的 `blockMemberToken` 操作在 #277
-中被删除。原子的 `evictMemberToken` 现在只限制执行节点的等待：到期返回
+仍有六个持久写按设计不设上限：运行时存储经 `trackAwaitedOperation` 的三个（吊销 /
+generation / 删房），以及房间存储的三个房间体写。它们的副作用不会自行过期，所以 #237 的
+规则仍适用：一个可能是错的答复比一个慢的答复更糟。独立的 `blockMemberToken` 操作和房间存储
+中未被使用的无条件 `saveRoom` 写都在 #277 中被删除。原子的 `evictMemberToken` 现在只限制执行
+节点的等待：到期返回
 `status=error, confirmation=unconfirmed, code=block_unconfirmed`，原始 Promise 仍会在迟到
 成功后继续收敛 Redis 写入与本地镜像，再断开套接字以触发正常离房清理。真实效果独立于这道
 等待拥有自己的最终成功 / 失败日志。命令总线在发布后的等待超时时也返回同一个附加的类型化
@@ -724,7 +725,7 @@ generation / 删房），以及房间存储的四个房间体写。它们的副�
   之后房间存储与运行时存储的**请求路径也在这份名单里**——它们会打 `reason=timeout` 并答复
   调用方。僵住的踢人会返回 `status=error, confirmation=unconfirmed`，其完整踢出效果仍在
   进行中；封禁截止时间只会向后推进，所以可以安全重试。
-  仍然**保持沉默**的是上面点名的七个持久写；从外面看，就是一次永远不返回的吊销、teardown
+  仍然**保持沉默**的是上面点名的六个持久写；从外面看，就是一次永远不返回的吊销、teardown
   写或房间体写。
 
 ## 变更后回归清单

--- a/server/src/redis-command-timeout.ts
+++ b/server/src/redis-command-timeout.ts
@@ -57,11 +57,12 @@
  * ## What that leaves open, deliberately
  *
  * #277 closed the request-path gap with a cap that keeps each command tracked.
- * Seven persistent writes deliberately remain uncapped: three runtime-store
- * writes through `trackAwaitedOperation` and four room-body writes. Their
+ * Six persistent writes deliberately remain uncapped: three runtime-store
+ * writes through `trackAwaitedOperation` and three room-body writes. Their
  * effects do not expire, so a timed-out answer could be contradicted by a late
- * write. The unused standalone `blockMemberToken` path was removed in #277;
- * atomic eviction instead bounds the executor's wait while keeping its real
+ * write. The unused standalone `blockMemberToken` path and unconditional
+ * room-store `saveRoom` write were removed in #277; atomic eviction instead
+ * bounds the executor's wait while keeping its real
  * effect alive, reports a typed unconfirmed outcome, and keeps its block
  * deadline monotonic so cross-node retries can land in either order.
  *

--- a/server/src/redis-room-store.ts
+++ b/server/src/redis-room-store.ts
@@ -311,34 +311,6 @@ end
 return "ok"
 `;
 
-// Unconditional write, so the previous body is read inside the script rather
-// than by the caller: there is nothing to compare against, and taking it here
-// means no extra round trip and no window between the read and the write.
-//
-// The membership write is guarded and the body restored if it fails. Without
-// that the caller is told the save failed while the body has in fact already
-// changed, leaving the index carrying a score for a room state that no longer
-// exists — the same partial commit create and update already guard against.
-const SAVE_ROOM_LUA = `
-local previous = redis.call("GET", KEYS[1])
-redis.call("SET", KEYS[1], ARGV[1])
-
-local indexed = pcall(function()
-  redis.call("ZADD", KEYS[2], ARGV[2], ARGV[3])
-end)
-
-if not indexed then
-  if previous then
-    redis.call("SET", KEYS[1], previous)
-  else
-    redis.call("DEL", KEYS[1])
-  end
-  return "index_failed"
-end
-
-return "ok"
-`;
-
 // Membership goes first: a Lua error does not roll back, and a body left
 // without membership is repaired by the next reconcile, whereas a membership
 // left without a body would keep the room in every count until the orphan
@@ -801,14 +773,14 @@ export async function createRedisRoomStore(
     // reading the silence they derive their bounds from (#277). That is why the
     // choice is per CALL — the two passes reach the very same helpers.
     //
-    // What this does NOT resolve: the four durable writes (`createRoom`,
-    // `saveRoom`, `updateRoom`, `deleteRoom`). Capping a write whose effect
+    // What this does NOT resolve: the three durable writes (`createRoom`,
+    // `updateRoom`, `deleteRoom`). Capping a write whose effect
     // does not expire on its own tells a caller it failed while the write may
     // still land, which is #237's trade and needs its own derivation.
     (createBoundedRedisClient(redisUrl, {
       bound: "caller",
       boundedBy:
-        "boundCommand's cap on the request path, plus room-reaper's sweep cap and room-index-reconciler's, both via maintenance-pass; NOT the four durable writes",
+        "boundCommand's cap on the request path, plus room-reaper's sweep cap and room-index-reconciler's, both via maintenance-pass; NOT the three durable writes",
     }) as RedisRoomStoreClient);
   const {
     orphanedRoomCodesKey,
@@ -1304,27 +1276,10 @@ export async function createRedisRoomStore(
         code,
       );
     },
-    async saveRoom(room) {
-      const saved = await redis.eval(
-        SAVE_ROOM_LUA,
-        2,
-        roomKey(room.code),
-        roomsByExpiryKey,
-        serializeRoom(room),
-        expiryScore(room),
-        room.code,
-      );
-      if (saved !== "ok") {
-        throw new Error(
-          `Room ${room.code} could not be indexed; the save was rolled back.`,
-        );
-      }
-      return room;
-    },
     async updateRoom(code, expectedVersion, patch): Promise<RoomUpdateResult> {
       const key = roomKey(code);
       // The read half is capped like any other read; the CAS below is one of
-      // the four durable writes this change leaves for its own derivation.
+      // the three durable writes this change leaves for its own derivation.
       const rawRoom = await boundCommand("update_room", () => redis.get(key));
       if (rawRoom === null) {
         return { ok: false, reason: "not_found" };

--- a/server/src/room-store-instrumentation.ts
+++ b/server/src/room-store-instrumentation.ts
@@ -49,7 +49,6 @@ export function instrumentRoomStore(
   const instrumented: RoomStore = {
     createRoom: measure("create_room", (input) => roomStore.createRoom(input)),
     getRoom: measure("get_room", (code) => roomStore.getRoom(code)),
-    saveRoom: measure("save_room", (room) => roomStore.saveRoom(room)),
     updateRoom: measure("update_room", (code, expectedVersion, patch) =>
       roomStore.updateRoom(code, expectedVersion, patch),
     ),

--- a/server/src/room-store.ts
+++ b/server/src/room-store.ts
@@ -54,7 +54,6 @@ export type ExpiredRoomSweep = {
 export type RoomStore = {
   createRoom: (input: CreatePersistedRoomInput) => Promise<PersistedRoom>;
   getRoom: (code: string) => Promise<PersistedRoom | null>;
-  saveRoom: (room: PersistedRoom) => Promise<PersistedRoom>;
   updateRoom: (
     code: string,
     expectedVersion: number,
@@ -191,11 +190,6 @@ export function createInMemoryRoomStore(
     async getRoom(code): Promise<PersistedRoom | null> {
       const room = rooms.get(code);
       return room ? cloneRoom(room) : null;
-    },
-    async saveRoom(room): Promise<PersistedRoom> {
-      const storedRoom = cloneRoom(room);
-      rooms.set(room.code, storedRoom);
-      return cloneRoom(storedRoom);
     },
     async updateRoom(code, expectedVersion, patch): Promise<RoomUpdateResult> {
       const currentRoom = rooms.get(code);

--- a/server/test/admin-action-service.test.ts
+++ b/server/test/admin-action-service.test.ts
@@ -88,9 +88,6 @@ function createService(options: {
       listRooms: async () => [],
       countRooms: async () => 0,
       isReady: async () => true,
-      saveRoom: async () => {
-        throw new Error("saveRoom should not be called in this test");
-      },
       deleteExpiredRooms: async () => ({
         deletedRoomCodes: [],
         orphanedIndexCodes: [],

--- a/server/test/admin-room-query-keyword.test.ts
+++ b/server/test/admin-room-query-keyword.test.ts
@@ -74,30 +74,23 @@ async function buildFixture() {
   const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
   const runtimeStore = createInMemoryRuntimeStore(() => 1_000);
 
-  await roomStore.createRoom({
+  const roomA = await roomStore.createRoom({
     code: "ROOMAA",
     joinToken: "join-a",
     createdAt: 100,
     ownerMemberId: "owner-alice",
     ownerDisplayName: "Alice",
   });
-  await roomStore.saveRoom({
-    code: "ROOMAA",
-    joinToken: "join-a",
-    createdAt: 100,
-    ownerMemberId: "owner-alice",
-    ownerDisplayName: "Alice",
+  const updatedRoomA = await roomStore.updateRoom(roomA.code, roomA.version, {
     sharedVideo: {
       videoId: "BV1aa",
       url: "https://www.bilibili.com/video/BV1aa",
       title: "猫咪的日常 vlog",
       sharedByDisplayName: "Alice",
     },
-    playback: null,
-    version: 1,
     lastActiveAt: 200,
-    expiresAt: null,
   });
+  assert.equal(updatedRoomA.ok, true);
   runtimeStore.registerSession(
     makeSession({
       id: "session-alice",
@@ -117,30 +110,23 @@ async function buildFixture() {
   );
   runtimeStore.markSessionJoinedRoom("session-bob", "ROOMAA");
 
-  await roomStore.createRoom({
+  const roomB = await roomStore.createRoom({
     code: "ROOMBB",
     joinToken: "join-b",
     createdAt: 110,
     ownerMemberId: "owner-carol",
     ownerDisplayName: "Carol",
   });
-  await roomStore.saveRoom({
-    code: "ROOMBB",
-    joinToken: "join-b",
-    createdAt: 110,
-    ownerMemberId: "owner-carol",
-    ownerDisplayName: "Carol",
+  const updatedRoomB = await roomStore.updateRoom(roomB.code, roomB.version, {
     sharedVideo: {
       videoId: "BV1bb",
       url: "https://www.bilibili.com/video/BV1bb",
       title: "深度学习入门教程",
       sharedByDisplayName: "Carol",
     },
-    playback: null,
-    version: 1,
     lastActiveAt: 210,
-    expiresAt: null,
   });
+  assert.equal(updatedRoomB.ok, true);
   runtimeStore.registerSession(
     makeSession({
       id: "session-carol",
@@ -151,25 +137,17 @@ async function buildFixture() {
   );
   runtimeStore.markSessionJoinedRoom("session-carol", "ROOMBB");
 
-  await roomStore.createRoom({
+  const roomC = await roomStore.createRoom({
     code: "ROOMCC",
     joinToken: "join-c",
     createdAt: 120,
     ownerMemberId: null,
     ownerDisplayName: null,
   });
-  await roomStore.saveRoom({
-    code: "ROOMCC",
-    joinToken: "join-c",
-    createdAt: 120,
-    ownerMemberId: null,
-    ownerDisplayName: null,
-    sharedVideo: null,
-    playback: null,
-    version: 1,
+  const updatedRoomC = await roomStore.updateRoom(roomC.code, roomC.version, {
     lastActiveAt: 220,
-    expiresAt: null,
   });
+  assert.equal(updatedRoomC.ok, true);
 
   const service = createAdminRoomQueryService({
     instanceId: INSTANCE_ID,

--- a/server/test/redis-room-store.test.ts
+++ b/server/test/redis-room-store.test.ts
@@ -187,7 +187,14 @@ test("redis room store scores non-expiring rooms at +inf and expiring ones at th
     assert.equal(revived.ok, true);
     assert.equal(await redis.zscore(roomsKey, room.code), "inf");
 
-    await store.saveRoom({ ...room, expiresAt: 1_500, lastActiveAt: 900 });
+    if (!revived.ok) {
+      throw new Error("Expected revive to succeed.");
+    }
+    const reexpired = await store.updateRoom(room.code, revived.room.version, {
+      expiresAt: 1_500,
+      lastActiveAt: 900,
+    });
+    assert.equal(reexpired.ok, true);
     assert.equal(await redis.zscore(roomsKey, room.code), "1500");
   } finally {
     await store.deleteRoom("SCORE1");
@@ -1090,54 +1097,6 @@ test("redis room count answers every filter from the sorted set alone", async (t
     await store.deleteRoom("GONEBB");
     await store.deleteRoom("LATERC");
     await redis.del(`${namespace}:rooms-by-expiry`);
-    await redis.quit();
-    await store.close();
-  }
-});
-
-test("redis room save rolls the room body back when indexing fails", async (t) => {
-  if (!REDIS_URL) {
-    t.skip("REDIS_URL is not configured.");
-    return;
-  }
-
-  const namespace = uniqueNamespace("saveroll");
-  const roomsKey = `${namespace}:rooms-by-expiry`;
-  const store = await createRedisRoomStore(REDIS_URL, { namespace });
-  const redis = await connect();
-
-  try {
-    const room = await store.createRoom({
-      code: "SAVERB",
-      joinToken: "join-token-123456",
-      createdAt: 1,
-    });
-    const before = await store.getRoom(room.code);
-    assert.ok(before);
-
-    // Wrong type for the set key: the body is written first and the ZADD then
-    // fails. Reporting the failure is not enough — the caller believes nothing
-    // was saved, so the body must still hold its previous state, or the index
-    // would carry a score for a room state that never took effect.
-    await redis.del(roomsKey);
-    await redis.set(roomsKey, "not-a-sorted-set");
-
-    await assert.rejects(() =>
-      store.saveRoom({ ...before, expiresAt: 500, lastActiveAt: 400 }),
-    );
-    assert.deepEqual(await store.getRoom(room.code), before);
-
-    // A save that would have created the body must leave none behind.
-    await assert.rejects(() =>
-      store.saveRoom({ ...before, code: "SAVENW", expiresAt: 600 }),
-    );
-    assert.equal(await redis.exists(`${namespace}:room:SAVENW`), 0);
-  } finally {
-    await redis.del(
-      `${namespace}:room:SAVERB`,
-      `${namespace}:room:SAVENW`,
-      roomsKey,
-    );
     await redis.quit();
     await store.close();
   }

--- a/server/test/redis-store-command-bounds.test.ts
+++ b/server/test/redis-store-command-bounds.test.ts
@@ -501,8 +501,6 @@ const ROOM_BOUNDED_ELSEWHERE: Record<string, string> = {
 const ROOM_UNBOUNDED_DURABLE_WRITES: Record<string, string> = {
   createRoom:
     "#237's trade: the write may land after the caller is told it did not",
-  saveRoom:
-    "#237's trade: the write may land after the caller is told it did not",
   updateRoom: "read half capped; the CAS is #237's trade",
   deleteRoom:
     "#237's trade: the write may land after the caller is told it did not",

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -4402,19 +4402,16 @@ test("a failed generation stamp does not roll back a room that recycled the code
         // Concurrently: our memberless room is expired and reaped, and another
         // request takes the freed code. Only then does our stamp fail.
         await roomStore.deleteRoom("ROOMRC");
-        await roomStore.saveRoom({
+        const replacement = await roomStore.createRoom({
           code: "ROOMRC",
           joinToken: "replacement-token",
           ownerMemberId: "other-owner",
           ownerDisplayName: "Bob",
           createdAt: 2_000,
-          lastActiveAt: 2_000,
-          expiresAt: null,
-          version: 1,
-          sharedVideo: null,
-          playback: null,
         });
-        await roomStore.updateRoom("ROOMRC", 1, { lastActiveAt: 2_500 });
+        await roomStore.updateRoom("ROOMRC", replacement.version, {
+          lastActiveAt: 2_500,
+        });
         throw new Error("redis unavailable");
       },
     },

--- a/server/test/room-state-view.test.ts
+++ b/server/test/room-state-view.test.ts
@@ -5,10 +5,7 @@ import {
   getDefaultPersistenceConfig,
   getDefaultSecurityConfig,
 } from "../src/app.js";
-import {
-  createPersistedRoom,
-  createInMemoryRoomStore,
-} from "../src/room-store.js";
+import { createInMemoryRoomStore } from "../src/room-store.js";
 import { createRoomService } from "../src/room-service.js";
 import type { RuntimeStore } from "../src/runtime-store.js";
 import type { LogEvent, Session } from "../src/types.js";
@@ -45,12 +42,11 @@ function createSession(
 
 test("room state query uses cluster sessions instead of only local active members", async () => {
   const roomStore = createInMemoryRoomStore({ now: () => 1_000 });
-  const room = createPersistedRoom({
+  await roomStore.createRoom({
     code: "ROOM01",
     joinToken: "join-token-1",
     createdAt: 1_000,
   });
-  await roomStore.saveRoom(room);
 
   const localOwner = createSession("owner", "ROOM01", "Alice");
   const remoteJoiner = createSession("joiner", "ROOM01", "Bob");


### PR DESCRIPTION
## 根因

`RoomStore.saveRoom` 是一条无条件覆盖房间体的持久写，但生产代码没有任何调用方。继续保留它，就必须为一个死 API 设计身份守卫、未确认结果和迟到效果收敛；测试还通过它直接灌入完整状态，绕过了生产实际使用的版本化 `updateRoom` 路径。

## 结构性收敛

- 从 `RoomStore`、内存/Redis 实现和指标包装中完整删除 `saveRoom`，同时删除对应的无条件 Redis Lua 写原语。
- 测试 fixture 改走生产真实的 `createRoom` + 带版本守卫的 `updateRoom`；删除只验证已不存在写原语的 rollback 用例。
- Redis 命令分类表继续机械覆盖 store 的全部方法；中英文不变量和运行手册把剩余无界持久写从 7 条更新为 6 条。

这不是给问题叠超时，而是删除没有业务所有者的第二套写机制。

## 验证

- 区分力探针：临时恢复 `saveRoom` 返回方法后，`every room store method is classified` 精确以未分类方法 `saveRoom` 失败；恢复后通过。
- 真实 Redis 全量：849 tests，849 pass，0 fail，0 skipped。
- 提交前与推送前均完整通过：
  - `npm run format:check`
  - `npm run lint`
  - `npm run typecheck`
  - `npm run build`
  - `npm test`
  - `npm run audit`
- 本地 `codex review --uncommitted`：未发现遗漏调用或明确缺陷。

Part of #277. 此 PR 将剩余持久写从 7 条降为 6 条，不关闭 issue。
