### PR TITLE
fix(extension): 聚合页面快照重复诊断

### DIFF
--- a/extension/src/content/share-controller.ts
+++ b/extension/src/content/share-controller.ts
@@ -43,6 +43,26 @@ interface CurrentPartIdentity {
   cid: string | null;
 }
 
+interface DiscardedPageSnapshotLogState {
+  videoId: string;
+  pathname: string;
+  pageVisitUrl: string;
+  count: number;
+  firstObservedAt: number;
+  lastReportedCount: number;
+}
+
+interface DetectedPageSnapshotLogState {
+  videoId: string;
+  title: string;
+  url: string;
+  pageVisitUrl: string;
+}
+
+// A count boundary, rather than an assumed recovery event, guarantees a
+// cumulative report even if Bilibili's page globals never catch up (#290).
+const DISCARDED_PAGE_SNAPSHOT_REPORT_EVERY = 10;
+
 export function shouldIncludePlaybackInSharePayload(args: {
   activeRoomCode: string | null;
   activeSharedUrl: string | null;
@@ -280,9 +300,106 @@ export function createShareController(args: {
    * and returning through the same link.
    */
   let snapshotResolvedPageUrl: string | null = null;
+  let discardedPageSnapshotLogState: DiscardedPageSnapshotLogState | null =
+    null;
+  let detectedPageSnapshotLogState: DetectedPageSnapshotLogState | null = null;
+
+  function reportDiscardedPageSnapshotSummary(
+    state: DiscardedPageSnapshotLogState,
+    now: number,
+  ): void {
+    if (state.count <= 1 || state.count === state.lastReportedCount) {
+      return;
+    }
+    args.debugLog(
+      `Discarded page video snapshot ${state.videoId} ${state.count} times over ${Math.max(0, Math.round(now - state.firstObservedAt))}ms; address bar names ${state.pathname}`,
+    );
+    state.lastReportedCount = state.count;
+  }
+
+  function finishDiscardedPageSnapshotRun(now = args.getMonotonicNow()): void {
+    if (!discardedPageSnapshotLogState) {
+      return;
+    }
+    reportDiscardedPageSnapshotSummary(discardedPageSnapshotLogState, now);
+    discardedPageSnapshotLogState = null;
+  }
+
+  function recordDiscardedPageSnapshot(argsForRecord: {
+    videoId: string;
+    pathname: string;
+    pageUrl: string;
+  }): void {
+    const now = args.getMonotonicNow();
+    const pageVisitUrl = normalizePageVisitUrl(argsForRecord.pageUrl);
+    // A stale read re-opens the healthy transition even when the page later
+    // recovers to the same snapshot that was logged before the stale window.
+    detectedPageSnapshotLogState = null;
+    const state = discardedPageSnapshotLogState;
+    if (
+      state?.videoId !== argsForRecord.videoId ||
+      state.pathname !== argsForRecord.pathname ||
+      state.pageVisitUrl !== pageVisitUrl
+    ) {
+      finishDiscardedPageSnapshotRun(now);
+      discardedPageSnapshotLogState = {
+        videoId: argsForRecord.videoId,
+        pathname: argsForRecord.pathname,
+        pageVisitUrl,
+        count: 1,
+        firstObservedAt: now,
+        lastReportedCount: 0,
+      };
+      args.debugLog(
+        `Discarded page video snapshot ${argsForRecord.videoId}; address bar names ${argsForRecord.pathname}`,
+      );
+      return;
+    }
+
+    state.count += 1;
+    if (state.count % DISCARDED_PAGE_SNAPSHOT_REPORT_EVERY === 0) {
+      reportDiscardedPageSnapshotSummary(state, now);
+    }
+  }
+
+  function recordDetectedPageSnapshot(
+    snapshot: SharedVideo,
+    pageUrl: string,
+  ): void {
+    const pageVisitUrl = normalizePageVisitUrl(pageUrl);
+    if (
+      detectedPageSnapshotLogState?.videoId === snapshot.videoId &&
+      detectedPageSnapshotLogState.title === snapshot.title &&
+      detectedPageSnapshotLogState.url === snapshot.url &&
+      detectedPageSnapshotLogState.pageVisitUrl === pageVisitUrl
+    ) {
+      return;
+    }
+    detectedPageSnapshotLogState = {
+      videoId: snapshot.videoId,
+      title: snapshot.title,
+      url: snapshot.url,
+      pageVisitUrl,
+    };
+    args.debugLog(
+      `Page video snapshot detected id=${snapshot.videoId} title=${snapshot.title} url=${snapshot.url}`,
+    );
+  }
 
   function observePageVisit(pageUrl: string): void {
     const pageVisitUrl = normalizePageVisitUrl(pageUrl);
+    if (
+      discardedPageSnapshotLogState !== null &&
+      discardedPageSnapshotLogState.pageVisitUrl !== pageVisitUrl
+    ) {
+      finishDiscardedPageSnapshotRun();
+    }
+    if (
+      detectedPageSnapshotLogState !== null &&
+      detectedPageSnapshotLogState.pageVisitUrl !== pageVisitUrl
+    ) {
+      detectedPageSnapshotLogState = null;
+    }
     if (
       snapshotResolvedPageUrl !== null &&
       snapshotResolvedPageUrl !== pageVisitUrl
@@ -417,18 +534,19 @@ export function createShareController(args: {
         episodeId: readSnapshotEpisodeId(nextSnapshot),
       })
     ) {
-      args.debugLog(
-        `Discarded page video snapshot ${nextSnapshot.videoId}; address bar names ${pathname}`,
-      );
+      recordDiscardedPageSnapshot({
+        videoId: nextSnapshot.videoId,
+        pathname,
+        pageUrl,
+      });
       return null;
     }
+    finishDiscardedPageSnapshotRun();
     // Recorded here as well as in `getSharedVideo`: a refresh is the
     // authoritative resolution, and it can happen while no caller is reading the
     // cached snapshot — the address bar is stale from this moment on either way.
     rememberSnapshotResolved(pageUrl);
-    args.debugLog(
-      `Page video snapshot detected id=${nextSnapshot.videoId} title=${nextSnapshot.title} url=${nextSnapshot.url}`,
-    );
+    recordDetectedPageSnapshot(nextSnapshot, pageUrl);
     return nextSnapshot;
   }
 

--- a/extension/test/share-controller.test.ts
+++ b/extension/test/share-controller.test.ts
@@ -1036,6 +1036,8 @@ function makeEpisodePageController(overrides: {
     pathname?: string;
     pageUrl?: string;
   } | null;
+  getMonotonicNow?: () => number;
+  debugLog?: (message: string) => void;
 }) {
   const runtimeState = createContentRuntimeState();
   runtimeState.activeRoomCode = "V52NR6";
@@ -1044,12 +1046,12 @@ function makeEpisodePageController(overrides: {
     getActiveCorrectionBaseRate: () => null,
     runtimeState,
     bufferPauseUpgradeMs: 1_500,
-    getMonotonicNow: () => 10_000,
+    getMonotonicNow: overrides.getMonotonicNow ?? (() => 10_000),
     festivalSnapshotTtlMs: 1_200,
     nextSeq: () => 414,
     getFestivalSnapshot: overrides.getFestivalSnapshot ?? (() => null),
     refreshFestivalBridge: overrides.refreshFestivalBridge,
-    debugLog: () => undefined,
+    debugLog: overrides.debugLog ?? (() => undefined),
   });
 }
 
@@ -1306,6 +1308,241 @@ test("bangumi ep page refuses a snapshot that names no episode at all", async ()
       1,
       "explicit sharing retried an already-refused snapshot",
     );
+  } finally {
+    dom.restore();
+  }
+});
+
+test("bangumi ep page coalesces repeated unconfirmed snapshot diagnostics", async () => {
+  const dom = installEpisodePageDomStub({
+    currentPartTitle: "44 连影",
+    currentPartEpId: "ep396138",
+  });
+
+  let now = 1_000;
+  let snapshotVideoId = "ep396138";
+  const debugLogs: string[] = [];
+  const controller = makeEpisodePageController({
+    refreshFestivalBridge: async () => ({
+      videoId: snapshotVideoId,
+      url: `https://www.bilibili.com/bangumi/play/${snapshotVideoId}`,
+      title: snapshotVideoId === "ep396139" ? "45 某话" : "44 连影",
+    }),
+    getMonotonicNow: () => now,
+    debugLog: (message) => {
+      debugLogs.push(message);
+    },
+  });
+
+  try {
+    for (let read = 1; read <= 25; read += 1) {
+      await controller.refreshFestivalSnapshot(0);
+      now += 250;
+    }
+
+    assert.deepEqual(debugLogs, [
+      "Discarded page video snapshot ep396138; address bar names /bangumi/play/ep396139",
+      "Discarded page video snapshot ep396138 10 times over 2250ms; address bar names /bangumi/play/ep396139",
+      "Discarded page video snapshot ep396138 20 times over 4750ms; address bar names /bangumi/play/ep396139",
+    ]);
+
+    snapshotVideoId = "ep396139";
+    assert.equal(
+      (await controller.refreshFestivalSnapshot(0))?.videoId,
+      "ep396139",
+    );
+    assert.deepEqual(debugLogs.slice(3), [
+      "Discarded page video snapshot ep396138 25 times over 6250ms; address bar names /bangumi/play/ep396139",
+      "Page video snapshot detected id=ep396139 title=45 某话 url=https://www.bilibili.com/bangumi/play/ep396139",
+    ]);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("bangumi ep page logs a confirmed snapshot once and reopens it after a stale window", async () => {
+  const dom = installEpisodePageDomStub({
+    currentPartTitle: "45 某话",
+    currentPartEpId: "ep396139",
+  });
+
+  let now = 1_000;
+  let snapshotVideoId = "ep396139";
+  const debugLogs: string[] = [];
+  const controller = makeEpisodePageController({
+    refreshFestivalBridge: async () => ({
+      videoId: snapshotVideoId,
+      url: `https://www.bilibili.com/bangumi/play/${snapshotVideoId}`,
+      title: snapshotVideoId === "ep396139" ? "45 某话" : "44 连影",
+    }),
+    getMonotonicNow: () => now,
+    debugLog: (message) => {
+      debugLogs.push(message);
+    },
+  });
+
+  try {
+    await controller.refreshFestivalSnapshot(0);
+    now = 1_250;
+    await controller.refreshFestivalSnapshot(0);
+    now = 1_500;
+    await controller.refreshFestivalSnapshot(0);
+
+    snapshotVideoId = "ep396138";
+    now = 1_750;
+    await controller.refreshFestivalSnapshot(0);
+    now = 2_000;
+    await controller.refreshFestivalSnapshot(0);
+
+    snapshotVideoId = "ep396139";
+    now = 2_250;
+    await controller.refreshFestivalSnapshot(0);
+
+    assert.deepEqual(debugLogs, [
+      "Page video snapshot detected id=ep396139 title=45 某话 url=https://www.bilibili.com/bangumi/play/ep396139",
+      "Discarded page video snapshot ep396138; address bar names /bangumi/play/ep396139",
+      "Discarded page video snapshot ep396138 2 times over 500ms; address bar names /bangumi/play/ep396139",
+      "Page video snapshot detected id=ep396139 title=45 某话 url=https://www.bilibili.com/bangumi/play/ep396139",
+    ]);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("bangumi ep page starts a fresh diagnostic after the stale snapshot identity changes", async () => {
+  const dom = installEpisodePageDomStub({
+    currentPartTitle: "44 连影",
+    currentPartEpId: "ep396138",
+  });
+
+  let now = 1_000;
+  let snapshotVideoId = "ep396138";
+  const debugLogs: string[] = [];
+  const controller = makeEpisodePageController({
+    refreshFestivalBridge: async () => ({
+      videoId: snapshotVideoId,
+      url: `https://www.bilibili.com/bangumi/play/${snapshotVideoId}`,
+      title: "Stale episode",
+    }),
+    getMonotonicNow: () => now,
+    debugLog: (message) => {
+      debugLogs.push(message);
+    },
+  });
+
+  try {
+    await controller.refreshFestivalSnapshot(0);
+    now = 1_250;
+    await controller.refreshFestivalSnapshot(0);
+    now = 1_500;
+    snapshotVideoId = "ep396137";
+    await controller.refreshFestivalSnapshot(0);
+
+    assert.deepEqual(debugLogs, [
+      "Discarded page video snapshot ep396138; address bar names /bangumi/play/ep396139",
+      "Discarded page video snapshot ep396138 2 times over 500ms; address bar names /bangumi/play/ep396139",
+      "Discarded page video snapshot ep396137; address bar names /bangumi/play/ep396139",
+    ]);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("bangumi ep page keeps an unconfirmed diagnostic open across empty bridge reads", async () => {
+  const dom = installEpisodePageDomStub({
+    currentPartTitle: "44 连影",
+    currentPartEpId: "ep396138",
+  });
+
+  let now = 1_000;
+  let bridgeResult: "stale" | "empty" | "current" = "stale";
+  const debugLogs: string[] = [];
+  const controller = makeEpisodePageController({
+    refreshFestivalBridge: async () => {
+      if (bridgeResult === "empty") {
+        return null;
+      }
+      const videoId = bridgeResult === "current" ? "ep396139" : "ep396138";
+      return {
+        videoId,
+        url: `https://www.bilibili.com/bangumi/play/${videoId}`,
+        title: bridgeResult === "current" ? "45 某话" : "44 连影",
+      };
+    },
+    getMonotonicNow: () => now,
+    debugLog: (message) => {
+      debugLogs.push(message);
+    },
+  });
+
+  try {
+    await controller.refreshFestivalSnapshot(0);
+    now = 1_250;
+    bridgeResult = "empty";
+    await controller.refreshFestivalSnapshot(0);
+    now = 1_500;
+    bridgeResult = "stale";
+    await controller.refreshFestivalSnapshot(0);
+    now = 1_750;
+    bridgeResult = "current";
+    await controller.refreshFestivalSnapshot(0);
+
+    assert.deepEqual(debugLogs, [
+      "Discarded page video snapshot ep396138; address bar names /bangumi/play/ep396139",
+      "Discarded page video snapshot ep396138 2 times over 750ms; address bar names /bangumi/play/ep396139",
+      "Page video snapshot detected id=ep396139 title=45 某话 url=https://www.bilibili.com/bangumi/play/ep396139",
+    ]);
+  } finally {
+    dom.restore();
+  }
+});
+
+test("bangumi ep page starts a fresh diagnostic after leaving and returning to the same visit", async () => {
+  const dom = installEpisodePageDomStub({
+    currentPartTitle: "44 连影",
+    currentPartEpId: "ep396138",
+  });
+
+  let now = 1_000;
+  const debugLogs: string[] = [];
+  const controller = makeEpisodePageController({
+    refreshFestivalBridge: async () => ({
+      videoId: "ep396138",
+      url: "https://www.bilibili.com/bangumi/play/ep396138",
+      title: "44 连影",
+    }),
+    getMonotonicNow: () => now,
+    debugLog: (message) => {
+      debugLogs.push(message);
+    },
+  });
+
+  try {
+    await controller.refreshFestivalSnapshot(0);
+    now = 1_250;
+    await controller.refreshFestivalSnapshot(0);
+
+    now = 1_500;
+    const awayUrl = "https://www.bilibili.com/video/BVaway";
+    controller.observePageVisit(awayUrl);
+    Object.assign(window.location, {
+      href: awayUrl,
+      pathname: "/video/BVaway",
+    });
+    controller.observePageVisit(EP_PAGE_HREF);
+    Object.assign(window.location, {
+      href: EP_PAGE_HREF,
+      pathname: "/bangumi/play/ep396139",
+    });
+
+    now = 1_750;
+    await controller.refreshFestivalSnapshot(0);
+
+    assert.deepEqual(debugLogs, [
+      "Discarded page video snapshot ep396138; address bar names /bangumi/play/ep396139",
+      "Discarded page video snapshot ep396138 2 times over 500ms; address bar names /bangumi/play/ep396139",
+      "Discarded page video snapshot ep396138; address bar names /bangumi/play/ep396139",
+    ]);
   } finally {
     dom.restore();
   }


### PR DESCRIPTION
## Summary
- 同一 videoId/pathname 的陈旧页面快照只记录首条，每 10 次输出累计次数与单调时长，并在恢复、换键或跨页面时补未汇报摘要
- 相同的成功页面快照只记录一次；陈旧窗口后恢复时重新记录，保留关键状态转换
- 审计同段高频日志：Broadcast trace 已过滤高频事件，Forced pause 在暂停后由 video.paused 前置条件收敛，无需同类修复

Fixes #290

## Test plan
- [x] 新增 5 条 share-controller 回归，覆盖 25 次重复、恢复、换键、空桥接结果与跨 page visit
- [x] 反向探针：只撤掉陈旧聚合后，核心回归从 3 条聚合日志退化为 25 条重复并失败
- [x] 反向探针：只撤掉成功快照去重后，对应回归因 3 条重复成功日志失败
- [x] 本地 Codex review：未发现需修复问题
- [x] npm run format:check && npm run lint && npm run typecheck && npm run build && npm test && npm run audit
