### PR TITLE
docs: 更正 release:version 之后无需手动格式化

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -338,7 +338,7 @@ This command updates:
 - `extension/package.json`
 - `package-lock.json`
 
-The rewritten JSON and manifest files may not match Prettier style, so run `npm run format:check` (and `npm run format` if needed) before committing the version bump.
+The script runs Prettier on every file it rewrites, so the version bump is already formatted — the usual pre-commit sequence still applies, but no extra formatting step is needed.
 
 Build the extension release packages:
 

--- a/docs/development.zh-CN.md
+++ b/docs/development.zh-CN.md
@@ -337,7 +337,7 @@ npm run release:version -- 1.3.0
 - `extension/package.json`
 - `package-lock.json`
 
-脚本重写的 JSON 与 manifest 文件可能不符合 Prettier 风格，提交版本号变更前先执行 `npm run format:check`（必要时 `npm run format`）。
+脚本会对自己重写的每个文件跑 Prettier，版本号变更已经是格式化好的——照常走提交前的检查序列即可，不需要额外补格式化。
 
 构建扩展发布包：
 


### PR DESCRIPTION
`docs/development.md` 与中文版的发版章节写着：

> The rewritten JSON and manifest files may not match Prettier style, so run `npm run format:check` (and `npm run format` if needed) before committing the version bump.

这条自 #154 起就过时了。`scripts/release-version.mjs` 在写完版本文件、跑完 `npm install --package-lock-only` 之后，会对它重写的每个文件执行 `prettier --write`（脚本第 63-79 行，注释也写明了原因：`JSON.stringify` 的输出与仓库风格不一致，不格式化会被预提交的 `format:check` 拦下）。

1.3.7 发版（#299）实测：`npm run release:version -- 1.3.7` 之后直接 `npm run format:check` 就是 0。

改为说明脚本已内置格式化，照常走提交前的检查序列即可。中英文同步更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176HwHez4onaWPLAyBob5Lo
