### PR TITLE
fix(admin-ui): 修复房间管理移动端布局

### DIFF
--- a/packages/admin-ui/src/layout/app-layout.tsx
+++ b/packages/admin-ui/src/layout/app-layout.tsx
@@ -31,8 +31,12 @@ export function AppLayout() {
   };
 
   return (
-    <Layout style={{ minHeight: "100vh" }}>
-      <Layout.Sider breakpoint="lg" collapsedWidth={0}>
+    <Layout className="admin-layout">
+      <Layout.Sider
+        breakpoint="lg"
+        collapsedWidth={0}
+        zeroWidthTriggerStyle={{ top: 12 }}
+      >
         <div style={{ padding: "16px 24px" }}>
           <Typography.Text
             style={{ color: "rgba(255, 255, 255, 0.65)", fontSize: 12 }}
@@ -59,27 +63,24 @@ export function AppLayout() {
         />
       </Layout.Sider>
       <Layout>
-        <Layout.Header
-          style={{
-            background: "#fff",
-            padding: "0 24px",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-          }}
-        >
+        <Layout.Header className="admin-layout__header">
           <Typography.Title level={4} style={{ margin: 0 }}>
             {activeItem?.label ?? "概览"}
           </Typography.Title>
-          <Space>
-            <Typography.Text strong>{me?.username}</Typography.Text>
+          <Space className="admin-layout__account">
+            <Typography.Text className="admin-layout__username" strong>
+              {me?.username}
+            </Typography.Text>
             {me ? <Tag color="blue">{me.role}</Tag> : null}
             <Button onClick={handleLogout}>退出</Button>
           </Space>
         </Layout.Header>
-        <Layout.Content style={{ padding: 24 }}>
+        <Layout.Content className="admin-layout__content">
           {activeItem ? (
-            <Typography.Paragraph type="secondary">
+            <Typography.Paragraph
+              className="admin-layout__description"
+              type="secondary"
+            >
               {activeItem.description}
             </Typography.Paragraph>
           ) : null}

--- a/packages/admin-ui/src/main.tsx
+++ b/packages/admin-ui/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app.js";
+import "./styles.css";
 
 const rootElement = document.querySelector("#root");
 if (!rootElement) {

--- a/packages/admin-ui/src/pages/rooms/rooms-filter.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-filter.tsx
@@ -17,14 +17,14 @@ export function RoomsFilter({
   }, [query.keyword]);
 
   return (
-    <Space wrap>
+    <Space className="rooms-filter" wrap>
       <Input.Search
+        className="rooms-filter__search"
         allowClear
         placeholder="房间号 / 成员 / 视频标题 / URL，空格分隔多关键字"
         value={keywordDraft}
         onChange={(event) => setKeywordDraft(event.target.value)}
         onSearch={(keyword) => onChange({ keyword: keyword.trim(), page: 1 })}
-        style={{ width: 360 }}
       />
       <Segmented<RoomStatusFilter>
         value={query.status ?? "all"}

--- a/packages/admin-ui/src/pages/rooms/rooms-page.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-page.tsx
@@ -224,7 +224,7 @@ export function RoomsPage() {
 
   return (
     <Space direction="vertical" size={16} style={{ display: "flex" }}>
-      <Card>
+      <Card className="rooms-filter-card">
         <Space direction="vertical" size={12} style={{ display: "flex" }}>
           <RoomsFilter query={query} onChange={updateQuery} />
           <Space wrap>

--- a/packages/admin-ui/src/pages/rooms/rooms-table.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-table.tsx
@@ -83,6 +83,7 @@ export function RoomsTable({
       loading={loading}
       dataSource={data?.items ?? []}
       locale={{ emptyText: "没有符合条件的房间。" }}
+      scroll={{ x: 1180 }}
       rowSelection={
         manageable
           ? {
@@ -105,6 +106,7 @@ export function RoomsTable({
         {
           title: "房间",
           dataIndex: "roomCode",
+          width: 128,
           render: (roomCode: string, room) => (
             <>
               <Typography.Link onClick={() => onOpenRoom(roomCode)}>
@@ -120,11 +122,13 @@ export function RoomsTable({
         {
           title: "状态",
           dataIndex: "isActive",
+          width: 110,
           render: (_value, room) => <RoomStatusTag room={room} />,
         },
         {
           title: "共享视频",
           dataIndex: "sharedVideo",
+          width: 260,
           render: (_value, room) =>
             room.sharedVideo ? (
               <Typography.Link
@@ -143,11 +147,13 @@ export function RoomsTable({
         {
           title: "播放进度",
           dataIndex: "playback",
+          width: 140,
           render: (_value, room) => <PlaybackCell room={room} />,
         },
         {
           title: "最近活跃",
           dataIndex: "lastActiveAt",
+          width: 160,
           sorter: true,
           sortOrder: controlledSortOrder("lastActiveAt"),
           render: (value: number) => formatDateTime(value),
@@ -155,6 +161,7 @@ export function RoomsTable({
         {
           title: "创建时间",
           dataIndex: "createdAt",
+          width: 160,
           sorter: true,
           sortOrder: controlledSortOrder("createdAt"),
           render: (value: number) => formatDateTime(value),
@@ -162,6 +169,7 @@ export function RoomsTable({
         {
           title: "操作",
           key: "actions",
+          width: 130,
           render: (_value, room) => (
             <Space>
               <Button size="small" onClick={() => onOpenRoom(room.roomCode)}>

--- a/packages/admin-ui/src/styles.css
+++ b/packages/admin-ui/src/styles.css
@@ -1,0 +1,75 @@
+html,
+body,
+#root {
+  min-width: 0;
+  min-height: 100%;
+  margin: 0;
+}
+
+.admin-layout {
+  min-width: 0;
+  min-height: 100vh;
+}
+
+.admin-layout__header {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  background: #fff;
+}
+
+.admin-layout__account {
+  flex: none;
+}
+
+.admin-layout__content {
+  min-width: 0;
+  padding: 24px;
+}
+
+.rooms-filter {
+  display: flex;
+  width: 100%;
+}
+
+.rooms-filter__search {
+  width: 360px;
+  max-width: 100%;
+}
+
+@media (max-width: 991px) {
+  .admin-layout__header {
+    padding-right: 16px;
+    padding-left: 56px;
+  }
+
+  .admin-layout__content {
+    padding: 16px;
+  }
+}
+
+@media (max-width: 575px) {
+  .admin-layout__header {
+    gap: 8px;
+    padding-right: 12px;
+  }
+
+  .admin-layout__username {
+    display: none;
+  }
+
+  .admin-layout__content {
+    padding: 12px;
+  }
+
+  .rooms-filter-card > .ant-card-body {
+    padding: 16px;
+  }
+
+  .rooms-filter > .ant-space-item:first-child,
+  .rooms-filter__search {
+    width: 100%;
+  }
+}

--- a/packages/admin-ui/test/rooms-page.test.tsx
+++ b/packages/admin-ui/test/rooms-page.test.tsx
@@ -135,6 +135,20 @@ describe("RoomsPage", () => {
     expect(screen.getAllByText("阿伟").length).toBeGreaterThan(0);
   });
 
+  it("keeps the room table readable with horizontal scrolling", async () => {
+    renderRooms(
+      createOperatorAuth({
+        listRooms: vi.fn().mockResolvedValue(makeListResult([makeRoom()])),
+      }),
+    );
+
+    await screen.findByText("ROOM1");
+    const table = screen.getByRole("table");
+    expect(table.style.width).toBe("1180px");
+    expect(table.style.minWidth).toBe("100%");
+    expect(table.parentElement?.style.overflowX).toBe("auto");
+  });
+
   it("passes URL search params through to the rooms query", async () => {
     const listRooms = vi.fn().mockResolvedValue(makeListResult([]));
     renderRooms(


### PR DESCRIPTION
## 变更

- 为房间列表设置可读列宽，并在窄屏内提供横向滚动，避免房间号逐字换行和后续列溢出。
- 调整移动端页头菜单按钮、内容边距和账号区域，避免菜单遮挡页面说明。
- 让房间筛选卡片和搜索框在手机宽度下自适应，并增加表格滚动回归测试。

## 验证

- 本地 Codex 复审：未发现问题。
- `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test && npm run audit`
- 新增回归测试已确认在修复前失败、修复后通过。