### PR TITLE
fix(admin): 显示实际节点运行时长

### DIFF
--- a/packages/admin-ui/src/api/types.ts
+++ b/packages/admin-ui/src/api/types.ts
@@ -41,6 +41,7 @@ export type OverviewNode = {
   instanceId: string;
   version: string;
   startedAt: number;
+  uptimeMs: number | null;
   lastHeartbeatAt: number;
   staleAt: number;
   expiresAt: number;

--- a/packages/admin-ui/src/pages/overview/nodes-table.tsx
+++ b/packages/admin-ui/src/pages/overview/nodes-table.tsx
@@ -1,6 +1,6 @@
 import { Table, Tag, Typography } from "antd";
 import type { NodeHealth, OverviewNode } from "../../api/types.js";
-import { formatDateTime } from "../../lib/format.js";
+import { formatDateTime, formatDuration } from "../../lib/format.js";
 
 const HEALTH_PRESENTATION: Record<
   NodeHealth,
@@ -44,6 +44,12 @@ export function NodesTable({ nodes }: { nodes: OverviewNode[] }) {
         { title: "连接", dataIndex: "connectionCount" },
         { title: "房间", dataIndex: "currentRoomCount" },
         { title: "用户", dataIndex: "currentMemberCount" },
+        {
+          title: "运行时长",
+          dataIndex: "uptimeMs",
+          render: (value: number | null | undefined) =>
+            typeof value === "number" ? formatDuration(value) : "—",
+        },
         {
           title: "最近心跳",
           dataIndex: "lastHeartbeatAt",

--- a/packages/admin-ui/src/pages/overview/overview-page.tsx
+++ b/packages/admin-ui/src/pages/overview/overview-page.tsx
@@ -15,10 +15,22 @@ import {
   Typography,
 } from "antd";
 import { useState } from "react";
+import type { OverviewNode } from "../../api/types.js";
 import { formatDuration, formatTime } from "../../lib/format.js";
 import { useOverviewQuery, useReadyQuery } from "./overview-queries.js";
 import { EventStatsTable } from "./event-stats-table.js";
 import { NodesTable } from "./nodes-table.js";
+
+function hasUsableUptime(
+  node: OverviewNode,
+): node is OverviewNode & { uptimeMs: number } {
+  return (
+    node.health !== "offline" &&
+    typeof node.uptimeMs === "number" &&
+    Number.isFinite(node.uptimeMs) &&
+    node.uptimeMs >= 0
+  );
+}
 
 export function OverviewPage() {
   const [autoRefresh, setAutoRefresh] = useState(true);
@@ -63,6 +75,14 @@ export function OverviewPage() {
   const ready = readyQuery.data;
   const readyDegraded =
     readyQuery.isError || (ready && ready.status !== "ready");
+  const nodesWithUptime = overview.nodes.items.filter(hasUsableUptime);
+  const longestRunningNode = nodesWithUptime.reduce<
+    (typeof nodesWithUptime)[number] | null
+  >(
+    (longest, node) =>
+      longest === null || node.uptimeMs > longest.uptimeMs ? node : longest,
+    null,
+  );
 
   return (
     <Space direction="vertical" size={16} style={{ display: "flex" }}>
@@ -128,11 +148,19 @@ export function OverviewPage() {
         <Col xs={24} sm={12} lg={6}>
           <Card>
             <Statistic
-              title="运行时长"
-              value={formatDuration(overview.service.uptimeMs)}
+              title={
+                nodesWithUptime.length > 1 ? "最长节点运行时长" : "节点运行时长"
+              }
+              value={
+                longestRunningNode
+                  ? formatDuration(longestRunningNode.uptimeMs)
+                  : "—"
+              }
             />
             <Typography.Text type="secondary">
-              {overview.service.name} v{overview.service.version}
+              {longestRunningNode
+                ? `${longestRunningNode.instanceId} · ${longestRunningNode.version}`
+                : "暂无可用的节点运行时长"}
             </Typography.Text>
           </Card>
         </Col>

--- a/packages/admin-ui/test/overview-page.test.tsx
+++ b/packages/admin-ui/test/overview-page.test.tsx
@@ -25,8 +25,8 @@ function createOverviewFixture(
       instanceId: "node-a",
       name: "bili-syncplay-server",
       version: "1.2.4",
-      startedAt: Date.now() - 3_600_000,
-      uptimeMs: 3_600_000,
+      startedAt: Date.now() - 5_000,
+      uptimeMs: 5_000,
     },
     storage: { provider: "redis", redisConnected: true },
     runtime: {
@@ -45,6 +45,7 @@ function createOverviewFixture(
           instanceId: "node-a",
           version: "1.2.4",
           startedAt: Date.now() - 3_600_000,
+          uptimeMs: 3_600_000,
           lastHeartbeatAt: Date.now(),
           staleAt: Date.now() + 30_000,
           expiresAt: Date.now() + 60_000,
@@ -108,8 +109,46 @@ describe("OverviewPage", () => {
     expect(screen.getByText("总计 9 非过期")).toBeTruthy();
     expect(screen.getByText("已连接")).toBeTruthy();
     expect(screen.getByText("node-a")).toBeTruthy();
+    expect(screen.getByText("节点运行时长")).toBeTruthy();
+    expect(screen.getAllByText("1 小时 0 分钟").length).toBeGreaterThan(0);
+    expect(screen.queryByText("5 秒")).toBeNull();
     expect(screen.getByText("最近一小时")).toBeTruthy();
     expect(screen.queryByText(/readyz 状态为|readyz 检查失败/)).toBeNull();
+  });
+
+  it("labels and selects the longest non-offline node in a multi-node cluster", async () => {
+    const overview = createOverviewFixture();
+    overview.nodes = {
+      total: 3,
+      online: 2,
+      stale: 0,
+      offline: 1,
+      items: [
+        ...overview.nodes.items,
+        {
+          ...overview.nodes.items[0]!,
+          instanceId: "node-b",
+          uptimeMs: 7_200_000,
+        },
+        {
+          ...overview.nodes.items[0]!,
+          instanceId: "node-offline",
+          health: "offline",
+          uptimeMs: 10_800_000,
+        },
+      ],
+    };
+
+    renderOverview(
+      createAuthValue({
+        getOverview: vi.fn().mockResolvedValue(overview),
+        getReady: vi.fn().mockResolvedValue(readyFixture),
+      }),
+    );
+
+    expect(await screen.findByText("最长节点运行时长")).toBeTruthy();
+    expect(screen.getAllByText("2 小时 0 分钟").length).toBeGreaterThan(0);
+    expect(screen.getByText("node-b · 1.2.4")).toBeTruthy();
   });
 
   it("shows a degradation banner when readyz is not ready", async () => {

--- a/server/src/admin/global-overview-service.ts
+++ b/server/src/admin/global-overview-service.ts
@@ -6,5 +6,8 @@ export function createGlobalAdminOverviewService(
   return createAdminOverviewService({
     ...options,
     serviceName: options.serviceName || "bili-syncplay-global-admin",
+    // The standalone control plane owns a RuntimeStore for shared reads, but
+    // it is not a room node and must not appear in the node inventory.
+    includeLocalNodeFallback: false,
   });
 }

--- a/server/src/admin/overview-service.ts
+++ b/server/src/admin/overview-service.ts
@@ -29,11 +29,14 @@ type NodeWorkload = {
 
 function summarizeNodeWorkloads(
   sessions: Session[],
-  fallbackInstanceId: string,
+  fallbackInstanceId: string | null,
 ): Map<string, NodeWorkload> {
   const workloads = new Map<string, NodeWorkload>();
   for (const session of sessions) {
     const instanceId = session.instanceId || fallbackInstanceId;
+    if (!instanceId) {
+      continue;
+    }
     const workload = workloads.get(instanceId) ?? {
       connectionCount: 0,
       currentMemberCount: 0,
@@ -56,16 +59,18 @@ function synthesizeNodeStatus(
   workload: NodeWorkload | undefined,
   options: {
     currentTime: number;
-    fallbackInstanceId: string;
+    localInstanceId: string | null;
+    localUptimeMs: number;
     serviceVersion: string;
     startedAt: number;
   },
 ): ClusterNodeStatus {
+  const isLocalNode = instanceId === options.localInstanceId;
   return {
     instanceId,
     version: options.serviceVersion,
-    startedAt:
-      instanceId === options.fallbackInstanceId ? options.startedAt : 0,
+    startedAt: isLocalNode ? options.startedAt : 0,
+    ...(isLocalNode ? { uptimeMs: options.localUptimeMs } : {}),
     lastHeartbeatAt: options.currentTime,
     staleAt: options.currentTime,
     expiresAt: options.currentTime,
@@ -84,14 +89,19 @@ export function createAdminOverviewService(options: {
   roomStore: RoomStore;
   runtimeStore: RuntimeStore;
   eventStore: GlobalEventStore;
+  includeLocalNodeFallback?: boolean;
   now?: () => number;
+  uptimeMs?: () => number;
 }) {
   const now = options.now ?? Date.now;
+  const uptimeMs = options.uptimeMs ?? (() => process.uptime() * 1_000);
+  const includeLocalNodeFallback = options.includeLocalNodeFallback ?? true;
   const roomFanOut = createRoomFanOutLimiter();
 
   return {
     async getOverview() {
       const currentTime = now();
+      const localUptimeMs = Math.max(0, uptimeMs());
       // Use the literal ms window [now - windowMs, now]. Event stores keep a
       // timestamp index for recent events, so these counters stay precise even
       // after the query buffer or Redis stream has trimmed older entries.
@@ -147,8 +157,18 @@ export function createAdminOverviewService(options: {
         await options.runtimeStore.listClusterSessions("request");
       const nodeWorkloads = summarizeNodeWorkloads(
         clusterSessions,
-        options.instanceId,
+        includeLocalNodeFallback ? options.instanceId : null,
       );
+      if (includeLocalNodeFallback && !nodeWorkloads.has(options.instanceId)) {
+        // A standalone room node may run with heartbeats disabled (the
+        // default), and a shared session read may also be unavailable while
+        // the local runtime remains authoritative for its own workload.
+        nodeWorkloads.set(options.instanceId, {
+          connectionCount: options.runtimeStore.getConnectionCount(),
+          currentMemberCount: options.runtimeStore.getActiveMemberCount(),
+          roomCodes: options.runtimeStore.getActiveRoomCodes(),
+        });
+      }
       const nodeStatusByInstanceId = new Map(
         nodeStatuses.map((status) => [status.instanceId, status]),
       );
@@ -156,7 +176,7 @@ export function createAdminOverviewService(options: {
         ...nodeStatuses.map((status) => status.instanceId),
         ...nodeWorkloads.keys(),
       ]);
-      if (nodeInstanceIds.size > 0) {
+      if (includeLocalNodeFallback) {
         nodeInstanceIds.add(options.instanceId);
       }
       const nodeItems = Array.from(nodeInstanceIds)
@@ -167,13 +187,22 @@ export function createAdminOverviewService(options: {
             nodeStatusByInstanceId.get(instanceId) ??
             synthesizeNodeStatus(instanceId, workload, {
               currentTime,
-              fallbackInstanceId: options.instanceId,
+              localInstanceId: includeLocalNodeFallback
+                ? options.instanceId
+                : null,
+              localUptimeMs,
               serviceVersion: options.serviceVersion,
               startedAt: options.runtimeStore.getStartedAt(),
             });
           const roomCodes = Array.from(workload?.roomCodes ?? []).sort();
           return {
             ...status,
+            uptimeMs:
+              status.uptimeMs !== undefined &&
+              Number.isFinite(status.uptimeMs) &&
+              status.uptimeMs >= 0
+                ? status.uptimeMs
+                : null,
             connectionCount:
               workload?.connectionCount ?? status.connectionCount,
             currentRoomCount: workload
@@ -206,7 +235,7 @@ export function createAdminOverviewService(options: {
           name: options.serviceName,
           version: options.serviceVersion,
           startedAt: options.runtimeStore.getStartedAt(),
-          uptimeMs: currentTime - options.runtimeStore.getStartedAt(),
+          uptimeMs: localUptimeMs,
         },
         storage: {
           provider: options.persistenceConfig.provider,

--- a/server/src/node-heartbeat.ts
+++ b/server/src/node-heartbeat.ts
@@ -77,9 +77,11 @@ export function createNodeHeartbeat(options: {
   intervalMs: number;
   ttlMs: number;
   now?: () => number;
+  uptimeMs?: () => number;
   logEvent?: LogEvent;
 }): NodeHeartbeat {
   const now = options.now ?? Date.now;
+  const uptimeMs = options.uptimeMs ?? (() => process.uptime() * 1_000);
   const staleAfterMs = Math.max(
     options.intervalMs,
     Math.min(options.ttlMs, options.intervalMs * 2),
@@ -99,10 +101,15 @@ export function createNodeHeartbeat(options: {
     unrefTimer: true,
     run: async () => {
       const currentTime = now();
+      const startedAt = options.runtimeStore.getStartedAt();
       const status: ClusterNodeStatus = {
         instanceId: options.instanceId,
         version: options.serviceVersion,
-        startedAt: options.runtimeStore.getStartedAt(),
+        startedAt,
+        // Sample the node-local monotonic process clock. Neither cross-machine
+        // clock skew nor a wall-clock correction on this host may change the
+        // reported process lifetime.
+        uptimeMs: Math.max(0, uptimeMs()),
         lastHeartbeatAt: currentTime,
         staleAt: currentTime + staleAfterMs,
         expiresAt: currentTime + options.ttlMs,

--- a/server/src/redis-runtime-store.ts
+++ b/server/src/redis-runtime-store.ts
@@ -2327,6 +2327,17 @@ export async function createRedisRuntimeStore(
           instanceId: status.instanceId,
           version: status.version,
           startedAt: String(status.startedAt),
+          ...(status.uptimeMs === undefined
+            ? {}
+            : {
+                uptimeMs: String(status.uptimeMs),
+                // An older node does not know either uptime field. If it takes
+                // over the same instance id, it updates `lastHeartbeatAt` but
+                // leaves unknown hash fields untouched. Matching the sample
+                // timestamp prevents a new reader from showing that stale
+                // duration forever after a rollback.
+                uptimeSampledAt: String(status.lastHeartbeatAt),
+              }),
           lastHeartbeatAt: String(status.lastHeartbeatAt),
           staleAt: String(status.staleAt),
           expiresAt: String(status.expiresAt),
@@ -2355,6 +2366,12 @@ export async function createRedisRuntimeStore(
               instanceId: fields.instanceId || instanceId,
               version: fields.version || "unknown",
               startedAt: Number(fields.startedAt ?? "0"),
+              ...(fields.uptimeSampledAt === fields.lastHeartbeatAt &&
+              fields.uptimeMs !== undefined &&
+              Number.isFinite(Number(fields.uptimeMs)) &&
+              Number(fields.uptimeMs) >= 0
+                ? { uptimeMs: Number(fields.uptimeMs) }
+                : {}),
               lastHeartbeatAt: Number(fields.lastHeartbeatAt ?? "0"),
               staleAt: Number(fields.staleAt ?? "0"),
               expiresAt: Number(fields.expiresAt ?? "0"),

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -113,6 +113,12 @@ export type ClusterNodeStatus = {
   instanceId: string;
   version: string;
   startedAt: number;
+  /**
+   * Duration sampled by the node itself. Optional so a new reader can coexist
+   * with node-status hashes written by an older process during a rolling
+   * upgrade.
+   */
+  uptimeMs?: number;
   lastHeartbeatAt: number;
   staleAt: number;
   expiresAt: number;

--- a/server/test/admin-overview-service.test.ts
+++ b/server/test/admin-overview-service.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { createGlobalAdminOverviewService } from "../src/admin/global-overview-service.js";
 import { createAdminOverviewService } from "../src/admin/overview-service.js";
 import { createEventStore } from "../src/admin/event-store.js";
 import { createInMemoryRoomStore } from "../src/room-store.js";
@@ -135,13 +136,20 @@ test("overview preserves local runtime count fallback when node data is unavaila
     runtimeStore,
     eventStore: createEventStore(),
     now: () => now,
+    uptimeMs: () => 120_000,
   });
 
   const overview = await service.getOverview();
 
   assert.equal(overview.runtime.connectionCount, 1);
   assert.equal(overview.runtime.activeMemberCount, 1);
-  assert.equal(overview.nodes.items.length, 0);
+  assert.deepEqual(
+    overview.nodes.items.map((node) => ({
+      instanceId: node.instanceId,
+      uptimeMs: node.uptimeMs,
+    })),
+    [{ instanceId: "instance-a", uptimeMs: 120_000 }],
+  );
 });
 
 test("overview falls back to heartbeat room count when node workload is unavailable", async () => {
@@ -157,6 +165,7 @@ test("overview falls back to heartbeat room count when node workload is unavaila
     instanceId: "instance-b",
     version: "0.9.2-test",
     startedAt: now - 2_000,
+    uptimeMs: 120_000,
     lastHeartbeatAt: now,
     staleAt: now + 10_000,
     expiresAt: now + 20_000,
@@ -184,6 +193,54 @@ test("overview falls back to heartbeat room count when node workload is unavaila
 
   assert.equal(remoteNode?.currentRoomCount, 3);
   assert.equal(remoteNode?.currentMemberCount, 7);
+  assert.equal(remoteNode?.uptimeMs, 120_000);
+});
+
+test("global overview reports room-node uptime without inventing a global-admin node", async () => {
+  const now = Date.parse("2026-04-05T12:00:00.000Z");
+  const roomStore = createInMemoryRoomStore({ now: () => now });
+  const runtimeStore = createInMemoryRuntimeStore(() => now - 5_000);
+  const persistenceConfig = {
+    ...getDefaultPersistenceConfig(),
+    instanceId: "global-admin",
+  };
+
+  await runtimeStore.heartbeatNode({
+    instanceId: "room-node-a",
+    version: "0.9.2-test",
+    startedAt: now - 3_600_000,
+    // Deliberately different from `now - startedAt`: the overview must use
+    // the duration sampled on the room node, not subtract clocks itself.
+    uptimeMs: 3_000_000,
+    lastHeartbeatAt: now,
+    staleAt: now + 10_000,
+    expiresAt: now + 20_000,
+    connectionCount: 0,
+    activeRoomCount: 0,
+    activeMemberCount: 0,
+    health: "ok",
+  });
+
+  const service = createGlobalAdminOverviewService({
+    instanceId: persistenceConfig.instanceId,
+    serviceName: "bili-syncplay-global-admin",
+    serviceVersion: "0.9.2-test",
+    persistenceConfig,
+    roomStore,
+    runtimeStore,
+    eventStore: createEventStore(),
+    now: () => now,
+  });
+
+  const overview = await service.getOverview();
+
+  assert.deepEqual(
+    overview.nodes.items.map((node) => ({
+      instanceId: node.instanceId,
+      uptimeMs: node.uptimeMs,
+    })),
+    [{ instanceId: "room-node-a", uptimeMs: 3_000_000 }],
+  );
 });
 
 test("overview aggregates event statistics from the event store", async () => {

--- a/server/test/node-heartbeat.test.ts
+++ b/server/test/node-heartbeat.test.ts
@@ -52,6 +52,7 @@ test("node heartbeat writes shared node status into redis runtime store", async 
     intervalMs: 50,
     ttlMs: 200,
     now: () => currentTime,
+    uptimeMs: () => 123,
   });
 
   try {
@@ -64,7 +65,30 @@ test("node heartbeat writes shared node status into redis runtime store", async 
     assert.equal(statuses.length, 1);
     assert.equal(statuses[0]?.instanceId, instanceId);
     assert.equal(statuses[0]?.version, "test-version");
+    assert.equal(statuses[0]?.uptimeMs, 123);
     assert.equal(statuses[0]?.health, "ok");
+
+    currentTime += 1;
+    await sharedRuntimeStore.heartbeatNode({
+      instanceId,
+      version: "old-version-without-uptime",
+      startedAt: 1,
+      lastHeartbeatAt: currentTime,
+      staleAt: currentTime + 100,
+      expiresAt: currentTime + 200,
+      connectionCount: 0,
+      activeRoomCount: 0,
+      activeMemberCount: 0,
+      health: "ok",
+    });
+    statuses = await sharedRuntimeStore.listNodeStatuses(
+      "maintenance_pass",
+      currentTime,
+    );
+    // Redis HSET leaves fields unknown to an older writer in place. Tie the
+    // duration to its heartbeat sample so a rollback cannot freeze a stale
+    // `uptimeMs` in the admin UI forever.
+    assert.equal(statuses[0]?.uptimeMs, undefined);
 
     currentTime += 120;
     statuses = await sharedRuntimeStore.listNodeStatuses(
@@ -192,6 +216,9 @@ test("start() beats immediately, not one interval from now", async () => {
     intervalMs: 60_000,
     ttlMs: 180_000,
     now: () => 10,
+    // Deliberately unrelated to the wall-clock timestamps: uptime must come
+    // from the monotonic node-local source.
+    uptimeMs: () => 321,
   });
 
   try {
@@ -202,6 +229,7 @@ test("start() beats immediately, not one interval from now", async () => {
     await firstBeat;
     assert.equal(beats[0]?.instanceId, "node-a");
     assert.equal(beats[0]?.connectionCount, 2);
+    assert.equal(beats[0]?.uptimeMs, 321);
     // staleAt is two intervals out — one missed beat is not yet news — capped
     // by the TTL and floored at a single interval; expiresAt is the full TTL.
     // Both are stamped from the same instant the beat was built.


### PR DESCRIPTION
## 变更说明

- Room Node 在心跳中上报基于单调时钟采样的实际进程运行时长
- 独立 global-admin 不再被合成为 Room Node，管理概览不再显示管理进程运行时长
- 概览卡片和节点表展示节点运行时长；多节点时展示最长的非离线节点
- 保留默认未启用心跳时的本地单节点运行时长兜底
- Redis 心跳字段采用增量兼容设计，旧节点缺少字段时显示为不可用，并通过采样标记避免回滚后残留旧值

## 验证

- npm run format:check && npm run lint && npm run typecheck && npm run build && npm test && npm run audit
- REDIS_URL=redis://127.0.0.1:6379 node --test --import tsx server/test/node-heartbeat.test.ts
- 回退关键实现后，节点时间源与无心跳单节点两条回归测试均按预期失败

## 兼容性

这是管理 API 与内部 Redis 心跳数据的增量变更，不涉及客户端同步协议，因此无需提升协议版本。Room Node 与 global-admin 同版本部署后即可显示完整节点运行时长。