### PR TITLE
chore(release): 1.3.6

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-exclude='../packages/**' test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.5"
+    "@bili-syncplay/protocol": "1.3.6"
   },
   "devDependencies": {
     "@types/chrome": "^0.2.2",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["alarms", "storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "workspaces": [
         "packages/*",
         "server",
@@ -28,9 +28,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.5"
+        "@bili-syncplay/protocol": "1.3.6"
       },
       "devDependencies": {
         "@types/chrome": "^0.2.2",
@@ -5650,10 +5650,10 @@
     },
     "packages/admin-ui": {
       "name": "@bili-syncplay/admin-ui",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
-        "@bili-syncplay/protocol": "1.3.5",
+        "@bili-syncplay/protocol": "1.3.6",
         "@tanstack/react-query": "^5.101.2",
         "antd": "^6.5.1",
         "dayjs": "^1.11.21",
@@ -5697,7 +5697,7 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "devDependencies": {
         "@types/node": "^24.0.0",
         "typescript": "^6.0.3"
@@ -5705,9 +5705,9 @@
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.5",
+        "@bili-syncplay/protocol": "1.3.6",
         "ioredis": "^5.10.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/admin-ui",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
-    "@bili-syncplay/protocol": "1.3.5",
+    "@bili-syncplay/protocol": "1.3.6",
     "@tanstack/react-query": "^5.101.2",
     "antd": "^6.5.1",
     "dayjs": "^1.11.21",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.5",
+    "@bili-syncplay/protocol": "1.3.6",
     "ioredis": "^5.10.0",
     "ws": "^8.21.0"
   },


### PR DESCRIPTION
## 发布内容

基于 `8af4fd0` 发布 1.3.6。协议版本保持 4（与 v1.3.5 相同），扩展与服务端发布顺序无约束。

### 扩展

- #286：加载暂停纠正不再被误判为用户暂停并广播给房间
- #292：季页自然结束时可以正确推进下一集
- #293：稳定 ep 路由分享跳过无收益的页面快照重试
- #294：聚合陈旧页面快照的重复诊断，避免日志淹没
- #295：跨导航保留季页自然结束的事件身份，补齐 #292 的竞态

## 已知未收敛

- #277 仍保留 5 条持久写切片；这是 v1.3.5 已明确接受的分批收敛项，表现为调用方等待而非 join 无声挂死，本次扩展修复未扩大该风险。
- #280 是依赖 #277 的 Redis 连接级可观测性改进，不是运行正确性回归。
- #240 标为低优先级，且期望行为仍待产品决策。

以上均不阻塞本次补丁发布。

## 验证

本地 Codex 复审未发现问题。提交前与推送前均按顺序运行以下六道门禁，退出码全部为 0：

| 命令 | 结果 |
| --- | --- |
| `npm run format:check` | exit 0 |
| `npm run lint` | exit 0 |
| `npm run typecheck` | exit 0 |
| `npm run build` | exit 0 |
| `npm test` | exit 0（audit gate 7、scripts 14、protocol 83、server 860、extension 734、admin-ui 70；fail 0） |
| `npm run audit` | exit 0：`no unallowlisted high+ vulnerability findings` |

本 PR 仅改动 workspace、内部协议依赖、扩展 manifest 与 lockfile 的版本号，无行为变更。