### PR TITLE
fix(server): 让运行时删房效果在确认超时后继续收敛 (#277)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,9 +215,12 @@ before changing the code it describes.
   exact effect shares one confirmation cap. Maintenance callers keep awaiting
   the real effect so `stalled` remains observable; the request deadline is its
   own constant rather than the Redis connection's liveness backstop. Retry debt
-  is owned by the latest exact effect (or by no effect while awaiting a fresh
-  attempt), so a newer generation's success or a live persisted room supersedes
-  older effects whose late skip/failure must not retain or resurrect the debt.
+  is assigned only when the latest exact effect is created (or has no owner
+  while awaiting a fresh attempt); a waiter reusing an effect never transfers
+  ownership. The generation pinned before the room read is confirmed again
+  after that await before any effect can be created or reused. Thus a newer
+  generation's success or a live persisted room supersedes older effects whose
+  late skip/failure must not retain or resurrect the debt.
   Still open on purpose: the five durable writes, where
   #237's trade holds because their effects — unlike a lock's or a dedup slot's
   — do not expire. The former

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,8 +214,11 @@ before changing the code it describes.
   remains tracked through every local mirror, and every request waiting on that
   exact effect shares one confirmation cap. Maintenance callers keep awaiting
   the real effect so `stalled` remains observable; the request deadline is its
-  own constant rather than the Redis connection's liveness backstop. Still open
-  on purpose: the five durable writes, where
+  own constant rather than the Redis connection's liveness backstop. Retry debt
+  is owned by the latest exact effect (or by no effect while awaiting a fresh
+  attempt), so a newer generation's success or a live persisted room supersedes
+  older effects whose late skip/failure must not retain or resurrect the debt.
+  Still open on purpose: the five durable writes, where
   #237's trade holds because their effects — unlike a lock's or a dedup slot's
   — do not expire. The former
   standalone `blockMemberToken` had no production caller and was removed rather

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,9 +218,12 @@ before changing the code it describes.
   is assigned only when the latest exact effect is created (or has no owner
   while awaiting a fresh attempt); a waiter reusing an effect never transfers
   ownership. The generation pinned before the room read is confirmed again
-  after that await before any effect can be created or reused. Thus a newer
-  generation's success or a live persisted room supersedes older effects whose
-  late skip/failure must not retain or resurrect the debt.
+  after that await before any effect can be created or reused. Each pending debt
+  is also a unique record: a maintenance candidate snapshots that identity and
+  re-checks it after all precondition awaits, so a debt settled meanwhile
+  cannot be recreated. Thus a newer generation's success or a live persisted
+  room supersedes older effects whose late skip/failure must not retain or
+  resurrect the debt.
   Still open on purpose: the five durable writes, where
   #237's trade holds because their effects — unlike a lock's or a dedup slot's
   — do not expire. The former

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,9 +208,16 @@ before changing the code it describes.
   maximum so cross-node retries commute. That effect ownership includes close:
   shut the dispatch gate before unsubscribe can wait, and drain accepted
   handlers plus late evictions inside one shared budget; report what remains
-  instead of relying on a later store close to do it implicitly. Still
-  open on purpose: the six durable writes, where #237's trade holds because
-  their effects — unlike a lock's or a dedup slot's — do not expire. The former
+  instead of relying on a later store close to do it implicitly. Runtime room
+  teardown follows the same two-lifetime rule one layer up: its generation is
+  mandatory (there is no wildcard delete), one real effect per room generation
+  remains tracked through every local mirror, and every request waiting on that
+  exact effect shares one confirmation cap. Maintenance callers keep awaiting
+  the real effect so `stalled` remains observable; the request deadline is its
+  own constant rather than the Redis connection's liveness backstop. Still open
+  on purpose: the five durable writes, where
+  #237's trade holds because their effects — unlike a lock's or a dedup slot's
+  — do not expire. The former
   standalone `blockMemberToken` had no production caller and was removed rather
   than kept as another unbounded path beside atomic eviction; the room store's
   unused unconditional `saveRoom` write was removed for the same reason.

--- a/docs/reference/invariants.md
+++ b/docs/reference/invariants.md
@@ -865,8 +865,12 @@ do NOT compose, and that is the part that decides which connection gets which:
   constant; it is deliberately not Redis's connection-liveness constant. A
   request records an unconfirmed outcome, while a reaper passes
   `maintenance_pass` to both precondition reads and awaits the real promise so
-  `stalled` remains reachable. Late success clears the retry debt; late failure
-  leaves it queued, and each owns a terminal log. The remaining five differ from
+  `stalled` remains reachable. Retry debt names the latest exact effect that
+  owns it (or no effect while awaiting a fresh attempt); a newer generation's
+  success or a live persisted room supersedes older effects, so their late skip
+  or failure cannot retain or resurrect the debt. An owning late success clears
+  the debt, an owning late failure leaves it queued, and each effect owns a
+  terminal log. The remaining five differ from
   `acquireRoomLock` and `tryClaimMessageSlot`, which ARE capped at the store:
   a `SET NX PX` that lands after its caller gave up releases itself at its TTL,
   so "may have landed" costs one lock interval rather than a permanent wrong

--- a/docs/reference/invariants.md
+++ b/docs/reference/invariants.md
@@ -869,7 +869,10 @@ do NOT compose, and that is the part that decides which connection gets which:
   effect is created (or has no owner while awaiting a fresh attempt); a waiter
   reusing an effect never transfers ownership, because its generation may have
   crossed the room-read await. The generation pinned before that read is
-  confirmed again afterwards before an effect may be created or reused. A newer
+  confirmed again afterwards before an effect may be created or reused. Every
+  pending debt is a unique record; a maintenance candidate snapshots that
+  identity and re-checks it after the preconditions, so an owner success during
+  those awaits cannot be followed by a new effect for the settled debt. A newer
   generation's success or a live persisted room supersedes older effects, so
   their late skip or failure cannot retain or resurrect the debt. An owning late
   success clears the debt, an owning late failure leaves it queued, and each

--- a/docs/reference/invariants.md
+++ b/docs/reference/invariants.md
@@ -865,12 +865,15 @@ do NOT compose, and that is the part that decides which connection gets which:
   constant; it is deliberately not Redis's connection-liveness constant. A
   request records an unconfirmed outcome, while a reaper passes
   `maintenance_pass` to both precondition reads and awaits the real promise so
-  `stalled` remains reachable. Retry debt names the latest exact effect that
-  owns it (or no effect while awaiting a fresh attempt); a newer generation's
-  success or a live persisted room supersedes older effects, so their late skip
-  or failure cannot retain or resurrect the debt. An owning late success clears
-  the debt, an owning late failure leaves it queued, and each effect owns a
-  terminal log. The remaining five differ from
+  `stalled` remains reachable. Retry debt is assigned when the latest exact
+  effect is created (or has no owner while awaiting a fresh attempt); a waiter
+  reusing an effect never transfers ownership, because its generation may have
+  crossed the room-read await. The generation pinned before that read is
+  confirmed again afterwards before an effect may be created or reused. A newer
+  generation's success or a live persisted room supersedes older effects, so
+  their late skip or failure cannot retain or resurrect the debt. An owning late
+  success clears the debt, an owning late failure leaves it queued, and each
+  effect owns a terminal log. The remaining five differ from
   `acquireRoomLock` and `tryClaimMessageSlot`, which ARE capped at the store:
   a `SET NX PX` that lands after its caller gave up releases itself at its TTL,
   so "may have landed" costs one lock interval rather than a permanent wrong

--- a/docs/reference/invariants.md
+++ b/docs/reference/invariants.md
@@ -823,8 +823,9 @@ do NOT compose, and that is the part that decides which connection gets which:
   stalled Redis is never answered — measured, after #269 and the first round of
   #277 both leaned on it in a comment. Any argument of the form "this path is at
   least bounded by the HTTP server" is false here.
-- **Still open, deliberately: six durable writes.** Three runtime-store writes
-  through `trackAwaitedOperation` and three room-body writes stay uncapped,
+- **Still open, deliberately: five durable writes.** Two runtime-store writes
+  through `trackAwaitedOperation` (`revokeMemberToken` and
+  `markRoomGeneration`) and three room-body writes stay uncapped,
   because #237 settled that an answer which can be wrong is worse than a slow
   one and their effects do not expire on their own. The standalone
   `blockMemberToken` path and the room store's unconditional `saveRoom` write
@@ -854,8 +855,18 @@ do NOT compose, and that is the part that decides which connection gets which:
   than relying on a later runtime-store close to drain an effect the consumer
   owns. The gate matters because the Redis bus may already have captured a
   handler behind a promise boundary; such a handler answers `stale_target`
-  instead of creating fresh work after the drain snapshot.
-  The remaining six differ from
+  instead of creating fresh work after the drain snapshot. Runtime room
+  teardown is bounded without cutting that effect trail: its generation
+  argument is mandatory and the Redis script has no wildcard mode;
+  `room-service` keeps one real teardown promise per room generation through the
+  Redis write and every local mirror, so an old unanswered effect cannot hide
+  cleanup for a later occupant of the same code. Every request waiting on that
+  exact effect shares one confirmation promise and one behaviour-deadline
+  constant; it is deliberately not Redis's connection-liveness constant. A
+  request records an unconfirmed outcome, while a reaper passes
+  `maintenance_pass` to both precondition reads and awaits the real promise so
+  `stalled` remains reachable. Late success clears the retry debt; late failure
+  leaves it queued, and each owns a terminal log. The remaining five differ from
   `acquireRoomLock` and `tryClaimMessageSlot`, which ARE capped at the store:
   a `SET NX PX` that lands after its caller gave up releases itself at its TTL,
   so "may have landed" costs one lock interval rather than a permanent wrong

--- a/docs/reference/invariants.zh-CN.md
+++ b/docs/reference/invariants.zh-CN.md
@@ -602,10 +602,12 @@
   一条真实 teardown Promise，直到 Redis 写和每层本地镜像全部结算，因此旧 generation 的
   僵死效果不会遮住复用房间码后的清理。同一效果的所有请求等待者复用同一条确认 Promise 和
   同一个行为期限；这个期限使用独立常量，不与 Redis 连接的 liveness 常量耦合。reaper 给两条
-  前置读取都传 `maintenance_pass`，继续等待真实 Promise，因此 `stalled` 仍可达。重试债会
-  点名当前拥有它的最新 generation 效果（等待新尝试时则没有 owner）：owner 迟到成功会清债，
-  owner 迟到失败会留债，两者都有最终日志。新 generation 成功或观察到仍存在的持久房间会
-  取代旧 owner，因此旧效果迟到的跳过或失败不能继续占着、也不能复活这笔债。
+  前置读取都传 `maintenance_pass`，继续等待真实 Promise，因此 `stalled` 仍可达。重试债只在
+  创建最新 generation 效果时授予 owner（等待新尝试时则没有 owner）；复用效果的等待者可能
+  带着跨过房间读取 `await` 的旧 generation，因此绝不能转移 owner；房间读取前 pin 的
+  generation 还必须在该 `await` 后再次确认，确认一致才可创建或复用效果。owner 迟到成功会
+  清债，owner 迟到失败会留债，两者都有最终日志。新 generation 成功或观察到仍存在的持久
+  房间会取代旧 owner，因此旧效果迟到的跳过或失败不能继续占着、也不能复活这笔债。
   剩下五个与在
   store 内**已经**加了上限的
   `acquireRoomLock`、`tryClaimMessageSlot` 不同：一条 `SET NX PX` 即使在调用方放弃之后

--- a/docs/reference/invariants.zh-CN.md
+++ b/docs/reference/invariants.zh-CN.md
@@ -602,8 +602,10 @@
   一条真实 teardown Promise，直到 Redis 写和每层本地镜像全部结算，因此旧 generation 的
   僵死效果不会遮住复用房间码后的清理。同一效果的所有请求等待者复用同一条确认 Promise 和
   同一个行为期限；这个期限使用独立常量，不与 Redis 连接的 liveness 常量耦合。reaper 给两条
-  前置读取都传 `maintenance_pass`，继续等待真实 Promise，因此 `stalled` 仍可达。迟到成功会
-  清掉重试债，迟到失败会把债留在队列里，两者都有最终日志。
+  前置读取都传 `maintenance_pass`，继续等待真实 Promise，因此 `stalled` 仍可达。重试债会
+  点名当前拥有它的最新 generation 效果（等待新尝试时则没有 owner）：owner 迟到成功会清债，
+  owner 迟到失败会留债，两者都有最终日志。新 generation 成功或观察到仍存在的持久房间会
+  取代旧 owner，因此旧效果迟到的跳过或失败不能继续占着、也不能复活这笔债。
   剩下五个与在
   store 内**已经**加了上限的
   `acquireRoomLock`、`tryClaimMessageSlot` 不同：一条 `SET NX PX` 即使在调用方放弃之后

--- a/docs/reference/invariants.zh-CN.md
+++ b/docs/reference/invariants.zh-CN.md
@@ -606,8 +606,10 @@
   创建最新 generation 效果时授予 owner（等待新尝试时则没有 owner）；复用效果的等待者可能
   带着跨过房间读取 `await` 的旧 generation，因此绝不能转移 owner；房间读取前 pin 的
   generation 还必须在该 `await` 后再次确认，确认一致才可创建或复用效果。owner 迟到成功会
-  清债，owner 迟到失败会留债，两者都有最终日志。新 generation 成功或观察到仍存在的持久
-  房间会取代旧 owner，因此旧效果迟到的跳过或失败不能继续占着、也不能复活这笔债。
+  清债，owner 迟到失败会留债，两者都有最终日志。每笔 pending debt 还是一个唯一记录；
+  maintenance 候选会捕获该记录的身份，并在前置等待后复核，因此 owner 在这些 `await` 中成功
+  清掉的债不能被候选重新创建。新 generation 成功或观察到仍存在的持久房间会取代旧 owner，
+  因此旧效果迟到的跳过或失败不能继续占着、也不能复活这笔债。
   剩下五个与在
   store 内**已经**加了上限的
   `acquireRoomLock`、`tryClaimMessageSlot` 不同：一条 `SET NX PX` 即使在调用方放弃之后

--- a/docs/reference/invariants.zh-CN.md
+++ b/docs/reference/invariants.zh-CN.md
@@ -576,8 +576,9 @@
 - **Node 的 `requestTimeout` 不是慢 handler 的兜底。** 它约束的是**接收**请求，不是产出响应，
   所以一个在等僵死 Redis 的 HTTP handler 永远不会被答复——这是实测结论，而 #269 和 #277 的
   第一轮都曾在注释里倚靠它。任何"这条路径至少还有 HTTP 服务器兜底"的论证在这里都不成立。
-- **仍然刻意留着的：六个持久写。** 运行时存储经 `trackAwaitedOperation` 的三个写和房间
-  存储的三个房间体写维持无上限，因为 #237 已经判过"一个可能是错的答复比一个慢的答复更
+- **仍然刻意留着的：五个持久写。** 运行时存储经 `trackAwaitedOperation` 的两个写
+  （`revokeMemberToken` 与 `markRoomGeneration`）和房间存储的三个房间体写维持无上限，
+  因为 #237 已经判过"一个可能是错的答复比一个慢的答复更
   糟"，而它们的副作用不会自己过期。独立的 `blockMemberToken` 路径和房间存储中无条件写入的
   `saveRoom` 都没有生产调用方，所以 #277 直接删除了它们。原子的 `evictMemberToken` 不同：
   管理命令执行器只限制自己的等待并返回
@@ -596,7 +597,14 @@
   `admin_command_consumer_close_unfinished`，分别报告仍未结束的 handler 与驱逐，而不是依赖
   更晚的 runtime-store 关闭去排空一份本来属于 consumer 的效果。分发闸门不可省：Redis 总线
   可能已经在 Promise 边界后捕获了 handler；这类 handler 在关服后应答 `stale_target`，不能在
-  drain 快照之后再创建新工作。剩下六个与在
+  drain 快照之后再创建新工作。运行时删房则在不截断效果轨迹的前提下拿到了界：generation
+  参数变成必填，Redis 脚本不再存在通配删除；`room-service` 为每个房间 generation 保留唯一
+  一条真实 teardown Promise，直到 Redis 写和每层本地镜像全部结算，因此旧 generation 的
+  僵死效果不会遮住复用房间码后的清理。同一效果的所有请求等待者复用同一条确认 Promise 和
+  同一个行为期限；这个期限使用独立常量，不与 Redis 连接的 liveness 常量耦合。reaper 给两条
+  前置读取都传 `maintenance_pass`，继续等待真实 Promise，因此 `stalled` 仍可达。迟到成功会
+  清掉重试债，迟到失败会把债留在队列里，两者都有最终日志。
+  剩下五个与在
   store 内**已经**加了上限的
   `acquireRoomLock`、`tryClaimMessageSlot` 不同：一条 `SET NX PX` 即使在调用方放弃之后
   才落地，也会在 TTL 到期时自行释放，"可能已经落地"的代价是一个锁周期，而不是一个永久

--- a/docs/runbook/multi-node-operations.md
+++ b/docs/runbook/multi-node-operations.md
@@ -825,8 +825,11 @@ incident:
   `room_runtime_cleanup_unconfirmed`, and one real effect per room generation
   continues through local-mirror settlement. Waiters on the exact effect share
   one confirmation deadline, independent of the Redis liveness constant. The
-  retry debt belongs to the latest exact effect, so a newer generation's
-  success or a live persisted room supersedes any older late skip/failure. A
+  retry debt is assigned only when the latest exact effect is created; waiters
+  reusing an effect never transfer it, and confirm their pre-read generation
+  again after the room-read await before reaching an effect. A newer
+  generation's success or a live persisted room therefore supersedes any older
+  late skip/failure. A
   maintenance-driven teardown deliberately stays silent so the reaper can
   report `timed_out` and then `stalled`.
 

--- a/docs/runbook/multi-node-operations.md
+++ b/docs/runbook/multi-node-operations.md
@@ -827,9 +827,11 @@ incident:
   one confirmation deadline, independent of the Redis liveness constant. The
   retry debt is assigned only when the latest exact effect is created; waiters
   reusing an effect never transfer it, and confirm their pre-read generation
-  again after the room-read await before reaching an effect. A newer
-  generation's success or a live persisted room therefore supersedes any older
-  late skip/failure. A
+  again after the room-read await before reaching an effect. Maintenance backlog
+  candidates also snapshot the unique debt record and re-check it after their
+  preconditions, so already-settled debt is never recreated. A newer generation's
+  success or a live persisted room therefore supersedes any older late
+  skip/failure. A
   maintenance-driven teardown deliberately stays silent so the reaper can
   report `timed_out` and then `stalled`.
 

--- a/docs/runbook/multi-node-operations.md
+++ b/docs/runbook/multi-node-operations.md
@@ -748,9 +748,9 @@ on the background passes**, on purpose:
   `room_reaper_sweep_timeout` → `room_reaper_sweep_stalled`,
   `node_heartbeat_failed`.
 
-Six persistent writes remain uncapped by design: the runtime store's three
-writes through `trackAwaitedOperation` (revoke / generation / delete) and the
-room store's three room-body writes. Their effects do not expire, so #237's rule
+Five persistent writes remain uncapped by design: the runtime store's two
+writes through `trackAwaitedOperation` (revoke / generation) and the room
+store's three room-body writes. Their effects do not expire, so #237's rule
 still applies: an answer that may be wrong is worse than a slow one. The unused
 standalone `blockMemberToken` operation and the unused unconditional room-store
 `saveRoom` write were removed in #277. The atomic
@@ -818,10 +818,15 @@ incident:
   `reason=timeout` and answer their caller. A stalled kick returns
   `status=error, confirmation=unconfirmed`; its complete kick effect remains
   outstanding. Retry is safe because the block deadline only moves later. What
-  still stays **silent**
-  is the six durable writes named above; a
-  revoke, teardown write, or room-body write that never returns is what that
-  looks like from outside.
+  still stays **silent** is the five durable writes named above; a revoke,
+  generation stamp, or room-body write that never returns is what that looks
+  like from outside. Runtime room teardown is different: its generation guard
+  is mandatory, requests stop waiting with
+  `room_runtime_cleanup_unconfirmed`, and one real effect per room generation
+  continues through local-mirror settlement. Waiters on the exact effect share
+  one confirmation deadline, independent of the Redis liveness constant. A
+  maintenance-driven teardown deliberately stays silent so the reaper can
+  report `timed_out` and then `stalled`.
 
 ## Post-Change Regression Checklist
 

--- a/docs/runbook/multi-node-operations.md
+++ b/docs/runbook/multi-node-operations.md
@@ -824,7 +824,9 @@ incident:
   is mandatory, requests stop waiting with
   `room_runtime_cleanup_unconfirmed`, and one real effect per room generation
   continues through local-mirror settlement. Waiters on the exact effect share
-  one confirmation deadline, independent of the Redis liveness constant. A
+  one confirmation deadline, independent of the Redis liveness constant. The
+  retry debt belongs to the latest exact effect, so a newer generation's
+  success or a live persisted room supersedes any older late skip/failure. A
   maintenance-driven teardown deliberately stays silent so the reaper can
   report `timed_out` and then `stalled`.
 

--- a/docs/runbook/multi-node-operations.zh-CN.md
+++ b/docs/runbook/multi-node-operations.zh-CN.md
@@ -728,10 +728,11 @@ generation），以及房间存储的三个房间体写。它们的副作用不�
   仍然**保持沉默**的是上面点名的五个持久写；从外面看，就是一次永远不返回的吊销、
   generation 写或房间体写。运行时删房不同：generation 守卫为必填，请求等待到期会记录
   `room_runtime_cleanup_unconfirmed`，每个房间 generation 唯一一条真实效果继续完成本地镜像
-  收敛；同一效果的等待者共用一条独立于 Redis liveness 常量的确认期限。重试债归属于最新
-  的精确 generation 效果，所以新 generation 成功或观察到仍存在的持久房间后，旧效果迟到的
-  跳过 / 失败不能继续占着或复活这笔债。由 maintenance 驱动的删房则刻意保持沉默，让 reaper
-  仍能报告 `timed_out`，下一轮再报告 `stalled`。
+  收敛；同一效果的等待者共用一条独立于 Redis liveness 常量的确认期限。重试债只在创建最新
+  的精确 generation 效果时授予 owner，复用效果的等待者不能转移它，并且在房间读取 `await`
+  之后必须再次确认读取前 pin 的 generation；所以新 generation 成功或观察到仍存在的持久
+  房间后，旧效果迟到的跳过 / 失败不能继续占着或复活这笔债。由 maintenance 驱动的删房则
+  刻意保持沉默，让 reaper 仍能报告 `timed_out`，下一轮再报告 `stalled`。
 
 ## 变更后回归清单
 

--- a/docs/runbook/multi-node-operations.zh-CN.md
+++ b/docs/runbook/multi-node-operations.zh-CN.md
@@ -672,8 +672,8 @@ socket，并在重抛意外实现错误之前 settle 两端结果。房间事件
   僵住，靠的正是这份沉默。它们的信号还是调用方的那些：`room_reaper_sweep_timeout` →
   `room_reaper_sweep_stalled`、`node_heartbeat_failed`。
 
-仍有六个持久写按设计不设上限：运行时存储经 `trackAwaitedOperation` 的三个（吊销 /
-generation / 删房），以及房间存储的三个房间体写。它们的副作用不会自行过期，所以 #237 的
+仍有五个持久写按设计不设上限：运行时存储经 `trackAwaitedOperation` 的两个（吊销 /
+generation），以及房间存储的三个房间体写。它们的副作用不会自行过期，所以 #237 的
 规则仍适用：一个可能是错的答复比一个慢的答复更糟。独立的 `blockMemberToken` 操作和房间存储
 中未被使用的无条件 `saveRoom` 写都在 #277 中被删除。原子的 `evictMemberToken` 现在只限制执行
 节点的等待：到期返回
@@ -725,8 +725,11 @@ generation / 删房），以及房间存储的三个房间体写。它们的副�
   之后房间存储与运行时存储的**请求路径也在这份名单里**——它们会打 `reason=timeout` 并答复
   调用方。僵住的踢人会返回 `status=error, confirmation=unconfirmed`，其完整踢出效果仍在
   进行中；封禁截止时间只会向后推进，所以可以安全重试。
-  仍然**保持沉默**的是上面点名的六个持久写；从外面看，就是一次永远不返回的吊销、teardown
-  写或房间体写。
+  仍然**保持沉默**的是上面点名的五个持久写；从外面看，就是一次永远不返回的吊销、
+  generation 写或房间体写。运行时删房不同：generation 守卫为必填，请求等待到期会记录
+  `room_runtime_cleanup_unconfirmed`，每个房间 generation 唯一一条真实效果继续完成本地镜像
+  收敛；同一效果的等待者共用一条独立于 Redis liveness 常量的确认期限。由 maintenance 驱动
+  的删房则刻意保持沉默，让 reaper 仍能报告 `timed_out`，下一轮再报告 `stalled`。
 
 ## 变更后回归清单
 

--- a/docs/runbook/multi-node-operations.zh-CN.md
+++ b/docs/runbook/multi-node-operations.zh-CN.md
@@ -730,9 +730,10 @@ generation），以及房间存储的三个房间体写。它们的副作用不�
   `room_runtime_cleanup_unconfirmed`，每个房间 generation 唯一一条真实效果继续完成本地镜像
   收敛；同一效果的等待者共用一条独立于 Redis liveness 常量的确认期限。重试债只在创建最新
   的精确 generation 效果时授予 owner，复用效果的等待者不能转移它，并且在房间读取 `await`
-  之后必须再次确认读取前 pin 的 generation；所以新 generation 成功或观察到仍存在的持久
-  房间后，旧效果迟到的跳过 / 失败不能继续占着或复活这笔债。由 maintenance 驱动的删房则
-  刻意保持沉默，让 reaper 仍能报告 `timed_out`，下一轮再报告 `stalled`。
+  之后必须再次确认读取前 pin 的 generation。maintenance backlog 候选还会捕获唯一 debt
+  记录并在前置等待后复核，已经清偿的债不会被重新创建；所以新 generation 成功或观察到仍
+  存在的持久房间后，旧效果迟到的跳过 / 失败不能继续占着或复活这笔债。由 maintenance 驱动
+  的删房则刻意保持沉默，让 reaper 仍能报告 `timed_out`，下一轮再报告 `stalled`。
 
 ## 变更后回归清单
 

--- a/docs/runbook/multi-node-operations.zh-CN.md
+++ b/docs/runbook/multi-node-operations.zh-CN.md
@@ -728,8 +728,10 @@ generation），以及房间存储的三个房间体写。它们的副作用不�
   仍然**保持沉默**的是上面点名的五个持久写；从外面看，就是一次永远不返回的吊销、
   generation 写或房间体写。运行时删房不同：generation 守卫为必填，请求等待到期会记录
   `room_runtime_cleanup_unconfirmed`，每个房间 generation 唯一一条真实效果继续完成本地镜像
-  收敛；同一效果的等待者共用一条独立于 Redis liveness 常量的确认期限。由 maintenance 驱动
-  的删房则刻意保持沉默，让 reaper 仍能报告 `timed_out`，下一轮再报告 `stalled`。
+  收敛；同一效果的等待者共用一条独立于 Redis liveness 常量的确认期限。重试债归属于最新
+  的精确 generation 效果，所以新 generation 成功或观察到仍存在的持久房间后，旧效果迟到的
+  跳过 / 失败不能继续占着或复活这笔债。由 maintenance 驱动的删房则刻意保持沉默，让 reaper
+  仍能报告 `timed_out`，下一轮再报告 `stalled`。
 
 ## 变更后回归清单
 

--- a/server/src/mirrored-runtime-store.ts
+++ b/server/src/mirrored-runtime-store.ts
@@ -50,7 +50,10 @@ function mirrorConditionalTeardown(
   return async (code, expectedGeneration) => {
     const applied = await sharedDelete(code, expectedGeneration);
     if (applied) {
-      localDelete(code);
+      // This process-local mirror deliberately carries no generation; the
+      // shared store above already made the ownership decision. `null` is the
+      // mirror's actual expected state, not an unguarded delete.
+      localDelete(code, null);
     }
     return applied;
   };

--- a/server/src/redis-command-timeout.ts
+++ b/server/src/redis-command-timeout.ts
@@ -57,14 +57,18 @@
  * ## What that leaves open, deliberately
  *
  * #277 closed the request-path gap with a cap that keeps each command tracked.
- * Six persistent writes deliberately remain uncapped: three runtime-store
+ * Five persistent writes deliberately remain uncapped: two runtime-store
  * writes through `trackAwaitedOperation` and three room-body writes. Their
  * effects do not expire, so a timed-out answer could be contradicted by a late
  * write. The unused standalone `blockMemberToken` path and unconditional
  * room-store `saveRoom` write were removed in #277; atomic eviction instead
  * bounds the executor's wait while keeping its real
  * effect alive, reports a typed unconfirmed outcome, and keeps its block
- * deadline monotonic so cross-node retries can land in either order.
+ * deadline monotonic so cross-node retries can land in either order. Runtime
+ * room teardown instead requires a generation guard and keeps one real effect
+ * per room generation alive in `room-service`; waiters on the same effect share
+ * one confirmation cap whose behaviour-deadline constant is independent of
+ * this liveness backstop, while maintenance passes still await the real effect.
  *
  * ## What `commandTimeout` does NOT do
  *

--- a/server/src/redis-room-store.ts
+++ b/server/src/redis-room-store.ts
@@ -1268,11 +1268,13 @@ export async function createRedisRoomStore(
       }
       return room;
     },
-    async getRoom(code) {
-      // On the join path. Uncapped, a stalled Redis held the WebSocket join
-      // open with nothing else waiting behind it (#277).
+    async getRoom(code, caller = "request") {
+      // Requests own this deadline; the runtime-teardown precondition read is
+      // also reached from the room reaper, whose maintenance pass must keep
+      // deriving `stalled` from the command's silence (#277).
+      const bound = caller === "request" ? boundCommand : boundedByOuterCaller;
       return parseRoom(
-        await boundCommand("get_room", () => redis.get(roomKey(code))),
+        await bound("get_room", () => redis.get(roomKey(code))),
         code,
       );
     },

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -521,11 +521,9 @@ return 1
  * since been stamped by a new occupant is left alone.
  */
 const DELETE_ROOM_LUA = `
-if ARGV[1] ~= "*" then
-  local stored = redis.call("GET", KEYS[1])
-  if (stored or "") ~= ARGV[1] then
-    return 0
-  end
+local stored = redis.call("GET", KEYS[1])
+if (stored or "") ~= ARGV[1] then
+  return 0
 end
 for index = 3, #KEYS do
   redis.call("DEL", KEYS[index])
@@ -816,18 +814,21 @@ export async function createRedisRuntimeStore(
     // also why the bound has to be chosen per CALL, not per method:
     // `loadSession` is reached from the join path AND from the reaper.
     //
-    // What this does NOT resolve: the three durable writes through
-    // `trackAwaitedOperation` (`revokeMemberToken`, `markRoomGeneration`,
-    // `deleteRoom`). Capping those
+    // What this does NOT resolve: two durable writes through
+    // `trackAwaitedOperation` (`revokeMemberToken`, `markRoomGeneration`).
+    // Capping those
     // re-opens #237's trade that an answer which can be wrong is worse than a
     // slow one, and their side effects do not expire on their own the way a
     // lock or a dedup slot does. The former standalone `blockMemberToken` path
     // had no production caller and was removed in #277 rather than preserving
-    // another unbounded persistent write.
+    // another unbounded persistent write. `deleteRoom` is different: its
+    // generation guard is mandatory, and `room-service` caps only a request's
+    // wait while retaining one real per-room effect through local settlement;
+    // maintenance callers still await that effect.
     createBoundedRedisClient(redisUrl, {
       bound: "caller",
       boundedBy:
-        "boundCommand's cap on the request path, the durable write queue's capAttempt at pendingOperationTimeoutMs, trackOperation's cap, admin-command-consumer's member-eviction confirmation deadline, and maintenance-pass's per-tick caps; NOT trackAwaitedOperation's three durable writes",
+        "boundCommand's cap on the request path, the durable write queue's capAttempt at pendingOperationTimeoutMs, trackOperation's cap, admin-command-consumer's member-eviction confirmation deadline, room-service's guarded runtime-teardown confirmation deadline, and maintenance-pass's per-tick caps; NOT trackAwaitedOperation's two remaining durable writes",
     })) as RedisClient;
   const activeRedisCommands = new Set<Promise<void>>();
   const trackRedisCommand: TrackRedisCommand = <T>(
@@ -972,9 +973,10 @@ export async function createRedisRuntimeStore(
    * Applied to reads, and to writes whose side effect expires on its own. An
    * `acquireRoomLock` or `tryClaimMessageSlot` that secretly landed releases
    * itself at its TTL, so "may have landed" costs at most one lock interval.
-   * The three remaining durable writes are not in that class; see the note on
-   * the client. Eviction is bounded at its informed caller so its complete
-   * mirrored effect, rather than only this Redis command, remains alive.
+   * The two remaining durable writes are not in that class; see the note on the
+   * client. Eviction and guarded room teardown are bounded at their informed
+   * callers so their complete mirrored effects, rather than only one Redis
+   * command, remain alive.
    *
    * `async`, and that is load-bearing rather than style: two callers build a
    * `Promise.all([...])` literal out of two of these, and a SYNCHRONOUS throw
@@ -2050,11 +2052,14 @@ export async function createRedisRuntimeStore(
       );
       return Number(found) === 1;
     },
-    async getRoomGeneration(code: string) {
-      // The read a join makes before it may delete a room it believes is empty.
-      // It was the last command on that path with no bound of any kind, which
-      // is what an operator saw as a WebSocket join that never completed (#277).
-      return await boundCommand("get_room_generation", () =>
+    async getRoomGeneration(
+      code: string,
+      caller: RuntimeReadCaller = "request",
+    ) {
+      // Requests own this deadline; the same generation pin is also read by a
+      // room-reaper teardown, where `maintenance-pass` must keep deriving
+      // `stalled` from the command's silence (#277).
+      return await boundFor(caller)("get_room_generation", () =>
         redis.get(roomGenerationKey(keyPrefix, code)),
       );
     },
@@ -2070,7 +2075,7 @@ export async function createRedisRuntimeStore(
         ),
       ).then(() => undefined);
     },
-    deleteRoom(code: string, expectedGeneration?: string | null) {
+    deleteRoom(code: string, expectedGeneration: string | null) {
       ensurePendingCapacity("delete_room");
       // Shared first here, unlike the other teardowns: whether this delete may
       // proceed at all is decided by the script, against the generation every
@@ -2096,7 +2101,7 @@ export async function createRedisRuntimeStore(
             DELETE_ROOM_LUA,
             keys.length,
             ...keys,
-            expectedGeneration === undefined ? "*" : (expectedGeneration ?? ""),
+            expectedGeneration ?? "",
             code,
             ROOM_GENERATION_TOMBSTONE,
           );
@@ -2105,7 +2110,11 @@ export async function createRedisRuntimeStore(
         if (Number(applied) !== 1) {
           return false;
         }
-        localRuntimeStore.deleteRoom(code);
+        // This private mirror deliberately carries no generation; the shared
+        // script above already made the ownership decision. Passing `null`
+        // keeps even the local cleanup conditional instead of preserving an
+        // unguarded mode in the public RuntimeStore contract.
+        localRuntimeStore.deleteRoom(code, null);
         return true;
       });
     },

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -24,9 +24,11 @@ import {
   createRoomCode,
   roomStateFromSessions,
   roomStateOf,
+  type RoomReadCaller,
   type RoomStore,
 } from "./room-store.js";
-import type { RuntimeStore } from "./runtime-store.js";
+import { createRetryPacer } from "./retry-pacer.js";
+import type { RuntimeReadCaller, RuntimeStore } from "./runtime-store.js";
 import { sharedVideoOwnerChangedOnLeave } from "./shared-video-owner.js";
 import { hasAttachedSocket } from "./types.js";
 import type {
@@ -48,6 +50,15 @@ const JOIN_ADMISSION_LOCK_TTL_MS = 30_000;
 const JOIN_ADMISSION_LOCK_MAX_WAIT_MS = 5_000;
 const JOIN_ADMISSION_LOCK_RETRY_INTERVAL_MS = 25;
 
+/**
+ * How long a request waits to confirm guarded runtime teardown.
+ *
+ * This is a behaviour deadline, not Redis's connection-liveness backstop. The
+ * two happen to start at the same magnitude, but must be free to move for
+ * different reasons (#271, #277).
+ */
+export const DEFAULT_RUNTIME_TEARDOWN_CONFIRM_TIMEOUT_MS = 5_000;
+
 type ServiceErrorReason =
   | "room_not_found"
   | "join_token_invalid"
@@ -65,6 +76,14 @@ export class RoomServiceError extends Error {
     readonly details: Record<string, unknown> = {},
   ) {
     super(message);
+  }
+}
+
+class RuntimeTeardownConfirmationTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(
+      `Runtime room teardown did not confirm within ${timeoutMs}ms; its real effect is still tracked.`,
+    );
   }
 }
 
@@ -167,6 +186,8 @@ export function createRoomService(options: {
     currentTime: number,
   ) => Promise<boolean>;
   resolveRoomResidue?: (roomCode: string) => Promise<boolean>;
+  /** Request-side confirmation budget; maintenance passes keep their own cap. */
+  runtimeTeardownConfirmationTimeoutMs?: number;
 }): {
   createRoomForSession: (
     session: Session,
@@ -229,6 +250,13 @@ export function createRoomService(options: {
   const runtimeStoreOption = options.runtimeStore ?? options.activeRooms;
   const now = options.now ?? Date.now;
   const nextRoomCode = options.createRoomCode ?? createRoomCode;
+  const runtimeTeardownConfirmationTimeoutMs =
+    options.runtimeTeardownConfirmationTimeoutMs ??
+    DEFAULT_RUNTIME_TEARDOWN_CONFIRM_TIMEOUT_MS;
+  const runtimeTeardownConfirmationPacer = createRetryPacer({
+    initialDelayMs: runtimeTeardownConfirmationTimeoutMs,
+    maxDelayMs: runtimeTeardownConfirmationTimeoutMs,
+  });
   const playbackAuthorityByRoom = new Map<string, PlaybackAuthority>();
 
   if (!runtimeStoreOption) {
@@ -476,15 +504,169 @@ export function createRoomService(options: {
   }
 
   /**
-   * Room codes whose runtime teardown failed, retried on every later reaper
-   * pass. Kept because a failed teardown is otherwise unrecoverable: the
+   * Room codes whose runtime teardown is unfinished, retried on every later
+   * reaper pass. Kept because a failed teardown is otherwise unrecoverable: the
    * persisted room and its expiry index are already gone, so nothing else will
    * ever produce this code again (#237 review).
    */
   const pendingRuntimeTeardowns = new Set<string>();
 
+  /**
+   * One real teardown effect per room generation. A request may stop waiting
+   * for confirmation, but this promise stays alive until the guarded Redis
+   * write and every local mirror behind it have settled. The generation belongs
+   * in the identity: a stale effect must not hide cleanup for a later occupant
+   * that reused the same room code. Reusing each exact effect prevents a busy
+   * request path from turning one stalled teardown into duplicate commands.
+   */
+  type RuntimeTeardownEffect = {
+    expectedGeneration: string | null;
+    effect: Promise<boolean>;
+    /** One request-side cap shared by every waiter on this exact effect. */
+    requestConfirmation: Promise<boolean> | null;
+    confirmationTimedOut: boolean;
+  };
+  const runtimeTeardownEffects = new Map<
+    string,
+    Map<string | null, RuntimeTeardownEffect>
+  >();
+
+  function removeRuntimeTeardownEffect(
+    code: string,
+    entry: RuntimeTeardownEffect,
+  ): void {
+    const effectsByGeneration = runtimeTeardownEffects.get(code);
+    if (effectsByGeneration?.get(entry.expectedGeneration) !== entry) {
+      return;
+    }
+    effectsByGeneration.delete(entry.expectedGeneration);
+    if (effectsByGeneration.size === 0) {
+      runtimeTeardownEffects.delete(code);
+    }
+  }
+
+  function logRuntimeTeardownTerminal(
+    event:
+      "room_runtime_cleanup_late_settled" | "room_runtime_cleanup_late_failed",
+    code: string,
+    details: Record<string, unknown>,
+  ): void {
+    try {
+      logEvent(event, {
+        roomCode: code,
+        provider: persistence.provider,
+        pendingRetryCount: pendingRuntimeTeardowns.size,
+        ...details,
+      });
+    } catch {
+      // Diagnostics must not turn a settled cleanup effect into a rejection.
+    }
+  }
+
+  function startRuntimeTeardownEffect(
+    code: string,
+    expectedGeneration: string | null,
+  ): RuntimeTeardownEffect {
+    let effectsByGeneration = runtimeTeardownEffects.get(code);
+    const existing = effectsByGeneration?.get(expectedGeneration);
+    if (existing) {
+      return existing;
+    }
+
+    pendingRuntimeTeardowns.add(code);
+    let effect: Promise<boolean>;
+    try {
+      effect = Promise.resolve(
+        runtimeStore.deleteRoom(code, expectedGeneration),
+      );
+    } catch (error) {
+      effect = Promise.reject(error);
+    }
+    const entry: RuntimeTeardownEffect = {
+      expectedGeneration,
+      effect,
+      requestConfirmation: null,
+      confirmationTimedOut: false,
+    };
+    if (!effectsByGeneration) {
+      effectsByGeneration = new Map();
+      runtimeTeardownEffects.set(code, effectsByGeneration);
+    }
+    effectsByGeneration.set(expectedGeneration, entry);
+
+    void effect.then(
+      (applied) => {
+        removeRuntimeTeardownEffect(code, entry);
+        if (applied && !runtimeTeardownEffects.has(code)) {
+          pendingRuntimeTeardowns.delete(code);
+        }
+        if (entry.confirmationTimedOut) {
+          logRuntimeTeardownTerminal(
+            "room_runtime_cleanup_late_settled",
+            code,
+            { result: applied ? "ok" : "skipped" },
+          );
+        }
+      },
+      (error: unknown) => {
+        removeRuntimeTeardownEffect(code, entry);
+        pendingRuntimeTeardowns.add(code);
+        if (entry.confirmationTimedOut) {
+          logRuntimeTeardownTerminal("room_runtime_cleanup_late_failed", code, {
+            result: "error",
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      },
+    );
+    return entry;
+  }
+
+  async function awaitRuntimeTeardownEffect(
+    entry: RuntimeTeardownEffect,
+    caller: RuntimeReadCaller,
+  ): Promise<boolean> {
+    if (caller === "maintenance_pass") {
+      return await entry.effect;
+    }
+    if (!entry.requestConfirmation) {
+      entry.requestConfirmation = runtimeTeardownConfirmationPacer.capAttempt(
+        entry.effect,
+        runtimeTeardownConfirmationTimeoutMs,
+        () => {
+          entry.confirmationTimedOut = true;
+          return new RuntimeTeardownConfirmationTimeoutError(
+            runtimeTeardownConfirmationTimeoutMs,
+          );
+        },
+      );
+    }
+    return await entry.requestConfirmation;
+  }
+
+  function reportRuntimeTeardownWaitFailure(
+    code: string,
+    error: unknown,
+  ): void {
+    const unconfirmed =
+      error instanceof RuntimeTeardownConfirmationTimeoutError;
+    logEvent(
+      unconfirmed
+        ? "room_runtime_cleanup_unconfirmed"
+        : "room_runtime_cleanup_failed",
+      {
+        roomCode: code,
+        provider: persistence.provider,
+        result: unconfirmed ? "unconfirmed" : "error",
+        pendingRetryCount: pendingRuntimeTeardowns.size,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+
   async function collectRuntimeStateForDeletedRooms(
     codes: Iterable<string>,
+    caller: RoomReadCaller,
   ): Promise<Set<string>> {
     const settledCodes = new Set<string>();
     for (const code of new Set(codes)) {
@@ -503,7 +685,7 @@ export function createRoomService(options: {
       // room's generation, which then matched and wiped it (#237 review).
       let expectedGeneration: string | null;
       try {
-        expectedGeneration = await runtimeStore.getRoomGeneration(code);
+        expectedGeneration = await runtimeStore.getRoomGeneration(code, caller);
       } catch {
         pendingRuntimeTeardowns.add(code);
         continue;
@@ -511,7 +693,7 @@ export function createRoomService(options: {
 
       let currentRoom: PersistedRoom | null;
       try {
-        currentRoom = await roomStore.getRoom(code);
+        currentRoom = await roomStore.getRoom(code, caller);
       } catch {
         // A read failure is "unknown", NOT "absent". Treating it as absent made
         // this guard fail in exactly the conditions that queue teardowns in the
@@ -528,18 +710,11 @@ export function createRoomService(options: {
         // The delete only applies while that generation still holds. Both
         // guards around it are check-then-act; no arrangement of them makes the
         // delete itself conditional, which is what actually closes the race.
-        await runtimeStore.deleteRoom(code, expectedGeneration);
-        pendingRuntimeTeardowns.delete(code);
+        const effect = startRuntimeTeardownEffect(code, expectedGeneration);
+        await awaitRuntimeTeardownEffect(effect, caller);
         settledCodes.add(code);
       } catch (error) {
-        pendingRuntimeTeardowns.add(code);
-        logEvent("room_runtime_cleanup_failed", {
-          roomCode: code,
-          provider: persistence.provider,
-          result: "error",
-          pendingRetryCount: pendingRuntimeTeardowns.size,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        reportRuntimeTeardownWaitFailure(code, error);
       }
     }
     return settledCodes;
@@ -566,7 +741,7 @@ export function createRoomService(options: {
       }
       // Same helper as the reaper: it refuses to tear down a code that has
       // already been recycled, and queues a failed teardown for retry.
-      await collectRuntimeStateForDeletedRooms([code]);
+      await collectRuntimeStateForDeletedRooms([code], "request");
       return null;
     }
     return room;
@@ -1297,10 +1472,10 @@ export function createRoomService(options: {
       // that drains it, and the standalone global-admin process never runs the
       // reaper — an admin close/expire whose teardown failed there would have
       // queued a retry nothing ever performed (#237 review).
-      await collectRuntimeStateForDeletedRooms([
-        ...pendingRuntimeTeardowns,
-        code,
-      ]);
+      await collectRuntimeStateForDeletedRooms(
+        [...pendingRuntimeTeardowns, code],
+        "request",
+      );
     },
     async createRoomForSession(session, displayName) {
       setSessionDisplayName(session, displayName);
@@ -1972,11 +2147,14 @@ export function createRoomService(options: {
       // state that outlives it (member tokens survive a disconnect on purpose,
       // #234), and once the persisted room is gone nothing will ever name that
       // code again.
-      const settledCodes = await collectRuntimeStateForDeletedRooms([
-        ...pendingRuntimeTeardowns,
-        ...swept.deletedRoomCodes,
-        ...swept.orphanedIndexCodes,
-      ]);
+      const settledCodes = await collectRuntimeStateForDeletedRooms(
+        [
+          ...pendingRuntimeTeardowns,
+          ...swept.deletedRoomCodes,
+          ...swept.orphanedIndexCodes,
+        ],
+        "maintenance_pass",
+      );
       const settledClaims = (swept.orphanedIndexClaims ?? []).filter(
         ({ code }) => settledCodes.has(code),
       );

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -519,22 +519,27 @@ export function createRoomService(options: {
     confirmationTimedOut: boolean;
   };
 
+  type RuntimeTeardownDebt = {
+    /** The effect currently responsible for settling this debt, if any. */
+    owner: RuntimeTeardownEffect | null;
+  };
+
   /**
    * Room codes whose runtime teardown is unfinished, and the exact effect that
-   * most recently took responsibility for each debt. `null` means the debt is
-   * waiting for a fresh attempt after an unreadable precondition or a terminal
-   * skip/failure. A newer generation effect, or observing a live persisted
-   * room, supersedes an older owner; that older effect may still settle and log
-   * its own outcome, but cannot resurrect or retain someone else's debt.
+   * most recently took responsibility for each debt. Every debt is its own
+   * identity so a reaper candidate can prove, after its precondition awaits,
+   * that the debt it captured still exists. A null owner means that exact debt
+   * is waiting for a fresh attempt after an unreadable precondition or a
+   * terminal skip/failure. A newer generation effect, or observing a live
+   * persisted room, supersedes the whole debt record; an older effect may still
+   * settle and log its own outcome, but cannot resurrect or retain someone
+   * else's debt.
    *
    * Kept because a failed teardown is otherwise unrecoverable: the persisted
    * room and its expiry index are already gone, so nothing else will ever
    * produce this code again (#237 review, #277).
    */
-  const pendingRuntimeTeardowns = new Map<
-    string,
-    RuntimeTeardownEffect | null
-  >();
+  const pendingRuntimeTeardowns = new Map<string, RuntimeTeardownDebt>();
   const runtimeTeardownEffects = new Map<
     string,
     Map<string | null, RuntimeTeardownEffect>
@@ -544,7 +549,7 @@ export function createRoomService(options: {
     if (!pendingRuntimeTeardowns.has(code)) {
       // Do not replace an in-flight owner merely because a sibling precondition
       // read was inconclusive. Its terminal result still answers this debt.
-      pendingRuntimeTeardowns.set(code, null);
+      pendingRuntimeTeardowns.set(code, { owner: null });
     }
   }
 
@@ -613,16 +618,17 @@ export function createRoomService(options: {
       runtimeTeardownEffects.set(code, effectsByGeneration);
     }
     effectsByGeneration.set(expectedGeneration, entry);
-    pendingRuntimeTeardowns.set(code, entry);
+    pendingRuntimeTeardowns.set(code, { owner: entry });
 
     void effect.then(
       (applied) => {
         removeRuntimeTeardownEffect(code, entry);
-        if (pendingRuntimeTeardowns.get(code) === entry) {
+        const debt = pendingRuntimeTeardowns.get(code);
+        if (debt?.owner === entry) {
           if (applied) {
             pendingRuntimeTeardowns.delete(code);
           } else {
-            pendingRuntimeTeardowns.set(code, null);
+            debt.owner = null;
           }
         }
         if (entry.confirmationTimedOut) {
@@ -635,8 +641,9 @@ export function createRoomService(options: {
       },
       (error: unknown) => {
         removeRuntimeTeardownEffect(code, entry);
-        if (pendingRuntimeTeardowns.get(code) === entry) {
-          pendingRuntimeTeardowns.set(code, null);
+        const debt = pendingRuntimeTeardowns.get(code);
+        if (debt?.owner === entry) {
+          debt.owner = null;
         }
         if (entry.confirmationTimedOut) {
           logRuntimeTeardownTerminal("room_runtime_cleanup_late_failed", code, {
@@ -692,11 +699,22 @@ export function createRoomService(options: {
   }
 
   async function collectRuntimeStateForDeletedRooms(
-    codes: Iterable<string>,
+    pendingCandidates: Iterable<readonly [string, RuntimeTeardownDebt]>,
+    freshCodes: Iterable<string>,
     caller: RoomReadCaller,
   ): Promise<Set<string>> {
     const settledCodes = new Set<string>();
-    for (const code of new Set(codes)) {
+    const candidates = new Map<string, RuntimeTeardownDebt | undefined>();
+    for (const [code, debt] of pendingCandidates) {
+      candidates.set(code, debt);
+    }
+    // A fresh persisted-room deletion or explicit admin teardown supersedes a
+    // backlog snapshot for the same code and owns a new cleanup decision.
+    for (const code of freshCodes) {
+      candidates.set(code, undefined);
+    }
+
+    for (const [code, expectedDebt] of candidates) {
       // Defence in depth behind the allocation-time check: a teardown queued
       // for retry could otherwise fire after its code came back into use — the
       // residue it was queued for may have expired on its own in the meantime,
@@ -753,6 +771,14 @@ export function createRoomService(options: {
         // stale waiter must not create, reuse, or take ownership of an effect.
         continue;
       }
+      if (
+        expectedDebt !== undefined &&
+        pendingRuntimeTeardowns.get(code) !== expectedDebt
+      ) {
+        // This backlog item was settled or superseded while its preconditions
+        // were in flight. It no longer licenses another teardown effect.
+        continue;
+      }
       try {
         // The delete only applies while that generation still holds. Both
         // guards around it are check-then-act; no arrangement of them makes the
@@ -788,7 +814,7 @@ export function createRoomService(options: {
       }
       // Same helper as the reaper: it refuses to tear down a code that has
       // already been recycled, and queues a failed teardown for retry.
-      await collectRuntimeStateForDeletedRooms([code], "request");
+      await collectRuntimeStateForDeletedRooms([], [code], "request");
       return null;
     }
     return room;
@@ -1520,7 +1546,8 @@ export function createRoomService(options: {
       // reaper — an admin close/expire whose teardown failed there would have
       // queued a retry nothing ever performed (#237 review).
       await collectRuntimeStateForDeletedRooms(
-        [...pendingRuntimeTeardowns.keys(), code],
+        pendingRuntimeTeardowns,
+        [code],
         "request",
       );
     },
@@ -2195,11 +2222,8 @@ export function createRoomService(options: {
       // #234), and once the persisted room is gone nothing will ever name that
       // code again.
       const settledCodes = await collectRuntimeStateForDeletedRooms(
-        [
-          ...pendingRuntimeTeardowns.keys(),
-          ...swept.deletedRoomCodes,
-          ...swept.orphanedIndexCodes,
-        ],
+        pendingRuntimeTeardowns,
+        [...swept.deletedRoomCodes, ...swept.orphanedIndexCodes],
         "maintenance_pass",
       );
       const settledClaims = (swept.orphanedIndexClaims ?? []).filter(

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -587,7 +587,10 @@ export function createRoomService(options: {
     let effectsByGeneration = runtimeTeardownEffects.get(code);
     const existing = effectsByGeneration?.get(expectedGeneration);
     if (existing) {
-      pendingRuntimeTeardowns.set(code, existing);
+      // Ownership is assigned when an effect is CREATED, never when it is
+      // reused. A waiter may carry this generation across the room-read await;
+      // letting it reassign here would allow an old snapshot to take the debt
+      // back from a newer generation effect that started in the meantime.
       return existing;
     }
 
@@ -707,6 +710,9 @@ export function createRoomService(options: {
       // teardown is about. Reading it after the absence check below left a
       // second window: a code recycled between the two reads handed us the NEW
       // room's generation, which then matched and wiped it (#237 review).
+      // It is re-read after the room lookup as a CONFIRMATION: otherwise a
+      // waiter carrying this old pin across that await can retake retry-debt
+      // ownership from a newer generation effect (#277 review).
       let expectedGeneration: string | null;
       try {
         expectedGeneration = await runtimeStore.getRoomGeneration(code, caller);
@@ -728,6 +734,23 @@ export function createRoomService(options: {
       if (currentRoom) {
         pendingRuntimeTeardowns.delete(code);
         settledCodes.add(code);
+        continue;
+      }
+
+      let confirmedGeneration: string | null;
+      try {
+        confirmedGeneration = await runtimeStore.getRoomGeneration(
+          code,
+          caller,
+        );
+      } catch {
+        rememberRuntimeTeardownDebt(code);
+        continue;
+      }
+      if (confirmedGeneration !== expectedGeneration) {
+        // This invocation's absence snapshot and generation pin no longer name
+        // one room instance. A current/newer effect owns any cleanup debt; this
+        // stale waiter must not create, reuse, or take ownership of an effect.
         continue;
       }
       try {

--- a/server/src/room-service.ts
+++ b/server/src/room-service.ts
@@ -504,14 +504,6 @@ export function createRoomService(options: {
   }
 
   /**
-   * Room codes whose runtime teardown is unfinished, retried on every later
-   * reaper pass. Kept because a failed teardown is otherwise unrecoverable: the
-   * persisted room and its expiry index are already gone, so nothing else will
-   * ever produce this code again (#237 review).
-   */
-  const pendingRuntimeTeardowns = new Set<string>();
-
-  /**
    * One real teardown effect per room generation. A request may stop waiting
    * for confirmation, but this promise stays alive until the guarded Redis
    * write and every local mirror behind it have settled. The generation belongs
@@ -526,10 +518,35 @@ export function createRoomService(options: {
     requestConfirmation: Promise<boolean> | null;
     confirmationTimedOut: boolean;
   };
+
+  /**
+   * Room codes whose runtime teardown is unfinished, and the exact effect that
+   * most recently took responsibility for each debt. `null` means the debt is
+   * waiting for a fresh attempt after an unreadable precondition or a terminal
+   * skip/failure. A newer generation effect, or observing a live persisted
+   * room, supersedes an older owner; that older effect may still settle and log
+   * its own outcome, but cannot resurrect or retain someone else's debt.
+   *
+   * Kept because a failed teardown is otherwise unrecoverable: the persisted
+   * room and its expiry index are already gone, so nothing else will ever
+   * produce this code again (#237 review, #277).
+   */
+  const pendingRuntimeTeardowns = new Map<
+    string,
+    RuntimeTeardownEffect | null
+  >();
   const runtimeTeardownEffects = new Map<
     string,
     Map<string | null, RuntimeTeardownEffect>
   >();
+
+  function rememberRuntimeTeardownDebt(code: string): void {
+    if (!pendingRuntimeTeardowns.has(code)) {
+      // Do not replace an in-flight owner merely because a sibling precondition
+      // read was inconclusive. Its terminal result still answers this debt.
+      pendingRuntimeTeardowns.set(code, null);
+    }
+  }
 
   function removeRuntimeTeardownEffect(
     code: string,
@@ -570,10 +587,10 @@ export function createRoomService(options: {
     let effectsByGeneration = runtimeTeardownEffects.get(code);
     const existing = effectsByGeneration?.get(expectedGeneration);
     if (existing) {
+      pendingRuntimeTeardowns.set(code, existing);
       return existing;
     }
 
-    pendingRuntimeTeardowns.add(code);
     let effect: Promise<boolean>;
     try {
       effect = Promise.resolve(
@@ -593,12 +610,17 @@ export function createRoomService(options: {
       runtimeTeardownEffects.set(code, effectsByGeneration);
     }
     effectsByGeneration.set(expectedGeneration, entry);
+    pendingRuntimeTeardowns.set(code, entry);
 
     void effect.then(
       (applied) => {
         removeRuntimeTeardownEffect(code, entry);
-        if (applied && !runtimeTeardownEffects.has(code)) {
-          pendingRuntimeTeardowns.delete(code);
+        if (pendingRuntimeTeardowns.get(code) === entry) {
+          if (applied) {
+            pendingRuntimeTeardowns.delete(code);
+          } else {
+            pendingRuntimeTeardowns.set(code, null);
+          }
         }
         if (entry.confirmationTimedOut) {
           logRuntimeTeardownTerminal(
@@ -610,7 +632,9 @@ export function createRoomService(options: {
       },
       (error: unknown) => {
         removeRuntimeTeardownEffect(code, entry);
-        pendingRuntimeTeardowns.add(code);
+        if (pendingRuntimeTeardowns.get(code) === entry) {
+          pendingRuntimeTeardowns.set(code, null);
+        }
         if (entry.confirmationTimedOut) {
           logRuntimeTeardownTerminal("room_runtime_cleanup_late_failed", code, {
             result: "error",
@@ -687,7 +711,7 @@ export function createRoomService(options: {
       try {
         expectedGeneration = await runtimeStore.getRoomGeneration(code, caller);
       } catch {
-        pendingRuntimeTeardowns.add(code);
+        rememberRuntimeTeardownDebt(code);
         continue;
       }
 
@@ -698,7 +722,7 @@ export function createRoomService(options: {
         // A read failure is "unknown", NOT "absent". Treating it as absent made
         // this guard fail in exactly the conditions that queue teardowns in the
         // first place. Keep the debt and try again later.
-        pendingRuntimeTeardowns.add(code);
+        rememberRuntimeTeardownDebt(code);
         continue;
       }
       if (currentRoom) {
@@ -1473,7 +1497,7 @@ export function createRoomService(options: {
       // reaper — an admin close/expire whose teardown failed there would have
       // queued a retry nothing ever performed (#237 review).
       await collectRuntimeStateForDeletedRooms(
-        [...pendingRuntimeTeardowns, code],
+        [...pendingRuntimeTeardowns.keys(), code],
         "request",
       );
     },
@@ -2149,7 +2173,7 @@ export function createRoomService(options: {
       // code again.
       const settledCodes = await collectRuntimeStateForDeletedRooms(
         [
-          ...pendingRuntimeTeardowns,
+          ...pendingRuntimeTeardowns.keys(),
           ...swept.deletedRoomCodes,
           ...swept.orphanedIndexCodes,
         ],

--- a/server/src/room-store-instrumentation.ts
+++ b/server/src/room-store-instrumentation.ts
@@ -48,7 +48,9 @@ export function instrumentRoomStore(
 
   const instrumented: RoomStore = {
     createRoom: measure("create_room", (input) => roomStore.createRoom(input)),
-    getRoom: measure("get_room", (code) => roomStore.getRoom(code)),
+    getRoom: measure("get_room", (code, caller) =>
+      roomStore.getRoom(code, caller),
+    ),
     updateRoom: measure("update_room", (code, expectedVersion, patch) =>
       roomStore.updateRoom(code, expectedVersion, patch),
     ),

--- a/server/src/room-store.ts
+++ b/server/src/room-store.ts
@@ -28,6 +28,9 @@ export type RoomUpdateResult =
   | { ok: true; room: PersistedRoom }
   | { ok: false; reason: "not_found" | "version_conflict" };
 
+/** Chooses whether this read owns its deadline or is inside a maintenance pass. */
+export type RoomReadCaller = "request" | "maintenance_pass";
+
 /** A durable handoff naming one discovery of an orphaned room-index entry. */
 export type OrphanedIndexClaim = {
   code: string;
@@ -53,7 +56,10 @@ export type ExpiredRoomSweep = {
 
 export type RoomStore = {
   createRoom: (input: CreatePersistedRoomInput) => Promise<PersistedRoom>;
-  getRoom: (code: string) => Promise<PersistedRoom | null>;
+  getRoom: (
+    code: string,
+    caller?: RoomReadCaller,
+  ) => Promise<PersistedRoom | null>;
   updateRoom: (
     code: string,
     expectedVersion: number,
@@ -187,7 +193,7 @@ export function createInMemoryRoomStore(
       rooms.set(room.code, room);
       return cloneRoom(room);
     },
-    async getRoom(code): Promise<PersistedRoom | null> {
+    async getRoom(code, _caller = "request"): Promise<PersistedRoom | null> {
       const room = rooms.get(code);
       return room ? cloneRoom(room) : null;
     },

--- a/server/src/runtime-store.ts
+++ b/server/src/runtime-store.ts
@@ -205,11 +205,12 @@ export type RuntimeStore = {
    * teardown is decided and pass it here; a mismatch means the code changed
    * hands and the teardown is skipped. `null` matches only `null`, so a room
    * that predates generations is still collected, and one that has since been
-   * stamped is left alone.
+   * stamped is left alone. The generation is required: an unguarded teardown
+   * is not part of the shared-store contract.
    */
   deleteRoom: (
     code: string,
-    expectedGeneration?: string | null,
+    expectedGeneration: string | null,
   ) => boolean | Promise<boolean>;
   /**
    * Whether ANY runtime state remains under this code.
@@ -221,7 +222,10 @@ export type RuntimeStore = {
    */
   hasRoomResidue: (code: string) => boolean | Promise<boolean>;
   /** The generation stamped on this code's runtime state, or null. */
-  getRoomGeneration: (code: string) => string | null | Promise<string | null>;
+  getRoomGeneration: (
+    code: string,
+    caller?: RuntimeReadCaller,
+  ) => string | null | Promise<string | null>;
   /**
    * Stamp a fresh generation on a code, marking the start of a new room
    * instance. Called once when a room is created.
@@ -596,17 +600,14 @@ export function createInMemoryRuntimeStore(
         claimedSlotsByRoom.has(code)
       );
     },
-    getRoomGeneration(code) {
+    getRoomGeneration(code, _caller = "request") {
       return roomGenerations.get(code) ?? null;
     },
     markRoomGeneration(code, generation) {
       roomGenerations.set(code, generation);
     },
     deleteRoom(code, expectedGeneration) {
-      if (
-        expectedGeneration !== undefined &&
-        (roomGenerations.get(code) ?? null) !== expectedGeneration
-      ) {
+      if ((roomGenerations.get(code) ?? null) !== expectedGeneration) {
         return false;
       }
       roomGenerations.delete(code);

--- a/server/test/redis-runtime-store.test.ts
+++ b/server/test/redis-runtime-store.test.ts
@@ -1536,9 +1536,40 @@ test("redis runtime store surfaces a failed room teardown to the caller", async 
 
   try {
     await assert.rejects(
-      Promise.resolve(store.deleteRoom("ROOMTD")),
+      Promise.resolve(store.deleteRoom("ROOMTD", null)),
       /redis unavailable/,
     );
+  } finally {
+    await store.close();
+  }
+});
+
+test("redis runtime teardown always carries an explicit generation guard", async () => {
+  const guardedValues: string[] = [];
+  const fakeRedis = {
+    ...createFakeRedisClient([]),
+    async zrange() {
+      return [];
+    },
+    async eval(
+      _script: string,
+      keyCount: number,
+      ...keysAndArguments: Array<string | number>
+    ) {
+      guardedValues.push(String(keysAndArguments[keyCount] ?? "missing"));
+      return 0;
+    },
+  };
+  const store = await createRedisRuntimeStore("redis://unused", {
+    keyPrefix: "bsp:test:teardown-guard:",
+    redisClient: fakeRedis,
+  });
+
+  try {
+    assert.equal(await store.deleteRoom("ROOMG0", null), false);
+    assert.equal(await store.deleteRoom("ROOMG1", "generation-1"), false);
+    assert.deepEqual(guardedValues, ["", "generation-1"]);
+    assert.equal(guardedValues.includes("*"), false);
   } finally {
     await store.close();
   }

--- a/server/test/redis-store-command-bounds.test.ts
+++ b/server/test/redis-store-command-bounds.test.ts
@@ -33,6 +33,7 @@ import {
   type RedisRoomStoreClient,
 } from "../src/redis-room-store.js";
 import { RedisStoreUnavailableError } from "../src/redis-store-unavailable.js";
+import type { RoomReadCaller } from "../src/room-store.js";
 import type { RuntimeReadCaller } from "../src/runtime-store.js";
 import { settleWithin } from "../src/retry-pacer.js";
 
@@ -164,8 +165,6 @@ const RUNTIME_REQUEST_PATH: Record<
   isMemberTokenBlocked: (store) =>
     Promise.resolve(store.isMemberTokenBlocked("ROOM01", "token-1", 1_000)),
   hasRoomResidue: (store) => Promise.resolve(store.hasRoomResidue("ROOM01")),
-  getRoomGeneration: (store) =>
-    Promise.resolve(store.getRoomGeneration("ROOM01")),
   tryClaimMessageSlot: (store) =>
     Promise.resolve(
       store.tryClaimMessageSlot("ROOM01", "share:1", "claim-token", 60_000),
@@ -207,6 +206,8 @@ const RUNTIME_BOUNDED_ELSEWHERE: Record<string, string> = {
   purgeNodeStatus: "maintenance-pass: runtime-index-reaper's per-tick cap",
   evictMemberToken:
     "admin-command-consumer: typed member-eviction confirmation deadline; the real effect stays tracked and retry deadlines are monotonic",
+  deleteRoom:
+    "room-service: request confirmation deadline or maintenance-pass; one real guarded effect stays tracked through local mirror settlement",
 };
 
 /**
@@ -221,6 +222,8 @@ const RUNTIME_CALLER_CHOSEN: Record<
   string,
   (store: RuntimeStoreUnderTest, caller: RuntimeReadCaller) => Promise<unknown>
 > = {
+  getRoomGeneration: (store, caller) =>
+    Promise.resolve(store.getRoomGeneration("ROOM01", caller)),
   listNodeStatuses: (store, caller) =>
     Promise.resolve(store.listNodeStatuses?.(caller, 1_000)),
   listClusterSessions: (store, caller) =>
@@ -228,7 +231,7 @@ const RUNTIME_CALLER_CHOSEN: Record<
 };
 
 /**
- * The three remaining durable writes #237 argued must never be told they failed
+ * The two remaining durable writes #237 argued must never be told they failed
  * while their write may still land. Their side effect does not expire on its
  * own, so bounding them re-opens that trade — deliberately still open (#277).
  * The unused standalone token-block write was deleted, and the production
@@ -240,7 +243,6 @@ const RUNTIME_UNBOUNDED_DURABLE_WRITES: Record<string, string> = {
     "#237: an answer that can be wrong is worse than a slow one",
   markRoomGeneration:
     "#237: an answer that can be wrong is worse than a slow one",
-  deleteRoom: "#237: an answer that can be wrong is worse than a slow one",
 };
 
 /** Methods that answer from the in-process mirror and issue no command. */
@@ -475,7 +477,6 @@ const ROOM_REQUEST_PATH: Record<
   string,
   (store: RoomStoreUnderTest) => Promise<unknown>
 > = {
-  getRoom: (store) => store.getRoom("ROOM01"),
   listRooms: (store) =>
     store.listRooms({
       keyword: "",
@@ -488,6 +489,13 @@ const ROOM_REQUEST_PATH: Record<
   countRooms: (store) =>
     store.countRooms({ keyword: "", includeExpired: true }),
   isReady: (store) => store.isReady(),
+};
+
+const ROOM_CALLER_CHOSEN: Record<
+  string,
+  (store: RoomStoreUnderTest, caller: RoomReadCaller) => Promise<unknown>
+> = {
+  getRoom: (store, caller) => store.getRoom("ROOM01", caller),
 };
 
 const ROOM_BOUNDED_ELSEWHERE: Record<string, string> = {
@@ -510,6 +518,7 @@ test("every room store method is classified by what bounds its commands", async 
   await withRoomStore(null, async (store) => {
     const classified = new Set([
       ...Object.keys(ROOM_REQUEST_PATH),
+      ...Object.keys(ROOM_CALLER_CHOSEN),
       ...Object.keys(ROOM_BOUNDED_ELSEWHERE),
       ...Object.keys(ROOM_UNBOUNDED_DURABLE_WRITES),
     ]);
@@ -522,6 +531,65 @@ test("every room store method is classified by what bounds its commands", async 
       "a new room store method must declare what bounds its Redis commands",
     );
   });
+});
+
+test("a room read whose bound belongs to a maintenance pass is left unanswered", async () => {
+  const bootstrapCommands = await withRoomStore(
+    null,
+    async (_store, commands) => commands.issuedCount(),
+    { settleBootstrap: true },
+  );
+
+  for (const [method, call] of Object.entries(ROOM_CALLER_CHOSEN)) {
+    await withRoomStore(
+      bootstrapCommands,
+      async (store) => {
+        const answered = await settleWithin(
+          call(store, "maintenance_pass").catch(() => undefined),
+          OBSERVATION_MS,
+        );
+        assert.equal(
+          answered,
+          false,
+          `${method} must not answer a maintenance pass`,
+        );
+      },
+      { settleBootstrap: true },
+    );
+  }
+});
+
+test("the same room read DOES answer when a request is the caller", async () => {
+  for (const [method, call] of Object.entries(ROOM_CALLER_CHOSEN)) {
+    const { firstOwnCommand, issued } = await withRoomStore(
+      null,
+      async (store, commands) => {
+        const before = commands.issuedCount();
+        await call(store, "request").catch(() => undefined);
+        return { firstOwnCommand: before, issued: commands.issuedCount() };
+      },
+      { settleBootstrap: true },
+    );
+    assert.ok(issued > firstOwnCommand, `${method} issued no Redis command`);
+
+    for (let hangAt = firstOwnCommand; hangAt < issued; hangAt += 1) {
+      await withRoomStore(
+        hangAt,
+        async (store) => {
+          const answered = await settleWithin(
+            call(store, "request").catch(() => undefined),
+            OBSERVATION_MS,
+          );
+          assert.equal(
+            answered,
+            true,
+            `${method} never answered a request with command #${hangAt} unanswered`,
+          );
+        },
+        { settleBootstrap: true },
+      );
+    }
+  }
 });
 
 test("every request-path room command answers its caller, whichever one stalls", async () => {

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -4195,6 +4195,12 @@ test("a stale teardown effect does not hide cleanup for a reused room generation
   releaseFirstDelete();
   assert.ok(firstDeleteEffect);
   await firstDeleteEffect;
+
+  // The new generation's successful effect owned and satisfied the retry
+  // debt. The older generation now settles as skipped; it must not retain that
+  // debt merely because it happened to finish last.
+  await service.deleteExpiredRooms();
+  assert.equal(deleteGenerations.length, 2);
 });
 
 test("a late runtime teardown failure stays on the retry trail", async () => {

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -8,10 +8,16 @@ import {
   getDefaultSecurityConfig,
 } from "../src/app.js";
 import { createSessionRateLimitState } from "../src/rate-limit.js";
-import { createInMemoryRoomStore, type RoomStore } from "../src/room-store.js";
+import {
+  createInMemoryRoomStore,
+  type RoomReadCaller,
+  type RoomStore,
+} from "../src/room-store.js";
 import { createRoomService, RoomServiceError } from "../src/room-service.js";
+import { settleWithin } from "../src/retry-pacer.js";
 import {
   createInMemoryRuntimeStore,
+  type RuntimeReadCaller,
   type RuntimeStore,
 } from "../src/runtime-store.js";
 import type { ActiveRoom, LogEvent, Session } from "../src/types.js";
@@ -166,8 +172,8 @@ test("room service rejects reconnect skip path when room was deleted concurrentl
   let validationReadCount = 0;
   const roomStore = {
     ...baseRoomStore,
-    async getRoom(code: string) {
-      const room = await baseRoomStore.getRoom(code);
+    async getRoom(code: string, caller?: RoomReadCaller) {
+      const room = await baseRoomStore.getRoom(code, caller);
       if (validateDeletedRoom) {
         validationReadCount += 1;
         if (validationReadCount === 2) {
@@ -374,7 +380,7 @@ test("room service does not recover stale session leave state when member remova
   });
   const failingRoomStore = {
     ...roomStore,
-    async getRoom() {
+    async getRoom(_code: string, _caller?: RoomReadCaller) {
       throw new Error("transient read failure");
     },
   };
@@ -636,7 +642,7 @@ test("room service still notifies remaining members when socket-detached leave h
   // `room_member_changed` and remaining clients see a fresh roster.
   const failingRoomStore = {
     ...roomStore,
-    async getRoom() {
+    async getRoom(_code: string, _caller?: RoomReadCaller) {
       throw new Error("transient read failure");
     },
   };
@@ -1217,15 +1223,15 @@ test("room service flushes pending runtime store writes before exposing updated 
     hasRoomResidue(code) {
       return activeRooms.hasRoomResidue(code);
     },
-    getRoomGeneration(code) {
-      return activeRooms.getRoomGeneration(code);
+    getRoomGeneration(code, caller?: RuntimeReadCaller) {
+      return activeRooms.getRoomGeneration(code, caller);
     },
     markRoomGeneration(code, generation) {
       return activeRooms.markRoomGeneration(code, generation);
     },
-    deleteRoom(code) {
+    deleteRoom(code, expectedGeneration) {
       clusterSessionsByRoom.delete(code);
-      return activeRooms.deleteRoom(code);
+      return activeRooms.deleteRoom(code, expectedGeneration);
     },
     async heartbeatNode() {},
     async listNodeStatuses() {
@@ -4001,6 +4007,303 @@ test("restores the member when revoking their identity fails on leave", async ()
   );
 });
 
+test("a request stops waiting for runtime teardown while its one real effect still converges", async () => {
+  const currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const created = await roomStore.createRoom({
+    code: "ROOMUC",
+    joinToken: "join-token-123456",
+    createdAt: 1,
+  });
+  await roomStore.updateRoom(created.code, created.version, {
+    expiresAt: currentTime,
+  });
+
+  const activeRooms = createActiveRoomRegistry();
+  const ghost = createSession("runtime-teardown-ghost");
+  ghost.memberId = "member-runtime-teardown-ghost";
+  ghost.memberToken = "token-runtime-teardown-ghost";
+  activeRooms.addMember(created.code, ghost.memberId, ghost, ghost.memberToken);
+
+  let releaseDelete!: () => void;
+  const deleteGate = new Promise<void>((resolve) => {
+    releaseDelete = resolve;
+  });
+  let deleteCalls = 0;
+  let realEffect: Promise<boolean> | null = null;
+  const events: string[] = [];
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...activeRooms,
+      deleteRoom(code, expectedGeneration) {
+        deleteCalls += 1;
+        realEffect = deleteGate.then(() =>
+          activeRooms.deleteRoom(code, expectedGeneration),
+        );
+        return realEffect;
+      },
+    },
+    generateToken: () => "generated-token-123456",
+    logEvent: ((event) => events.push(event)) satisfies LogEvent,
+    now: () => currentTime,
+    runtimeTeardownConfirmationTimeoutMs: 10,
+  });
+
+  const request = service.getRoomStateByCode(created.code);
+  assert.equal(await settleWithin(request, 200), true);
+  assert.equal(await request, null);
+  assert.equal(deleteCalls, 1);
+  assert.ok(activeRooms.getRoom(created.code));
+  assert.ok(events.includes("room_runtime_cleanup_unconfirmed"));
+
+  releaseDelete();
+  assert.ok(realEffect);
+  await realEffect;
+  await Promise.resolve();
+  assert.equal(activeRooms.getRoom(created.code), null);
+  assert.ok(events.includes("room_runtime_cleanup_late_settled"));
+
+  // The late success retired the debt itself. An empty later sweep must not
+  // issue a second teardown merely to discover that the first one landed.
+  await service.deleteExpiredRooms();
+  assert.equal(deleteCalls, 1);
+});
+
+test("request waiters reuse one confirmation cap for the same runtime teardown effect", async () => {
+  const currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const created = await roomStore.createRoom({
+    code: "ROOMUD",
+    joinToken: "join-token-123456",
+    createdAt: 1,
+  });
+  await roomStore.updateRoom(created.code, created.version, {
+    expiresAt: currentTime,
+  });
+
+  const activeRooms = createActiveRoomRegistry();
+  let releaseDelete!: () => void;
+  const deleteGate = new Promise<void>((resolve) => {
+    releaseDelete = resolve;
+  });
+  let deleteCalls = 0;
+  let realEffect: Promise<boolean> | null = null;
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...activeRooms,
+      deleteRoom(code, expectedGeneration) {
+        deleteCalls += 1;
+        realEffect = deleteGate.then(() =>
+          activeRooms.deleteRoom(code, expectedGeneration),
+        );
+        return realEffect;
+      },
+    },
+    generateToken: () => "generated-token-123456",
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    runtimeTeardownConfirmationTimeoutMs: 40,
+  });
+
+  assert.equal(await service.getRoomStateByCode(created.code), null);
+
+  // The exact effect is already known to be unconfirmed. A new waiter shares
+  // that settled confirmation instead of creating another timer and another
+  // tracked promise which would live as long as the unanswered Redis command.
+  const repeatedWait = service.teardownRoomRuntime(created.code);
+  assert.equal(await settleWithin(repeatedWait, 10), true);
+  await repeatedWait;
+  assert.equal(deleteCalls, 1);
+
+  releaseDelete();
+  assert.ok(realEffect);
+  await realEffect;
+  await service.deleteExpiredRooms();
+  assert.equal(deleteCalls, 1);
+});
+
+test("a stale teardown effect does not hide cleanup for a reused room generation", async () => {
+  let currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const runtime = createInMemoryRuntimeStore(() => currentTime, 5_000);
+  let releaseFirstDelete!: () => void;
+  const firstDeleteGate = new Promise<void>((resolve) => {
+    releaseFirstDelete = resolve;
+  });
+  const deleteGenerations: Array<string | null> = [];
+  let firstDeleteEffect: Promise<boolean> | null = null;
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: {
+      ...getDefaultPersistenceConfig(),
+      emptyRoomTtlMs: 1_000,
+    },
+    roomStore,
+    activeRooms: {
+      ...runtime,
+      deleteRoom(code, expectedGeneration) {
+        deleteGenerations.push(expectedGeneration);
+        if (deleteGenerations.length === 1) {
+          firstDeleteEffect = firstDeleteGate.then(() =>
+            runtime.deleteRoom(code, expectedGeneration),
+          );
+          return firstDeleteEffect;
+        }
+        return runtime.deleteRoom(code, expectedGeneration);
+      },
+    },
+    generateToken: (() => {
+      let id = 0;
+      return () => `token-${++id}`.padEnd(16, "x");
+    })(),
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    createRoomCode: () => "ROOMUG",
+    resolveActiveRoom: async (code) => runtime.getRoom(code),
+    runtimeTeardownConfirmationTimeoutMs: 10,
+  });
+
+  const first = createSession("first-generation-owner");
+  const firstRoom = await service.createRoomForSession(first, "Alice");
+  await service.leaveRoomForSession(first, "disconnect");
+  currentTime += 1_001;
+  assert.equal(await service.getRoomStateByCode(firstRoom.room.code), null);
+  assert.equal(deleteGenerations.length, 1);
+
+  // The old identity ages out, so allocation may reuse the code even though
+  // its guarded teardown command is still unanswered.
+  currentTime += 5_001;
+  const second = createSession("second-generation-owner");
+  const secondRoom = await service.createRoomForSession(second, "Bob");
+  assert.equal(secondRoom.room.code, firstRoom.room.code);
+  await roomStore.deleteRoom(secondRoom.room.code);
+
+  // Cleanup for the new generation is a distinct effect. Keying only by code
+  // reused the old promise here, returned unconfirmed, and stranded the new
+  // room's runtime state until some unrelated future teardown happened.
+  await service.teardownRoomRuntime(secondRoom.room.code);
+  assert.equal(deleteGenerations.length, 2);
+  assert.notEqual(deleteGenerations[0], deleteGenerations[1]);
+  assert.equal(runtime.getRoom(secondRoom.room.code), null);
+
+  releaseFirstDelete();
+  assert.ok(firstDeleteEffect);
+  await firstDeleteEffect;
+});
+
+test("a late runtime teardown failure stays on the retry trail", async () => {
+  const currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const created = await roomStore.createRoom({
+    code: "ROOMUF",
+    joinToken: "join-token-123456",
+    createdAt: 1,
+  });
+  await roomStore.updateRoom(created.code, created.version, {
+    expiresAt: currentTime,
+  });
+
+  const activeRooms = createActiveRoomRegistry();
+  const ghost = createSession("runtime-teardown-failure");
+  ghost.memberId = "member-runtime-teardown-failure";
+  ghost.memberToken = "token-runtime-teardown-failure";
+  activeRooms.addMember(created.code, ghost.memberId, ghost, ghost.memberToken);
+
+  let rejectDelete!: (error: Error) => void;
+  const firstDelete = new Promise<boolean>((_resolve, reject) => {
+    rejectDelete = reject;
+  });
+  let deleteCalls = 0;
+  const events: string[] = [];
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...activeRooms,
+      deleteRoom(code, expectedGeneration) {
+        deleteCalls += 1;
+        if (deleteCalls === 1) {
+          return firstDelete;
+        }
+        return activeRooms.deleteRoom(code, expectedGeneration);
+      },
+    },
+    generateToken: () => "generated-token-123456",
+    logEvent: ((event) => events.push(event)) satisfies LogEvent,
+    now: () => currentTime,
+    runtimeTeardownConfirmationTimeoutMs: 10,
+  });
+
+  const request = service.getRoomStateByCode(created.code);
+  assert.equal(await settleWithin(request, 200), true);
+  assert.equal(await request, null);
+  assert.equal(deleteCalls, 1);
+
+  rejectDelete(new Error("redis unavailable after deadline"));
+  await assert.rejects(firstDelete, /redis unavailable after deadline/);
+  await Promise.resolve();
+  assert.ok(events.includes("room_runtime_cleanup_late_failed"));
+
+  await service.deleteExpiredRooms();
+  assert.equal(deleteCalls, 2);
+  assert.equal(activeRooms.getRoom(created.code), null);
+});
+
+test("a maintenance pass keeps waiting for the real runtime teardown effect", async () => {
+  const currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const created = await roomStore.createRoom({
+    code: "ROOMUM",
+    joinToken: "join-token-123456",
+    createdAt: 1,
+  });
+  await roomStore.updateRoom(created.code, created.version, {
+    expiresAt: currentTime,
+  });
+
+  const activeRooms = createActiveRoomRegistry();
+  let releaseDelete!: () => void;
+  const deleteGate = new Promise<void>((resolve) => {
+    releaseDelete = resolve;
+  });
+  let deleteCalls = 0;
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...activeRooms,
+      deleteRoom(code, expectedGeneration) {
+        deleteCalls += 1;
+        return deleteGate.then(() =>
+          activeRooms.deleteRoom(code, expectedGeneration),
+        );
+      },
+    },
+    generateToken: () => "generated-token-123456",
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    runtimeTeardownConfirmationTimeoutMs: 10,
+  });
+
+  const reaping = service.deleteExpiredRooms();
+  assert.equal(await settleWithin(reaping, 50), false);
+  assert.equal(deleteCalls, 1);
+
+  releaseDelete();
+  assert.deepEqual(await reaping, {
+    deletedRooms: 1,
+    orphanedIndexEntries: 0,
+  });
+});
+
 test("reaper keeps collecting rooms when one runtime teardown fails", async () => {
   let currentTime = 1_000;
   const roomStore = createInMemoryRoomStore({ now: () => currentTime });
@@ -4012,12 +4315,12 @@ test("reaper keeps collecting rooms when one runtime teardown fails", async () =
     roomStore,
     activeRooms: {
       ...activeRooms,
-      deleteRoom: async (code: string) => {
+      deleteRoom: async (code: string, expectedGeneration: string | null) => {
         if (code === "ROOMF1") {
           failedFor.push(code);
           throw new Error("redis unavailable");
         }
-        return activeRooms.deleteRoom(code);
+        return activeRooms.deleteRoom(code, expectedGeneration);
       },
     },
     generateToken: (() => {
@@ -4062,12 +4365,12 @@ test("retries a failed runtime teardown on the next reaper pass", async () => {
     roomStore,
     activeRooms: {
       ...activeRooms,
-      deleteRoom: async (code: string) => {
+      deleteRoom: async (code: string, expectedGeneration: string | null) => {
         if (failTeardown) {
           throw new Error("redis unavailable");
         }
         teardowns.push(code);
-        return activeRooms.deleteRoom(code);
+        return activeRooms.deleteRoom(code, expectedGeneration);
       },
     },
     generateToken: (() => {
@@ -4118,11 +4421,11 @@ test("does not hand out a room code that still has runtime state under it", asyn
     roomStore,
     activeRooms: {
       ...activeRooms,
-      deleteRoom: async (code: string) => {
+      deleteRoom: async (code: string, expectedGeneration: string | null) => {
         if (failTeardown) {
           throw new Error("redis unavailable");
         }
-        return activeRooms.deleteRoom(code);
+        return activeRooms.deleteRoom(code, expectedGeneration);
       },
     },
     generateToken: (() => {
@@ -4178,21 +4481,21 @@ test("keeps an owed teardown when the room store cannot be read", async () => {
     persistence: getDefaultPersistenceConfig(),
     roomStore: {
       ...roomStore,
-      getRoom: async (code: string) => {
+      getRoom: async (code: string, caller?: RoomReadCaller) => {
         if (failRoomRead) {
           throw new Error("redis unavailable");
         }
-        return roomStore.getRoom(code);
+        return roomStore.getRoom(code, caller);
       },
     },
     activeRooms: {
       ...activeRooms,
-      deleteRoom: async (code: string) => {
+      deleteRoom: async (code: string, expectedGeneration: string | null) => {
         if (failTeardown) {
           throw new Error("redis unavailable");
         }
         teardowns.push(code);
-        return activeRooms.deleteRoom(code);
+        return activeRooms.deleteRoom(code, expectedGeneration);
       },
     },
     generateToken: (() => {
@@ -4245,7 +4548,7 @@ test("an owed teardown does not wipe a room that took the code in the meantime",
     roomStore,
     activeRooms: {
       ...runtime,
-      deleteRoom: async (code: string, expectedGeneration?: string | null) => {
+      deleteRoom: async (code: string, expectedGeneration: string | null) => {
         if (gateTeardown) {
           await teardownGate;
         }
@@ -4308,8 +4611,8 @@ test("pins the teardown generation before checking whether the room is gone", as
       ...roomStore,
       // Stall the absence check itself. Reading the generation after this point
       // hands the teardown the NEW room's value, which then matches.
-      getRoom: async (code: string) => {
-        const room = await roomStore.getRoom(code);
+      getRoom: async (code: string, caller?: RoomReadCaller) => {
+        const room = await roomStore.getRoom(code, caller);
         if (gateRoomRead) {
           await roomReadGate;
         }
@@ -4449,7 +4752,7 @@ test("an admin teardown works through the retry backlog", async () => {
     roomStore,
     activeRooms: {
       ...runtime,
-      deleteRoom: async (code: string, expectedGeneration?: string | null) => {
+      deleteRoom: async (code: string, expectedGeneration: string | null) => {
         if (failTeardown) {
           throw new Error("redis unavailable");
         }
@@ -5166,7 +5469,7 @@ test("room service tears down orphaned index codes without metering them as recl
     roomStore,
     activeRooms: {
       ...runtime,
-      deleteRoom: async (code: string, expectedGeneration?: string | null) => {
+      deleteRoom: async (code: string, expectedGeneration: string | null) => {
         cleanupOrder.push(`teardown:${code}`);
         tornDown.push(code);
         return runtime.deleteRoom(code, expectedGeneration);
@@ -5208,11 +5511,11 @@ test("room service keeps an orphan claim until runtime teardown succeeds", async
   let roomReadFails = true;
   const roomStore = {
     ...baseRoomStore,
-    async getRoom(code: string) {
+    async getRoom(code: string, caller?: RoomReadCaller) {
       if (roomReadFails) {
         throw new Error("invalid persisted room body");
       }
-      return baseRoomStore.getRoom(code);
+      return baseRoomStore.getRoom(code, caller);
     },
     async deleteExpiredRooms() {
       return {
@@ -5234,7 +5537,7 @@ test("room service keeps an orphan claim until runtime teardown succeeds", async
     roomStore,
     activeRooms: {
       ...runtime,
-      deleteRoom: async (code: string, expectedGeneration?: string | null) => {
+      deleteRoom: async (code: string, expectedGeneration: string | null) => {
         teardownAttempts += 1;
         if (teardownFails) {
           throw new Error("redis unavailable");

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -4128,10 +4128,33 @@ test("request waiters reuse one confirmation cap for the same runtime teardown e
   assert.equal(deleteCalls, 1);
 });
 
-test("a stale teardown effect does not hide cleanup for a reused room generation", async () => {
+async function assertStaleTeardownWaiterCannotRetakeDebt(
+  settleOldEffectBeforeWaiter: boolean,
+): Promise<void> {
   let currentTime = 1_000;
   const roomStore = createInMemoryRoomStore({ now: () => currentTime });
   const runtime = createInMemoryRuntimeStore(() => currentTime, 5_000);
+  let holdNextMissingRoomRead = false;
+  let markStaleRoomReadStarted!: () => void;
+  const staleRoomReadStarted = new Promise<void>((resolve) => {
+    markStaleRoomReadStarted = resolve;
+  });
+  let releaseStaleRoomRead!: () => void;
+  const staleRoomReadGate = new Promise<void>((resolve) => {
+    releaseStaleRoomRead = resolve;
+  });
+  const serviceRoomStore: typeof roomStore = {
+    ...roomStore,
+    async getRoom(code, caller) {
+      const snapshot = await roomStore.getRoom(code, caller);
+      if (holdNextMissingRoomRead && snapshot === null) {
+        holdNextMissingRoomRead = false;
+        markStaleRoomReadStarted();
+        await staleRoomReadGate;
+      }
+      return snapshot;
+    },
+  };
   let releaseFirstDelete!: () => void;
   const firstDeleteGate = new Promise<void>((resolve) => {
     releaseFirstDelete = resolve;
@@ -4144,7 +4167,7 @@ test("a stale teardown effect does not hide cleanup for a reused room generation
       ...getDefaultPersistenceConfig(),
       emptyRoomTtlMs: 1_000,
     },
-    roomStore,
+    roomStore: serviceRoomStore,
     activeRooms: {
       ...runtime,
       deleteRoom(code, expectedGeneration) {
@@ -4176,6 +4199,12 @@ test("a stale teardown effect does not hide cleanup for a reused room generation
   assert.equal(await service.getRoomStateByCode(firstRoom.room.code), null);
   assert.equal(deleteGenerations.length, 1);
 
+  // This waiter pins the old generation and captures the absent room, then
+  // pauses across the room-read await while a new generation takes the code.
+  holdNextMissingRoomRead = true;
+  const staleWaiter = service.teardownRoomRuntime(firstRoom.room.code);
+  await staleRoomReadStarted;
+
   // The old identity ages out, so allocation may reuse the code even though
   // its guarded teardown command is still unanswered.
   currentTime += 5_001;
@@ -4192,15 +4221,37 @@ test("a stale teardown effect does not hide cleanup for a reused room generation
   assert.notEqual(deleteGenerations[0], deleteGenerations[1]);
   assert.equal(runtime.getRoom(secondRoom.room.code), null);
 
-  releaseFirstDelete();
-  assert.ok(firstDeleteEffect);
-  await firstDeleteEffect;
+  if (settleOldEffectBeforeWaiter) {
+    // Once the old effect is gone, the stale waiter must not create a new copy
+    // of it and take the newer generation's already-satisfied debt.
+    releaseFirstDelete();
+    assert.ok(firstDeleteEffect);
+    await firstDeleteEffect;
+    releaseStaleRoomRead();
+    await staleWaiter;
+  } else {
+    // While the old effect remains, the stale waiter may reuse its promise but
+    // must not transfer the retry debt back from the newer generation.
+    releaseStaleRoomRead();
+    await staleWaiter;
+    releaseFirstDelete();
+    assert.ok(firstDeleteEffect);
+    await firstDeleteEffect;
+  }
 
   // The new generation's successful effect owned and satisfied the retry
   // debt. The older generation now settles as skipped; it must not retain that
   // debt merely because it happened to finish last.
   await service.deleteExpiredRooms();
   assert.equal(deleteGenerations.length, 2);
+}
+
+test("a stale waiter cannot retake debt by reusing an old generation effect", async () => {
+  await assertStaleTeardownWaiterCannotRetakeDebt(false);
+});
+
+test("a stale waiter cannot retake debt by recreating an old generation effect", async () => {
+  await assertStaleTeardownWaiterCannotRetakeDebt(true);
 });
 
 test("a late runtime teardown failure stays on the retry trail", async () => {

--- a/server/test/room-service.test.ts
+++ b/server/test/room-service.test.ts
@@ -4072,6 +4072,89 @@ test("a request stops waiting for runtime teardown while its one real effect sti
   assert.equal(deleteCalls, 1);
 });
 
+test("a maintenance backlog snapshot cannot recreate a teardown debt settled during its reads", async () => {
+  const currentTime = 1_000;
+  const roomStore = createInMemoryRoomStore({ now: () => currentTime });
+  const created = await roomStore.createRoom({
+    code: "ROOMUB",
+    joinToken: "join-token-123456",
+    createdAt: 1,
+  });
+  await roomStore.updateRoom(created.code, created.version, {
+    expiresAt: currentTime,
+  });
+
+  const activeRooms = createActiveRoomRegistry();
+  const ghost = createSession("runtime-teardown-backlog-ghost");
+  ghost.memberId = "member-runtime-teardown-backlog-ghost";
+  ghost.memberToken = "token-runtime-teardown-backlog-ghost";
+  activeRooms.addMember(created.code, ghost.memberId, ghost, ghost.memberToken);
+
+  let holdMaintenanceGenerationRead = false;
+  let markMaintenanceReadStarted!: () => void;
+  const maintenanceReadStarted = new Promise<void>((resolve) => {
+    markMaintenanceReadStarted = resolve;
+  });
+  let releaseMaintenanceRead!: () => void;
+  const maintenanceReadGate = new Promise<void>((resolve) => {
+    releaseMaintenanceRead = resolve;
+  });
+  let releaseDelete!: () => void;
+  const deleteGate = new Promise<void>((resolve) => {
+    releaseDelete = resolve;
+  });
+  let deleteCalls = 0;
+  let realEffect: Promise<boolean> | null = null;
+  const service = createRoomService({
+    config: getDefaultSecurityConfig(),
+    persistence: getDefaultPersistenceConfig(),
+    roomStore,
+    activeRooms: {
+      ...activeRooms,
+      async getRoomGeneration(code, caller) {
+        if (holdMaintenanceGenerationRead && caller === "maintenance_pass") {
+          holdMaintenanceGenerationRead = false;
+          markMaintenanceReadStarted();
+          await maintenanceReadGate;
+        }
+        return activeRooms.getRoomGeneration(code, caller);
+      },
+      deleteRoom(code, expectedGeneration) {
+        deleteCalls += 1;
+        realEffect = deleteGate.then(() =>
+          activeRooms.deleteRoom(code, expectedGeneration),
+        );
+        return realEffect;
+      },
+    },
+    generateToken: () => "generated-token-123456",
+    logEvent: (() => undefined) satisfies LogEvent,
+    now: () => currentTime,
+    runtimeTeardownConfirmationTimeoutMs: 10,
+  });
+
+  assert.equal(await service.getRoomStateByCode(created.code), null);
+  assert.equal(deleteCalls, 1);
+
+  // The reaper snapshots the pending debt, then blocks before reading the
+  // generation. The original effect settles and retires that exact debt while
+  // the maintenance candidate is still carrying its identity.
+  holdMaintenanceGenerationRead = true;
+  const reaping = service.deleteExpiredRooms();
+  await maintenanceReadStarted;
+  releaseDelete();
+  assert.ok(realEffect);
+  await realEffect;
+  await Promise.resolve();
+  releaseMaintenanceRead();
+
+  assert.deepEqual(await reaping, {
+    deletedRooms: 0,
+    orphanedIndexEntries: 0,
+  });
+  assert.equal(deleteCalls, 1);
+});
+
 test("request waiters reuse one confirmation cap for the same runtime teardown effect", async () => {
   const currentTime = 1_000;
   const roomStore = createInMemoryRoomStore({ now: () => currentTime });

--- a/server/test/room-store-instrumentation.test.ts
+++ b/server/test/room-store-instrumentation.test.ts
@@ -75,6 +75,25 @@ test("instrumented room store counts failures and still records duration", async
   );
 });
 
+test("instrumented room store forwards the caller that owns the read bound", async () => {
+  const recorder = createRecorder();
+  const base = createInMemoryRoomStore({ now: () => 0 });
+  let receivedCaller: string | undefined;
+  const store = instrumentRoomStore(
+    {
+      ...base,
+      getRoom(code, caller) {
+        receivedCaller = caller;
+        return base.getRoom(code, caller);
+      },
+    },
+    recorder.collector,
+  );
+
+  await store.getRoom("ROOM01", "maintenance_pass");
+  assert.equal(receivedCaller, "maintenance_pass");
+});
+
 test("instrumented room store preserves the underlying close hook", async () => {
   const recorder = createRecorder();
   let closed = 0;

--- a/server/test/runtime-lifecycle.test.ts
+++ b/server/test/runtime-lifecycle.test.ts
@@ -373,7 +373,10 @@ test("websocket lifecycle mirrors sessions into the shared redis runtime store",
   } finally {
     if (roomCode) {
       await roomStore.deleteRoom(roomCode);
-      await runtimeStore.deleteRoom(roomCode);
+      await runtimeStore.deleteRoom(
+        roomCode,
+        await runtimeStore.getRoomGeneration(roomCode),
+      );
     }
     await roomStore.close();
     await runtimeStore.close();
@@ -462,7 +465,10 @@ test("profile updates are reflected in redis-backed room state views", async (t)
   } finally {
     if (roomCode) {
       await roomStore.deleteRoom(roomCode);
-      await runtimeStore.deleteRoom(roomCode);
+      await runtimeStore.deleteRoom(
+        roomCode,
+        await runtimeStore.getRoomGeneration(roomCode),
+      );
     }
     await roomStore.close();
     await runtimeStore.close();


### PR DESCRIPTION
## 根因

运行时删房把“请求愿意等多久”和“带 generation 守卫的真实删房效果何时完成”当成了同一个 promise。给请求直接加超时会丢掉真实效果及本地镜像的收敛轨迹；继续无界等待则会让 WebSocket / HTTP 请求永久挂起。同时，公开 `deleteRoom` 仍允许省略 generation 并退化成通配删除，且删房前置读同时服务请求与 maintenance pass，不能用同一层界。

后续评审进一步暴露出同一根因的三个并发分支：teardown 效果与“待重试债务”缺少稳定的所有权身份，导致旧 generation 的晚到完成、跨 `await` 的陈旧等待者，以及 maintenance backlog 的陈旧快照，都可能重新覆盖或复活已经收敛的债务。

## 结构性修复

- `deleteRoom` 的 generation 变为必填，Redis Lua 永远比较 generation，不再存在通配删房。
- room-service 以 `(roomCode, generation)` 唯一化真实 teardown effect；请求只等待一条共享确认期限，超时后真实效果继续被跟踪并记录晚到成功或失败。
- 相同房间码的新 generation 可以启动独立效果，不会被旧 generation 的悬挂效果遮蔽。
- pending teardown debt 由创建它的最新 generation effect 持有；复用既有效果不会转移所有权。
- 所有跨 `await` 的重建路径都会重新确认当前 generation；maintenance 候选还会核对同一条 debt 记录的身份，陈旧快照不能复活已结清债务。
- maintenance pass 透传 caller 身份，前置读不加内层 cap，并直接等待真实效果，使 `maintenance-pass` 的 `timed_out` / `stalled` 语义保持可观测。
- 请求确认期限使用独立的行为常量，不复用 Redis `commandTimeout` 的连接存活常量。
- 更新运行时约束、运维文档和 Redis 命令边界分类；未设上限的持久写从 6 个降到 5 个。

## 验证

- 回滚判别覆盖无界请求等待、通配删除、按房间码误复用效果、每个等待者单独建 cap，以及 maintenance 前置读误加内层 cap。
- 并发回滚判别覆盖：旧效果晚到覆盖新效果、跨 `await` 后陈旧 waiter 重建债务、复用效果误转移债务所有权、maintenance 陈旧候选复活已结清债务；恢复缺陷后测试均按预期失败。
- 最新完整门禁：`format:check`、`lint`、`typecheck`、`build`、`test`、`audit` 全部通过。
- 最新常规环境测试：server 860 项中 763 通过、97 因未配置 `REDIS_URL` 跳过；protocol 83/83、extension 705/705、admin-ui 70/70，脚本测试 7/7 与 14/14。
- 真实 Redis 集成检查与 GitHub Actions 的 `verify`、`redis-integration`、`benchmark-baseline` 均通过。
- 最新 Codex 评审信号通过，未解决 review thread 为 0。

Part of #277.

本 PR 后仍剩 5 个持久写切片：runtime `revokeMemberToken` / `markRoomGeneration`，以及 room `createRoom` / `updateRoom` / `deleteRoom`。