### PR TITLE
chore(release): 1.3.5

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-exclude='../packages/**' test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.4"
+    "@bili-syncplay/protocol": "1.3.5"
   },
   "devDependencies": {
     "@types/chrome": "^0.2.2",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["alarms", "storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "workspaces": [
         "packages/*",
         "server",
@@ -28,9 +28,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.4"
+        "@bili-syncplay/protocol": "1.3.5"
       },
       "devDependencies": {
         "@types/chrome": "^0.2.2",
@@ -5650,10 +5650,10 @@
     },
     "packages/admin-ui": {
       "name": "@bili-syncplay/admin-ui",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
-        "@bili-syncplay/protocol": "1.3.4",
+        "@bili-syncplay/protocol": "1.3.5",
         "@tanstack/react-query": "^5.101.2",
         "antd": "^6.5.1",
         "dayjs": "^1.11.21",
@@ -5697,7 +5697,7 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "devDependencies": {
         "@types/node": "^24.0.0",
         "typescript": "^6.0.3"
@@ -5705,9 +5705,9 @@
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.4",
+        "@bili-syncplay/protocol": "1.3.5",
         "ioredis": "^5.10.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/admin-ui",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
-    "@bili-syncplay/protocol": "1.3.4",
+    "@bili-syncplay/protocol": "1.3.5",
     "@tanstack/react-query": "^5.101.2",
     "antd": "^6.5.1",
     "dayjs": "^1.11.21",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.4",
+    "@bili-syncplay/protocol": "1.3.5",
     "ioredis": "^5.10.0",
     "ws": "^8.21.0"
   },


### PR DESCRIPTION
## 发布内容

基于 `0c13051` 发 1.3.5，协议版本保持 4（与 v1.3.4 相同），扩展与服务端发布顺序无约束。

### 服务端

Redis 僵死加固系列：#262 / #265 / #266 / #269 / #272 / #273 / #275 / #278 / #279 / #281 / #282 / #283 / #284。

其中 #277 推进到：join 路径的两条裸读（`isMemberTokenBlocked`、`getRoomGeneration`）与房间存储读路径已取得调用方一侧的界，僵死 Redis 不再让 WebSocket join 无声挂死。另有孤儿房间清理债务不再随对账丢失（#279），回收房间数单独计数（#254）。

### 扩展

- #276：番剧 ep 页 SPA 切集后不再以上一集身份重新分享（#274）
- #260：暂停的视频不再被当作 buffering 共享给房间

## 已知未收敛

#277 仍开启，剩 5 个持久写切片（runtime 的 `revokeMemberToken`、`markRoomGeneration`，room store 的 `createRoom`、`updateRoom`、`deleteRoom`）。按 #237 的取舍，它们的表现是调用方等待而非 join 挂死，不阻塞本次发布。

## 验证

本地预提交序列六项逐项确认退出码，全部为 0：

| 命令 | 结果 |
| --- | --- |
| `npm run format:check` | exit 0 |
| `npm run lint` | exit 0 |
| `npm run typecheck` | exit 0 |
| `npm run build` | exit 0 |
| `npm test` | exit 0（7 + 14 + 83 + 860 + 705，fail 0） |
| `npm run audit` | exit 0，allowlist 为空 |

`npm test` 的 97 项 skip 全在 server 包，为未设 `REDIS_URL` 时跳过的 Redis 集成测试；本次改动仅版本号字符串，且 CI 会在带 Redis 的环境执行。

本 PR 仅改动六处版本号与 lockfile，无行为变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
