### PR TITLE
chore(release): 1.3.7

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/extension",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "coverage": "tsx --test --experimental-test-coverage --test-coverage-exclude='test/**' --test-coverage-exclude='../packages/**' test/**/*.test.ts"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.6"
+    "@bili-syncplay/protocol": "1.3.7"
   },
   "devDependencies": {
     "@types/chrome": "^0.2.2",

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "__MSG_extensionDescription__",
   "default_locale": "zh_CN",
   "permissions": ["alarms", "storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bili-syncplay",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "workspaces": [
         "packages/*",
         "server",
@@ -28,9 +28,9 @@
     },
     "extension": {
       "name": "@bili-syncplay/extension",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.6"
+        "@bili-syncplay/protocol": "1.3.7"
       },
       "devDependencies": {
         "@types/chrome": "^0.2.2",
@@ -5650,10 +5650,10 @@
     },
     "packages/admin-ui": {
       "name": "@bili-syncplay/admin-ui",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
-        "@bili-syncplay/protocol": "1.3.6",
+        "@bili-syncplay/protocol": "1.3.7",
         "@tanstack/react-query": "^5.101.2",
         "antd": "^6.5.1",
         "dayjs": "^1.11.21",
@@ -5697,7 +5697,7 @@
     },
     "packages/protocol": {
       "name": "@bili-syncplay/protocol",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "devDependencies": {
         "@types/node": "^24.0.0",
         "typescript": "^6.0.3"
@@ -5705,9 +5705,9 @@
     },
     "server": {
       "name": "@bili-syncplay/server",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "dependencies": {
-        "@bili-syncplay/protocol": "1.3.6",
+        "@bili-syncplay/protocol": "1.3.7",
         "ioredis": "^5.10.0",
         "ws": "^8.21.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bili-syncplay",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "private": true,
   "workspaces": [
     "packages/*",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/admin-ui",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
-    "@bili-syncplay/protocol": "1.3.6",
+    "@bili-syncplay/protocol": "1.3.7",
     "@tanstack/react-query": "^5.101.2",
     "antd": "^6.5.1",
     "dayjs": "^1.11.21",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/protocol",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bili-syncplay/server",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
     "test:redis": "node scripts/run-redis-test.mjs"
   },
   "dependencies": {
-    "@bili-syncplay/protocol": "1.3.6",
+    "@bili-syncplay/protocol": "1.3.7",
     "ioredis": "^5.10.0",
     "ws": "^8.21.0"
   },


### PR DESCRIPTION
版本号 bump 到 1.3.7，只改版本文件，无行为变更。

本次发布包含：

- **feat(protocol): 识别收藏夹与合集列表播放页 URL** (#297) —— B 站收藏夹「播放全部」的 `/list/ml<收藏夹 id>?...&bvid=...` 与 UP 主合集的 `/list/<mid>?sid=...&bvid=...` 此前既不注入内容脚本也解析不出视频身份，现已支持。
- **fix(server): 关闭期间完成的退订不再报为失败** (#298) —— room event bus 的 `reconcileSubscription` 在关闭时对两个调用方向给了同一个结论，导致一个已完成的退订被 reject，fire-and-forget 的消费者据此产生 unhandledRejection（main 上 redis-integration 的偶发红）。

版本策略：按仓库惯例走 patch（v1.2.4 这个 patch 版同样包含过 feat，minor 留给成批功能，如 v1.3.0 的管理后台重写）。

`npm run release:version -- 1.3.7` 改动了根 `package.json`、`packages/protocol`、`packages/admin-ui`、`server`、`extension` 的 `package.json`、`extension/public/manifest.json` 与 `package-lock.json`。已确认 manifest 里除版本号外没有其他改动（#297 新增的 `content_scripts.matches` 原样保留）。

门禁：`format:check` / `lint` / `typecheck` / `build` / `test` / `audit` 退出码全 0。

合并后打 `v1.3.7` 标签触发 `release.yml`（扩展 Chrome/Firefox 产物）与 `docker-release.yml`（服务端镜像推 GHCR + Docker Hub）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176HwHez4onaWPLAyBob5Lo
