### PR TITLE
fix(server): 关闭期间完成的退订不再报为失败

### DIFF
--- a/server/src/redis-room-event-bus.ts
+++ b/server/src/redis-room-event-bus.ts
@@ -141,7 +141,25 @@ export async function createRedisRoomEventBus(
     connectWithin(subscribeClient),
   ]);
 
-  async function reconcileSubscription(): Promise<void> {
+  /**
+   * Drives the connection's subscription to the desired state, then reports
+   * whether the caller's intent was met.
+   *
+   * A close that lands while a command is awaiting its ACK is the opposite
+   * answer for the two intents, which is why this takes one:
+   *
+   * - `subscribe` did NOT happen — `close` clears `subscribed` and refuses to
+   *   let a late SUBSCRIBE set it, so the caller must not be told it has a
+   *   subscription. It throws.
+   * - `unsubscribe` DID happen. `close` removes every listener, clears
+   *   `subscribers`, and resets `subscribed` itself, so "stop delivering to me"
+   *   is already true by the time the loop notices `closing`. Reporting that as
+   *   a failure rejects a promise for work that completed — and consumers'
+   *   fire-and-forget unsubscribes turn it into an unhandled rejection.
+   */
+  async function reconcileSubscription(
+    intent: "subscribe" | "unsubscribe",
+  ): Promise<void> {
     while (!closing) {
       let operation = subscriptionOperation;
       if (!operation) {
@@ -175,6 +193,9 @@ export async function createRedisRoomEventBus(
       // Desired state may have changed while the command was awaiting its ACK.
       // Re-read both sides before allowing the caller to observe completion.
     }
+    if (intent === "unsubscribe") {
+      return;
+    }
     throw new Error("Room event bus closed while changing its subscription.");
   }
 
@@ -187,7 +208,7 @@ export async function createRedisRoomEventBus(
     }
     subscribers.delete(handler);
     subscribeClient.off("message", listener);
-    await reconcileSubscription();
+    await reconcileSubscription("unsubscribe");
   }
 
   return {
@@ -246,7 +267,7 @@ export async function createRedisRoomEventBus(
       subscribers.set(handler, listener);
       subscribeClient.on("message", listener);
       try {
-        await reconcileSubscription();
+        await reconcileSubscription("subscribe");
       } catch (error) {
         if (subscribers.get(handler) === listener) {
           subscribers.delete(handler);

--- a/server/src/redis-room-event-bus.ts
+++ b/server/src/redis-room-event-bus.ts
@@ -185,6 +185,19 @@ export async function createRedisRoomEventBus(
       }
       try {
         await operation;
+      } catch (error) {
+        // `close` can settle an in-flight command by REJECTION, not just by
+        // flipping `closing`: `quitAllWithin` falls back to `disconnect()`,
+        // which fails everything still on the socket. For an unsubscribe that
+        // is still success — the listener is off, `subscribers` is cleared, and
+        // the connection is gone, so nothing can be delivered — and rejecting
+        // it here would revive exactly the unhandled rejection this intent
+        // exists to prevent. A failure that arrives BEFORE the close is a real
+        // one and stays the caller's answer.
+        if (closing && intent === "unsubscribe") {
+          return;
+        }
+        throw error;
       } finally {
         if (subscriptionOperation === operation) {
           subscriptionOperation = null;

--- a/server/test/redis-room-event-bus.test.ts
+++ b/server/test/redis-room-event-bus.test.ts
@@ -579,3 +579,77 @@ test("redis room event bus records publish metrics on success and failure", asyn
     await bus.close();
   }
 });
+
+test("redis room event bus resolves an unsubscribe whose ACK lands after close", async () => {
+  // The consumer asked to stop receiving messages, and `close` grants exactly
+  // that before the UNSUBSCRIBE is acknowledged. Rejecting here rejects a
+  // promise for work that completed; consumers that unsubscribe without
+  // awaiting then take the process down with an unhandled rejection.
+  let acknowledgeUnsubscribe: () => void = () => undefined;
+  let unsubscribeIssued: () => void = () => undefined;
+  const unsubscribeReachedRedis = new Promise<void>((resolve) => {
+    unsubscribeIssued = resolve;
+  });
+  const subscriber = createFakeRedisPubSubClient(async () => undefined, {
+    unsubscribe: () =>
+      new Promise((resolve) => {
+        acknowledgeUnsubscribe = () => resolve(1);
+        unsubscribeIssued();
+      }),
+  });
+  const publisher = createFakeRedisPubSubClient(async () => undefined);
+  const bus = await createRedisRoomEventBus("redis://unused", {
+    channel: createChannel(),
+    redisClients: {
+      publisher: publisher.client,
+      subscriber: subscriber.client,
+    },
+  });
+
+  const unsubscribe = await bus.subscribe(() => undefined);
+  const unsubscribed = unsubscribe();
+  await unsubscribeReachedRedis;
+  const closed = bus.close();
+  acknowledgeUnsubscribe();
+
+  await assert.doesNotReject(unsubscribed);
+  await closed;
+  assert.equal(subscriber.messageListenerCount(), 0);
+});
+
+test("redis room event bus rejects a subscribe whose ACK lands after close", async () => {
+  // The opposite intent gets the opposite answer: `close` refuses to let a late
+  // SUBSCRIBE mark the bus subscribed, so the caller must not be handed a
+  // subscription that does not exist.
+  let acknowledgeSubscribe: () => void = () => undefined;
+  let subscribeIssued: () => void = () => undefined;
+  const subscribeReachedRedis = new Promise<void>((resolve) => {
+    subscribeIssued = resolve;
+  });
+  const subscriber = createFakeRedisPubSubClient(async () => undefined, {
+    subscribe: () =>
+      new Promise((resolve) => {
+        acknowledgeSubscribe = () => resolve(1);
+        subscribeIssued();
+      }),
+  });
+  const publisher = createFakeRedisPubSubClient(async () => undefined);
+  const bus = await createRedisRoomEventBus("redis://unused", {
+    channel: createChannel(),
+    redisClients: {
+      publisher: publisher.client,
+      subscriber: subscriber.client,
+    },
+  });
+
+  const subscribed = bus.subscribe(() => undefined);
+  await subscribeReachedRedis;
+  const closed = bus.close();
+  acknowledgeSubscribe();
+
+  await assert.rejects(subscribed, {
+    message: "Room event bus closed while changing its subscription.",
+  });
+  await closed;
+  assert.equal(subscriber.messageListenerCount(), 0);
+});

--- a/server/test/redis-room-event-bus.test.ts
+++ b/server/test/redis-room-event-bus.test.ts
@@ -653,3 +653,61 @@ test("redis room event bus rejects a subscribe whose ACK lands after close", asy
   await closed;
   assert.equal(subscriber.messageListenerCount(), 0);
 });
+
+test("redis room event bus resolves an unsubscribe rejected by the close's disconnect", async () => {
+  // `close` does not only flip `closing`: when QUIT overruns its budget it
+  // falls back to `disconnect()`, which rejects whatever is still on the
+  // socket. The unsubscribe still got what it asked for.
+  let failUnsubscribe: () => void = () => undefined;
+  let unsubscribeIssued: () => void = () => undefined;
+  const unsubscribeReachedRedis = new Promise<void>((resolve) => {
+    unsubscribeIssued = resolve;
+  });
+  const subscriber = createFakeRedisPubSubClient(async () => undefined, {
+    unsubscribe: () =>
+      new Promise((_resolve, reject) => {
+        failUnsubscribe = () => reject(new Error("Connection is closed."));
+        unsubscribeIssued();
+      }),
+  });
+  const publisher = createFakeRedisPubSubClient(async () => undefined);
+  const bus = await createRedisRoomEventBus("redis://unused", {
+    channel: createChannel(),
+    redisClients: {
+      publisher: publisher.client,
+      subscriber: subscriber.client,
+    },
+  });
+
+  const unsubscribe = await bus.subscribe(() => undefined);
+  const unsubscribed = unsubscribe();
+  await unsubscribeReachedRedis;
+  const closed = bus.close();
+  failUnsubscribe();
+
+  await assert.doesNotReject(unsubscribed);
+  await closed;
+  assert.equal(subscriber.messageListenerCount(), 0);
+});
+
+test("redis room event bus reports an unsubscribe that fails before any close", async () => {
+  // Nothing has granted the caller's intent here, so the real Redis failure is
+  // the answer it gets.
+  const subscriber = createFakeRedisPubSubClient(async () => undefined, {
+    unsubscribe: async () => {
+      throw new Error("UNSUBSCRIBE failed.");
+    },
+  });
+  const publisher = createFakeRedisPubSubClient(async () => undefined);
+  const bus = await createRedisRoomEventBus("redis://unused", {
+    channel: createChannel(),
+    redisClients: {
+      publisher: publisher.client,
+      subscriber: subscriber.client,
+    },
+  });
+
+  const unsubscribe = await bus.subscribe(() => undefined);
+  await assert.rejects(unsubscribe(), { message: "UNSUBSCRIBE failed." });
+  await bus.close();
+});


### PR DESCRIPTION
## 问题

main 上 `f5fc042` 的 CI 红了（[run 32551094842](https://github.com/sky1wu/Bili-SyncPlay/actions/runs/32551094842)），`redis-integration` 里 860 条测试挂了一条：

```
not ok 494 - redis room event bus delivers published events across instances
  failureType: 'unhandledRejection'
  error: 'Room event bus closed while changing its subscription.'
    reconcileSubscription (server/src/redis-room-event-bus.ts:178)
    async removeSubscriber (server/src/redis-room-event-bus.ts:190)
```

同一份代码在 #297 的 `redis-integration` 上是绿的，跟那个 PR 的改动无关（它没碰 `server/`）——这是一个既有的时序竞态。

## 根因

`reconcileSubscription` 的 `while (!closing)` 循环对「关闭」只有一个结论：抛错。但两个调用方向的正确答案相反：

- **subscribe 方向**：`close` 会清掉 `subscribed`，并拒绝让迟到的 SUBSCRIBE 重新置位。订阅确实没有建立，抛错正确。
- **unsubscribe 方向**：`close` 自己就会 `off` 掉全部 listener、清空 `subscribers`、把 `subscribed` 归位。「别再给我发消息了」这个后置条件在循环发现 `closing` 时早已成立。抛错等于把一个**已经完成**的退订报成失败。

竞态因此发生在 `removeSubscriber` 正 `await` UNSUBSCRIBE 的 ACK、而 `close()` 在这期间置 `closing = true` 时。消费者的 fire-and-forget 退订（`redis-room-event-bus.test.ts:306` 就是一例）没有接收方，rejection 直接变成 `unhandledRejection`。

生产侧同源：`server/src/room-event-consumer.ts:196` 的 `close()` 里是 `await unsubscribe()`。当前关闭顺序是 consumer 先关，所以线上碰不到；一旦变成并发或 bus 先 `closing`，一个成功的退订会被报成失败的关闭步骤。

## 改动

`reconcileSubscription` 接受调用方的意图，只有 `subscribe` 在关闭时抛；`unsubscribe` 按成功返回。

## 验证

- 两条新回归测试用注入的 fake pub/sub 连接（`redisClients` 注入点）确定性地把 ACK 排在 `close()` 之后，**不依赖真实 Redis、不依赖时序**，所以它们在 `verify` job 里也会跑。
- 判别力双向验证：
  - 回退成「关闭时一律抛」→ 新增的 unsubscribe 用例失败，**并且 CI 上原本失败的那条 `delivers published events across instances` 也跟着失败**（本地确定性复现，直接证明因果）。
  - 回退成「关闭时一律成功返回」→ 新增的 subscribe 用例失败，锁住两个方向答案相反这个性质。
- 门禁：`format:check` / `lint` / `typecheck` / `build` / `test` / `audit` 退出码全 0；带本地 Redis 的完整套件 `test:server:redis` 为 862 pass / 0 fail / 0 skip。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176HwHez4onaWPLAyBob5Lo
