### PR TITLE
feat(admin-ui): 支持按房间人数排序

### DIFF
--- a/packages/admin-ui/src/api/types.ts
+++ b/packages/admin-ui/src/api/types.ts
@@ -101,7 +101,7 @@ export type ReadyStatus = {
 };
 
 export type RoomStatusFilter = "all" | "active" | "idle";
-export type RoomSortBy = "lastActiveAt" | "createdAt";
+export type RoomSortBy = "lastActiveAt" | "createdAt" | "memberCount";
 export type SortOrder = "asc" | "desc";
 
 export type RoomListQuery = {

--- a/packages/admin-ui/src/pages/rooms/rooms-page.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-page.tsx
@@ -41,7 +41,10 @@ export function queryFromSearchParams(params: URLSearchParams): RoomListQuery {
     keyword: params.get("keyword") ?? undefined,
     page: Number.isInteger(page) && page > 0 ? page : 1,
     pageSize: Number.isInteger(pageSize) && pageSize > 0 ? pageSize : 20,
-    sortBy: sortBy === "createdAt" ? "createdAt" : "lastActiveAt",
+    sortBy:
+      sortBy === "createdAt" || sortBy === "memberCount"
+        ? sortBy
+        : "lastActiveAt",
     sortOrder: params.get("sortOrder") === "asc" ? "asc" : "desc",
     includeExpired: params.get("includeExpired") === "true",
   };

--- a/packages/admin-ui/src/pages/rooms/rooms-table.tsx
+++ b/packages/admin-ui/src/pages/rooms/rooms-table.tsx
@@ -54,7 +54,9 @@ export function RoomsTable({
     const sortBy: RoomSortBy = hasSorter
       ? activeSorter?.field === "createdAt"
         ? "createdAt"
-        : "lastActiveAt"
+        : activeSorter?.field === "memberCount"
+          ? "memberCount"
+          : "lastActiveAt"
       : (query.sortBy ?? "lastActiveAt");
     const sortOrder = hasSorter
       ? activeSorter?.order === "ascend"
@@ -121,8 +123,10 @@ export function RoomsTable({
         },
         {
           title: "状态",
-          dataIndex: "isActive",
+          dataIndex: "memberCount",
           width: 110,
+          sorter: true,
+          sortOrder: controlledSortOrder("memberCount"),
           render: (_value, room) => <RoomStatusTag room={room} />,
         },
         {

--- a/packages/admin-ui/test/rooms-page.test.tsx
+++ b/packages/admin-ui/test/rooms-page.test.tsx
@@ -265,6 +265,25 @@ describe("RoomsPage", () => {
     });
   });
 
+  it("sorts the status column by room member count", async () => {
+    const listRooms = vi.fn().mockResolvedValue(makeListResult([makeRoom()]));
+    const user = userEvent.setup({ delay: null });
+    renderRooms(createOperatorAuth({ listRooms }));
+
+    expect(await screen.findByText("ROOM1")).toBeTruthy();
+    await user.click(screen.getByRole("columnheader", { name: /状态/ }));
+
+    await waitFor(() => {
+      expect(listRooms).toHaveBeenCalledWith(
+        expect.objectContaining({
+          page: 1,
+          sortBy: "memberCount",
+          sortOrder: "asc",
+        }),
+      );
+    });
+  });
+
   it("drops the previous room's detail while switching rooms", async () => {
     const room1 = makeRoom();
     const room2 = makeRoom({ roomCode: "ROOM2" });

--- a/server/src/admin/room-query-service.ts
+++ b/server/src/admin/room-query-service.ts
@@ -110,14 +110,24 @@ export function createAdminRoomQueryService(options: {
   return {
     async listRooms(query: RoomListQuery) {
       const tokens = tokenizeKeyword(query.keyword);
-      const needsRuntime = query.status !== "all" || tokens.length > 0;
+      const needsRuntime =
+        query.status !== "all" ||
+        tokens.length > 0 ||
+        query.sortBy === "memberCount";
       const normalizedQuery: RoomListQuery = {
         ...query,
         keyword: tokens.length > 0 ? query.keyword : undefined,
       };
+      const roomStoreQuery = {
+        ...normalizedQuery,
+        sortBy:
+          normalizedQuery.sortBy === "memberCount"
+            ? ("lastActiveAt" as const)
+            : normalizedQuery.sortBy,
+      };
 
       if (!needsRuntime) {
-        const baseRooms = await options.roomStore.listRooms(normalizedQuery);
+        const baseRooms = await options.roomStore.listRooms(roomStoreQuery);
         const total = await options.roomStore.countRooms(normalizedQuery);
         const roomItems = await Promise.all(
           baseRooms.map(async (room) =>
@@ -143,7 +153,7 @@ export function createAdminRoomQueryService(options: {
       }
 
       const allRooms = await options.roomStore.listRooms({
-        ...normalizedQuery,
+        ...roomStoreQuery,
         keyword: undefined,
         page: 1,
         pageSize: Number.MAX_SAFE_INTEGER,
@@ -163,6 +173,14 @@ export function createAdminRoomQueryService(options: {
         }
         return true;
       });
+
+      if (normalizedQuery.sortBy === "memberCount") {
+        const factor = normalizedQuery.sortOrder === "asc" ? 1 : -1;
+        filtered.sort(
+          (left, right) =>
+            (left.sessions.length - right.sessions.length) * factor,
+        );
+      }
 
       const total = filtered.length;
       const start = (normalizedQuery.page - 1) * normalizedQuery.pageSize;

--- a/server/src/admin/routes/read-routes.ts
+++ b/server/src/admin/routes/read-routes.ts
@@ -37,6 +37,7 @@ export const handleReadRoutes: AdminRouteHandler = async ({
     }
     const queryParams = getQueryParams(request);
     const status = queryParams.get("status");
+    const sortBy = queryParams.get("sortBy");
     const query: RoomListQuery = {
       status:
         status === "active" || status === "idle" || status === "all"
@@ -49,8 +50,8 @@ export const handleReadRoutes: AdminRouteHandler = async ({
         100,
       ),
       sortBy:
-        queryParams.get("sortBy") === "createdAt"
-          ? "createdAt"
+        sortBy === "createdAt" || sortBy === "memberCount"
+          ? sortBy
           : "lastActiveAt",
       sortOrder: queryParams.get("sortOrder") === "asc" ? "asc" : "desc",
       includeExpired: queryParams.get("includeExpired") === "true",

--- a/server/src/admin/types.ts
+++ b/server/src/admin/types.ts
@@ -62,7 +62,7 @@ export type AdminErrorResponse = {
 };
 
 export type RoomListStatus = "active" | "idle" | "all";
-export type RoomSortBy = "createdAt" | "lastActiveAt";
+export type RoomSortBy = "createdAt" | "lastActiveAt" | "memberCount";
 export type SortOrder = "asc" | "desc";
 
 export type RoomListQuery = {

--- a/server/src/redis-room-store.ts
+++ b/server/src/redis-room-store.ts
@@ -17,6 +17,7 @@ import {
   createPersistedRoom,
   type OrphanedIndexClaim,
   type RoomDeleteOutcome,
+  type RoomStoreListQuery,
   type RoomStore,
   type RoomUpdateResult,
 } from "./room-store.js";
@@ -1213,17 +1214,7 @@ export async function createRedisRoomStore(
   // other services. Only reads depend on the result, so they await it instead.
   void reconcileRoomIndex().catch(() => undefined);
 
-  async function fetchRooms(
-    query: Pick<
-      RoomListQuery,
-      | "keyword"
-      | "includeExpired"
-      | "page"
-      | "pageSize"
-      | "sortBy"
-      | "sortOrder"
-    >,
-  ) {
+  async function fetchRooms(query: RoomStoreListQuery) {
     await awaitBootstrapReconcile("list_rooms");
 
     // Members are the room codes; ordering here is irrelevant because rooms
@@ -1569,17 +1560,7 @@ export async function createRedisRoomStore(
         ),
       );
     },
-    async listRooms(
-      query: Pick<
-        RoomListQuery,
-        | "keyword"
-        | "includeExpired"
-        | "page"
-        | "pageSize"
-        | "sortBy"
-        | "sortOrder"
-      >,
-    ) {
+    async listRooms(query: RoomStoreListQuery) {
       return await fetchRooms(query);
     },
     // Every branch is a single command against a single key, so each answer is

--- a/server/src/room-store.ts
+++ b/server/src/room-store.ts
@@ -45,6 +45,13 @@ export type RoomDeleteOutcome = "deleted" | "already_deleted" | "superseded";
 /** Chooses whether this read owns its deadline or is inside a maintenance pass. */
 export type RoomReadCaller = "request" | "maintenance_pass";
 
+export type RoomStoreListQuery = Pick<
+  RoomListQuery,
+  "keyword" | "includeExpired" | "page" | "pageSize" | "sortOrder"
+> & {
+  sortBy: Exclude<RoomListQuery["sortBy"], "memberCount">;
+};
+
 /**
  * What an update is allowed to overwrite.
  *
@@ -173,17 +180,7 @@ export type RoomStore = {
   acknowledgeOrphanedIndexClaims?: (
     claims: readonly OrphanedIndexClaim[],
   ) => Promise<void>;
-  listRooms: (
-    query: Pick<
-      RoomListQuery,
-      | "keyword"
-      | "includeExpired"
-      | "page"
-      | "pageSize"
-      | "sortBy"
-      | "sortOrder"
-    >,
-  ) => Promise<PersistedRoom[]>;
+  listRooms: (query: RoomStoreListQuery) => Promise<PersistedRoom[]>;
   countRooms: (
     query: Pick<RoomListQuery, "keyword" | "includeExpired">,
   ) => Promise<number>;
@@ -256,7 +253,7 @@ export function createInMemoryRoomStore(
   function sortRooms(
     left: PersistedRoom,
     right: PersistedRoom,
-    query: Pick<RoomListQuery, "sortBy" | "sortOrder">,
+    query: Pick<RoomStoreListQuery, "sortBy" | "sortOrder">,
   ): number {
     const factor = query.sortOrder === "asc" ? 1 : -1;
     return (left[query.sortBy] - right[query.sortBy]) * factor;

--- a/server/test/admin-backend.test.ts
+++ b/server/test/admin-backend.test.ts
@@ -451,6 +451,87 @@ test("admin endpoints support auth, overview, rooms, and events without breaking
   }
 });
 
+test("admin room endpoint sorts all rooms by member count before pagination", async () => {
+  const roomStore = createInMemoryRoomStore();
+  await roomStore.createRoom({
+    code: "ROOMA1",
+    joinToken: "join-token-room-a",
+    createdAt: 100,
+  });
+  await roomStore.createRoom({
+    code: "ROOMB2",
+    joinToken: "join-token-room-b",
+    createdAt: 200,
+  });
+  const server = await startAdminServer({ roomStore });
+  const sockets: WebSocket[] = [];
+
+  const joinRoom = async (
+    roomCode: string,
+    joinToken: string,
+    displayName: string,
+  ) => {
+    const socket = await connectClient(server.wsUrl);
+    sockets.push(socket);
+    const collector = createMessageCollector(socket);
+    socket.send(
+      JSON.stringify({
+        type: "room:join",
+        payload: {
+          roomCode,
+          joinToken,
+          displayName,
+          protocolVersion: PROTOCOL_VERSION,
+        },
+      }),
+    );
+    await collector.next("room:joined");
+    await collector.next("room:state");
+  };
+
+  try {
+    await joinRoom("ROOMA1", "join-token-room-a", "Alice");
+    await joinRoom("ROOMB2", "join-token-room-b", "Bob");
+    await joinRoom("ROOMB2", "join-token-room-b", "Carol");
+    const token = await login(server.httpBaseUrl);
+
+    const descending = await requestJson(
+      server.httpBaseUrl,
+      "/api/admin/rooms?page=1&pageSize=1&sortBy=memberCount&sortOrder=desc",
+      { token },
+    );
+    assert.equal(descending.status, 200);
+    const descendingData = descending.body.data as {
+      items: Array<{ roomCode: string; memberCount: number }>;
+      pagination: { total: number };
+    };
+    assert.equal(descendingData.pagination.total, 2);
+    assert.equal(descendingData.items.length, 1);
+    assert.equal(descendingData.items[0]?.roomCode, "ROOMB2");
+    assert.equal(descendingData.items[0]?.memberCount, 2);
+
+    const ascending = await requestJson(
+      server.httpBaseUrl,
+      "/api/admin/rooms?page=1&pageSize=1&sortBy=memberCount&sortOrder=asc",
+      { token },
+    );
+    assert.equal(ascending.status, 200);
+    const ascendingItems = (
+      ascending.body.data as {
+        items: Array<{ roomCode: string; memberCount: number }>;
+      }
+    ).items;
+    assert.equal(ascendingItems.length, 1);
+    assert.equal(ascendingItems[0]?.roomCode, "ROOMA1");
+    assert.equal(ascendingItems[0]?.memberCount, 1);
+  } finally {
+    for (const socket of sockets) {
+      await closeClient(socket);
+    }
+    await server.close();
+  }
+});
+
 test("admin UI endpoints support CORS preflights and responses for allowed origins", async () => {
   const server = await startAdminServer();
 

--- a/server/test/admin-room-query-keyword.test.ts
+++ b/server/test/admin-room-query-keyword.test.ts
@@ -243,3 +243,36 @@ test("blank keyword falls back to the unfiltered fast path", async () => {
   const result = await service.listRooms({ ...baseQuery, keyword: "   " });
   assert.equal(result.pagination.total, 3);
 });
+
+test("member count sorting happens before pagination", async () => {
+  const { service } = await buildFixture();
+
+  const descending = await service.listRooms({
+    ...baseQuery,
+    pageSize: 2,
+    sortBy: "memberCount",
+  });
+  assert.equal(descending.pagination.total, 3);
+  assert.deepEqual(
+    descending.items.map((item) => [item.roomCode, item.memberCount]),
+    [
+      ["ROOMAA", 2],
+      ["ROOMBB", 1],
+    ],
+  );
+
+  const ascending = await service.listRooms({
+    ...baseQuery,
+    pageSize: 2,
+    sortBy: "memberCount",
+    sortOrder: "asc",
+  });
+  assert.equal(ascending.pagination.total, 3);
+  assert.deepEqual(
+    ascending.items.map((item) => [item.roomCode, item.memberCount]),
+    [
+      ["ROOMCC", 0],
+      ["ROOMBB", 1],
+    ],
+  );
+});


### PR DESCRIPTION
## Summary
- 为房间管理页“状态”列增加按在线人数升序/降序排序，并将排序状态同步到 URL
- 扩展管理 API 的 `sortBy=memberCount` 契约，在实时会话富化后排序、分页
- 收窄持久化房间存储排序契约，避免把运行时人数排序下推到内存或 Redis 房间记录
- 增加 UI 交互、查询服务以及 HTTP 端到端回归覆盖

## Test plan
- [x] `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test && npm run audit`
- [x] DOM 交互验证：点击“状态”列发送 `memberCount` 升序查询
- [x] HTTP 端到端验证：按人数升/降序均在分页前生效
- [ ] 真实浏览器手测（当前执行环境未安装 Chromium/Playwright）
